### PR TITLE
feat(core): add revocable support passport grants

### DIFF
--- a/packages/remnic-core/src/maintenance/atomic-file.ts
+++ b/packages/remnic-core/src/maintenance/atomic-file.ts
@@ -1,5 +1,5 @@
-import { copyFile, mkdir, open, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
+import { copyFile, mkdir, open, rename, rm, stat } from "node:fs/promises";
 
 async function syncDirectory(dir: string): Promise<void> {
   let handle: Awaited<ReturnType<typeof open>> | undefined;
@@ -18,7 +18,10 @@ function tempPathFor(outputPath: string): string {
   return path.join(path.dirname(outputPath), `.${path.basename(outputPath)}.${suffix}.tmp`);
 }
 
-export async function copyExistingFileToBackup(sourcePath: string, backupPath: string): Promise<string | undefined> {
+export async function copyExistingFileToBackup(
+  sourcePath: string,
+  backupPath: string,
+): Promise<string | undefined> {
   try {
     await stat(sourcePath);
   } catch (err) {
@@ -35,7 +38,6 @@ export async function writeFileAtomically(
   outputPath: string,
   content: string | Uint8Array,
   backupPath?: string,
-  options: { mode?: number } = {}
 ): Promise<string | undefined> {
   const dir = path.dirname(outputPath);
   await mkdir(dir, { recursive: true });
@@ -43,7 +45,7 @@ export async function writeFileAtomically(
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   let resolvedBackupPath: string | undefined;
   try {
-    handle = await open(tempPath, "wx", options.mode);
+    handle = await open(tempPath, "w");
     if (typeof content === "string") {
       await handle.writeFile(content, "utf-8");
     } else {
@@ -69,7 +71,7 @@ export async function writeFileAtomically(
 export async function commitPreparedFileAtomically(
   tempPath: string,
   outputPath: string,
-  backupPath?: string
+  backupPath?: string,
 ): Promise<string | undefined> {
   const dir = path.dirname(outputPath);
   let resolvedBackupPath: string | undefined;

--- a/packages/remnic-core/src/maintenance/atomic-file.ts
+++ b/packages/remnic-core/src/maintenance/atomic-file.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { copyFile, mkdir, open, rename, rm, stat } from "node:fs/promises";
+import path from "node:path";
 
 async function syncDirectory(dir: string): Promise<void> {
   let handle: Awaited<ReturnType<typeof open>> | undefined;
@@ -18,10 +18,7 @@ function tempPathFor(outputPath: string): string {
   return path.join(path.dirname(outputPath), `.${path.basename(outputPath)}.${suffix}.tmp`);
 }
 
-export async function copyExistingFileToBackup(
-  sourcePath: string,
-  backupPath: string,
-): Promise<string | undefined> {
+export async function copyExistingFileToBackup(sourcePath: string, backupPath: string): Promise<string | undefined> {
   try {
     await stat(sourcePath);
   } catch (err) {
@@ -38,6 +35,7 @@ export async function writeFileAtomically(
   outputPath: string,
   content: string | Uint8Array,
   backupPath?: string,
+  options: { mode?: number } = {}
 ): Promise<string | undefined> {
   const dir = path.dirname(outputPath);
   await mkdir(dir, { recursive: true });
@@ -45,7 +43,7 @@ export async function writeFileAtomically(
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   let resolvedBackupPath: string | undefined;
   try {
-    handle = await open(tempPath, "w");
+    handle = await open(tempPath, "wx", options.mode);
     if (typeof content === "string") {
       await handle.writeFile(content, "utf-8");
     } else {
@@ -71,7 +69,7 @@ export async function writeFileAtomically(
 export async function commitPreparedFileAtomically(
   tempPath: string,
   outputPath: string,
-  backupPath?: string,
+  backupPath?: string
 ): Promise<string | undefined> {
   const dir = path.dirname(outputPath);
   let resolvedBackupPath: string | undefined;

--- a/packages/remnic-core/src/support-passport/card-service.test.ts
+++ b/packages/remnic-core/src/support-passport/card-service.test.ts
@@ -201,7 +201,7 @@ test("card reads and mutations stay inside the resolved namespace on shared stor
       supportPassportOwnerLockPath(subject.storage, { namespace: "alice", principal: "owner:alice" }),
       supportPassportOwnerLockPath(subject.storage, { namespace: "bob", principal: "owner:bob" })
     );
-    assert.equal(
+    assert.notEqual(
       supportPassportOwnerLockPath(subject.storage, { namespace: "alice", principal: "owner:alice" }),
       supportPassportOwnerLockPath(subject.storage, {
         namespace: "alice",

--- a/packages/remnic-core/src/support-passport/card-service.test.ts
+++ b/packages/remnic-core/src/support-passport/card-service.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import { StorageManager } from "../storage.js";
 import { stripAttributesSuffix } from "../structured-attributes.js";
 import {
+  computeSupportPassportOwnerKey,
   decodeSupportPassportNamespaceAttributes,
   projectSupportPassportCard,
 } from "./card-projection.js";
@@ -199,6 +200,13 @@ test("card reads and mutations stay inside the resolved namespace on shared stor
     assert.notEqual(
       supportPassportOwnerLockPath(subject.storage, { namespace: "alice", principal: "owner:alice" }),
       supportPassportOwnerLockPath(subject.storage, { namespace: "bob", principal: "owner:bob" })
+    );
+    assert.equal(
+      supportPassportOwnerLockPath(subject.storage, { namespace: "alice", principal: "owner:alice" }),
+      supportPassportOwnerLockPath(subject.storage, {
+        namespace: "alice",
+        ownerKey: computeSupportPassportOwnerKey("owner:alice"),
+      })
     );
     const aliceDraft = await subject.service.createManualDraft({
       principal: "owner:alice",

--- a/packages/remnic-core/src/support-passport/errors.ts
+++ b/packages/remnic-core/src/support-passport/errors.ts
@@ -1,6 +1,7 @@
 export type SupportPassportErrorCode =
   | "card_data_invalid"
   | "card_not_found"
+  | "grant_expired"
   | "grant_gone"
   | "grant_not_found"
   | "grant_stale"

--- a/packages/remnic-core/src/support-passport/errors.ts
+++ b/packages/remnic-core/src/support-passport/errors.ts
@@ -7,6 +7,7 @@ export type SupportPassportErrorCode =
   | "invalid_card_status"
   | "invalid_input"
   | "revision_conflict"
+  | "state_conflict"
   | "storage_conflict";
 
 export class SupportPassportError extends Error {

--- a/packages/remnic-core/src/support-passport/errors.ts
+++ b/packages/remnic-core/src/support-passport/errors.ts
@@ -1,6 +1,9 @@
 export type SupportPassportErrorCode =
   | "card_data_invalid"
   | "card_not_found"
+  | "grant_gone"
+  | "grant_not_found"
+  | "grant_stale"
   | "invalid_card_status"
   | "invalid_input"
   | "revision_conflict"

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -6,89 +6,117 @@ const IsoTimestampSchema = z.string().datetime({ offset: true });
 const RevisionSchema = z.string().regex(/^[a-f0-9]{64}$/);
 const GrantIdSchema = z.string().uuid();
 
-export const SupportPassportGrantCardRefSchema = z.object({
-  cardId: SupportPassportMemoryIdSchema,
-  revision: RevisionSchema,
-}).strict();
+export const SupportPassportGrantCardRefSchema = z
+  .object({
+    cardId: SupportPassportMemoryIdSchema,
+    revision: RevisionSchema,
+  })
+  .strict();
 
-export const SupportPassportGrantStateSchema = z.object({
-  schemaVersion: z.literal(1),
-  stateVersion: z.number().int().positive(),
-  grantId: GrantIdSchema,
-  namespace: z.string().trim().min(1).max(256),
-  principalHash: RevisionSchema,
-  secretHash: RevisionSchema,
-  cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
-  createdAt: IsoTimestampSchema,
-  expiresAt: IsoTimestampSchema,
-  revokedAt: IsoTimestampSchema.optional(),
-}).strict().superRefine((grant, ctx) => {
-  const ids = new Set<string>();
-  for (const [index, card] of grant.cards.entries()) {
-    if (ids.has(card.cardId)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "card IDs must be unique", path: ["cards", index, "cardId"] });
+export const SupportPassportGrantStateSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    stateVersion: z.number().int().positive(),
+    grantId: GrantIdSchema,
+    namespace: z.string().trim().min(1).max(256),
+    principalHash: RevisionSchema,
+    secretHash: RevisionSchema,
+    cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
+    createdAt: IsoTimestampSchema,
+    expiresAt: IsoTimestampSchema,
+    revokedAt: IsoTimestampSchema.optional(),
+  })
+  .strict()
+  .superRefine((grant, ctx) => {
+    const ids = new Set<string>();
+    for (const [index, card] of grant.cards.entries()) {
+      if (ids.has(card.cardId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "card IDs must be unique",
+          path: ["cards", index, "cardId"],
+        });
+      }
+      ids.add(card.cardId);
     }
-    ids.add(card.cardId);
-  }
-  if (Date.parse(grant.expiresAt) <= Date.parse(grant.createdAt)) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "expiresAt must follow createdAt", path: ["expiresAt"] });
-  }
-});
-
-export const SupportPassportCreateGrantInputSchema = z.object({
-  principal: z.string().trim().min(1).max(512),
-  cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
-  durationSeconds: z.number().int().min(300).max(604_800),
-}).strict().superRefine((input, ctx) => {
-  const ids = new Set<string>();
-  for (const [index, card] of input.cards.entries()) {
-    if (ids.has(card.cardId)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "card IDs must be unique", path: ["cards", index, "cardId"] });
+    if (Date.parse(grant.expiresAt) <= Date.parse(grant.createdAt)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "expiresAt must follow createdAt", path: ["expiresAt"] });
     }
-    ids.add(card.cardId);
-  }
-});
+  });
 
-export const SupportPassportOwnerGrantSchema = z.object({
-  grantId: GrantIdSchema,
-  stateVersion: z.number().int().positive(),
-  cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
-  createdAt: IsoTimestampSchema,
-  expiresAt: IsoTimestampSchema,
-  revokedAt: IsoTimestampSchema.optional(),
-  status: z.enum(["active", "expired", "revoked"]),
-}).strict();
+export const SupportPassportCreateGrantInputSchema = z
+  .object({
+    principal: z.string().trim().min(1).max(512),
+    cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
+    durationSeconds: z.number().int().min(300).max(604_800),
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    const ids = new Set<string>();
+    for (const [index, card] of input.cards.entries()) {
+      if (ids.has(card.cardId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "card IDs must be unique",
+          path: ["cards", index, "cardId"],
+        });
+      }
+      ids.add(card.cardId);
+    }
+  });
 
-export const SupportPassportCreatedGrantSchema = z.object({
-  grant: SupportPassportOwnerGrantSchema,
-  secret: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
-}).strict();
+export const SupportPassportOwnerGrantSchema = z
+  .object({
+    grantId: GrantIdSchema,
+    stateVersion: z.number().int().positive(),
+    cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
+    createdAt: IsoTimestampSchema,
+    expiresAt: IsoTimestampSchema,
+    revokedAt: IsoTimestampSchema.optional(),
+    status: z.enum(["active", "expired", "revoked"]),
+  })
+  .strict();
 
-export const SupportPassportPublicCardSchema = z.object({
-  cardId: SupportPassportMemoryIdSchema,
-  title: z.string().trim().min(1).max(80),
-  statement: z.string().trim().min(1).max(500),
-  category: SupportPassportCardCategorySchema,
-  updatedAt: IsoTimestampSchema,
-}).strict();
+export const SupportPassportCreatedGrantSchema = z
+  .object({
+    grant: SupportPassportOwnerGrantSchema,
+    secret: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+  })
+  .strict();
 
-export const SupportPassportPublicGuideSchema = z.object({
-  schemaVersion: z.literal(1),
-  grantId: GrantIdSchema,
-  expiresAt: IsoTimestampSchema,
-  updatedAt: IsoTimestampSchema,
-  cards: z.array(SupportPassportPublicCardSchema).min(1).max(8),
-}).strict();
+export const SupportPassportPublicCardSchema = z
+  .object({
+    cardId: SupportPassportMemoryIdSchema,
+    title: z.string().trim().min(1).max(80),
+    statement: z.string().trim().min(1).max(500),
+    category: SupportPassportCardCategorySchema,
+    updatedAt: IsoTimestampSchema,
+  })
+  .strict();
 
-export const SupportPassportRevokeGrantInputSchema = z.object({
-  principal: z.string().trim().min(1).max(512),
-  grantId: GrantIdSchema,
-  expectedStateVersion: z.number().int().positive().optional(),
-}).strict();
+export const SupportPassportPublicGuideSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    grantId: GrantIdSchema,
+    expiresAt: IsoTimestampSchema,
+    updatedAt: IsoTimestampSchema,
+    cards: z.array(SupportPassportPublicCardSchema).min(1).max(8),
+  })
+  .strict();
 
-export const SupportPassportListGrantsInputSchema = z.object({
-  principal: z.string().trim().min(1).max(512),
-}).strict();
+export const SupportPassportRevokeGrantInputSchema = z
+  .object({
+    principal: z.string().trim().min(1).max(512),
+    grantId: GrantIdSchema,
+    expectedStateVersion: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const SupportPassportListGrantsInputSchema = z
+  .object({
+    principal: z.string().trim().min(1).max(512),
+  })
+  .strict();
 
 export type SupportPassportGrantCardRef = z.infer<typeof SupportPassportGrantCardRefSchema>;
 export type SupportPassportGrantState = z.infer<typeof SupportPassportGrantStateSchema>;

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 
 import { SupportPassportCardCategorySchema, SupportPassportMemoryIdSchema } from "./contracts.js";
 
-const IsoTimestampSchema = z.string().datetime({ offset: true });
+const IsoTimestampSchema = z
+  .string()
+  .datetime({ offset: true })
+  .refine((value) => Number.isFinite(Date.parse(value)), "timestamp must be a real date");
 const RevisionSchema = z.string().regex(/^[a-f0-9]{64}$/);
 const GrantIdSchema = z.string().uuid();
 

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { parseIsoOffsetTimestamp } from "../utils/iso-timestamp.js";
 import {
   SupportPassportCardCategorySchema,
   SupportPassportMemoryIdSchema,
@@ -9,9 +10,12 @@ import {
 const IsoTimestampSchema = z
   .string()
   .datetime({ offset: true })
-  .refine((value) => Number.isFinite(Date.parse(value)), "timestamp must be a real date");
+  .refine((value) => parseIsoOffsetTimestamp(value) !== null, "timestamp must be a real date");
 const RevisionSchema = z.string().regex(/^[a-f0-9]{64}$/);
-const GrantIdSchema = z.string().uuid();
+const GrantIdSchema = z
+  .string()
+  .uuid()
+  .transform((value) => value.toLowerCase());
 
 export const SupportPassportGrantCardRefSchema = z
   .object({

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -48,7 +48,7 @@ export const SupportPassportCreateGrantInputSchema = z
   .object({
     principal: z.string().trim().min(1).max(512),
     cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
-    durationSeconds: z.number().int().min(300).max(604_800),
+    expiresAt: IsoTimestampSchema,
   })
   .strict()
   .superRefine((input, ctx) => {

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+
+import { SupportPassportCardCategorySchema, SupportPassportMemoryIdSchema } from "./contracts.js";
+
+const IsoTimestampSchema = z.string().datetime({ offset: true });
+const RevisionSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const GrantIdSchema = z.string().uuid();
+
+export const SupportPassportGrantCardRefSchema = z.object({
+  cardId: SupportPassportMemoryIdSchema,
+  revision: RevisionSchema,
+}).strict();
+
+export const SupportPassportGrantStateSchema = z.object({
+  schemaVersion: z.literal(1),
+  stateVersion: z.number().int().positive(),
+  grantId: GrantIdSchema,
+  namespace: z.string().trim().min(1).max(256),
+  principalHash: RevisionSchema,
+  secretHash: RevisionSchema,
+  cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
+  createdAt: IsoTimestampSchema,
+  expiresAt: IsoTimestampSchema,
+  revokedAt: IsoTimestampSchema.optional(),
+}).strict().superRefine((grant, ctx) => {
+  const ids = new Set<string>();
+  for (const [index, card] of grant.cards.entries()) {
+    if (ids.has(card.cardId)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "card IDs must be unique", path: ["cards", index, "cardId"] });
+    }
+    ids.add(card.cardId);
+  }
+  if (Date.parse(grant.expiresAt) <= Date.parse(grant.createdAt)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "expiresAt must follow createdAt", path: ["expiresAt"] });
+  }
+});
+
+export const SupportPassportCreateGrantInputSchema = z.object({
+  principal: z.string().trim().min(1).max(512),
+  cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
+  durationSeconds: z.number().int().min(300).max(604_800),
+}).strict().superRefine((input, ctx) => {
+  const ids = new Set<string>();
+  for (const [index, card] of input.cards.entries()) {
+    if (ids.has(card.cardId)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "card IDs must be unique", path: ["cards", index, "cardId"] });
+    }
+    ids.add(card.cardId);
+  }
+});
+
+export const SupportPassportOwnerGrantSchema = z.object({
+  grantId: GrantIdSchema,
+  stateVersion: z.number().int().positive(),
+  cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
+  createdAt: IsoTimestampSchema,
+  expiresAt: IsoTimestampSchema,
+  revokedAt: IsoTimestampSchema.optional(),
+  status: z.enum(["active", "expired", "revoked"]),
+}).strict();
+
+export const SupportPassportCreatedGrantSchema = z.object({
+  grant: SupportPassportOwnerGrantSchema,
+  secret: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+}).strict();
+
+export const SupportPassportPublicCardSchema = z.object({
+  cardId: SupportPassportMemoryIdSchema,
+  title: z.string().trim().min(1).max(80),
+  statement: z.string().trim().min(1).max(500),
+  category: SupportPassportCardCategorySchema,
+  updatedAt: IsoTimestampSchema,
+}).strict();
+
+export const SupportPassportPublicGuideSchema = z.object({
+  schemaVersion: z.literal(1),
+  grantId: GrantIdSchema,
+  expiresAt: IsoTimestampSchema,
+  updatedAt: IsoTimestampSchema,
+  cards: z.array(SupportPassportPublicCardSchema).min(1).max(8),
+}).strict();
+
+export const SupportPassportRevokeGrantInputSchema = z.object({
+  principal: z.string().trim().min(1).max(512),
+  grantId: GrantIdSchema,
+  expectedStateVersion: z.number().int().positive().optional(),
+}).strict();
+
+export const SupportPassportListGrantsInputSchema = z.object({
+  principal: z.string().trim().min(1).max(512),
+}).strict();
+
+export type SupportPassportGrantCardRef = z.infer<typeof SupportPassportGrantCardRefSchema>;
+export type SupportPassportGrantState = z.infer<typeof SupportPassportGrantStateSchema>;
+export type SupportPassportCreateGrantInput = z.input<typeof SupportPassportCreateGrantInputSchema>;
+export type SupportPassportOwnerGrant = z.infer<typeof SupportPassportOwnerGrantSchema>;
+export type SupportPassportCreatedGrant = z.infer<typeof SupportPassportCreatedGrantSchema>;
+export type SupportPassportPublicGuide = z.infer<typeof SupportPassportPublicGuideSchema>;
+export type SupportPassportRevokeGrantInput = z.input<typeof SupportPassportRevokeGrantInputSchema>;

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-import { SupportPassportCardCategorySchema, SupportPassportMemoryIdSchema } from "./contracts.js";
+import {
+  SupportPassportCardCategorySchema,
+  SupportPassportMemoryIdSchema,
+  SupportPassportNamespaceSchema,
+} from "./contracts.js";
 
 const IsoTimestampSchema = z
   .string()
@@ -21,7 +25,7 @@ export const SupportPassportGrantStateSchema = z
     schemaVersion: z.literal(1),
     stateVersion: z.number().int().positive(),
     grantId: GrantIdSchema,
-    namespace: z.string().trim().min(1).max(256),
+    namespace: SupportPassportNamespaceSchema,
     principalHash: RevisionSchema,
     secretHash: RevisionSchema,
     cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),

--- a/packages/remnic-core/src/support-passport/grant-contracts.ts
+++ b/packages/remnic-core/src/support-passport/grant-contracts.ts
@@ -31,6 +31,7 @@ export const SupportPassportGrantStateSchema = z
     grantId: GrantIdSchema,
     namespace: SupportPassportNamespaceSchema,
     principalHash: RevisionSchema,
+    ownerLockKey: RevisionSchema,
     secretHash: RevisionSchema,
     cards: z.array(SupportPassportGrantCardRefSchema).min(1).max(8),
     createdAt: IsoTimestampSchema,

--- a/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
@@ -41,16 +41,23 @@ function supportCardMemory(): MemoryFile {
 
 test("card snapshots match the storage cache freshness window", async () => {
   let nowMs = Date.parse("2026-08-11T12:00:00.000Z");
-  let memories = [supportCardMemory()];
-  let reads = 0;
+  let diskMemories = [supportCardMemory()];
+  let cachedMemories: MemoryFile[] | undefined;
+  let cacheLoadedAt = 0;
+  let calls = 0;
+  let diskReads = 0;
   const storage = {
     getCorpusScanVersion: () => 1,
     hotCacheKeyId: () => "stable",
     hotCacheTtlMs: () => 60_000,
     isHotCacheEnabled: () => true,
     readAllMemories: async () => {
-      reads += 1;
-      return memories;
+      calls += 1;
+      if (cachedMemories && nowMs - cacheLoadedAt <= 60_000) return cachedMemories;
+      diskReads += 1;
+      cachedMemories = diskMemories;
+      cacheLoadedAt = nowMs;
+      return cachedMemories;
     },
   } as unknown as StorageManager;
   const service = new SupportPassportGrantService({
@@ -69,14 +76,16 @@ test("card snapshots match the storage cache freshness window", async () => {
   const ownerKey = computeSupportPassportOwnerKey("owner:alice");
 
   assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 1);
-  memories = [];
+  diskMemories = [];
   nowMs += 1_001;
   assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 1);
-  assert.equal(reads, 1);
+  assert.equal(calls, 2);
+  assert.equal(diskReads, 1);
   nowMs += 59_000;
 
   assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 0);
-  assert.equal(reads, 2);
+  assert.equal(calls, 3);
+  assert.equal(diskReads, 2);
 });
 
 test("guide assembly rechecks snapshot age after owner-lock delay", async () => {

--- a/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
@@ -39,13 +39,19 @@ function supportCardMemory(): MemoryFile {
   } as MemoryFile;
 }
 
-test("card snapshots expire when a direct file edit bypasses corpus version counters", async () => {
+test("card snapshots match the storage cache freshness window", async () => {
   let nowMs = Date.parse("2026-08-11T12:00:00.000Z");
   let memories = [supportCardMemory()];
+  let reads = 0;
   const storage = {
     getCorpusScanVersion: () => 1,
     hotCacheKeyId: () => "stable",
-    readAllMemories: async () => memories,
+    hotCacheTtlMs: () => 60_000,
+    isHotCacheEnabled: () => true,
+    readAllMemories: async () => {
+      reads += 1;
+      return memories;
+    },
   } as unknown as StorageManager;
   const service = new SupportPassportGrantService({
     grantStore: {} as SupportPassportGrantStore,
@@ -57,7 +63,7 @@ test("card snapshots expire when a direct file edit bypasses corpus version coun
     readStoredCardSnapshot(
       storage: StorageManager,
       namespace?: string,
-      ownerKey?: string,
+      ownerKey?: string
     ): Promise<{ cardsById: ReadonlyMap<string, unknown> }>;
   };
   const ownerKey = computeSupportPassportOwnerKey("owner:alice");
@@ -65,8 +71,12 @@ test("card snapshots expire when a direct file edit bypasses corpus version coun
   assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 1);
   memories = [];
   nowMs += 1_001;
+  assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 1);
+  assert.equal(reads, 1);
+  nowMs += 59_000;
 
   assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 0);
+  assert.equal(reads, 2);
 });
 
 test("guide assembly rechecks snapshot age after owner-lock delay", async () => {
@@ -93,6 +103,8 @@ test("guide assembly rechecks snapshot age after owner-lock delay", async () => 
       dir: root,
       getCorpusScanVersion: () => 1,
       hotCacheKeyId: () => "stable",
+      hotCacheTtlMs: () => 1_000,
+      isHotCacheEnabled: () => true,
       readAllMemories: async () => memories,
     } as unknown as StorageManager;
     const grantStore = {
@@ -101,7 +113,7 @@ test("guide assembly rechecks snapshot age after owner-lock delay", async () => 
         _grantId: string,
         _secret: string,
         task: (current: SupportPassportGrantState) => Promise<T>,
-        beforeReturn?: (current: SupportPassportGrantState) => Promise<void>,
+        beforeReturn?: (current: SupportPassportGrantState) => Promise<void>
       ): Promise<T> => {
         nowMs += 1_001;
         memories = [];
@@ -119,7 +131,7 @@ test("guide assembly rechecks snapshot age after owner-lock delay", async () => 
 
     await assert.rejects(
       service.readGrant({ grantId: state.grantId, secret: "secret" }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import type { StorageManager } from "../index.js";
 import type { MemoryFile } from "../types.js";
-import { computeSupportPassportOwnerKey } from "./card-projection.js";
+import { computeSupportPassportOwnerKey, projectSupportPassportCard } from "./card-projection.js";
+import { SupportPassportError } from "./errors.js";
+import type { SupportPassportGrantState } from "./grant-contracts.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import type { SupportPassportGrantStore } from "./grant-store.js";
 
@@ -63,4 +67,61 @@ test("card snapshots expire when a direct file edit bypasses corpus version coun
   nowMs += 1_001;
 
   assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 0);
+});
+
+test("guide assembly rechecks snapshot age after owner-lock delay", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cache-"));
+  try {
+    await mkdir(path.join(root, "state"), { recursive: true });
+    let nowMs = Date.parse("2026-08-11T12:00:00.000Z");
+    let memories = [supportCardMemory()];
+    const projected = projectSupportPassportCard(memories[0]);
+    assert.ok(projected);
+    const state: SupportPassportGrantState = {
+      schemaVersion: 1,
+      stateVersion: 1,
+      grantId: "00000000-0000-4000-8000-000000000001",
+      namespace: "alice",
+      principalHash: computeSupportPassportOwnerKey("owner:alice"),
+      ownerLockKey: "a".repeat(64),
+      secretHash: "b".repeat(64),
+      cards: [{ cardId: projected.card.cardId, revision: projected.card.revision }],
+      createdAt: "2026-08-11T12:00:00.000Z",
+      expiresAt: "2026-08-11T13:00:00.000Z",
+    };
+    const storage = {
+      dir: root,
+      getCorpusScanVersion: () => 1,
+      hotCacheKeyId: () => "stable",
+      readAllMemories: async () => memories,
+    } as unknown as StorageManager;
+    const grantStore = {
+      authenticate: async () => state,
+      withAuthenticatedGrant: async <T>(
+        _grantId: string,
+        _secret: string,
+        task: (current: SupportPassportGrantState) => Promise<T>,
+        beforeReturn?: (current: SupportPassportGrantState) => Promise<void>,
+      ): Promise<T> => {
+        nowMs += 1_001;
+        memories = [];
+        const result = await task(state);
+        await beforeReturn?.(state);
+        return result;
+      },
+    } as unknown as SupportPassportGrantStore;
+    const service = new SupportPassportGrantService({
+      grantStore,
+      resolveOwner: async (principal) => ({ principal, namespace: "alice", storage }),
+      resolveNamespace: async () => storage,
+      now: () => new Date(nowMs),
+    });
+
+    await assert.rejects(
+      service.readGrant({ grantId: state.grantId, secret: "secret" }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service-cache.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import type { StorageManager } from "../index.js";
+import type { MemoryFile } from "../types.js";
+import { computeSupportPassportOwnerKey } from "./card-projection.js";
+import { SupportPassportGrantService } from "./grant-service.js";
+import type { SupportPassportGrantStore } from "./grant-store.js";
+
+function supportCardMemory(): MemoryFile {
+  return {
+    path: path.resolve(import.meta.dirname, "fixtures", "support-card.md"),
+    content: "Offer me a quiet place and time.",
+    frontmatter: {
+      id: "support-card-1",
+      category: "preference",
+      source: "support-passport",
+      confidence: 1,
+      confidenceTier: "explicit",
+      created: "2026-08-11T12:00:00.000Z",
+      updated: "2026-08-11T12:00:00.000Z",
+      status: "active",
+      tags: ["support-passport-card"],
+      structuredAttributes: {
+        "support-passport-namespace": "alice",
+        "support-passport-owner": computeSupportPassportOwnerKey("owner:alice"),
+        "support-passport-title": "Quiet space",
+        "support-passport-category": "environment",
+        "support-passport-order": "0",
+        "support-passport-review-by": "2026-09-01T12:00:00.000Z",
+        "support-passport-source-ids": "source-1",
+      },
+    },
+  } as MemoryFile;
+}
+
+test("card snapshots expire when a direct file edit bypasses corpus version counters", async () => {
+  let nowMs = Date.parse("2026-08-11T12:00:00.000Z");
+  let memories = [supportCardMemory()];
+  const storage = {
+    getCorpusScanVersion: () => 1,
+    hotCacheKeyId: () => "stable",
+    readAllMemories: async () => memories,
+  } as unknown as StorageManager;
+  const service = new SupportPassportGrantService({
+    grantStore: {} as SupportPassportGrantStore,
+    resolveOwner: async (principal) => ({ principal, namespace: "alice", storage }),
+    resolveNamespace: async () => storage,
+    now: () => new Date(nowMs),
+  });
+  const inspected = service as unknown as {
+    readStoredCardSnapshot(
+      storage: StorageManager,
+      namespace?: string,
+      ownerKey?: string,
+    ): Promise<{ cardsById: ReadonlyMap<string, unknown> }>;
+  };
+  const ownerKey = computeSupportPassportOwnerKey("owner:alice");
+
+  assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 1);
+  memories = [];
+  nowMs += 1_001;
+
+  assert.equal((await inspected.readStoredCardSnapshot(storage, "alice", ownerKey)).cardsById.size, 0);
+});

--- a/packages/remnic-core/src/support-passport/grant-service-cancellation.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service-cancellation.test.ts
@@ -43,6 +43,8 @@ test("grant creation checks cancellation again before commit", async () => {
     const storage = {
       dir: root,
       readAllMemories: async () => [memory],
+      getCorpusScanVersion: () => 1,
+      hotCacheKeyId: () => "owner-cache",
     } as unknown as StorageManager;
     const controller = new AbortController();
     let committed = false;

--- a/packages/remnic-core/src/support-passport/grant-service-cancellation.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service-cancellation.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { StorageManager } from "../index.js";
+import type { MemoryFile } from "../types.js";
+import { computeSupportPassportOwnerKey, projectSupportPassportCard } from "./card-projection.js";
+import { SupportPassportGrantService } from "./grant-service.js";
+import type { SupportPassportGrantStore } from "./grant-store.js";
+
+test("grant creation checks cancellation again before commit", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cancel-"));
+  try {
+    await mkdir(path.join(root, "state"), { recursive: true });
+    const memory = {
+      path: path.join(root, "preferences", "support-card.md"),
+      content: "Offer me a quiet place and time.",
+      frontmatter: {
+        id: "support-card-1",
+        category: "preference",
+        source: "support-passport",
+        confidence: 1,
+        confidenceTier: "explicit",
+        created: "2026-08-11T12:00:00.000Z",
+        updated: "2026-08-11T12:00:00.000Z",
+        status: "active",
+        tags: ["support-passport-card"],
+        structuredAttributes: {
+          "support-passport-namespace": "alice",
+          "support-passport-owner": computeSupportPassportOwnerKey("owner:alice"),
+          "support-passport-title": "Quiet space",
+          "support-passport-category": "environment",
+          "support-passport-order": "0",
+          "support-passport-review-by": "2026-09-01T12:00:00.000Z",
+          "support-passport-source-ids": "source-1",
+        },
+      },
+    } as MemoryFile;
+    const projected = projectSupportPassportCard(memory);
+    assert.ok(projected);
+    const storage = {
+      dir: root,
+      readAllMemories: async () => [memory],
+    } as unknown as StorageManager;
+    const controller = new AbortController();
+    let committed = false;
+    const grantStore = {
+      create: async (_input: unknown, hooks: { beforeCommit?: () => Promise<void> }) => {
+        controller.abort();
+        await hooks.beforeCommit?.();
+        committed = true;
+        throw new Error("commit should not run");
+      },
+    } as unknown as SupportPassportGrantStore;
+    const service = new SupportPassportGrantService({
+      grantStore,
+      resolveOwner: async (principal) => ({ principal, namespace: "alice", storage }),
+      resolveNamespace: async () => storage,
+      now: () => new Date("2026-08-11T12:00:00.000Z"),
+    });
+
+    await assert.rejects(
+      service.createGrant(
+        {
+          principal: "owner:alice",
+          cards: [{ cardId: projected.card.cardId, revision: projected.card.revision }],
+          expiresAt: "2026-08-11T13:00:00.000Z",
+        },
+        { signal: controller.signal }
+      ),
+      (error: unknown) => error instanceof Error && error.name === "AbortError"
+    );
+    assert.equal(committed, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -678,6 +678,40 @@ test("grant creation rechecks the owner lock immediately before commit", async (
   }
 });
 
+test("grant creation revokes its committed link when the owner lock is lost after storage", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const create = subject.grantStore.create.bind(subject.grantStore);
+    let committedGrantId = "";
+    subject.grantStore.create = async (...args) => {
+      const created = await create(...args);
+      committedGrantId = created.state.grantId;
+      const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+        namespace: "alice",
+        principal: "owner:alice",
+      });
+      await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+      return created;
+    };
+
+    await assert.rejects(
+      subject.grantService.createGrant({
+        principal: "owner:alice",
+        cards: [{ cardId: card.cardId, revision: card.revision }],
+        expiresAt: expiryAfter(subject, 3_600_000),
+      }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+    assert.ok(committedGrantId);
+    const [stored] = await subject.grantStore.listForOwner("alice", "owner:alice");
+    assert.equal(stored?.grantId, committedGrantId);
+    assert.ok(stored?.revokedAt);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("grant creation measures its minimum lifetime from request receipt", async () => {
   const subject = await makeSubject();
   try {
@@ -2104,6 +2138,22 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
     assert.equal(syncs, expectedSyncs);
     assert.equal((await lstat(target)).isDirectory(), true);
     assert.equal((await lstat(target)).mode & 0o777, 0o700);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("private directory tree ignores a read-only filesystem-root sync", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-readonly-"));
+  try {
+    const target = path.join(root, "memory", "state", "support-passport", "grants");
+    let firstSync = true;
+    await ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed", async () => {
+      if (!firstSync) return;
+      firstSync = false;
+      throw Object.assign(new Error("simulated read-only filesystem root"), { code: "EROFS" });
+    });
+    assert.equal((await lstat(target)).isDirectory(), true);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -24,6 +24,7 @@ import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 import {
   ensurePrivateDirectoryNoFollow,
+  ensurePrivateDirectoryTreeNoFollow,
   requirePrivateFileDescriptorRoot,
   resolvePrivateDirectoryPath,
 } from "./private-file.js";
@@ -187,25 +188,70 @@ test("owner grant listings propagate indexed grant read failures", async () => {
   }
 });
 
-test("owner grant operations use one trimmed namespace and principal", async () => {
+test("owner grant listings put active links before inactive history", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-order-"));
+  try {
+    let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
+    let nextGrantId = 1;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      now: () => new Date(currentTime),
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(currentTime + 3_600_000).toISOString(),
+    };
+    const inactive = await store.create(input);
+    currentTime += 1_000;
+    const active = await store.create({ ...input, expiresAt: new Date(currentTime + 3_600_000).toISOString() });
+    await store.revoke({
+      grantId: inactive.state.grantId,
+      namespace: input.namespace,
+      principal: input.principal,
+    });
+
+    const listed = await store.listForOwner(input.namespace, input.principal);
+
+    assert.deepEqual(
+      listed.map((state) => state.grantId),
+      [active.state.grantId, inactive.state.grantId]
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("owner grant operations reject a noncanonical namespace and trim the principal", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-namespace-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    await assert.rejects(
+      store.create({
+        namespace: " alice ",
+        principal: " owner:alice ",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+      }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+    );
     const created = await store.create({
-      namespace: " alice ",
+      namespace: "alice",
       principal: " owner:alice ",
       cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
       expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
     });
 
     assert.deepEqual(
-      (await store.listForOwner(" alice ", "owner:alice")).map((state) => state.grantId),
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
       [created.state.grantId]
     );
     const revoked = await store.revoke({
       grantId: created.state.grantId,
-      namespace: " alice ",
+      namespace: "alice",
       principal: " owner:alice ",
       expectedStateVersion: created.state.stateVersion,
     });
@@ -555,6 +601,63 @@ test("a helper sees only the selected active card through a valid secret", async
     assert.equal("namespace" in guide, false);
   } finally {
     await subject.cleanup();
+  }
+});
+
+test("grants reject cards owned by another namespace in shared storage", async () => {
+  StorageManager.clearAllStaticCaches();
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-card-scope-"));
+  try {
+    const storage = new StorageManager(path.join(root, "shared-storage"));
+    await storage.ensureDirectories();
+    const now = () => new Date("2026-08-11T12:00:00.000Z");
+    const resolveOwner = async (principal: string) => ({
+      principal,
+      namespace: principal === "owner:alice" ? "alice" : "bob",
+      storage,
+    });
+    const cardService = new SupportPassportCardService({ resolveOwner, now });
+    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
+    const grantService = new SupportPassportGrantService({
+      grantStore,
+      resolveOwner,
+      resolveNamespace: async () => storage,
+      now,
+    });
+    const draft = await cardService.createManualDraft({
+      principal: "owner:alice",
+      title: "Alice card",
+      statement: "Offer me a quiet place.",
+      category: "environment",
+      reviewBy: "2026-09-01T12:00:00.000Z",
+    });
+    const aliceCard = await cardService.approveCard({
+      principal: "owner:alice",
+      cardId: draft.cardId,
+      expectedRevision: draft.revision,
+    });
+
+    await assert.rejects(
+      grantService.createGrant({
+        principal: "owner:bob",
+        cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
+        expiresAt: "2026-08-11T13:00:00.000Z",
+      }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
+    );
+    const forged = await grantStore.create({
+      namespace: "bob",
+      principal: "owner:bob",
+      cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
+      expiresAt: "2026-08-11T13:00:00.000Z",
+    });
+    await assert.rejects(
+      grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+    );
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(root, { recursive: true, force: true });
   }
 });
 
@@ -1139,16 +1242,15 @@ test("grant creation rejects an approved card with an invalid update timestamp",
       }),
       true
     );
-    const [invalidCard] = await subject.cardService.listCards({ principal: "owner:alice" });
-    assert.ok(invalidCard);
+    assert.deepEqual(await subject.cardService.listCards({ principal: "owner:alice" }), []);
 
     await assert.rejects(
       subject.grantService.createGrant({
         principal: "owner:alice",
-        cards: [{ cardId: invalidCard.cardId, revision: invalidCard.revision }],
+        cards: [{ cardId: card.cardId, revision: card.revision }],
         expiresAt: expiryAfter(subject, 3_600_000),
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "card_data_invalid"
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
     );
     assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
   } finally {
@@ -1322,6 +1424,24 @@ test("private directory creation retries a failed parent sync", async () => {
       retrySyncs += 1;
     });
     assert.equal(retrySyncs, 3);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("private directory tree creation syncs missing memory-root ancestors", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-sync-"));
+  try {
+    const target = path.join(root, "new-parent", "memory");
+    let syncs = 0;
+
+    await ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed", async () => {
+      syncs += 1;
+    });
+
+    assert.equal(syncs, 2);
+    assert.equal((await lstat(target)).isDirectory(), true);
+    assert.equal((await lstat(target)).mode & 0o777, 0o700);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { renameSync, symlinkSync } from "node:fs";
 import {
-  type FileHandle,
   lstat,
   mkdir,
   mkdtemp,
@@ -27,7 +26,6 @@ import {
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
   requirePrivateFileDescriptorRoot,
-  resolvePrivateDirectoryPath,
 } from "./private-file.js";
 
 async function makeSubject() {
@@ -337,6 +335,64 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     );
     assert.deepEqual(evictedGrantLocks, [first.state.grantId]);
     await assert.rejects(lstat(firstGrantPath), (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation accepts a state write that committed before its durability error", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-commit-"));
+  try {
+    const grantId = "00000000-0000-4000-8000-000000000001";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
+    const inspected = store as unknown as {
+      writeState(state: unknown, requireAbsent: boolean): Promise<void>;
+    };
+    const writeState = inspected.writeState.bind(store);
+    inspected.writeState = async (state, requireAbsent) => {
+      await writeState(state, requireAbsent);
+      throw Object.assign(new Error("simulated post-commit state error"), { code: "EIO" });
+    };
+
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+
+    assert.equal(created.state.grantId, grantId);
+    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation accepts an owner index write that committed before its durability error", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-commit-"));
+  try {
+    const grantId = "00000000-0000-4000-8000-000000000001";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
+    const inspected = store as unknown as {
+      writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
+    };
+    const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
+    inspected.writeOwnerIndex = async (ownerHash, grantIds) => {
+      await writeOwnerIndex(ownerHash, grantIds);
+      throw Object.assign(new Error("simulated post-commit index error"), { code: "EIO" });
+    };
+
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+
+    assert.equal(created.state.grantId, grantId);
+    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1418,29 +1474,12 @@ test("the grant store rejects a symlinked grant directory", async () => {
 });
 
 test("private file operations select supported directory access strategies", () => {
-  for (const platform of ["win32", "darwin"] as const) {
-    assert.throws(
-      () => requirePrivateFileDescriptorRoot(platform, "private file directory cannot be pinned"),
-      /private file directory cannot be pinned/
-    );
-  }
+  assert.throws(
+    () => requirePrivateFileDescriptorRoot("win32", "private file directory cannot be pinned"),
+    /private file directory cannot be pinned/
+  );
   assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
-});
-
-test("macOS private files fail closed without descriptor-relative operations", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-darwin-"));
-  let handle: FileHandle | undefined;
-  try {
-    handle = await open(root, "r");
-    const opened = await handle.stat();
-    await assert.rejects(
-      resolvePrivateDirectoryPath(root, handle, opened, "private directory changed", "darwin"),
-      /private directory changed/
-    );
-  } finally {
-    await handle?.close();
-    await rm(root, { recursive: true, force: true });
-  }
+  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
 });
 
 test("private directory creation syncs every verified parent entry", async () => {
@@ -1480,6 +1519,31 @@ test("private directory creation retries a failed parent sync", async () => {
       retrySyncs += 1;
     });
     assert.equal(retrySyncs, 3);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("private directory creation retries parent sync when rollback cannot remove the child", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-populated-"));
+  try {
+    const target = path.join(root, "state");
+    let failed = false;
+    await assert.rejects(
+      ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+        if (failed) return;
+        failed = true;
+        await writeFile(path.join(target, "peer-entry"), "peer");
+        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    );
+
+    let retrySyncs = 0;
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+      retrySyncs += 1;
+    });
+    assert.equal(retrySyncs, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1830,7 +1830,11 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
       syncs += 1;
     });
 
-    assert.equal(syncs, 4);
+    const expectedSyncs = path
+      .relative(path.parse(target).root, target)
+      .split(path.sep)
+      .filter(Boolean).length;
+    assert.equal(syncs, expectedSyncs);
     assert.equal((await lstat(target)).isDirectory(), true);
     assert.equal((await lstat(target)).mode & 0o777, 0o700);
   } finally {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -892,7 +892,7 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
       const memory = await getMemoryById(memoryId);
       if (!wroteUnrelated) {
         wroteUnrelated = true;
-        await subject.aliceStorage.writeMemory("An unrelated memory write.", "fact", {
+        await subject.aliceStorage.writeMemory("fact", "An unrelated memory write.", {
           source: "support-passport-test",
         });
       }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -720,6 +720,53 @@ test("helper reads for different grants do not block each other", async () => {
   }
 });
 
+test("helper guide snapshots read selected cards in parallel", async () => {
+  const subject = await makeSubject();
+  const pairedReads = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
+  try {
+    const firstCard = await createActiveCard(subject, "First card");
+    const secondCard = await createActiveCard(subject, "Second card");
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [
+        { cardId: firstCard.cardId, revision: firstCard.revision },
+        { cardId: secondCard.cardId, revision: secondCard.revision },
+      ],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let selectedReads = 0;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const selectedRead = selectedReads;
+      selectedReads += 1;
+      const pair = pairedReads[Math.floor(selectedRead / 2)];
+      if (selectedRead % 2 === 1) pair?.resolve();
+      else {
+        const concurrent = await Promise.race([
+          pair?.promise.then(() => true),
+          new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
+        ]);
+        assert.equal(concurrent, true);
+      }
+      return await getMemoryById(memoryId);
+    };
+
+    const guide = await subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+
+    assert.deepEqual(
+      guide.cards.map((card) => card.cardId),
+      [firstCard.cardId, secondCard.cardId]
+    );
+    assert.equal(selectedReads, 4);
+  } finally {
+    for (const pair of pairedReads) pair.resolve();
+    await subject.cleanup();
+  }
+});
+
 test("final helper guide assembly blocks card withdrawal", async () => {
   const subject = await makeSubject();
   const finalAuthenticationStarted = Promise.withResolvers<void>();

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -260,6 +260,39 @@ test("a changed card makes the whole grant stale without a partial guide", async
   }
 });
 
+test("a card changed while a helper guide is assembled never returns the old guide", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let reads = 0;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      reads += 1;
+      if (reads === 1) {
+        await subject.cardService.withdrawCard({
+          principal: "owner:alice",
+          cardId: card.cardId,
+          expectedRevision: card.revision,
+        });
+      }
+      return memory;
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+    );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("grant creation rejects drafts, duplicate cards, and unsafe durations", async () => {
   const subject = await makeSubject();
   try {
@@ -285,6 +318,10 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
       {
         cards: [{ cardId: active.cardId, revision: active.revision }],
         expiresAt: expiryAfter(subject, 604_800_001),
+      },
+      {
+        cards: [{ cardId: active.cardId, revision: active.revision }],
+        expiresAt: "2026-08-11T13:00:00+99:99",
       },
     ]) {
       await assert.rejects(
@@ -353,6 +390,7 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
     await rm(linkedPath);
     await symlink(outsidePath, linkedPath);
     await assert.rejects(store.authenticate(secondGrantId, linked.secret), /must be regular files/);
+    assert.deepEqual(await store.listForOwner("alice", "owner:alice"), []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1003,6 +1003,48 @@ test("grant recovery propagates transient reads from an owner membership", async
   }
 });
 
+test("grant recovery stops after repeated owner-index lock loss", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-bounded-recovery-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => "00000000-0000-4000-8000-000000000001",
+      now: () => now,
+    });
+    const inspected = store as unknown as {
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+    };
+    let ownerLockRuns = 0;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRuns += 1;
+      let refreshes = 0;
+      return await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+    };
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+      }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict",
+    );
+    assert.equal(ownerLockRuns, 4);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("grant recovery prunes a stale owner-index entry after lock loss", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-stale-index-recovery-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -134,7 +134,10 @@ test("owner grant listings read only the indexed owner grants", async () => {
 
     const listed = await store.listForOwner("shared", "owner:alice");
 
-    assert.deepEqual(listed.map((state) => state.grantId), [alice.state.grantId]);
+    assert.deepEqual(
+      listed.map((state) => state.grantId),
+      [alice.state.grantId]
+    );
     assert.deepEqual(readGrantIds, [alice.state.grantId]);
     assert.notEqual(alice.state.grantId, bob.state.grantId);
   } finally {
@@ -177,8 +180,7 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => now,
     });
     const input = {
@@ -210,10 +212,7 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     inspected.writeOwnerIndex = async () => {
       throw Object.assign(new Error("simulated owner index write failure"), { code: "EIO" });
     };
-    await assert.rejects(
-      store.create(input),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
-    );
+    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
     inspected.writeOwnerIndex = writeOwnerIndex;
     assert.equal((await lstat(firstGrantPath)).isFile(), true);
     assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
@@ -224,21 +223,21 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
       }
       return await readState(grantId);
     };
-    await assert.rejects(
-      store.create(input),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
-    );
+    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
     inspected.readState = readState;
     assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
     const replacement = await store.create(input);
     const listed = await store.listForOwner(input.namespace, input.principal);
     assert.equal(listed.length, 100);
-    assert.equal(listed.some((state) => state.grantId === first.state.grantId), false);
-    assert.equal(listed.some((state) => state.grantId === replacement.state.grantId), true);
-    await assert.rejects(
-      lstat(firstGrantPath),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
+    assert.equal(
+      listed.some((state) => state.grantId === first.state.grantId),
+      false
     );
+    assert.equal(
+      listed.some((state) => state.grantId === replacement.state.grantId),
+      true
+    );
+    await assert.rejects(lstat(firstGrantPath), (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT");
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -509,8 +508,10 @@ test("bad secrets return not found, while valid revoked and expired grants revea
   }
 });
 
-test("a revoke during a helper read never returns the old guide", async () => {
+test("revocation waits until helper guide assembly completes", async () => {
   const subject = await makeSubject();
+  const cardReadStarted = Promise.withResolvers<void>();
+  const releaseCardRead = Promise.withResolvers<void>();
   try {
     const card = await createActiveCard(subject);
     const created = await subject.grantService.createGrant({
@@ -520,61 +521,47 @@ test("a revoke during a helper read never returns the old guide", async () => {
     });
     const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
     const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
-    let revoked = false;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      if (!revoked) {
-        revoked = true;
-        await peerStore.revoke({
-          namespace: "alice",
-          principal: "owner:alice",
-          grantId: created.grant.grantId,
-          expectedStateVersion: created.grant.stateVersion,
-        });
-      }
-      return await getMemoryById(memoryId);
-    };
-
-    await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
-    );
-  } finally {
-    await subject.cleanup();
-  }
-});
-
-test("a revoke during the confirmed card read never returns the old guide", async () => {
-  const subject = await makeSubject();
-  try {
-    const card = await createActiveCard(subject);
-    const created = await subject.grantService.createGrant({
-      principal: "owner:alice",
-      cards: [{ cardId: card.cardId, revision: card.revision }],
-      expiresAt: expiryAfter(subject, 3_600_000),
-    });
-    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
-    let reads = 0;
+    let paused = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
-      reads += 1;
-      if (reads === 2) {
-        await peerStore.revoke({
-          namespace: "alice",
-          principal: "owner:alice",
-          grantId: created.grant.grantId,
-          expectedStateVersion: created.grant.stateVersion,
-        });
+      if (!paused) {
+        paused = true;
+        cardReadStarted.resolve();
+        await releaseCardRead.promise;
       }
       return memory;
     };
 
+    const readPromise = subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+    await cardReadStarted.promise;
+    let revokeSettled = false;
+    const revokePromise = peerStore
+      .revoke({
+        namespace: "alice",
+        principal: "owner:alice",
+        grantId: created.grant.grantId,
+        expectedStateVersion: created.grant.stateVersion,
+      })
+      .finally(() => {
+        revokeSettled = true;
+      });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(revokeSettled, false);
+
+    releaseCardRead.resolve();
+    const guide = await readPromise;
+    assert.equal(guide.cards[0]?.cardId, card.cardId);
+    await revokePromise;
+    assert.equal(revokeSettled, true);
     await assert.rejects(
       subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
     );
-    assert.equal(reads, 2);
   } finally {
+    releaseCardRead.resolve();
     await subject.cleanup();
   }
 });
@@ -595,7 +582,7 @@ test("final helper guide assembly blocks card withdrawal", async () => {
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
       authentications += 1;
-      if (authentications === 3) {
+      if (authentications === 2) {
         finalAuthenticationStarted.resolve();
         await releaseFinalAuthentication.promise;
       }
@@ -645,7 +632,7 @@ test("helper guide assembly fails when owner-lock ownership is lost", async () =
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
       authentications += 1;
-      if (authentications === 3) {
+      if (authentications === 2) {
         const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
@@ -683,39 +670,6 @@ test("a changed card makes the whole grant stale without a partial guide", async
     await assert.rejects(
       subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale" && error.status === 410
-    );
-  } finally {
-    await subject.cleanup();
-  }
-});
-
-test("a card changed while a helper guide is assembled never returns the old guide", async () => {
-  const subject = await makeSubject();
-  try {
-    const card = await createActiveCard(subject);
-    const created = await subject.grantService.createGrant({
-      principal: "owner:alice",
-      cards: [{ cardId: card.cardId, revision: card.revision }],
-      expiresAt: expiryAfter(subject, 3_600_000),
-    });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
-    let reads = 0;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
-      reads += 1;
-      if (reads === 1) {
-        await subject.cardService.withdrawCard({
-          principal: "owner:alice",
-          cardId: card.cardId,
-          expectedRevision: card.revision,
-        });
-      }
-      return memory;
-    };
-
-    await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
     );
   } finally {
     await subject.cleanup();
@@ -816,10 +770,7 @@ test("grant cleanup never follows a swapped grant directory", async () => {
       removeGrantStates(grantIds: string[]): Promise<void>;
     };
 
-    await assert.rejects(
-      inspected.removeGrantStates([grantId]),
-      /regular files in a stable directory/
-    );
+    await assert.rejects(inspected.removeGrantStates([grantId]), /regular files in a stable directory/);
     assert.equal(await readFile(path.join(outsideDir, fileName), "utf8"), "outside must remain");
     assert.equal((await lstat(path.join(parkedDir, fileName))).isFile(), true);
   } finally {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -10,7 +10,7 @@ import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
-import { requirePrivateFileDescriptorRoot } from "./private-file.js";
+import { ensurePrivateDirectoryNoFollow, requirePrivateFileDescriptorRoot } from "./private-file.js";
 import { withHeldFileLock } from "../utils/serialize-mutations.js";
 
 async function makeSubject() {
@@ -819,6 +819,58 @@ test("final helper guide assembly blocks card withdrawal", async () => {
   }
 });
 
+test("final helper guide assembly blocks owner revocation", async () => {
+  const subject = await makeSubject();
+  const finalAuthenticationStarted = Promise.withResolvers<void>();
+  const releaseFinalAuthentication = Promise.withResolvers<void>();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    let authentications = 0;
+    subject.grantStore.authenticate = async (grantId, secret) => {
+      const state = await authenticate(grantId, secret);
+      authentications += 1;
+      if (authentications === 2) {
+        finalAuthenticationStarted.resolve();
+        await releaseFinalAuthentication.promise;
+      }
+      return state;
+    };
+
+    const readPromise = subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+    await finalAuthenticationStarted.promise;
+    let revocationSettled = false;
+    const revocationPromise = subject.grantService
+      .revokeGrant({
+        principal: "owner:alice",
+        grantId: created.grant.grantId,
+        expectedStateVersion: created.grant.stateVersion,
+      })
+      .finally(() => {
+        revocationSettled = true;
+      });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(revocationSettled, false);
+
+    releaseFinalAuthentication.resolve();
+    const guide = await readPromise;
+    assert.equal(guide.cards[0]?.cardId, card.cardId);
+    await revocationPromise;
+    assert.equal(revocationSettled, true);
+  } finally {
+    releaseFinalAuthentication.resolve();
+    await subject.cleanup();
+  }
+});
+
 test("helper guide assembly fails when owner-lock ownership is lost", async () => {
   const subject = await makeSubject();
   try {
@@ -906,6 +958,31 @@ test("helper guide assembly refreshes the owner lock after its final card read",
       (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(reads, 2);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("helper guide assembly rechecks expiry after its final owner-lock refresh", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 300_000),
+    });
+    const withAuthenticatedGrant = subject.grantStore.withAuthenticatedGrant.bind(subject.grantStore);
+    subject.grantStore.withAuthenticatedGrant = async (grantId, secret, task, beforeReturn) =>
+      await withAuthenticatedGrant(grantId, secret, task, async (state) => {
+        subject.advance(300_000);
+        await beforeReturn?.(state);
+      });
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_expired"
+    );
   } finally {
     await subject.cleanup();
   }
@@ -1113,6 +1190,24 @@ test("private file operations fail closed without descriptor-relative directory 
   );
   assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
   assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
+});
+
+test("private directory creation syncs each new parent entry", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-"));
+  try {
+    const target = path.join(root, "state", "support-passport", "grants");
+    let syncs = 0;
+    const syncCreatedParent = async () => {
+      syncs += 1;
+    };
+
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncCreatedParent);
+    assert.equal(syncs, 3);
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncCreatedParent);
+    assert.equal(syncs, 3);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("grant cleanup never follows a swapped grant directory", async () => {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1836,28 +1836,18 @@ test("the grant store rejects a symlink alias in the configured memory root", as
   }
 });
 
-test("the Windows private-file strategy writes, reads, and removes a private file", async () => {
+test("Windows private-file operations fail before mutation", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-win32-"));
   try {
     const directory = path.join(root, "state", "support-passport", "grants");
     const filePath = path.join(directory, "grant.json");
     const errorMessage = "private Windows file operation failed";
-    await ensurePrivateDirectoryNoFollow(root, directory, errorMessage, undefined, true, "win32");
-    await writePrivateFileAtomicallyNoFollow(
-      directory,
-      filePath,
-      '{"ok":true}\n',
-      errorMessage,
-      root,
-      "win32",
-    );
-
-    assert.equal(await readPrivateFileNoFollow(directory, filePath, errorMessage, root, "win32"), '{"ok":true}\n');
-    await removePrivateFilesNoFollow(directory, ["grant.json"], errorMessage, root, "win32");
     await assert.rejects(
-      readPrivateFileNoFollow(directory, filePath, errorMessage, root, "win32"),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
+      ensurePrivateDirectoryNoFollow(root, directory, errorMessage, undefined, true, "win32"),
+      new RegExp(errorMessage),
     );
+    assert.equal(await lstat(directory).then(() => true, () => false), false);
+    assert.equal(await lstat(filePath).then(() => true, () => false), false);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -38,7 +38,9 @@ async function makeSubject() {
 
   return {
     root,
+    aliceStorage,
     cardService,
+    grantStore,
     grantService,
     now,
     advance: (milliseconds: number) => {
@@ -144,6 +146,17 @@ test("bad secrets return not found, while valid revoked or expired grants return
         error instanceof SupportPassportError && error.code === "grant_not_found" && error.status === 404
     );
 
+    await assert.rejects(
+      subject.grantStore.revoke({
+        namespace: "alice",
+        principal: "owner:alice",
+        grantId: created.grant.grantId,
+        expectedStateVersion: created.grant.stateVersion + 1,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "state_conflict" && error.status === 409
+    );
+
     const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
     const peerRevoked = await peerStore.revoke({
       namespace: "alice",
@@ -169,9 +182,43 @@ test("bad secrets return not found, while valid revoked or expired grants return
       cards: [{ cardId: card.cardId, revision: card.revision }],
       durationSeconds: 300,
     });
-    subject.advance(300_001);
+    subject.advance(300_000);
     await assert.rejects(
       subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
+    );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("a revoke during a helper read never returns the old guide", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      durationSeconds: 3_600,
+    });
+    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let revoked = false;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      if (!revoked) {
+        revoked = true;
+        await peerStore.revoke({
+          namespace: "alice",
+          principal: "owner:alice",
+          grantId: created.grant.grantId,
+          expectedStateVersion: created.grant.stateVersion,
+        });
+      }
+      return await getMemoryById(memoryId);
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
     );
   } finally {
@@ -259,6 +306,40 @@ test("the grant store rejects a symlinked grant directory", async () => {
       }),
       /must not be a symbolic link/
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the grant store fails closed for corrupt and symlinked grant files", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-"));
+  try {
+    const firstGrantId = "00000000-0000-4000-8000-000000000001";
+    const secondGrantId = "00000000-0000-4000-8000-000000000002";
+    const grantIds = [firstGrantId, secondGrantId];
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? secondGrantId,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      durationSeconds: 300,
+    };
+    const corrupt = await store.create(input);
+    const grantDir = path.join(root, "state", "support-passport", "grants");
+    const corruptPath = path.join(grantDir, `${firstGrantId}.json`);
+    await writeFile(corruptPath, "{", { mode: 0o600 });
+    await assert.rejects(store.authenticate(firstGrantId, corrupt.secret));
+
+    const linked = await store.create(input);
+    const linkedPath = path.join(grantDir, `${secondGrantId}.json`);
+    const outsidePath = path.join(root, "outside.json");
+    await writeFile(outsidePath, await readFile(linkedPath), { mode: 0o600 });
+    await rm(linkedPath);
+    await symlink(outsidePath, linkedPath);
+    await assert.rejects(store.authenticate(secondGrantId, linked.secret), /must be regular files/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -103,6 +103,43 @@ test("a grant stores only hashed credentials with private file permissions", asy
   }
 });
 
+test("owner grant listings read only the indexed owner grants", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-"));
+  try {
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      now: () => now,
+    });
+    const common = {
+      namespace: "shared",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const alice = await store.create({ ...common, principal: "owner:alice" });
+    const bob = await store.create({ ...common, principal: "owner:bob" });
+    const inspected = store as unknown as {
+      readState(grantId: string): Promise<unknown>;
+    };
+    const readState = inspected.readState.bind(store);
+    const readGrantIds: string[] = [];
+    inspected.readState = async (grantId) => {
+      readGrantIds.push(grantId);
+      return await readState(grantId);
+    };
+
+    const listed = await store.listForOwner("shared", "owner:alice");
+
+    assert.deepEqual(listed.map((state) => state.grantId), [alice.state.grantId]);
+    assert.deepEqual(readGrantIds, [alice.state.grantId]);
+    assert.notEqual(alice.state.grantId, bob.state.grantId);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a helper sees only the selected active card through a valid secret", async () => {
   const subject = await makeSubject();
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -849,6 +849,37 @@ test("helper guide assembly fails when owner-lock ownership is lost", async () =
   }
 });
 
+test("helper guide assembly rechecks the owner lock after grant reauthentication", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    let authentications = 0;
+    subject.grantStore.authenticate = async (grantId, secret) => {
+      const state = await authenticate(grantId, secret);
+      authentications += 1;
+      if (authentications === 3) {
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+      }
+      return state;
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+    assert.equal(authentications, 3);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("helper guide assembly refreshes the owner lock after its final card read", async () => {
   const subject = await makeSubject();
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -23,6 +23,7 @@ import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 import {
+  canonicalizePrivateDirectoryTarget,
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
   requirePrivateFileDescriptorRoot,
@@ -647,6 +648,59 @@ test("grants reject cards owned by another namespace in shared storage", async (
     );
     const forged = await grantStore.create({
       namespace: "bob",
+      principal: "owner:bob",
+      cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
+      expiresAt: "2026-08-11T13:00:00.000Z",
+    });
+    await assert.rejects(
+      grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+    );
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grants reject cards owned by another principal inside a shared namespace", async () => {
+  StorageManager.clearAllStaticCaches();
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-scope-"));
+  try {
+    const storage = new StorageManager(path.join(root, "shared-storage"));
+    await storage.ensureDirectories();
+    const now = () => new Date("2026-08-11T12:00:00.000Z");
+    const resolveOwner = async (principal: string) => ({ principal, namespace: "team", storage });
+    const cardService = new SupportPassportCardService({ resolveOwner, now });
+    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
+    const grantService = new SupportPassportGrantService({
+      grantStore,
+      resolveOwner,
+      resolveNamespace: async () => storage,
+      now,
+    });
+    const draft = await cardService.createManualDraft({
+      principal: "owner:alice",
+      title: "Alice card",
+      statement: "Offer Alice a quiet place.",
+      category: "environment",
+      reviewBy: "2026-09-01T12:00:00.000Z",
+    });
+    const aliceCard = await cardService.approveCard({
+      principal: "owner:alice",
+      cardId: draft.cardId,
+      expectedRevision: draft.revision,
+    });
+
+    await assert.rejects(
+      grantService.createGrant({
+        principal: "owner:bob",
+        cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
+        expiresAt: "2026-08-11T13:00:00.000Z",
+      }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
+    );
+    const forged = await grantStore.create({
+      namespace: "team",
       principal: "owner:bob",
       cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
       expiresAt: "2026-08-11T13:00:00.000Z",
@@ -1401,7 +1455,7 @@ test("private directory creation syncs every verified parent entry", async () =>
     await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
     assert.equal(syncs, 3);
     await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
-    assert.equal(syncs, 6);
+    assert.equal(syncs, 3);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1417,7 +1471,9 @@ test("private directory creation retries a failed parent sync", async () => {
       }),
       (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
     );
-    assert.equal((await lstat(path.join(root, "state"))).isDirectory(), true);
+    await assert.rejects(lstat(path.join(root, "state")), (error: unknown) => {
+      return (error as NodeJS.ErrnoException).code === "ENOENT";
+    });
 
     let retrySyncs = 0;
     await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
@@ -1439,8 +1495,7 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
       syncs += 1;
     });
 
-    const ancestorCount = path.relative(path.parse(target).root, target).split(path.sep).length;
-    assert.equal(syncs, ancestorCount);
+    assert.equal(syncs, 2);
     assert.equal((await lstat(target)).isDirectory(), true);
     assert.equal((await lstat(target)).mode & 0o777, 0o700);
   } finally {
@@ -1462,6 +1517,23 @@ test("private directory tree creation rejects a symlink in the ancestor chain", 
       /private directory creation failed/
     );
     assert.deepEqual(await readdir(outside), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("configured private directory targets resolve existing symlink aliases once", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-alias-"));
+  try {
+    const actual = path.join(root, "actual");
+    const alias = path.join(root, "alias");
+    await mkdir(actual);
+    await symlink(actual, alias);
+
+    assert.equal(
+      await canonicalizePrivateDirectoryTarget(path.join(alias, "new-parent", "memory")),
+      path.join(actual, "new-parent", "memory")
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1839,6 +1839,38 @@ test("a changed card makes the whole grant stale without a partial guide", async
   }
 });
 
+test("a peer storage withdrawal invalidates a cached helper guide snapshot", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    await subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret });
+
+    const peerStorage = new StorageManager(subject.aliceStorage.dir);
+    await peerStorage.ensureDirectories();
+    const peerCards = new SupportPassportCardService({
+      resolveOwner: async (principal) => ({ principal, namespace: "alice", storage: peerStorage }),
+      now: subject.now,
+    });
+    await peerCards.withdrawCard({
+      principal: "owner:alice",
+      cardId: card.cardId,
+      expectedRevision: card.revision,
+    });
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+    );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("unrelated memory writes do not invalidate an unchanged shared guide", async () => {
   const subject = await makeSubject();
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -59,12 +59,17 @@ async function createActiveCard(subject: Awaited<ReturnType<typeof makeSubject>>
     title,
     statement: "Offer me a quiet place and time.",
     category: "environment",
+    reviewBy: "2026-09-01T12:00:00.000Z",
   });
   return await subject.cardService.approveCard({
     principal: "owner:alice",
     cardId: draft.cardId,
     expectedRevision: draft.revision,
   });
+}
+
+function expiryAfter(subject: Awaited<ReturnType<typeof makeSubject>>, milliseconds: number): string {
+  return new Date(subject.now().getTime() + milliseconds).toISOString();
 }
 
 test("a grant stores only hashed credentials with private file permissions", async () => {
@@ -74,11 +79,12 @@ test("a grant stores only hashed credentials with private file permissions", asy
     const created = await subject.grantService.createGrant({
       principal: "owner:alice",
       cards: [{ cardId: card.cardId, revision: card.revision }],
-      durationSeconds: 3_600,
+      expiresAt: "2026-08-11T13:00:00.123Z",
     });
 
     assert.match(created.secret, /^[A-Za-z0-9_-]{43}$/);
     assert.equal(created.grant.stateVersion, 1);
+    assert.equal(created.grant.expiresAt, "2026-08-11T13:00:00.123Z");
     const filePath = path.join(
       subject.root,
       "shared",
@@ -105,7 +111,7 @@ test("a helper sees only the selected active card through a valid secret", async
     const created = await subject.grantService.createGrant({
       principal: "owner:alice",
       cards: [{ cardId: selected.cardId, revision: selected.revision }],
-      durationSeconds: 3_600,
+      expiresAt: expiryAfter(subject, 3_600_000),
     });
 
     const guide = await subject.grantService.readGrant({
@@ -137,7 +143,7 @@ test("bad secrets return not found, while valid revoked or expired grants return
     const created = await subject.grantService.createGrant({
       principal: "owner:alice",
       cards: [{ cardId: card.cardId, revision: card.revision }],
-      durationSeconds: 300,
+      expiresAt: expiryAfter(subject, 300_000),
     });
 
     await assert.rejects(
@@ -180,7 +186,7 @@ test("bad secrets return not found, while valid revoked or expired grants return
     const second = await subject.grantService.createGrant({
       principal: "owner:alice",
       cards: [{ cardId: card.cardId, revision: card.revision }],
-      durationSeconds: 300,
+      expiresAt: expiryAfter(subject, 300_000),
     });
     subject.advance(300_000);
     await assert.rejects(
@@ -199,7 +205,7 @@ test("a revoke during a helper read never returns the old guide", async () => {
     const created = await subject.grantService.createGrant({
       principal: "owner:alice",
       cards: [{ cardId: card.cardId, revision: card.revision }],
-      durationSeconds: 3_600,
+      expiresAt: expiryAfter(subject, 3_600_000),
     });
     const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
     const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
@@ -237,7 +243,7 @@ test("a changed card makes the whole grant stale without a partial guide", async
         { cardId: first.cardId, revision: first.revision },
         { cardId: second.cardId, revision: second.revision },
       ],
-      durationSeconds: 3_600,
+      expiresAt: expiryAfter(subject, 3_600_000),
     });
     await subject.cardService.withdrawCard({
       principal: "owner:alice",
@@ -262,20 +268,24 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
       title: "Draft card",
       statement: "Give me time to answer.",
       category: "communication",
+      reviewBy: "2026-09-01T12:00:00.000Z",
     });
     const active = await createActiveCard(subject);
 
     for (const input of [
-      { cards: [{ cardId: draft.cardId, revision: draft.revision }], durationSeconds: 3_600 },
+      { cards: [{ cardId: draft.cardId, revision: draft.revision }], expiresAt: expiryAfter(subject, 3_600_000) },
       {
         cards: [
           { cardId: active.cardId, revision: active.revision },
           { cardId: active.cardId, revision: active.revision },
         ],
-        durationSeconds: 3_600,
+        expiresAt: expiryAfter(subject, 3_600_000),
       },
-      { cards: [{ cardId: active.cardId, revision: active.revision }], durationSeconds: 299 },
-      { cards: [{ cardId: active.cardId, revision: active.revision }], durationSeconds: 604_801 },
+      { cards: [{ cardId: active.cardId, revision: active.revision }], expiresAt: expiryAfter(subject, 299_999) },
+      {
+        cards: [{ cardId: active.cardId, revision: active.revision }],
+        expiresAt: expiryAfter(subject, 604_800_001),
+      },
     ]) {
       await assert.rejects(
         subject.grantService.createGrant({ principal: "owner:alice", ...input }),
@@ -295,14 +305,15 @@ test("the grant store rejects a symlinked grant directory", async () => {
     await mkdir(path.join(memoryDir, "state", "support-passport"), { recursive: true });
     await mkdir(outside);
     await symlink(outside, path.join(memoryDir, "state", "support-passport", "grants"));
-    const store = new SupportPassportGrantStore({ memoryDir });
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir, now: () => now });
 
     await assert.rejects(
       store.create({
         namespace: "alice",
         principal: "owner:alice",
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
-        durationSeconds: 300,
+        expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
       /must not be a symbolic link/
     );
@@ -317,15 +328,17 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
     const firstGrantId = "00000000-0000-4000-8000-000000000001";
     const secondGrantId = "00000000-0000-4000-8000-000000000002";
     const grantIds = [firstGrantId, secondGrantId];
+    const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
       makeGrantId: () => grantIds.shift() ?? secondGrantId,
+      now: () => now,
     });
     const input = {
       namespace: "alice",
       principal: "owner:alice",
       cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
-      durationSeconds: 300,
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
     };
     const corrupt = await store.create(input);
     const grantDir = path.join(root, "state", "support-passport", "grants");
@@ -349,12 +362,13 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-collision-"));
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
-    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId });
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
     const input = {
       namespace: "alice",
       principal: "owner:alice",
       cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
-      durationSeconds: 300,
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
     };
     await store.create(input);
     await assert.rejects(
@@ -362,7 +376,7 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
       (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     await assert.rejects(
-      store.create({ ...input, durationSeconds: 299 }),
+      store.create({ ...input, expiresAt: new Date(now.getTime() + 299_999).toISOString() }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
   } finally {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { renameSync, symlinkSync } from "node:fs";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -141,14 +142,14 @@ test("owner grant listings read only the indexed owner grants", async () => {
   }
 });
 
-test("owner grant operations use one trimmed namespace", async () => {
+test("owner grant operations use one trimmed namespace and principal", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-namespace-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
     const created = await store.create({
       namespace: " alice ",
-      principal: "owner:alice",
+      principal: " owner:alice ",
       cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
       expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
     });
@@ -160,7 +161,7 @@ test("owner grant operations use one trimmed namespace", async () => {
     const revoked = await store.revoke({
       grantId: created.state.grantId,
       namespace: " alice ",
-      principal: "owner:alice",
+      principal: " owner:alice ",
       expectedStateVersion: created.state.stateVersion,
     });
     assert.ok(revoked.revokedAt);
@@ -738,6 +739,41 @@ test("the grant store rejects a symlinked grant directory", async () => {
       }),
       /must not be a symbolic link/
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant writes reject a directory swapped after the initial safety check", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-swap-"));
+  try {
+    const memoryDir = path.join(root, "memory");
+    const outside = path.join(root, "outside");
+    const grantsDir = path.join(memoryDir, "state", "support-passport", "grants");
+    const parkedDir = path.join(root, "parked-grants");
+    await mkdir(outside, { recursive: true });
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir,
+      now: () => now,
+    });
+
+    await assert.rejects(
+      store.create(
+        {
+          namespace: "alice",
+          principal: "owner:alice",
+          cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+          expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+        },
+        async () => {
+          renameSync(grantsDir, parkedDir);
+          symlinkSync(outside, grantsDir, "dir");
+        }
+      ),
+      /regular files in a stable directory/
+    );
+    assert.deepEqual(await readdir(outside), []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -735,6 +735,29 @@ test("grant creation maps a clock jump past expiry to invalid input", async () =
   }
 });
 
+test("grant creation rejects a future request time that would extend the maximum lifetime", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-future-request-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const requestedAt = new Date("2027-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(requestedAt.getTime() + 300_000).toISOString(),
+        requestedAt,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "invalid_input" && error.status === 400,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("directory sync ignores only explicit unsupported errors", async () => {
   const failingOpen = (code: string) => async () => ({
     sync: async () => {
@@ -788,6 +811,72 @@ test("grant creation aborts before replacing an owner index after lock ownership
       (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
       [first.state.grantId]
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation reconciles peer state when the owner-index lock is lost after write", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-fence-"));
+  try {
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
+    const peerGrantId = "00000000-0000-4000-8000-000000000003";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000004",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const peerState = {
+      ...first.state,
+      grantId: peerGrantId,
+      secretHash: "b".repeat(64),
+    };
+    const inspected = store as unknown as {
+      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+      writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
+      writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
+    };
+    const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
+    let injectPeer = true;
+    inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
+      await writeOwnerIndex(ownerHash, indexedGrantIds);
+      if (!injectPeer) return;
+      injectPeer = false;
+      await inspected.writeState(peerState, true);
+      await writeOwnerIndex(ownerHash, [first.state.grantId, peerGrantId]);
+    };
+    let lockRun = 0;
+    let firstRunRefreshes = 0;
+    inspected.withMutationLock = async (task) => {
+      lockRun += 1;
+      return await task({
+        refresh: async () => {
+          if (lockRun !== 1) return true;
+          firstRunRefreshes += 1;
+          return firstRunRefreshes !== 4;
+        },
+      });
+    };
+
+    const created = await store.create(input);
+    const listedIds = new Set((await store.listForOwner(input.namespace, input.principal)).map(
+      (state) => state.grantId,
+    ));
+
+    assert.equal(lockRun, 2);
+    assert.equal(firstRunRefreshes, 4);
+    assert.deepEqual(listedIds, new Set([first.state.grantId, created.state.grantId, peerGrantId]));
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -2012,6 +2101,39 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
       /regular files in a stable directory/
     );
     assert.deepEqual(await readdir(path.join(outside, "grants")), ["owners"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant reads reject a memory-root ancestor swapped after a completed operation", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-late-ancestor-swap-"));
+  try {
+    const configuredParent = path.join(root, "configured");
+    const memoryDir = path.join(configuredParent, "memory");
+    const parkedParent = path.join(root, "parked-configured");
+    const outsideParent = path.join(root, "outside");
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir, now: () => now });
+    await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    });
+    await mkdir(path.join(outsideParent, "memory", "state", "support-passport", "grants", "owners"), {
+      recursive: true,
+    });
+    renameSync(configuredParent, parkedParent);
+    symlinkSync(outsideParent, configuredParent, "dir");
+
+    await assert.rejects(
+      store.listForOwner("alice", "owner:alice"),
+      /support passport owner indexes must be regular files in a stable directory/,
+    );
+    assert.deepEqual(await readdir(path.join(outsideParent, "memory", "state", "support-passport", "grants")), [
+      "owners",
+    ]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -19,8 +19,12 @@ import { StorageManager } from "../storage.js";
 import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
+import { supportPassportOwnerLockPath } from "./owner-lock.js";
 import { SupportPassportGrantService } from "./grant-service.js";
-import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
+import {
+  SupportPassportGrantStore,
+  syncDirectoryForDurability,
+} from "./grant-store.js";
 import {
   canonicalizePrivateDirectoryTarget,
   ensurePrivateDirectoryNoFollow,
@@ -33,16 +37,24 @@ async function makeSubject() {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grants-"));
   const aliceStorage = new StorageManager(path.join(root, "alice"));
   const bobStorage = new StorageManager(path.join(root, "bob"));
-  await Promise.all([aliceStorage.ensureDirectories(), bobStorage.ensureDirectories()]);
+  await Promise.all([
+    aliceStorage.ensureDirectories(),
+    bobStorage.ensureDirectories(),
+  ]);
   let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
   const now = () => new Date(currentTime);
   const resolveOwner = async (principal: string) => {
-    if (principal === "owner:alice") return { principal, namespace: "alice", storage: aliceStorage };
-    if (principal === "owner:bob") return { principal, namespace: "bob", storage: bobStorage };
+    if (principal === "owner:alice")
+      return { principal, namespace: "alice", storage: aliceStorage };
+    if (principal === "owner:bob")
+      return { principal, namespace: "bob", storage: bobStorage };
     throw new Error("unknown test principal");
   };
   const cardService = new SupportPassportCardService({ resolveOwner, now });
-  const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "shared"), now });
+  const grantStore = new SupportPassportGrantStore({
+    memoryDir: path.join(root, "shared"),
+    now,
+  });
   const grantService = new SupportPassportGrantService({
     grantStore,
     resolveOwner,
@@ -71,7 +83,10 @@ async function makeSubject() {
   };
 }
 
-async function createActiveCard(subject: Awaited<ReturnType<typeof makeSubject>>, title = "Quiet space") {
+async function createActiveCard(
+  subject: Awaited<ReturnType<typeof makeSubject>>,
+  title = "Quiet space",
+) {
   const draft = await subject.cardService.createManualDraft({
     principal: "owner:alice",
     title,
@@ -86,7 +101,10 @@ async function createActiveCard(subject: Awaited<ReturnType<typeof makeSubject>>
   });
 }
 
-function expiryAfter(subject: Awaited<ReturnType<typeof makeSubject>>, milliseconds: number): string {
+function expiryAfter(
+  subject: Awaited<ReturnType<typeof makeSubject>>,
+  milliseconds: number,
+): string {
   return new Date(subject.now().getTime() + milliseconds).toISOString();
 }
 
@@ -109,7 +127,7 @@ test("a grant stores only hashed credentials with private file permissions", asy
       "state",
       "support-passport",
       "grants",
-      `${created.grant.grantId}.json`
+      `${created.grant.grantId}.json`,
     );
     const body = await readFile(filePath, "utf8");
     assert.equal(body.includes(created.secret), false);
@@ -122,13 +140,19 @@ test("a grant stores only hashed credentials with private file permissions", asy
 });
 
 test("owner grant listings read only the indexed owner grants", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-index-"),
+  );
   try {
-    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      makeGrantId: () =>
+        grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
       now: () => now,
     });
     const common = {
@@ -152,7 +176,7 @@ test("owner grant listings read only the indexed owner grants", async () => {
 
     assert.deepEqual(
       listed.map((state) => state.grantId),
-      [alice.state.grantId]
+      [alice.state.grantId],
     );
     assert.deepEqual(readGrantIds, [alice.state.grantId]);
     assert.notEqual(alice.state.grantId, bob.state.grantId);
@@ -162,25 +186,34 @@ test("owner grant listings read only the indexed owner grants", async () => {
 });
 
 test("owner grant listings propagate indexed grant read failures", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-error-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-list-error-"),
+  );
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+    });
     const created = await store.create({
       namespace: "alice",
       principal: "owner:alice",
       cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
       expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
     });
-    const inspected = store as unknown as { readState(grantId: string): Promise<unknown> };
+    const inspected = store as unknown as {
+      readState(grantId: string): Promise<unknown>;
+    };
     inspected.readState = async (grantId) => {
       assert.equal(grantId, created.state.grantId);
-      throw Object.assign(new Error("simulated grant read failure"), { code: "EIO" });
+      throw Object.assign(new Error("simulated grant read failure"), {
+        code: "EIO",
+      });
     };
 
     await assert.rejects(
       store.listForOwner("alice", "owner:alice"),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -188,13 +221,16 @@ test("owner grant listings propagate indexed grant read failures", async () => {
 });
 
 test("owner grant listings put active links before inactive history", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-order-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-list-order-"),
+  );
   try {
     let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () =>
+        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => new Date(currentTime),
     });
     const input = {
@@ -205,7 +241,10 @@ test("owner grant listings put active links before inactive history", async () =
     };
     const inactive = await store.create(input);
     currentTime += 1_000;
-    const active = await store.create({ ...input, expiresAt: new Date(currentTime + 3_600_000).toISOString() });
+    const active = await store.create({
+      ...input,
+      expiresAt: new Date(currentTime + 3_600_000).toISOString(),
+    });
     await store.revoke({
       grantId: inactive.state.grantId,
       namespace: input.namespace,
@@ -216,7 +255,7 @@ test("owner grant listings put active links before inactive history", async () =
 
     assert.deepEqual(
       listed.map((state) => state.grantId),
-      [active.state.grantId, inactive.state.grantId]
+      [active.state.grantId, inactive.state.grantId],
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -224,10 +263,15 @@ test("owner grant listings put active links before inactive history", async () =
 });
 
 test("owner grant operations reject a noncanonical namespace and trim the principal", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-namespace-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-namespace-"),
+  );
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+    });
     await assert.rejects(
       store.create({
         namespace: " alice ",
@@ -235,7 +279,8 @@ test("owner grant operations reject a noncanonical namespace and trim the princi
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "invalid_input",
     );
     const created = await store.create({
       namespace: "alice",
@@ -245,8 +290,10 @@ test("owner grant operations reject a noncanonical namespace and trim the princi
     });
 
     assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
-      [created.state.grantId]
+      (await store.listForOwner("alice", "owner:alice")).map(
+        (state) => state.grantId,
+      ),
+      [created.state.grantId],
     );
     const revoked = await store.revoke({
       grantId: created.state.grantId,
@@ -261,13 +308,16 @@ test("owner grant operations reject a noncanonical namespace and trim the princi
 });
 
 test("owner grant history stays bounded while an inactive link frees capacity", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-history-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-history-"),
+  );
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () =>
+        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => now,
     });
     const input = {
@@ -281,7 +331,8 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
 
     await assert.rejects(
       store.create(input),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "invalid_input",
     );
     await store.revoke({
       grantId: first.state.grantId,
@@ -289,7 +340,13 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
       principal: input.principal,
       expectedStateVersion: first.state.stateVersion,
     });
-    const firstGrantPath = path.join(root, "state", "support-passport", "grants", `${first.state.grantId}.json`);
+    const firstGrantPath = path.join(
+      root,
+      "state",
+      "support-passport",
+      "grants",
+      `${first.state.grantId}.json`,
+    );
     const inspected = store as unknown as {
       readState(grantId: string): Promise<unknown>;
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
@@ -297,25 +354,44 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     const readState = inspected.readState.bind(store);
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
     inspected.writeOwnerIndex = async () => {
-      throw Object.assign(new Error("simulated owner index write failure"), { code: "EIO" });
+      throw Object.assign(new Error("simulated owner index write failure"), {
+        code: "EIO",
+      });
     };
-    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+    );
     inspected.writeOwnerIndex = writeOwnerIndex;
     assert.equal((await lstat(firstGrantPath)).isFile(), true);
-    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
+    assert.equal(
+      (await store.listForOwner(input.namespace, input.principal)).length,
+      100,
+    );
 
     inspected.readState = async (grantId) => {
       if (grantId === first.state.grantId) {
-        throw Object.assign(new Error("simulated indexed grant read failure"), { code: "EIO" });
+        throw Object.assign(new Error("simulated indexed grant read failure"), {
+          code: "EIO",
+        });
       }
       return await readState(grantId);
     };
-    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+    );
     inspected.readState = readState;
-    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
+    assert.equal(
+      (await store.listForOwner(input.namespace, input.principal)).length,
+      100,
+    );
     const evictedGrantLocks: string[] = [];
     const lockAwareStore = store as unknown as {
-      withGrantLock<T>(grantId: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+      withGrantLock<T>(
+        grantId: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
     };
     const withGrantLock = lockAwareStore.withGrantLock.bind(store);
     lockAwareStore.withGrantLock = async (grantId, task) => {
@@ -327,32 +403,43 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     assert.equal(listed.length, 100);
     assert.equal(
       listed.some((state) => state.grantId === first.state.grantId),
-      false
+      false,
     );
     assert.equal(
       listed.some((state) => state.grantId === replacement.state.grantId),
-      true
+      true,
     );
     assert.deepEqual(evictedGrantLocks, [first.state.grantId]);
-    await assert.rejects(lstat(firstGrantPath), (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT");
+    await assert.rejects(
+      lstat(firstGrantPath),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
 test("grant creation accepts a state write that committed before its durability error", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-commit-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-state-commit-"),
+  );
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId,
+      now: () => now,
+    });
     const inspected = store as unknown as {
       writeState(state: unknown, requireAbsent: boolean): Promise<void>;
     };
     const writeState = inspected.writeState.bind(store);
     inspected.writeState = async (state, requireAbsent) => {
       await writeState(state, requireAbsent);
-      throw Object.assign(new Error("simulated post-commit state error"), { code: "EIO" });
+      throw Object.assign(new Error("simulated post-commit state error"), {
+        code: "EIO",
+      });
     };
 
     const created = await store.create({
@@ -363,25 +450,38 @@ test("grant creation accepts a state write that committed before its durability 
     });
 
     assert.equal(created.state.grantId, grantId);
-    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map(
+        (state) => state.grantId,
+      ),
+      [grantId],
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
 test("grant creation accepts an owner index write that committed before its durability error", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-commit-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-index-commit-"),
+  );
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId,
+      now: () => now,
+    });
     const inspected = store as unknown as {
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
     };
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
     inspected.writeOwnerIndex = async (ownerHash, grantIds) => {
       await writeOwnerIndex(ownerHash, grantIds);
-      throw Object.assign(new Error("simulated post-commit index error"), { code: "EIO" });
+      throw Object.assign(new Error("simulated post-commit index error"), {
+        code: "EIO",
+      });
     };
 
     const created = await store.create({
@@ -392,20 +492,28 @@ test("grant creation accepts an owner index write that committed before its dura
     });
 
     assert.equal(created.state.grantId, grantId);
-    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map(
+        (state) => state.grantId,
+      ),
+      [grantId],
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
 test("owner grant rollover rejects a foreign grant without deleting it", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-foreign-index-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-foreign-index-"),
+  );
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () =>
+        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => now,
     });
     const common = {
@@ -415,7 +523,9 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
     };
     const aliceGrants = [];
     for (let index = 0; index < 99; index += 1) {
-      aliceGrants.push(await store.create({ ...common, principal: "owner:alice" }));
+      aliceGrants.push(
+        await store.create({ ...common, principal: "owner:alice" }),
+      );
     }
     const bob = await store.create({ ...common, principal: "owner:bob" });
     await store.revoke({
@@ -429,16 +539,25 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
     };
     const firstAliceGrant = aliceGrants[0];
     assert.ok(firstAliceGrant);
-    const aliceOwnerHash = inspected.ownerHash(common.namespace, firstAliceGrant.state.principalHash);
+    const aliceOwnerHash = inspected.ownerHash(
+      common.namespace,
+      firstAliceGrant.state.principalHash,
+    );
     await inspected.writeOwnerIndex(aliceOwnerHash, [
       ...aliceGrants.map((grant) => grant.state.grantId),
       bob.state.grantId,
     ]);
-    const bobGrantPath = path.join(root, "state", "support-passport", "grants", `${bob.state.grantId}.json`);
+    const bobGrantPath = path.join(
+      root,
+      "state",
+      "support-passport",
+      "grants",
+      `${bob.state.grantId}.json`,
+    );
 
     await assert.rejects(
       store.create({ ...common, principal: "owner:alice" }),
-      /owner index references a foreign grant/
+      /owner index references a foreign grant/,
     );
     assert.equal((await lstat(bobGrantPath)).isFile(), true);
   } finally {
@@ -447,7 +566,9 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
 });
 
 test("owner grant history uses one expiry cutoff while it prunes old links", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cutoff-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-cutoff-"),
+  );
   try {
     const initialTime = Date.parse("2026-08-11T12:00:00.000Z");
     let currentTime = initialTime;
@@ -456,10 +577,13 @@ test("owner grant history uses one expiry cutoff while it prunes old links", asy
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () =>
+        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => {
         partitionCalls += 1;
-        return new Date(currentTime + (crossExpiry && partitionCalls > 101 ? 1 : 0));
+        return new Date(
+          currentTime + (crossExpiry && partitionCalls > 101 ? 1 : 0),
+        );
       },
     });
     const common = {
@@ -501,11 +625,11 @@ test("owner grant history uses one expiry cutoff while it prunes old links", asy
     assert.equal(new Set(listed.map((state) => state.grantId)).size, 100);
     assert.equal(
       listed.some((state) => state.grantId === crossing.state.grantId),
-      true
+      true,
     );
     assert.equal(
       listed.some((state) => state.grantId === created.state.grantId),
-      true
+      true,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -517,7 +641,10 @@ test("grant mutations report a storage conflict when the file lock is busy", asy
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     const rejectLock = (async (_lockPath, _options, task) =>
-      await task(false, { refresh: async () => false, failure: "timeout" })) as typeof withHeldFileLock;
+      await task(false, {
+        refresh: async () => false,
+        failure: "timeout",
+      })) as typeof withHeldFileLock;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
       now: () => now,
@@ -532,7 +659,9 @@ test("grant mutations report a storage conflict when the file lock is busy", asy
         expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict" &&
+        error.status === 409,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -543,14 +672,22 @@ test("grant creation rechecks the owner lock immediately before commit", async (
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
-    const originalRead = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const originalRead = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let replacedLock = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await originalRead(memoryId);
       if (!replacedLock) {
         replacedLock = true;
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
-        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
+        await writeFile(
+          lockPath,
+          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
+        );
       }
       return memory;
     };
@@ -562,9 +699,14 @@ test("grant creation rechecks the owner lock immediately before commit", async (
         expiresAt: expiryAfter(subject, 300_000),
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict" &&
+        error.status === 409,
     );
-    assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
+    assert.deepEqual(
+      await subject.grantService.listGrants({ principal: "owner:alice" }),
+      [],
+    );
   } finally {
     await subject.cleanup();
   }
@@ -580,19 +722,25 @@ test("directory sync ignores only explicit unsupported errors", async () => {
 
   await assert.rejects(
     syncDirectoryForDurability("/unused", failingOpen("EIO")),
-    (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
   );
   await syncDirectoryForDurability("/unused", failingOpen("EINVAL"));
 });
 
 test("grant creation aborts before replacing an owner index after lock ownership is lost", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-lock-loss-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-lock-loss-"),
+  );
   try {
-    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      makeGrantId: () =>
+        grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
       now: () => now,
     });
     const input = {
@@ -604,7 +752,9 @@ test("grant creation aborts before replacing an owner index after lock ownership
     const first = await store.create(input);
     let refreshes = 0;
     const inspected = store as unknown as {
-      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+      withMutationLock<T>(
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
     };
     inspected.withMutationLock = async (task) =>
       await task({
@@ -616,12 +766,119 @@ test("grant creation aborts before replacing an owner index after lock ownership
 
     await assert.rejects(
       store.create(input),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
     );
     assert.equal(refreshes, 2);
     assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
-      [first.state.grantId]
+      (await store.listForOwner("alice", "owner:alice")).map(
+        (state) => state.grantId,
+      ),
+      [first.state.grantId],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation rechecks its mutation lock after the commit callback", async () => {
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-callback-lock-"),
+  );
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+    });
+    let refreshes = 0;
+    const inspected = store as unknown as {
+      withMutationLock<T>(
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+    };
+    inspected.withMutationLock = async (task) =>
+      await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+
+    await assert.rejects(
+      store.create(
+        {
+          namespace: "alice",
+          principal: "owner:alice",
+          cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+          expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+        },
+        async () => undefined,
+      ),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
+    );
+    assert.equal(refreshes, 2);
+    await assert.rejects(
+      lstat(path.join(root, "state", "support-passport", "grants")),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant revocation rechecks its mutation lock after the commit callback", async () => {
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-revoke-callback-lock-"),
+  );
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+    });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    });
+    let refreshes = 0;
+    const inspected = store as unknown as {
+      withGrantLock<T>(
+        grantId: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+    };
+    inspected.withGrantLock = async (_grantId, task) =>
+      await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+
+    await assert.rejects(
+      store.revoke(
+        {
+          grantId: created.state.grantId,
+          namespace: "alice",
+          principal: "owner:alice",
+        },
+        async () => undefined,
+      ),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
+    );
+    assert.equal(refreshes, 2);
+    assert.equal(
+      (await store.authenticate(created.state.grantId, created.secret))
+        .revokedAt,
+      undefined,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -663,7 +920,9 @@ test("a helper sees only the selected active card through a valid secret", async
 
 test("grants reject cards owned by another namespace in shared storage", async () => {
   StorageManager.clearAllStaticCaches();
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-card-scope-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-card-scope-"),
+  );
   try {
     const storage = new StorageManager(path.join(root, "shared-storage"));
     await storage.ensureDirectories();
@@ -674,7 +933,10 @@ test("grants reject cards owned by another namespace in shared storage", async (
       storage,
     });
     const cardService = new SupportPassportCardService({ resolveOwner, now });
-    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
+    const grantStore = new SupportPassportGrantStore({
+      memoryDir: path.join(root, "grants"),
+      now,
+    });
     const grantService = new SupportPassportGrantService({
       grantStore,
       resolveOwner,
@@ -700,7 +962,9 @@ test("grants reject cards owned by another namespace in shared storage", async (
         cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
         expiresAt: "2026-08-11T13:00:00.000Z",
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "invalid_card_status",
     );
     const forged = await grantStore.create({
       namespace: "bob",
@@ -709,8 +973,12 @@ test("grants reject cards owned by another namespace in shared storage", async (
       expiresAt: "2026-08-11T13:00:00.000Z",
     });
     await assert.rejects(
-      grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+      grantService.readGrant({
+        grantId: forged.state.grantId,
+        secret: forged.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_stale",
     );
   } finally {
     StorageManager.clearAllStaticCaches();
@@ -720,14 +988,23 @@ test("grants reject cards owned by another namespace in shared storage", async (
 
 test("grants reject cards owned by another principal inside a shared namespace", async () => {
   StorageManager.clearAllStaticCaches();
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-scope-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-owner-scope-"),
+  );
   try {
     const storage = new StorageManager(path.join(root, "shared-storage"));
     await storage.ensureDirectories();
     const now = () => new Date("2026-08-11T12:00:00.000Z");
-    const resolveOwner = async (principal: string) => ({ principal, namespace: "team", storage });
+    const resolveOwner = async (principal: string) => ({
+      principal,
+      namespace: "team",
+      storage,
+    });
     const cardService = new SupportPassportCardService({ resolveOwner, now });
-    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
+    const grantStore = new SupportPassportGrantStore({
+      memoryDir: path.join(root, "grants"),
+      now,
+    });
     const grantService = new SupportPassportGrantService({
       grantStore,
       resolveOwner,
@@ -753,7 +1030,9 @@ test("grants reject cards owned by another principal inside a shared namespace",
         cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
         expiresAt: "2026-08-11T13:00:00.000Z",
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "invalid_card_status",
     );
     const forged = await grantStore.create({
       namespace: "team",
@@ -762,8 +1041,12 @@ test("grants reject cards owned by another principal inside a shared namespace",
       expiresAt: "2026-08-11T13:00:00.000Z",
     });
     await assert.rejects(
-      grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+      grantService.readGrant({
+        grantId: forged.state.grantId,
+        secret: forged.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_stale",
     );
   } finally {
     StorageManager.clearAllStaticCaches();
@@ -775,7 +1058,9 @@ test("grant creation and card withdrawal cannot interleave", async () => {
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let releaseRead!: () => void;
     let markReadStarted!: () => void;
     const readStarted = new Promise<void>((resolve) => {
@@ -835,9 +1120,14 @@ test("bad secrets return not found, while valid revoked and expired grants revea
     });
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: "x".repeat(43) }),
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: "x".repeat(43),
+      }),
       (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_not_found" && error.status === 404
+        error instanceof SupportPassportError &&
+        error.code === "grant_not_found" &&
+        error.status === 404,
     );
 
     await assert.rejects(
@@ -848,10 +1138,15 @@ test("bad secrets return not found, while valid revoked and expired grants revea
         expectedStateVersion: created.grant.stateVersion + 1,
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "state_conflict" && error.status === 409
+        error instanceof SupportPassportError &&
+        error.code === "state_conflict" &&
+        error.status === 409,
     );
 
-    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
+    const peerStore = new SupportPassportGrantStore({
+      memoryDir: path.join(subject.root, "shared"),
+      now: subject.now,
+    });
     const peerRevoked = await peerStore.revoke({
       namespace: "alice",
       principal: "owner:alice",
@@ -867,8 +1162,14 @@ test("bad secrets return not found, while valid revoked and expired grants revea
     assert.equal(repeated.stateVersion, peerRevoked.stateVersion);
     assert.equal(repeated.revokedAt, peerRevoked.revokedAt);
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone" && error.status === 410
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "grant_gone" &&
+        error.status === 410,
     );
 
     const second = await subject.grantService.createGrant({
@@ -878,9 +1179,14 @@ test("bad secrets return not found, while valid revoked and expired grants revea
     });
     subject.advance(300_000);
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret }),
+      subject.grantService.readGrant({
+        grantId: second.grant.grantId,
+        secret: second.secret,
+      }),
       (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_expired" && error.status === 410
+        error instanceof SupportPassportError &&
+        error.code === "grant_expired" &&
+        error.status === 410,
     );
   } finally {
     await subject.cleanup();
@@ -896,7 +1202,9 @@ test("a grant that expires during guide assembly does not return a guide", async
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 300_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let advanced = false;
     subject.aliceStorage.getMemoryById = async (memoryId) => {
       const memory = await getMemoryById(memoryId);
@@ -908,8 +1216,12 @@ test("a grant that expires during guide assembly does not return a guide", async
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_expired"
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_expired",
     );
   } finally {
     await subject.cleanup();
@@ -927,8 +1239,13 @@ test("revocation wins while an optimistic helper card read is still pending", as
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const peerStore = new SupportPassportGrantStore({
+      memoryDir: path.join(subject.root, "shared"),
+      now: subject.now,
+    });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let paused = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
@@ -956,7 +1273,8 @@ test("revocation wins while an optimistic helper card read is still pending", as
     releaseCardRead.resolve();
     await assert.rejects(
       readPromise,
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_gone",
     );
   } finally {
     releaseCardRead.resolve();
@@ -982,7 +1300,9 @@ test("helper reads for different grants do not block each other", async () => {
     });
     const firstStarted = Promise.withResolvers<void>();
     const secondStarted = Promise.withResolvers<void>();
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
       if (memoryId === firstCard.cardId) {
@@ -992,16 +1312,25 @@ test("helper reads for different grants do not block each other", async () => {
       if (memoryId === secondCard.cardId) secondStarted.resolve();
       return memory;
     };
-    const firstRead = subject.grantService.readGrant({ grantId: first.grant.grantId, secret: first.secret });
+    const firstRead = subject.grantService.readGrant({
+      grantId: first.grant.grantId,
+      secret: first.secret,
+    });
     await firstStarted.promise;
-    const secondRead = subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret });
+    const secondRead = subject.grantService.readGrant({
+      grantId: second.grant.grantId,
+      secret: second.secret,
+    });
     const observedConcurrentRead = await Promise.race([
       secondStarted.promise.then(() => true),
       new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
     ]);
     releaseFirst.resolve();
 
-    const [firstGuide, secondGuide] = await Promise.all([firstRead, secondRead]);
+    const [firstGuide, secondGuide] = await Promise.all([
+      firstRead,
+      secondRead,
+    ]);
     assert.equal(observedConcurrentRead, true);
     assert.equal(firstGuide.cards[0]?.cardId, firstCard.cardId);
     assert.equal(secondGuide.cards[0]?.cardId, secondCard.cardId);
@@ -1013,7 +1342,10 @@ test("helper reads for different grants do not block each other", async () => {
 
 test("helper guide snapshots read selected cards in parallel", async () => {
   const subject = await makeSubject();
-  const pairedReads = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
+  const pairedReads = [
+    Promise.withResolvers<void>(),
+    Promise.withResolvers<void>(),
+  ];
   try {
     const firstCard = await createActiveCard(subject, "First card");
     const secondCard = await createActiveCard(subject, "Second card");
@@ -1025,7 +1357,9 @@ test("helper guide snapshots read selected cards in parallel", async () => {
       ],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let selectedReads = 0;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const selectedRead = selectedReads;
@@ -1035,7 +1369,9 @@ test("helper guide snapshots read selected cards in parallel", async () => {
       else {
         const concurrent = await Promise.race([
           pair?.promise.then(() => true),
-          new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
+          new Promise<false>((resolve) =>
+            setTimeout(() => resolve(false), 500),
+          ),
         ]);
         assert.equal(concurrent, true);
       }
@@ -1049,7 +1385,7 @@ test("helper guide snapshots read selected cards in parallel", async () => {
 
     assert.deepEqual(
       guide.cards.map((card) => card.cardId),
-      [firstCard.cardId, secondCard.cardId]
+      [firstCard.cardId, secondCard.cardId],
     );
     assert.equal(selectedReads, 4);
   } finally {
@@ -1069,7 +1405,9 @@ test("final helper guide assembly blocks card withdrawal", async () => {
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    const authenticate = subject.grantStore.authenticate.bind(
+      subject.grantStore,
+    );
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
@@ -1121,7 +1459,9 @@ test("final helper guide assembly blocks owner revocation", async () => {
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    const authenticate = subject.grantStore.authenticate.bind(
+      subject.grantStore,
+    );
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
@@ -1171,21 +1511,34 @@ test("helper guide assembly fails when owner-lock ownership is lost", async () =
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    const authenticate = subject.grantStore.authenticate.bind(
+      subject.grantStore,
+    );
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
       authentications += 1;
       if (authentications === 2) {
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
-        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
+        await writeFile(
+          lockPath,
+          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
+        );
       }
       return state;
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
     );
   } finally {
     await subject.cleanup();
@@ -1201,21 +1554,34 @@ test("helper guide assembly rechecks the owner lock after grant reauthentication
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    const authenticate = subject.grantStore.authenticate.bind(
+      subject.grantStore,
+    );
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
       authentications += 1;
       if (authentications === 3) {
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
-        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
+        await writeFile(
+          lockPath,
+          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
+        );
       }
       return state;
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
     );
     assert.equal(authentications, 3);
   } finally {
@@ -1232,21 +1598,34 @@ test("helper guide assembly refreshes the owner lock after its final card read",
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let reads = 0;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
       reads += 1;
       if (reads === 2) {
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
-        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
+        await writeFile(
+          lockPath,
+          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
+        );
       }
       return memory;
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
     );
     assert.equal(reads, 2);
   } finally {
@@ -1263,16 +1642,26 @@ test("helper guide assembly rechecks expiry after its final owner-lock refresh",
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 300_000),
     });
-    const withAuthenticatedGrant = subject.grantStore.withAuthenticatedGrant.bind(subject.grantStore);
-    subject.grantStore.withAuthenticatedGrant = async (grantId, secret, task, beforeReturn) =>
+    const withAuthenticatedGrant =
+      subject.grantStore.withAuthenticatedGrant.bind(subject.grantStore);
+    subject.grantStore.withAuthenticatedGrant = async (
+      grantId,
+      secret,
+      task,
+      beforeReturn,
+    ) =>
       await withAuthenticatedGrant(grantId, secret, task, async (state) => {
         subject.advance(300_000);
         await beforeReturn?.(state);
       });
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_expired"
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_expired",
     );
   } finally {
     await subject.cleanup();
@@ -1299,8 +1688,14 @@ test("a changed card makes the whole grant stale without a partial guide", async
     });
 
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale" && error.status === 410
+      subject.grantService.readGrant({
+        grantId: created.grant.grantId,
+        secret: created.secret,
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "grant_stale" &&
+        error.status === 410,
     );
   } finally {
     await subject.cleanup();
@@ -1316,15 +1711,21 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
+      subject.aliceStorage,
+    );
     let wroteUnrelated = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
       if (!wroteUnrelated) {
         wroteUnrelated = true;
-        await subject.aliceStorage.writeMemory("fact", "An unrelated memory write.", {
-          source: "support-passport-test",
-        });
+        await subject.aliceStorage.writeMemory(
+          "fact",
+          "An unrelated memory write.",
+          {
+            source: "support-passport-test",
+          },
+        );
       }
       return memory;
     };
@@ -1350,9 +1751,12 @@ test("grant creation rejects an approved card with an invalid update timestamp",
       await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(memory, {
         updated: "2026-08-11T12:00:00+99:99",
       }),
-      true
+      true,
     );
-    assert.deepEqual(await subject.cardService.listCards({ principal: "owner:alice" }), []);
+    assert.deepEqual(
+      await subject.cardService.listCards({ principal: "owner:alice" }),
+      [],
+    );
 
     await assert.rejects(
       subject.grantService.createGrant({
@@ -1360,9 +1764,14 @@ test("grant creation rejects an approved card with an invalid update timestamp",
         cards: [{ cardId: card.cardId, revision: card.revision }],
         expiresAt: expiryAfter(subject, 3_600_000),
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "invalid_card_status",
     );
-    assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
+    assert.deepEqual(
+      await subject.grantService.listGrants({ principal: "owner:alice" }),
+      [],
+    );
   } finally {
     await subject.cleanup();
   }
@@ -1374,25 +1783,38 @@ test("public guides compare card update timestamps as instants", async () => {
     const first = await createActiveCard(subject, "Earlier card");
     const second = await createActiveCard(subject, "Later card");
     const firstMemory = await subject.aliceStorage.getMemoryById(first.cardId);
-    const secondMemory = await subject.aliceStorage.getMemoryById(second.cardId);
+    const secondMemory = await subject.aliceStorage.getMemoryById(
+      second.cardId,
+    );
     assert.ok(firstMemory);
     assert.ok(secondMemory);
     assert.equal(
-      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(firstMemory, {
-        updated: "2026-08-11T12:00:00+05:00",
-      }),
-      true
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(
+        firstMemory,
+        {
+          updated: "2026-08-11T12:00:00+05:00",
+        },
+      ),
+      true,
     );
     assert.equal(
-      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(secondMemory, {
-        updated: "2026-08-11T10:00:00Z",
-      }),
-      true
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(
+        secondMemory,
+        {
+          updated: "2026-08-11T10:00:00Z",
+        },
+      ),
+      true,
     );
-    const cards = await subject.cardService.listCards({ principal: "owner:alice" });
+    const cards = await subject.cardService.listCards({
+      principal: "owner:alice",
+    });
     const created = await subject.grantService.createGrant({
       principal: "owner:alice",
-      cards: cards.map((card) => ({ cardId: card.cardId, revision: card.revision })),
+      cards: cards.map((card) => ({
+        cardId: card.cardId,
+        revision: card.revision,
+      })),
       expiresAt: expiryAfter(subject, 3_600_000),
     });
 
@@ -1420,7 +1842,10 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
     const active = await createActiveCard(subject);
 
     for (const input of [
-      { cards: [{ cardId: draft.cardId, revision: draft.revision }], expiresAt: expiryAfter(subject, 3_600_000) },
+      {
+        cards: [{ cardId: draft.cardId, revision: draft.revision }],
+        expiresAt: expiryAfter(subject, 3_600_000),
+      },
       {
         cards: [
           { cardId: active.cardId, revision: active.revision },
@@ -1428,7 +1853,10 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
         ],
         expiresAt: expiryAfter(subject, 3_600_000),
       },
-      { cards: [{ cardId: active.cardId, revision: active.revision }], expiresAt: expiryAfter(subject, 299_999) },
+      {
+        cards: [{ cardId: active.cardId, revision: active.revision }],
+        expiresAt: expiryAfter(subject, 299_999),
+      },
       {
         cards: [{ cardId: active.cardId, revision: active.revision }],
         expiresAt: expiryAfter(subject, 604_800_001),
@@ -1439,8 +1867,11 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
       },
     ]) {
       await assert.rejects(
-        subject.grantService.createGrant({ principal: "owner:alice", ...input }),
-        (error: unknown) => error instanceof SupportPassportError
+        subject.grantService.createGrant({
+          principal: "owner:alice",
+          ...input,
+        }),
+        (error: unknown) => error instanceof SupportPassportError,
       );
     }
   } finally {
@@ -1453,9 +1884,14 @@ test("the grant store rejects a symlinked grant directory", async () => {
   try {
     const memoryDir = path.join(root, "memory");
     const outside = path.join(root, "outside");
-    await mkdir(path.join(memoryDir, "state", "support-passport"), { recursive: true });
+    await mkdir(path.join(memoryDir, "state", "support-passport"), {
+      recursive: true,
+    });
     await mkdir(outside);
-    await symlink(outside, path.join(memoryDir, "state", "support-passport", "grants"));
+    await symlink(
+      outside,
+      path.join(memoryDir, "state", "support-passport", "grants"),
+    );
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({ memoryDir, now: () => now });
 
@@ -1466,7 +1902,7 @@ test("the grant store rejects a symlinked grant directory", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
-      /must remain inside the memory directory/
+      /must remain inside the memory directory/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1475,15 +1911,27 @@ test("the grant store rejects a symlinked grant directory", async () => {
 
 test("private file operations select supported directory access strategies", () => {
   assert.throws(
-    () => requirePrivateFileDescriptorRoot("win32", "private file directory cannot be pinned"),
-    /private file directory cannot be pinned/
+    () =>
+      requirePrivateFileDescriptorRoot(
+        "win32",
+        "private file directory cannot be pinned",
+      ),
+    /private file directory cannot be pinned/,
   );
-  assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
-  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
+  assert.equal(
+    requirePrivateFileDescriptorRoot("linux", "unreachable"),
+    "/proc/self/fd",
+  );
+  assert.equal(
+    requirePrivateFileDescriptorRoot("darwin", "unreachable"),
+    "/dev/fd",
+  );
 });
 
 test("private directory creation syncs every verified parent entry", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-private-directory-sync-"),
+  );
   try {
     const target = path.join(root, "state", "support-passport", "grants");
     let syncs = 0;
@@ -1491,9 +1939,19 @@ test("private directory creation syncs every verified parent entry", async () =>
       syncs += 1;
     };
 
-    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
+    await ensurePrivateDirectoryNoFollow(
+      root,
+      target,
+      "private directory creation failed",
+      syncVerifiedParent,
+    );
     assert.equal(syncs, 3);
-    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
+    await ensurePrivateDirectoryNoFollow(
+      root,
+      target,
+      "private directory creation failed",
+      syncVerifiedParent,
+    );
     assert.equal(syncs, 3);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1501,23 +1959,37 @@ test("private directory creation syncs every verified parent entry", async () =>
 });
 
 test("private directory creation retries a failed parent sync", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-retry-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-private-directory-sync-retry-"),
+  );
   try {
     const target = path.join(root, "state", "support-passport", "grants");
     await assert.rejects(
-      ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
-        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
-      }),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+      ensurePrivateDirectoryNoFollow(
+        root,
+        target,
+        "private directory creation failed",
+        async () => {
+          throw Object.assign(new Error("simulated directory sync failure"), {
+            code: "EIO",
+          });
+        },
+      ),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
     );
     await assert.rejects(lstat(path.join(root, "state")), (error: unknown) => {
       return (error as NodeJS.ErrnoException).code === "ENOENT";
     });
 
     let retrySyncs = 0;
-    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
-      retrySyncs += 1;
-    });
+    await ensurePrivateDirectoryNoFollow(
+      root,
+      target,
+      "private directory creation failed",
+      async () => {
+        retrySyncs += 1;
+      },
+    );
     assert.equal(retrySyncs, 3);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1525,24 +1997,38 @@ test("private directory creation retries a failed parent sync", async () => {
 });
 
 test("private directory creation retries parent sync when rollback cannot remove the child", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-populated-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-private-directory-sync-populated-"),
+  );
   try {
     const target = path.join(root, "state");
     let failed = false;
     await assert.rejects(
-      ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
-        if (failed) return;
-        failed = true;
-        await writeFile(path.join(target, "peer-entry"), "peer");
-        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
-      }),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+      ensurePrivateDirectoryNoFollow(
+        root,
+        target,
+        "private directory creation failed",
+        async () => {
+          if (failed) return;
+          failed = true;
+          await writeFile(path.join(target, "peer-entry"), "peer");
+          throw Object.assign(new Error("simulated directory sync failure"), {
+            code: "EIO",
+          });
+        },
+      ),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
     );
 
     let retrySyncs = 0;
-    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
-      retrySyncs += 1;
-    });
+    await ensurePrivateDirectoryNoFollow(
+      root,
+      target,
+      "private directory creation failed",
+      async () => {
+        retrySyncs += 1;
+      },
+    );
     assert.equal(retrySyncs, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1550,14 +2036,20 @@ test("private directory creation retries parent sync when rollback cannot remove
 });
 
 test("private directory tree creation syncs missing memory-root ancestors", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-sync-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-private-root-sync-"),
+  );
   try {
     const target = path.join(root, "new-parent", "memory");
     let syncs = 0;
 
-    await ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed", async () => {
-      syncs += 1;
-    });
+    await ensurePrivateDirectoryTreeNoFollow(
+      target,
+      "private directory creation failed",
+      async () => {
+        syncs += 1;
+      },
+    );
 
     assert.equal(syncs, 2);
     assert.equal((await lstat(target)).isDirectory(), true);
@@ -1568,7 +2060,9 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
 });
 
 test("private directory tree creation rejects a symlink in the ancestor chain", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-link-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-private-root-link-"),
+  );
   try {
     const outside = path.join(root, "outside");
     const linked = path.join(root, "linked");
@@ -1577,8 +2071,11 @@ test("private directory tree creation rejects a symlink in the ancestor chain", 
     await symlink(outside, linked);
 
     await assert.rejects(
-      ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed"),
-      /private directory creation failed/
+      ensurePrivateDirectoryTreeNoFollow(
+        target,
+        "private directory creation failed",
+      ),
+      /private directory creation failed/,
     );
     assert.deepEqual(await readdir(outside), []);
   } finally {
@@ -1587,7 +2084,9 @@ test("private directory tree creation rejects a symlink in the ancestor chain", 
 });
 
 test("configured private directory targets resolve existing symlink aliases once", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-alias-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-private-root-alias-"),
+  );
   try {
     const actual = path.join(root, "actual");
     const alias = path.join(root, "alias");
@@ -1595,8 +2094,10 @@ test("configured private directory targets resolve existing symlink aliases once
     await symlink(actual, alias);
 
     assert.equal(
-      await canonicalizePrivateDirectoryTarget(path.join(alias, "new-parent", "memory")),
-      path.join(actual, "new-parent", "memory")
+      await canonicalizePrivateDirectoryTarget(
+        path.join(alias, "new-parent", "memory"),
+      ),
+      path.join(actual, "new-parent", "memory"),
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1604,7 +2105,9 @@ test("configured private directory targets resolve existing symlink aliases once
 });
 
 test("grant cleanup never follows a swapped grant directory", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cleanup-swap-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-cleanup-swap-"),
+  );
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -1624,15 +2127,23 @@ test("grant cleanup never follows a swapped grant directory", async () => {
     const outsideDir = path.join(root, "outside");
     const fileName = `${grantId}.json`;
     await mkdir(outsideDir);
-    await writeFile(path.join(outsideDir, fileName), "outside must remain", { mode: 0o600 });
+    await writeFile(path.join(outsideDir, fileName), "outside must remain", {
+      mode: 0o600,
+    });
     renameSync(grantsDir, parkedDir);
     symlinkSync(outsideDir, grantsDir, "dir");
     const inspected = store as unknown as {
       removeGrantStates(grantIds: string[]): Promise<void>;
     };
 
-    await assert.rejects(inspected.removeGrantStates([grantId]), /regular files in a stable directory/);
-    assert.equal(await readFile(path.join(outsideDir, fileName), "utf8"), "outside must remain");
+    await assert.rejects(
+      inspected.removeGrantStates([grantId]),
+      /regular files in a stable directory/,
+    );
+    assert.equal(
+      await readFile(path.join(outsideDir, fileName), "utf8"),
+      "outside must remain",
+    );
     assert.equal((await lstat(path.join(parkedDir, fileName))).isFile(), true);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1644,7 +2155,12 @@ test("grant writes reject a directory swapped after the initial safety check", a
   try {
     const memoryDir = path.join(root, "memory");
     const outside = path.join(root, "outside");
-    const grantsDir = path.join(memoryDir, "state", "support-passport", "grants");
+    const grantsDir = path.join(
+      memoryDir,
+      "state",
+      "support-passport",
+      "grants",
+    );
     const parkedDir = path.join(root, "parked-grants");
     await mkdir(outside, { recursive: true });
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -1664,9 +2180,9 @@ test("grant writes reject a directory swapped after the initial safety check", a
         async () => {
           renameSync(grantsDir, parkedDir);
           symlinkSync(outside, grantsDir, "dir");
-        }
+        },
       ),
-      /regular files in a stable directory/
+      /regular files in a stable directory/,
     );
     assert.deepEqual(await readdir(outside), []);
   } finally {
@@ -1675,7 +2191,9 @@ test("grant writes reject a directory swapped after the initial safety check", a
 });
 
 test("grant writes reject an ancestor swapped after the initial safety check", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-ancestor-swap-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-ancestor-swap-"),
+  );
   try {
     const memoryDir = path.join(root, "memory");
     const passportDir = path.join(memoryDir, "state", "support-passport");
@@ -1683,7 +2201,9 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
     const outside = path.join(root, "outside-support-passport");
     await mkdir(path.join(outside, "grants", "owners"), { recursive: true });
     const acceptLock = (async (_lockPath, _options, task) =>
-      await task(true, { refresh: async () => true })) as typeof withHeldFileLock;
+      await task(true, {
+        refresh: async () => true,
+      })) as typeof withHeldFileLock;
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir,
@@ -1704,9 +2224,9 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
         async () => {
           renameSync(passportDir, parkedDir);
           symlinkSync(outside, passportDir, "dir");
-        }
+        },
       ),
-      /regular files in a stable directory/
+      /regular files in a stable directory/,
     );
     assert.deepEqual(await readdir(path.join(outside, "grants")), ["owners"]);
   } finally {
@@ -1715,7 +2235,9 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
 });
 
 test("the grant store fails closed for corrupt and symlinked grant files", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-state-"),
+  );
   try {
     const firstGrantId = "00000000-0000-4000-8000-000000000001";
     const secondGrantId = "00000000-0000-4000-8000-000000000002";
@@ -1744,7 +2266,10 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
     await writeFile(outsidePath, await readFile(linkedPath), { mode: 0o600 });
     await rm(linkedPath);
     await symlink(outsidePath, linkedPath);
-    await assert.rejects(store.authenticate(secondGrantId, linked.secret), /must be regular files/);
+    await assert.rejects(
+      store.authenticate(secondGrantId, linked.secret),
+      /must be regular files/,
+    );
     await assert.rejects(store.listForOwner("alice", "owner:alice"));
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1752,7 +2277,9 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
 });
 
 test("the grant store rejects a state file whose grant ID does not match its file name", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-identity-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-identity-"),
+  );
   try {
     const firstGrantId = "00000000-0000-4000-8000-000000000001";
     const secondGrantId = "00000000-0000-4000-8000-000000000002";
@@ -1775,11 +2302,17 @@ test("the grant store rejects a state file whose grant ID does not match its fil
     await writeFile(
       path.join(grantDir, `${secondGrantId}.json`),
       await readFile(path.join(grantDir, `${firstGrantId}.json`)),
-      { mode: 0o600 }
+      { mode: 0o600 },
     );
 
-    await assert.rejects(store.authenticate(secondGrantId, second.secret), /grant ID must match its file name/);
-    await assert.rejects(store.listForOwner("alice", "owner:alice"), /grant ID must match its file name/);
+    await assert.rejects(
+      store.authenticate(secondGrantId, second.secret),
+      /grant ID must match its file name/,
+    );
+    await assert.rejects(
+      store.listForOwner("alice", "owner:alice"),
+      /grant ID must match its file name/,
+    );
     assert.equal(first.state.grantId, firstGrantId);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1787,11 +2320,17 @@ test("the grant store rejects a state file whose grant ID does not match its fil
 });
 
 test("the grant store rejects unsafe durations and grant ID collisions", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-collision-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-collision-"),
+  );
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId,
+      now: () => now,
+    });
     const input = {
       namespace: "alice",
       principal: "owner:alice",
@@ -1801,11 +2340,17 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
     await store.create(input);
     await assert.rejects(
       store.create(input),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+      (error: unknown) =>
+        error instanceof SupportPassportError &&
+        error.code === "storage_conflict",
     );
     await assert.rejects(
-      store.create({ ...input, expiresAt: new Date(now.getTime() + 299_999).toISOString() }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+      store.create({
+        ...input,
+        expiresAt: new Date(now.getTime() + 299_999).toISOString(),
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "invalid_input",
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1813,7 +2358,9 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
 });
 
 test("the grant store canonicalizes UUID letter case", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-id-case-"));
+  const root = await mkdtemp(
+    path.join(tmpdir(), "remnic-support-grant-id-case-"),
+  );
   try {
     const uppercaseGrantId = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA";
     const lowercaseGrantId = uppercaseGrantId.toLowerCase();
@@ -1831,10 +2378,19 @@ test("the grant store canonicalizes UUID letter case", async () => {
     });
 
     assert.equal(created.state.grantId, lowercaseGrantId);
-    assert.equal((await store.authenticate(uppercaseGrantId, created.secret)).grantId, lowercaseGrantId);
     assert.equal(
-      (await store.revoke({ grantId: uppercaseGrantId, namespace: "alice", principal: "owner:alice" })).grantId,
-      lowercaseGrantId
+      (await store.authenticate(uppercaseGrantId, created.secret)).grantId,
+      lowercaseGrantId,
+    );
+    assert.equal(
+      (
+        await store.revoke({
+          grantId: uppercaseGrantId,
+          namespace: "alice",
+          principal: "owner:alice",
+        })
+      ).grantId,
+      lowercaseGrantId,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1845,7 +2401,10 @@ test("the grant store rejects invalid calendar dates", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-date-"));
   try {
     const now = new Date("2026-02-28T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+    });
 
     await assert.rejects(
       store.create({
@@ -1854,7 +2413,8 @@ test("the grant store rejects invalid calendar dates", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: "2026-02-31T12:00:00.000Z",
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "invalid_input",
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1862,7 +2422,9 @@ test("the grant store rejects invalid calendar dates", async () => {
 });
 
 test("the grant store expands a leading tilde in its memory directory", () => {
-  const store = new SupportPassportGrantStore({ memoryDir: "~/support-passport-path-test" });
+  const store = new SupportPassportGrantStore({
+    memoryDir: "~/support-passport-path-test",
+  });
   const memoryDir = (store as unknown as { memoryDir: string }).memoryDir;
   assert.equal(memoryDir.includes(`${path.sep}~${path.sep}`), false);
   assert.equal(path.basename(memoryDir), "support-passport-path-test");

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -136,7 +136,7 @@ test("a helper sees only the selected active card through a valid secret", async
   }
 });
 
-test("bad secrets return not found, while valid revoked or expired grants return gone", async () => {
+test("bad secrets return not found, while valid revoked and expired grants reveal safe lifecycle states", async () => {
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
@@ -191,7 +191,8 @@ test("bad secrets return not found, while valid revoked or expired grants return
     subject.advance(300_000);
     await assert.rejects(
       subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_expired" && error.status === 410
     );
   } finally {
     await subject.cleanup();

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1283,9 +1283,9 @@ test("grant creation rechecks its mutation lock after the commit callback", asyn
       (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(refreshes, 2);
-    await assert.rejects(
-      lstat(path.join(root, "state", "support-passport", "grants")),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
+    assert.deepEqual(
+      await readdir(path.join(root, "state", "support-passport", "grants")),
+      ["owners"]
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2568,7 +2568,7 @@ test("grant reads reject a memory-root ancestor swapped after a completed operat
 
     await assert.rejects(
       store.listForOwner("alice", "owner:alice"),
-      /support passport owner indexes must be regular files in a stable directory/
+      /support passport owner membership must remain inside the memory directory/
     );
     assert.deepEqual(await readdir(path.join(outsideParent, "memory", "state", "support-passport", "grants")), [
       "owners",
@@ -2643,7 +2643,10 @@ test("the grant store rejects a state file whose grant ID does not match its fil
     );
 
     await assert.rejects(store.authenticate(secondGrantId, second.secret), /grant ID must match its file name/);
-    await assert.rejects(store.listForOwner("alice", "owner:alice"), /grant ID must match its file name/);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [firstGrantId]
+    );
     assert.equal(first.state.grantId, firstGrantId);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -470,6 +470,43 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
   }
 });
 
+test("the grant store rejects a state file whose grant ID does not match its file name", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-identity-"));
+  try {
+    const firstGrantId = "00000000-0000-4000-8000-000000000001";
+    const secondGrantId = "00000000-0000-4000-8000-000000000002";
+    const grantIds = [firstGrantId, secondGrantId];
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? secondGrantId,
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const second = await store.create(input);
+    const grantDir = path.join(root, "state", "support-passport", "grants");
+    await writeFile(
+      path.join(grantDir, `${secondGrantId}.json`),
+      await readFile(path.join(grantDir, `${firstGrantId}.json`)),
+      { mode: 0o600 }
+    );
+
+    await assert.rejects(store.authenticate(secondGrantId, second.secret), /grant ID must match its file name/);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [first.state.grantId]
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("the grant store rejects unsafe durations and grant ID collisions", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-collision-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -813,6 +813,46 @@ test("grant writes reject a directory swapped after the initial safety check", a
   }
 });
 
+test("grant writes reject an ancestor swapped after the initial safety check", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-ancestor-swap-"));
+  try {
+    const memoryDir = path.join(root, "memory");
+    const passportDir = path.join(memoryDir, "state", "support-passport");
+    const parkedDir = path.join(root, "parked-support-passport");
+    const outside = path.join(root, "outside-support-passport");
+    await mkdir(path.join(outside, "grants", "owners"), { recursive: true });
+    const acceptLock = (async (_lockPath, _options, task) =>
+      await task(true, { refresh: async () => true })) as typeof withHeldFileLock;
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir,
+      now: () => now,
+      withHeldFileLock: acceptLock,
+    });
+    const inspected = store as unknown as { addToOwnerIndex(): Promise<void> };
+    inspected.addToOwnerIndex = async () => undefined;
+
+    await assert.rejects(
+      store.create(
+        {
+          namespace: "alice",
+          principal: "owner:alice",
+          cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+          expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+        },
+        async () => {
+          renameSync(passportDir, parkedDir);
+          symlinkSync(outside, passportDir, "dir");
+        }
+      ),
+      /regular files in a stable directory/
+    );
+    assert.deepEqual(await readdir(path.join(outside, "grants")), ["owners"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("the grant store fails closed for corrupt and symlinked grant files", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -22,8 +22,8 @@ async function makeSubject() {
   let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
   const now = () => new Date(currentTime);
   const resolveOwner = async (principal: string) => {
-    if (principal === "owner:alice") return { namespace: "alice", storage: aliceStorage };
-    if (principal === "owner:bob") return { namespace: "bob", storage: bobStorage };
+    if (principal === "owner:alice") return { principal, namespace: "alice", storage: aliceStorage };
+    if (principal === "owner:bob") return { principal, namespace: "bob", storage: bobStorage };
     throw new Error("unknown test principal");
   };
   const cardService = new SupportPassportCardService({ resolveOwner, now });
@@ -141,6 +141,32 @@ test("owner grant listings read only the indexed owner grants", async () => {
     );
     assert.deepEqual(readGrantIds, [alice.state.grantId]);
     assert.notEqual(alice.state.grantId, bob.state.grantId);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("owner grant listings propagate indexed grant read failures", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-error-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const inspected = store as unknown as { readState(grantId: string): Promise<unknown> };
+    inspected.readState = async (grantId) => {
+      assert.equal(grantId, created.state.grantId);
+      throw Object.assign(new Error("simulated grant read failure"), { code: "EIO" });
+    };
+
+    await assert.rejects(
+      store.listForOwner("alice", "owner:alice"),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -598,7 +624,7 @@ test("a grant that expires during guide assembly does not return a guide", async
   }
 });
 
-test("revocation waits until helper guide assembly completes", async () => {
+test("revocation wins while an optimistic helper card read is still pending", async () => {
   const subject = await makeSubject();
   const cardReadStarted = Promise.withResolvers<void>();
   const releaseCardRead = Promise.withResolvers<void>();
@@ -627,27 +653,18 @@ test("revocation waits until helper guide assembly completes", async () => {
       secret: created.secret,
     });
     await cardReadStarted.promise;
-    let revokeSettled = false;
     const revokePromise = peerStore
       .revoke({
         namespace: "alice",
         principal: "owner:alice",
         grantId: created.grant.grantId,
         expectedStateVersion: created.grant.stateVersion,
-      })
-      .finally(() => {
-        revokeSettled = true;
       });
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    assert.equal(revokeSettled, false);
+    await revokePromise;
 
     releaseCardRead.resolve();
-    const guide = await readPromise;
-    assert.equal(guide.cards[0]?.cardId, card.cardId);
-    await revokePromise;
-    assert.equal(revokeSettled, true);
     await assert.rejects(
-      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      readPromise,
       (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
     );
   } finally {
@@ -657,38 +674,49 @@ test("revocation waits until helper guide assembly completes", async () => {
 });
 
 test("helper reads for different grants do not block each other", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-read-lock-"));
+  const subject = await makeSubject();
   const releaseFirst = Promise.withResolvers<void>();
   try {
-    const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
-    const input = {
-      namespace: "alice",
+    const firstCard = await createActiveCard(subject, "First card");
+    const secondCard = await createActiveCard(subject, "Second card");
+    const first = await subject.grantService.createGrant({
       principal: "owner:alice",
-      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
-      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
-    };
-    const first = await store.create(input);
-    const second = await store.create(input);
-    const firstStarted = Promise.withResolvers<void>();
-    const firstRead = store.withAuthenticatedGrant(first.state.grantId, first.secret, async () => {
-      firstStarted.resolve();
-      await releaseFirst.promise;
-      return "first";
+      cards: [{ cardId: firstCard.cardId, revision: firstCard.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
     });
+    const second = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: secondCard.cardId, revision: secondCard.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const firstStarted = Promise.withResolvers<void>();
+    const secondStarted = Promise.withResolvers<void>();
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      if (memoryId === firstCard.cardId) {
+        firstStarted.resolve();
+        await releaseFirst.promise;
+      }
+      if (memoryId === secondCard.cardId) secondStarted.resolve();
+      return memory;
+    };
+    const firstRead = subject.grantService.readGrant({ grantId: first.grant.grantId, secret: first.secret });
     await firstStarted.promise;
-    const secondRead = store.withAuthenticatedGrant(second.state.grantId, second.secret, async () => "second");
+    const secondRead = subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret });
     const observedConcurrentRead = await Promise.race([
-      secondRead.then(() => true),
+      secondStarted.promise.then(() => true),
       new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
     ]);
     releaseFirst.resolve();
 
-    assert.deepEqual(await Promise.all([firstRead, secondRead]), ["first", "second"]);
+    const [firstGuide, secondGuide] = await Promise.all([firstRead, secondRead]);
     assert.equal(observedConcurrentRead, true);
+    assert.equal(firstGuide.cards[0]?.cardId, firstCard.cardId);
+    assert.equal(secondGuide.cards[0]?.cardId, secondCard.cardId);
   } finally {
     releaseFirst.resolve();
-    await rm(root, { recursive: true, force: true });
+    await subject.cleanup();
   }
 });
 
@@ -861,7 +889,7 @@ test("the grant store rejects a symlinked grant directory", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
-      /must not be a symbolic link/
+      /must remain inside the memory directory/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1019,7 +1047,7 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
     await rm(linkedPath);
     await symlink(outsidePath, linkedPath);
     await assert.rejects(store.authenticate(secondGrantId, linked.secret), /must be regular files/);
-    assert.deepEqual(await store.listForOwner("alice", "owner:alice"), []);
+    await assert.rejects(store.listForOwner("alice", "owner:alice"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1053,10 +1081,11 @@ test("the grant store rejects a state file whose grant ID does not match its fil
     );
 
     await assert.rejects(store.authenticate(secondGrantId, second.secret), /grant ID must match its file name/);
-    assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
-      [first.state.grantId]
+    await assert.rejects(
+      store.listForOwner("alice", "owner:alice"),
+      /grant ID must match its file name/
     );
+    assert.equal(first.state.grantId, firstGrantId);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -648,10 +648,10 @@ test("grant creation rechecks the owner lock immediately before commit", async (
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
-    const originalRead = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const originalRead = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let replacedLock = false;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await originalRead(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await originalRead(...args);
       if (!replacedLock) {
         replacedLock = true;
         const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
@@ -660,7 +660,7 @@ test("grant creation rechecks the owner lock immediately before commit", async (
         });
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
-      return memory;
+      return memories;
     };
 
     await assert.rejects(
@@ -717,15 +717,15 @@ test("grant creation measures its minimum lifetime from request receipt", async 
   try {
     const card = await createActiveCard(subject);
     const expiresAt = expiryAfter(subject, 300_000);
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let delayed = false;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await readAllMemories(...args);
       if (!delayed) {
         delayed = true;
         subject.advance(1_000);
       }
-      return memory;
+      return memories;
     };
 
     const created = await subject.grantService.createGrant({
@@ -1317,7 +1317,7 @@ test("grant creation and card withdrawal cannot interleave", async () => {
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let releaseRead!: () => void;
     let markReadStarted!: () => void;
     const readStarted = new Promise<void>((resolve) => {
@@ -1327,14 +1327,14 @@ test("grant creation and card withdrawal cannot interleave", async () => {
       releaseRead = resolve;
     });
     let pauseRead = true;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await readAllMemories(...args);
       if (pauseRead) {
         pauseRead = false;
         markReadStarted();
         await readReleased;
       }
-      return memory;
+      return memories;
     };
 
     const createPromise = subject.grantService.createGrant({
@@ -1438,15 +1438,15 @@ test("a grant that expires during guide assembly does not return a guide", async
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 300_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let advanced = false;
-    subject.aliceStorage.getMemoryById = async (memoryId) => {
-      const memory = await getMemoryById(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await readAllMemories(...args);
       if (!advanced) {
         advanced = true;
         subject.advance(300_000);
       }
-      return memory;
+      return memories;
     };
 
     await assert.rejects(
@@ -1470,16 +1470,16 @@ test("revocation wins while an optimistic helper card read is still pending", as
       expiresAt: expiryAfter(subject, 3_600_000),
     });
     const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let paused = false;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await readAllMemories(...args);
       if (!paused) {
         paused = true;
         cardReadStarted.resolve();
         await releaseCardRead.promise;
       }
-      return memory;
+      return memories;
     };
 
     const readPromise = subject.grantService.readGrant({
@@ -1523,28 +1523,24 @@ test("helper reads for different grants do not block each other", async () => {
       expiresAt: expiryAfter(subject, 3_600_000),
     });
     const firstStarted = Promise.withResolvers<void>();
-    const secondStarted = Promise.withResolvers<void>();
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
-      if (memoryId === firstCard.cardId) {
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    subject.grantStore.authenticate = async (grantId, secret) => {
+      const state = await authenticate(grantId, secret);
+      if (grantId === first.grant.grantId) {
         firstStarted.resolve();
         await releaseFirst.promise;
       }
-      if (memoryId === secondCard.cardId) secondStarted.resolve();
-      return memory;
+      return state;
     };
     const firstRead = subject.grantService.readGrant({ grantId: first.grant.grantId, secret: first.secret });
     await firstStarted.promise;
-    const secondRead = subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret });
-    const observedConcurrentRead = await Promise.race([
-      secondStarted.promise.then(() => true),
-      new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
-    ]);
+    const secondGuide = await subject.grantService.readGrant({
+      grantId: second.grant.grantId,
+      secret: second.secret,
+    });
     releaseFirst.resolve();
 
-    const [firstGuide, secondGuide] = await Promise.all([firstRead, secondRead]);
-    assert.equal(observedConcurrentRead, true);
+    const firstGuide = await firstRead;
     assert.equal(firstGuide.cards[0]?.cardId, firstCard.cardId);
     assert.equal(secondGuide.cards[0]?.cardId, secondCard.cardId);
   } finally {
@@ -1553,9 +1549,8 @@ test("helper reads for different grants do not block each other", async () => {
   }
 });
 
-test("helper guide snapshots read selected cards in parallel", async () => {
+test("helper guide snapshots reuse selected cards from the corpus snapshot", async () => {
   const subject = await makeSubject();
-  const pairedReads = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
   try {
     const firstCard = await createActiveCard(subject, "First card");
     const secondCard = await createActiveCard(subject, "Second card");
@@ -1567,21 +1562,8 @@ test("helper guide snapshots read selected cards in parallel", async () => {
       ],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
-    let selectedReads = 0;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const selectedRead = selectedReads;
-      selectedReads += 1;
-      const pair = pairedReads[Math.floor(selectedRead / 2)];
-      if (selectedRead % 2 === 1) pair?.resolve();
-      else {
-        const concurrent = await Promise.race([
-          pair?.promise.then(() => true),
-          new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
-        ]);
-        assert.equal(concurrent, true);
-      }
-      return await getMemoryById(memoryId);
+    subject.aliceStorage.getMemoryById = async () => {
+      throw new Error("guide reads must reuse the corpus snapshot");
     };
 
     const guide = await subject.grantService.readGrant({
@@ -1593,9 +1575,7 @@ test("helper guide snapshots read selected cards in parallel", async () => {
       guide.cards.map((card) => card.cardId),
       [firstCard.cardId, secondCard.cardId]
     );
-    assert.equal(selectedReads, 4);
   } finally {
-    for (const pair of pairedReads) pair.resolve();
     await subject.cleanup();
   }
 });
@@ -1771,7 +1751,7 @@ test("helper guide assembly rechecks the owner lock after grant reauthentication
   }
 });
 
-test("helper guide assembly refreshes the owner lock after its final card read", async () => {
+test("helper guide assembly refreshes the owner lock after its final snapshot read", async () => {
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
@@ -1780,26 +1760,26 @@ test("helper guide assembly refreshes the owner lock after its final card read",
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let reads = 0;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await readAllMemories(...args);
       reads += 1;
-      if (reads === 2) {
+      if (reads === 1) {
         const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
           namespace: "alice",
           principal: "owner:alice",
         });
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
-      return memory;
+      return memories;
     };
 
     await assert.rejects(
       subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
-    assert.equal(reads, 2);
+    assert.equal(reads, 1);
   } finally {
     await subject.cleanup();
   }
@@ -1867,17 +1847,17 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
     let wroteUnrelated = false;
-    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
-      const memory = await getMemoryById(memoryId);
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      const memories = await readAllMemories(...args);
       if (!wroteUnrelated) {
         wroteUnrelated = true;
         await subject.aliceStorage.writeMemory("fact", "An unrelated memory write.", {
           source: "support-passport-test",
         });
       }
-      return memory;
+      return memories;
     };
 
     const guide = await subject.grantService.readGrant({
@@ -1886,6 +1866,37 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
     });
 
     assert.equal(guide.cards[0]?.cardId, card.cardId);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("one unchanged guide read projects one corpus snapshot", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const readAllMemories = subject.aliceStorage.readAllMemories.bind(subject.aliceStorage);
+    let corpusReads = 0;
+    subject.aliceStorage.readAllMemories = async (...args) => {
+      corpusReads += 1;
+      return await readAllMemories(...args);
+    };
+    subject.aliceStorage.getMemoryById = async () => {
+      throw new Error("guide reads must reuse the corpus snapshot");
+    };
+
+    const guide = await subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+
+    assert.equal(guide.cards[0]?.cardId, card.cardId);
+    assert.equal(corpusReads, 1);
   } finally {
     await subject.cleanup();
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -656,6 +656,34 @@ test("grant creation measures its minimum lifetime from request receipt", async 
   }
 });
 
+test("grant creation maps a clock jump past expiry to invalid input", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-clock-jump-"));
+  try {
+    const requestedAt = new Date("2026-08-11T12:00:00.000Z");
+    let nowCalls = 0;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => {
+        nowCalls += 1;
+        return new Date(requestedAt.getTime() + (nowCalls > 1 ? 600_000 : 0));
+      },
+    });
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(requestedAt.getTime() + 300_000).toISOString(),
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "invalid_input" && error.status === 400
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("directory sync ignores only explicit unsupported errors", async () => {
   const failingOpen = (code: string) => async () => ({
     sync: async () => {
@@ -1665,7 +1693,7 @@ test("private directory creation syncs every verified parent entry", async () =>
     await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
     assert.equal(syncs, 3);
     await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
-    assert.equal(syncs, 3);
+    assert.equal(syncs, 6);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1681,9 +1709,7 @@ test("private directory creation retries a failed parent sync", async () => {
       }),
       (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
     );
-    await assert.rejects(lstat(path.join(root, "state")), (error: unknown) => {
-      return (error as NodeJS.ErrnoException).code === "ENOENT";
-    });
+    assert.equal((await lstat(path.join(root, "state"))).isDirectory(), true);
 
     let retrySyncs = 0;
     await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
@@ -1720,6 +1746,29 @@ test("private directory creation retries parent sync when rollback cannot remove
   }
 });
 
+test("a failed parent sync never unlinks a directory opened by a concurrent setup", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-race-"));
+  const releaseFirstSync = Promise.withResolvers<void>();
+  try {
+    const target = path.join(root, "state");
+    const firstSyncStarted = Promise.withResolvers<void>();
+    const first = ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+      firstSyncStarted.resolve();
+      await releaseFirstSync.promise;
+      throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+    });
+    await firstSyncStarted.promise;
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => undefined);
+    releaseFirstSync.resolve();
+
+    await assert.rejects(first, (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
+    assert.equal((await lstat(target)).isDirectory(), true);
+  } finally {
+    releaseFirstSync.resolve();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("private directory tree creation syncs missing memory-root ancestors", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-sync-"));
   try {
@@ -1730,7 +1779,7 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
       syncs += 1;
     });
 
-    assert.equal(syncs, 2);
+    assert.equal(syncs, 4);
     assert.equal((await lstat(target)).isDirectory(), true);
     assert.equal((await lstat(target)).mode & 0o777, 0o700);
   } finally {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1,16 +1,6 @@
 import assert from "node:assert/strict";
 import { renameSync, symlinkSync } from "node:fs";
-import {
-  lstat,
-  mkdir,
-  mkdtemp,
-  open,
-  readFile,
-  readdir,
-  rm,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, open, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -364,13 +354,16 @@ test("grant creation accepts a state write that committed before its durability 
     });
 
     assert.equal(created.state.grantId, grantId);
-    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [grantId]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("grant creation accepts an owner index write that committed before its durability error", async () => {
+test("grant creation re-syncs an owner index write that committed before its durability error", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-commit-"));
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
@@ -393,7 +386,10 @@ test("grant creation accepts an owner index write that committed before its dura
     });
 
     assert.equal(created.state.grantId, grantId);
-    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [grantId]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -684,10 +680,7 @@ test("grant revocation rechecks its mutation lock after the commit callback", as
     });
     let refreshes = 0;
     const inspected = store as unknown as {
-      withGrantLock<T>(
-        grantId: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>
-      ): Promise<T>;
+      withGrantLock<T>(grantId: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
     };
     inspected.withGrantLock = async (_grantId, task) =>
       await task({

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -41,7 +41,9 @@ async function makeSubject() {
     cardService,
     grantService,
     now,
-    advance: (milliseconds: number) => { currentTime += milliseconds; },
+    advance: (milliseconds: number) => {
+      currentTime += milliseconds;
+    },
     cleanup: async () => {
       StorageManager.clearAllStaticCaches();
       await rm(root, { recursive: true, force: true });
@@ -81,7 +83,7 @@ test("a grant stores only hashed credentials with private file permissions", asy
       "state",
       "support-passport",
       "grants",
-      `${created.grant.grantId}.json`,
+      `${created.grant.grantId}.json`
     );
     const body = await readFile(filePath, "utf8");
     assert.equal(body.includes(created.secret), false);
@@ -108,14 +110,18 @@ test("a helper sees only the selected active card through a valid secret", async
       grantId: created.grant.grantId,
       secret: created.secret,
     });
-    assert.deepEqual(guide.cards, [{
-      cardId: selected.cardId,
-      title: "Selected card",
-      statement: "Offer me a quiet place and time.",
-      category: "environment",
-      updatedAt: selected.updatedAt,
-    }]);
-    assert.equal("revision" in guide.cards[0]!, false);
+    assert.deepEqual(guide.cards, [
+      {
+        cardId: selected.cardId,
+        title: "Selected card",
+        statement: "Offer me a quiet place and time.",
+        category: "environment",
+        updatedAt: selected.updatedAt,
+      },
+    ]);
+    const sharedCard = guide.cards[0];
+    assert.ok(sharedCard);
+    assert.equal("revision" in sharedCard, false);
     assert.equal("namespace" in guide, false);
   } finally {
     await subject.cleanup();
@@ -134,7 +140,8 @@ test("bad secrets return not found, while valid revoked or expired grants return
 
     await assert.rejects(
       subject.grantService.readGrant({ grantId: created.grant.grantId, secret: "x".repeat(43) }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_not_found" && error.status === 404,
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "grant_not_found" && error.status === 404
     );
 
     const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
@@ -154,7 +161,7 @@ test("bad secrets return not found, while valid revoked or expired grants return
     assert.equal(repeated.revokedAt, peerRevoked.revokedAt);
     await assert.rejects(
       subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone" && error.status === 410,
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone" && error.status === 410
     );
 
     const second = await subject.grantService.createGrant({
@@ -165,7 +172,7 @@ test("bad secrets return not found, while valid revoked or expired grants return
     subject.advance(300_001);
     await assert.rejects(
       subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
     );
   } finally {
     await subject.cleanup();
@@ -193,7 +200,7 @@ test("a changed card makes the whole grant stale without a partial guide", async
 
     await assert.rejects(
       subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale" && error.status === 410,
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale" && error.status === 410
     );
   } finally {
     await subject.cleanup();
@@ -213,13 +220,19 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
 
     for (const input of [
       { cards: [{ cardId: draft.cardId, revision: draft.revision }], durationSeconds: 3_600 },
-      { cards: [{ cardId: active.cardId, revision: active.revision }, { cardId: active.cardId, revision: active.revision }], durationSeconds: 3_600 },
+      {
+        cards: [
+          { cardId: active.cardId, revision: active.revision },
+          { cardId: active.cardId, revision: active.revision },
+        ],
+        durationSeconds: 3_600,
+      },
       { cards: [{ cardId: active.cardId, revision: active.revision }], durationSeconds: 299 },
       { cards: [{ cardId: active.cardId, revision: active.revision }], durationSeconds: 604_801 },
     ]) {
       await assert.rejects(
         subject.grantService.createGrant({ principal: "owner:alice", ...input }),
-        (error: unknown) => error instanceof SupportPassportError,
+        (error: unknown) => error instanceof SupportPassportError
       );
     }
   } finally {
@@ -244,7 +257,7 @@ test("the grant store rejects a symlinked grant directory", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         durationSeconds: 300,
       }),
-      /must not be a symbolic link/,
+      /must not be a symbolic link/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -265,11 +278,11 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
     await store.create(input);
     await assert.rejects(
       store.create(input),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     await assert.rejects(
       store.create({ ...input, durationSeconds: 299 }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -244,6 +244,66 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
   }
 });
 
+test("owner grant history uses one expiry cutoff while it prunes old links", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cutoff-"));
+  try {
+    const initialTime = Date.parse("2026-08-11T12:00:00.000Z");
+    let currentTime = initialTime;
+    let partitionCalls = 0;
+    let crossExpiry = false;
+    let nextGrantId = 1;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      now: () => {
+        partitionCalls += 1;
+        return new Date(currentTime + (crossExpiry && partitionCalls > 101 ? 1 : 0));
+      },
+    });
+    const common = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(initialTime + 3_600_000).toISOString(),
+    };
+    const first = await store.create(common);
+    const second = await store.create(common);
+    for (let index = 2; index < 99; index += 1) await store.create(common);
+    await store.revoke({
+      grantId: first.state.grantId,
+      namespace: common.namespace,
+      principal: common.principal,
+    });
+    await store.revoke({
+      grantId: second.state.grantId,
+      namespace: common.namespace,
+      principal: common.principal,
+    });
+    currentTime = initialTime + 1_000;
+    const crossing = await store.create({
+      ...common,
+      expiresAt: new Date(currentTime + 300_000).toISOString(),
+    });
+    currentTime = Date.parse(crossing.state.expiresAt) - 1;
+    partitionCalls = 0;
+    crossExpiry = true;
+
+    const created = await store.create({
+      ...common,
+      expiresAt: new Date(currentTime + 3_600_000).toISOString(),
+    });
+    crossExpiry = false;
+    const listed = await store.listForOwner(common.namespace, common.principal);
+
+    assert.equal(listed.length, 100);
+    assert.equal(new Set(listed.map((state) => state.grantId)).size, 100);
+    assert.equal(listed.some((state) => state.grantId === crossing.state.grantId), true);
+    assert.equal(listed.some((state) => state.grantId === created.state.grantId), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("grant mutations report a storage conflict when the file lock is busy", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-busy-"));
   try {
@@ -593,6 +653,42 @@ test("revocation waits until helper guide assembly completes", async () => {
   } finally {
     releaseCardRead.resolve();
     await subject.cleanup();
+  }
+});
+
+test("helper reads for different grants do not block each other", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-read-lock-"));
+  const releaseFirst = Promise.withResolvers<void>();
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const second = await store.create(input);
+    const firstStarted = Promise.withResolvers<void>();
+    const firstRead = store.withAuthenticatedGrant(first.state.grantId, first.secret, async () => {
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      return "first";
+    });
+    await firstStarted.promise;
+    const secondRead = store.withAuthenticatedGrant(second.state.grantId, second.secret, async () => "second");
+    const observedConcurrentRead = await Promise.race([
+      secondRead.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
+    ]);
+    releaseFirst.resolve();
+
+    assert.deepEqual(await Promise.all([firstRead, secondRead]), ["first", "second"]);
+    assert.equal(observedConcurrentRead, true);
+  } finally {
+    releaseFirst.resolve();
+    await rm(root, { recursive: true, force: true });
   }
 });
 

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1439,9 +1439,29 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
       syncs += 1;
     });
 
-    assert.equal(syncs, 2);
+    const ancestorCount = path.relative(path.parse(target).root, target).split(path.sep).length;
+    assert.equal(syncs, ancestorCount);
     assert.equal((await lstat(target)).isDirectory(), true);
     assert.equal((await lstat(target)).mode & 0o777, 0o700);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("private directory tree creation rejects a symlink in the ancestor chain", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-link-"));
+  try {
+    const outside = path.join(root, "outside");
+    const linked = path.join(root, "linked");
+    const target = path.join(linked, "new-parent", "memory");
+    await mkdir(outside);
+    await symlink(outside, linked);
+
+    await assert.rejects(
+      ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed"),
+      /private directory creation failed/
+    );
+    assert.deepEqual(await readdir(outside), []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1649,6 +1669,55 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
     );
     await assert.rejects(
       store.create({ ...input, expiresAt: new Date(now.getTime() + 299_999).toISOString() }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the grant store canonicalizes UUID letter case", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-id-case-"));
+  try {
+    const uppercaseGrantId = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA";
+    const lowercaseGrantId = uppercaseGrantId.toLowerCase();
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => uppercaseGrantId,
+      now: () => now,
+    });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    });
+
+    assert.equal(created.state.grantId, lowercaseGrantId);
+    assert.equal((await store.authenticate(uppercaseGrantId, created.secret)).grantId, lowercaseGrantId);
+    assert.equal(
+      (await store.revoke({ grantId: uppercaseGrantId, namespace: "alice", principal: "owner:alice" })).grantId,
+      lowercaseGrantId
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the grant store rejects invalid calendar dates", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-date-"));
+  try {
+    const now = new Date("2026-02-28T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: "2026-02-31T12:00:00.000Z",
+      }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
   } finally {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -9,9 +9,9 @@ import { StorageManager } from "../storage.js";
 import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
-import { computeSupportPassportOwnerLockKey, supportPassportOwnerLockPath } from "./owner-lock.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
+import { computeSupportPassportOwnerLockKey, supportPassportOwnerLockPath } from "./owner-lock.js";
 import {
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
@@ -376,7 +376,10 @@ test("grant creation accepts a state write that committed before its durability 
       (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
       [grantId]
     );
-    assert.deepEqual(directorySyncs.map((directory) => path.basename(directory)), ["grants"]);
+    assert.deepEqual(
+      directorySyncs.map((directory) => path.basename(directory)),
+      ["grants"]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -454,7 +457,7 @@ test("grant creation re-syncs an owner index write that committed before its dur
   }
 });
 
-test("grant revocation retries directory durability before reporting an existing revoked state", async () => {
+test("idempotent revocation reports the persisted state without another sync", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-revoke-sync-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -497,13 +500,13 @@ test("grant revocation retries directory durability before reporting an existing
 
     assert.ok(repeated.revokedAt);
     assert.equal(repeated.stateVersion, 2);
-    assert.equal(syncAttempts, 2);
+    assert.equal(syncAttempts, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("owner grant rollover rejects a foreign grant without deleting it", async () => {
+test("owner grant rollover ignores a foreign derived-index entry", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-foreign-index-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -541,10 +544,10 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
     ]);
     const bobGrantPath = path.join(root, "state", "support-passport", "grants", `${bob.state.grantId}.json`);
 
-    await assert.rejects(
-      store.create({ ...common, principal: "owner:alice" }),
-      /owner index references a foreign grant/
-    );
+    const replacement = await store.create({ ...common, principal: "owner:alice" });
+
+    assert.equal((await store.listForOwner(common.namespace, "owner:alice")).length, 100);
+    assert.equal(replacement.state.principalHash, firstAliceGrant.state.principalHash);
     assert.equal((await lstat(bobGrantPath)).isFile(), true);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -785,7 +788,7 @@ test("grant creation rejects a future request time that would extend the maximum
         requestedAt,
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "invalid_input" && error.status === 400,
+        error instanceof SupportPassportError && error.code === "invalid_input" && error.status === 400
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -853,10 +856,7 @@ test("grant creation aborts before replacing an owner index after lock ownership
 test("grant creation reconciles peer state when the owner-index lock is lost after write", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-fence-"));
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const peerGrantId = "00000000-0000-4000-8000-000000000003";
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
@@ -877,10 +877,7 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       secretHash: "b".repeat(64),
     };
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
       writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
       writeOwnerMembership(state: typeof peerState): Promise<void>;
@@ -910,9 +907,9 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
     };
 
     const created = await store.create(input);
-    const listedIds = new Set((await store.listForOwner(input.namespace, input.principal)).map(
-      (state) => state.grantId,
-    ));
+    const listedIds = new Set(
+      (await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)
+    );
 
     assert.equal(ownerLockRun, 3);
     assert.equal(refreshesByRun.get(1), 2);
@@ -926,10 +923,7 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
 test("grant recovery propagates transient reads from an owner membership", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-recovery-read-"));
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const peerGrantId = "00000000-0000-4000-8000-000000000003";
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
@@ -950,10 +944,7 @@ test("grant recovery propagates transient reads from an owner membership", async
       secretHash: "b".repeat(64),
     };
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
       writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
       writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
       writeOwnerMembership(state: typeof peerState): Promise<void>;
@@ -989,14 +980,12 @@ test("grant recovery propagates transient reads from an owner membership", async
       return await readState(grantId);
     };
 
-    await assert.rejects(
-      store.create(input),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
-    );
+    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
     assert.equal(ownerLockRun, 2);
     assert.equal(
-      JSON.parse(await readFile(path.join(root, "state", "support-passport", "grants", `${peerGrantId}.json`), "utf8")).grantId,
-      peerGrantId,
+      JSON.parse(await readFile(path.join(root, "state", "support-passport", "grants", `${peerGrantId}.json`), "utf8"))
+        .grantId,
+      peerGrantId
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1013,10 +1002,7 @@ test("grant recovery stops after repeated owner-index lock loss", async () => {
       now: () => now,
     });
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
     };
     let ownerLockRuns = 0;
     inspected.withOwnerIndexLock = async (_ownerHash, task) => {
@@ -1037,7 +1023,7 @@ test("grant recovery stops after repeated owner-index lock loss", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
       }),
-      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(ownerLockRuns, 4);
   } finally {
@@ -1048,10 +1034,7 @@ test("grant recovery stops after repeated owner-index lock loss", async () => {
 test("grant recovery prunes a stale owner-index entry after lock loss", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-stale-index-recovery-"));
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
@@ -1066,10 +1049,7 @@ test("grant recovery prunes a stale owner-index entry after lock loss", async ()
     };
     const first = await store.create(input);
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
       writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
     };
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
@@ -1099,7 +1079,7 @@ test("grant recovery prunes a stale owner-index entry after lock loss", async ()
     assert.equal(firstRunRefreshes, 2);
     assert.deepEqual(
       (await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId),
-      [created.state.grantId],
+      [created.state.grantId]
     );
     assert.equal((await store.authenticate(created.state.grantId, created.secret)).grantId, created.state.grantId);
   } finally {
@@ -1110,10 +1090,7 @@ test("grant recovery prunes a stale owner-index entry after lock loss", async ()
 test("grant recovery ignores malformed unindexed grant files", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-scoped-recovery-"));
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const unindexedGrantId = "00000000-0000-4000-8000-000000000003";
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
@@ -1135,17 +1112,14 @@ test("grant recovery ignores malformed unindexed grant files", async () => {
     let ownerLockRun = 0;
     let firstRunRefreshes = 0;
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
       ownerHash(namespace: string, principalHash: string): string;
     };
     const ownerHash = inspected.ownerHash(first.state.namespace, first.state.principalHash);
     await writeFile(
       path.join(grantsDir, "owners", ownerHash, `${unindexedGrantId}.json`),
       `${JSON.stringify({ schemaVersion: 1, grantId: unindexedGrantId })}\n`,
-      { mode: 0o600 },
+      { mode: 0o600 }
     );
     inspected.withOwnerIndexLock = async (_ownerHash, task) => {
       ownerLockRun += 1;
@@ -1163,7 +1137,7 @@ test("grant recovery ignores malformed unindexed grant files", async () => {
     assert.equal(ownerLockRun, 2);
     assert.deepEqual(
       new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
-      new Set([first.state.grantId, created.state.grantId]),
+      new Set([first.state.grantId, created.state.grantId])
     );
     assert.equal(await readFile(path.join(grantsDir, `${unindexedGrantId}.json`), "utf8"), "not valid JSON");
   } finally {
@@ -1174,8 +1148,9 @@ test("grant recovery ignores malformed unindexed grant files", async () => {
 test("grant recovery reads only the affected owner's membership after lock loss", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-scoped-recovery-"));
   try {
-    const grantIds = Array.from({ length: 8 }, (_, index) =>
-      `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+    const grantIds = Array.from(
+      { length: 8 },
+      (_, index) => `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`
     );
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
@@ -1194,10 +1169,7 @@ test("grant recovery reads only the affected owner's membership after lock loss"
       bobGrantIds.add((await store.create({ ...input, principal: "owner:bob" })).state.grantId);
     }
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
       readState(grantId: string): Promise<{ grantId: string }>;
     };
     let ownerLockRun = 0;
@@ -1222,7 +1194,10 @@ test("grant recovery reads only the affected owner's membership after lock loss"
     await store.create({ ...input, principal: "owner:alice" });
 
     assert.equal(ownerLockRun, 2);
-    assert.equal(recoveryReads.some((grantId) => bobGrantIds.has(grantId)), false);
+    assert.equal(
+      recoveryReads.some((grantId) => bobGrantIds.has(grantId)),
+      false
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1232,10 +1207,7 @@ test("one owner's index transaction does not block another owner", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-concurrency-"));
   const releaseAlice = Promise.withResolvers<void>();
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
@@ -1243,10 +1215,7 @@ test("one owner's index transaction does not block another owner", async () => {
       now: () => now,
     });
     const inspected = store as unknown as {
-      withOwnerIndexLock<T>(
-        ownerHash: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
     };
     const withOwnerIndexLock = inspected.withOwnerIndexLock.bind(store);
     const aliceEntered = Promise.withResolvers<void>();
@@ -1272,7 +1241,7 @@ test("one owner's index transaction does not block another owner", async () => {
     const bob = await Promise.race([
       store.create({ ...input, principal: "owner:bob" }),
       new Promise<never>((_resolve, reject) =>
-        setTimeout(() => reject(new Error("another owner was blocked by Alice's index lock")), 1_000),
+        setTimeout(() => reject(new Error("another owner was blocked by Alice's index lock")), 1_000)
       ),
     ]);
     assert.equal(bob.state.namespace, "shared");
@@ -2364,10 +2333,7 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
       syncs += 1;
     });
 
-    const expectedSyncs = path
-      .relative(path.parse(target).root, target)
-      .split(path.sep)
-      .filter(Boolean).length;
+    const expectedSyncs = path.relative(path.parse(target).root, target).split(path.sep).filter(Boolean).length;
     assert.equal(syncs, expectedSyncs);
     assert.equal((await lstat(target)).isDirectory(), true);
     assert.equal((await lstat(target)).mode & 0o777, 0o700);
@@ -2431,7 +2397,7 @@ test("the grant store rejects a symlink alias in the configured memory root", as
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
-      /memory directory must be a stable directory/,
+      /memory directory must be a stable directory/
     );
     assert.deepEqual(await readdir(actual), []);
   } finally {
@@ -2447,10 +2413,22 @@ test("Windows private-file operations fail before mutation", async () => {
     const errorMessage = "private Windows file operation failed";
     await assert.rejects(
       ensurePrivateDirectoryNoFollow(root, directory, errorMessage, undefined, true, "win32"),
-      new RegExp(errorMessage),
+      new RegExp(errorMessage)
     );
-    assert.equal(await lstat(directory).then(() => true, () => false), false);
-    assert.equal(await lstat(filePath).then(() => true, () => false), false);
+    assert.equal(
+      await lstat(directory).then(
+        () => true,
+        () => false
+      ),
+      false
+    );
+    assert.equal(
+      await lstat(filePath).then(
+        () => true,
+        () => false
+      ),
+      false
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -2590,7 +2568,7 @@ test("grant reads reject a memory-root ancestor swapped after a completed operat
 
     await assert.rejects(
       store.listForOwner("alice", "owner:alice"),
-      /support passport owner indexes must be regular files in a stable directory/,
+      /support passport owner indexes must be regular files in a stable directory/
     );
     assert.deepEqual(await readdir(path.join(outsideParent, "memory", "state", "support-passport", "grants")), [
       "owners",

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -2136,7 +2136,7 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
   }
 });
 
-test("one unchanged guide read projects one corpus snapshot", async () => {
+test("one unchanged guide read validates a fresh final corpus snapshot", async () => {
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
@@ -2161,7 +2161,7 @@ test("one unchanged guide read projects one corpus snapshot", async () => {
     });
 
     assert.equal(guide.cards[0]?.cardId, card.cardId);
-    assert.equal(corpusReads, 1);
+    assert.equal(corpusReads, 2);
   } finally {
     await subject.cleanup();
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -19,12 +19,8 @@ import { StorageManager } from "../storage.js";
 import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
-import { supportPassportOwnerLockPath } from "./owner-lock.js";
 import { SupportPassportGrantService } from "./grant-service.js";
-import {
-  SupportPassportGrantStore,
-  syncDirectoryForDurability,
-} from "./grant-store.js";
+import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 import {
   canonicalizePrivateDirectoryTarget,
   ensurePrivateDirectoryNoFollow,
@@ -37,24 +33,16 @@ async function makeSubject() {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grants-"));
   const aliceStorage = new StorageManager(path.join(root, "alice"));
   const bobStorage = new StorageManager(path.join(root, "bob"));
-  await Promise.all([
-    aliceStorage.ensureDirectories(),
-    bobStorage.ensureDirectories(),
-  ]);
+  await Promise.all([aliceStorage.ensureDirectories(), bobStorage.ensureDirectories()]);
   let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
   const now = () => new Date(currentTime);
   const resolveOwner = async (principal: string) => {
-    if (principal === "owner:alice")
-      return { principal, namespace: "alice", storage: aliceStorage };
-    if (principal === "owner:bob")
-      return { principal, namespace: "bob", storage: bobStorage };
+    if (principal === "owner:alice") return { principal, namespace: "alice", storage: aliceStorage };
+    if (principal === "owner:bob") return { principal, namespace: "bob", storage: bobStorage };
     throw new Error("unknown test principal");
   };
   const cardService = new SupportPassportCardService({ resolveOwner, now });
-  const grantStore = new SupportPassportGrantStore({
-    memoryDir: path.join(root, "shared"),
-    now,
-  });
+  const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "shared"), now });
   const grantService = new SupportPassportGrantService({
     grantStore,
     resolveOwner,
@@ -83,10 +71,7 @@ async function makeSubject() {
   };
 }
 
-async function createActiveCard(
-  subject: Awaited<ReturnType<typeof makeSubject>>,
-  title = "Quiet space",
-) {
+async function createActiveCard(subject: Awaited<ReturnType<typeof makeSubject>>, title = "Quiet space") {
   const draft = await subject.cardService.createManualDraft({
     principal: "owner:alice",
     title,
@@ -101,10 +86,7 @@ async function createActiveCard(
   });
 }
 
-function expiryAfter(
-  subject: Awaited<ReturnType<typeof makeSubject>>,
-  milliseconds: number,
-): string {
+function expiryAfter(subject: Awaited<ReturnType<typeof makeSubject>>, milliseconds: number): string {
   return new Date(subject.now().getTime() + milliseconds).toISOString();
 }
 
@@ -127,7 +109,7 @@ test("a grant stores only hashed credentials with private file permissions", asy
       "state",
       "support-passport",
       "grants",
-      `${created.grant.grantId}.json`,
+      `${created.grant.grantId}.json`
     );
     const body = await readFile(filePath, "utf8");
     assert.equal(body.includes(created.secret), false);
@@ -140,19 +122,13 @@ test("a grant stores only hashed credentials with private file permissions", asy
 });
 
 test("owner grant listings read only the indexed owner grants", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-index-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-"));
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
       now: () => now,
     });
     const common = {
@@ -176,7 +152,7 @@ test("owner grant listings read only the indexed owner grants", async () => {
 
     assert.deepEqual(
       listed.map((state) => state.grantId),
-      [alice.state.grantId],
+      [alice.state.grantId]
     );
     assert.deepEqual(readGrantIds, [alice.state.grantId]);
     assert.notEqual(alice.state.grantId, bob.state.grantId);
@@ -186,34 +162,25 @@ test("owner grant listings read only the indexed owner grants", async () => {
 });
 
 test("owner grant listings propagate indexed grant read failures", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-list-error-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-error-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      now: () => now,
-    });
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
     const created = await store.create({
       namespace: "alice",
       principal: "owner:alice",
       cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
       expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
     });
-    const inspected = store as unknown as {
-      readState(grantId: string): Promise<unknown>;
-    };
+    const inspected = store as unknown as { readState(grantId: string): Promise<unknown> };
     inspected.readState = async (grantId) => {
       assert.equal(grantId, created.state.grantId);
-      throw Object.assign(new Error("simulated grant read failure"), {
-        code: "EIO",
-      });
+      throw Object.assign(new Error("simulated grant read failure"), { code: "EIO" });
     };
 
     await assert.rejects(
       store.listForOwner("alice", "owner:alice"),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -221,16 +188,13 @@ test("owner grant listings propagate indexed grant read failures", async () => {
 });
 
 test("owner grant listings put active links before inactive history", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-list-order-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-order-"));
   try {
     let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => new Date(currentTime),
     });
     const input = {
@@ -241,10 +205,7 @@ test("owner grant listings put active links before inactive history", async () =
     };
     const inactive = await store.create(input);
     currentTime += 1_000;
-    const active = await store.create({
-      ...input,
-      expiresAt: new Date(currentTime + 3_600_000).toISOString(),
-    });
+    const active = await store.create({ ...input, expiresAt: new Date(currentTime + 3_600_000).toISOString() });
     await store.revoke({
       grantId: inactive.state.grantId,
       namespace: input.namespace,
@@ -255,7 +216,7 @@ test("owner grant listings put active links before inactive history", async () =
 
     assert.deepEqual(
       listed.map((state) => state.grantId),
-      [active.state.grantId, inactive.state.grantId],
+      [active.state.grantId, inactive.state.grantId]
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -263,15 +224,10 @@ test("owner grant listings put active links before inactive history", async () =
 });
 
 test("owner grant operations reject a noncanonical namespace and trim the principal", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-namespace-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-namespace-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      now: () => now,
-    });
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
     await assert.rejects(
       store.create({
         namespace: " alice ",
@@ -279,8 +235,7 @@ test("owner grant operations reject a noncanonical namespace and trim the princi
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
       }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "invalid_input",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
     const created = await store.create({
       namespace: "alice",
@@ -290,10 +245,8 @@ test("owner grant operations reject a noncanonical namespace and trim the princi
     });
 
     assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map(
-        (state) => state.grantId,
-      ),
-      [created.state.grantId],
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [created.state.grantId]
     );
     const revoked = await store.revoke({
       grantId: created.state.grantId,
@@ -308,16 +261,13 @@ test("owner grant operations reject a noncanonical namespace and trim the princi
 });
 
 test("owner grant history stays bounded while an inactive link frees capacity", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-history-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-history-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => now,
     });
     const input = {
@@ -331,8 +281,7 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
 
     await assert.rejects(
       store.create(input),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "invalid_input",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
     await store.revoke({
       grantId: first.state.grantId,
@@ -340,13 +289,7 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
       principal: input.principal,
       expectedStateVersion: first.state.stateVersion,
     });
-    const firstGrantPath = path.join(
-      root,
-      "state",
-      "support-passport",
-      "grants",
-      `${first.state.grantId}.json`,
-    );
+    const firstGrantPath = path.join(root, "state", "support-passport", "grants", `${first.state.grantId}.json`);
     const inspected = store as unknown as {
       readState(grantId: string): Promise<unknown>;
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
@@ -354,44 +297,25 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     const readState = inspected.readState.bind(store);
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
     inspected.writeOwnerIndex = async () => {
-      throw Object.assign(new Error("simulated owner index write failure"), {
-        code: "EIO",
-      });
+      throw Object.assign(new Error("simulated owner index write failure"), { code: "EIO" });
     };
-    await assert.rejects(
-      store.create(input),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
-    );
+    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
     inspected.writeOwnerIndex = writeOwnerIndex;
     assert.equal((await lstat(firstGrantPath)).isFile(), true);
-    assert.equal(
-      (await store.listForOwner(input.namespace, input.principal)).length,
-      100,
-    );
+    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
 
     inspected.readState = async (grantId) => {
       if (grantId === first.state.grantId) {
-        throw Object.assign(new Error("simulated indexed grant read failure"), {
-          code: "EIO",
-        });
+        throw Object.assign(new Error("simulated indexed grant read failure"), { code: "EIO" });
       }
       return await readState(grantId);
     };
-    await assert.rejects(
-      store.create(input),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
-    );
+    await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
     inspected.readState = readState;
-    assert.equal(
-      (await store.listForOwner(input.namespace, input.principal)).length,
-      100,
-    );
+    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
     const evictedGrantLocks: string[] = [];
     const lockAwareStore = store as unknown as {
-      withGrantLock<T>(
-        grantId: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withGrantLock<T>(grantId: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
     };
     const withGrantLock = lockAwareStore.withGrantLock.bind(store);
     lockAwareStore.withGrantLock = async (grantId, task) => {
@@ -403,43 +327,32 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     assert.equal(listed.length, 100);
     assert.equal(
       listed.some((state) => state.grantId === first.state.grantId),
-      false,
+      false
     );
     assert.equal(
       listed.some((state) => state.grantId === replacement.state.grantId),
-      true,
+      true
     );
     assert.deepEqual(evictedGrantLocks, [first.state.grantId]);
-    await assert.rejects(
-      lstat(firstGrantPath),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
-    );
+    await assert.rejects(lstat(firstGrantPath), (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT");
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
 test("grant creation accepts a state write that committed before its durability error", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-state-commit-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-commit-"));
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      makeGrantId: () => grantId,
-      now: () => now,
-    });
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
     const inspected = store as unknown as {
       writeState(state: unknown, requireAbsent: boolean): Promise<void>;
     };
     const writeState = inspected.writeState.bind(store);
     inspected.writeState = async (state, requireAbsent) => {
       await writeState(state, requireAbsent);
-      throw Object.assign(new Error("simulated post-commit state error"), {
-        code: "EIO",
-      });
+      throw Object.assign(new Error("simulated post-commit state error"), { code: "EIO" });
     };
 
     const created = await store.create({
@@ -450,38 +363,25 @@ test("grant creation accepts a state write that committed before its durability 
     });
 
     assert.equal(created.state.grantId, grantId);
-    assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map(
-        (state) => state.grantId,
-      ),
-      [grantId],
-    );
+    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
 test("grant creation accepts an owner index write that committed before its durability error", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-index-commit-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-commit-"));
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      makeGrantId: () => grantId,
-      now: () => now,
-    });
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
     const inspected = store as unknown as {
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
     };
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
     inspected.writeOwnerIndex = async (ownerHash, grantIds) => {
       await writeOwnerIndex(ownerHash, grantIds);
-      throw Object.assign(new Error("simulated post-commit index error"), {
-        code: "EIO",
-      });
+      throw Object.assign(new Error("simulated post-commit index error"), { code: "EIO" });
     };
 
     const created = await store.create({
@@ -492,28 +392,20 @@ test("grant creation accepts an owner index write that committed before its dura
     });
 
     assert.equal(created.state.grantId, grantId);
-    assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map(
-        (state) => state.grantId,
-      ),
-      [grantId],
-    );
+    assert.deepEqual((await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId), [grantId]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
 test("owner grant rollover rejects a foreign grant without deleting it", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-foreign-index-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-foreign-index-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => now,
     });
     const common = {
@@ -523,9 +415,7 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
     };
     const aliceGrants = [];
     for (let index = 0; index < 99; index += 1) {
-      aliceGrants.push(
-        await store.create({ ...common, principal: "owner:alice" }),
-      );
+      aliceGrants.push(await store.create({ ...common, principal: "owner:alice" }));
     }
     const bob = await store.create({ ...common, principal: "owner:bob" });
     await store.revoke({
@@ -539,25 +429,16 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
     };
     const firstAliceGrant = aliceGrants[0];
     assert.ok(firstAliceGrant);
-    const aliceOwnerHash = inspected.ownerHash(
-      common.namespace,
-      firstAliceGrant.state.principalHash,
-    );
+    const aliceOwnerHash = inspected.ownerHash(common.namespace, firstAliceGrant.state.principalHash);
     await inspected.writeOwnerIndex(aliceOwnerHash, [
       ...aliceGrants.map((grant) => grant.state.grantId),
       bob.state.grantId,
     ]);
-    const bobGrantPath = path.join(
-      root,
-      "state",
-      "support-passport",
-      "grants",
-      `${bob.state.grantId}.json`,
-    );
+    const bobGrantPath = path.join(root, "state", "support-passport", "grants", `${bob.state.grantId}.json`);
 
     await assert.rejects(
       store.create({ ...common, principal: "owner:alice" }),
-      /owner index references a foreign grant/,
+      /owner index references a foreign grant/
     );
     assert.equal((await lstat(bobGrantPath)).isFile(), true);
   } finally {
@@ -566,9 +447,7 @@ test("owner grant rollover rejects a foreign grant without deleting it", async (
 });
 
 test("owner grant history uses one expiry cutoff while it prunes old links", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-cutoff-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cutoff-"));
   try {
     const initialTime = Date.parse("2026-08-11T12:00:00.000Z");
     let currentTime = initialTime;
@@ -577,13 +456,10 @@ test("owner grant history uses one expiry cutoff while it prunes old links", asy
     let nextGrantId = 1;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
       now: () => {
         partitionCalls += 1;
-        return new Date(
-          currentTime + (crossExpiry && partitionCalls > 101 ? 1 : 0),
-        );
+        return new Date(currentTime + (crossExpiry && partitionCalls > 101 ? 1 : 0));
       },
     });
     const common = {
@@ -625,11 +501,11 @@ test("owner grant history uses one expiry cutoff while it prunes old links", asy
     assert.equal(new Set(listed.map((state) => state.grantId)).size, 100);
     assert.equal(
       listed.some((state) => state.grantId === crossing.state.grantId),
-      true,
+      true
     );
     assert.equal(
       listed.some((state) => state.grantId === created.state.grantId),
-      true,
+      true
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -641,10 +517,7 @@ test("grant mutations report a storage conflict when the file lock is busy", asy
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
     const rejectLock = (async (_lockPath, _options, task) =>
-      await task(false, {
-        refresh: async () => false,
-        failure: "timeout",
-      })) as typeof withHeldFileLock;
+      await task(false, { refresh: async () => false, failure: "timeout" })) as typeof withHeldFileLock;
     const store = new SupportPassportGrantStore({
       memoryDir: root,
       now: () => now,
@@ -659,9 +532,7 @@ test("grant mutations report a storage conflict when the file lock is busy", asy
         expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict" &&
-        error.status === 409,
+        error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -672,22 +543,14 @@ test("grant creation rechecks the owner lock immediately before commit", async (
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
-    const originalRead = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const originalRead = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let replacedLock = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await originalRead(memoryId);
       if (!replacedLock) {
         replacedLock = true;
-        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
-          namespace: "alice",
-          principal: "owner:alice",
-        });
-        await writeFile(
-          lockPath,
-          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
-        );
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return memory;
     };
@@ -699,14 +562,9 @@ test("grant creation rechecks the owner lock immediately before commit", async (
         expiresAt: expiryAfter(subject, 300_000),
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict" &&
-        error.status === 409,
+        error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
     );
-    assert.deepEqual(
-      await subject.grantService.listGrants({ principal: "owner:alice" }),
-      [],
-    );
+    assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
   } finally {
     await subject.cleanup();
   }
@@ -722,25 +580,19 @@ test("directory sync ignores only explicit unsupported errors", async () => {
 
   await assert.rejects(
     syncDirectoryForDurability("/unused", failingOpen("EIO")),
-    (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+    (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
   );
   await syncDirectoryForDurability("/unused", failingOpen("EINVAL"));
 });
 
 test("grant creation aborts before replacing an owner index after lock ownership is lost", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-lock-loss-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-lock-loss-"));
   try {
-    const grantIds = [
-      "00000000-0000-4000-8000-000000000001",
-      "00000000-0000-4000-8000-000000000002",
-    ];
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir: root,
-      makeGrantId: () =>
-        grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
       now: () => now,
     });
     const input = {
@@ -752,9 +604,7 @@ test("grant creation aborts before replacing an owner index after lock ownership
     const first = await store.create(input);
     let refreshes = 0;
     const inspected = store as unknown as {
-      withMutationLock<T>(
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
+      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
     };
     inspected.withMutationLock = async (task) =>
       await task({
@@ -766,119 +616,12 @@ test("grant creation aborts before replacing an owner index after lock ownership
 
     await assert.rejects(
       store.create(input),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(refreshes, 2);
     assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map(
-        (state) => state.grantId,
-      ),
-      [first.state.grantId],
-    );
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
-test("grant creation rechecks its mutation lock after the commit callback", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-callback-lock-"),
-  );
-  try {
-    const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      now: () => now,
-    });
-    let refreshes = 0;
-    const inspected = store as unknown as {
-      withMutationLock<T>(
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
-    };
-    inspected.withMutationLock = async (task) =>
-      await task({
-        refresh: async () => {
-          refreshes += 1;
-          return refreshes === 1;
-        },
-      });
-
-    await assert.rejects(
-      store.create(
-        {
-          namespace: "alice",
-          principal: "owner:alice",
-          cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
-          expiresAt: new Date(now.getTime() + 300_000).toISOString(),
-        },
-        async () => undefined,
-      ),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
-    );
-    assert.equal(refreshes, 2);
-    await assert.rejects(
-      lstat(path.join(root, "state", "support-passport", "grants")),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
-    );
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
-test("grant revocation rechecks its mutation lock after the commit callback", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-revoke-callback-lock-"),
-  );
-  try {
-    const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      now: () => now,
-    });
-    const created = await store.create({
-      namespace: "alice",
-      principal: "owner:alice",
-      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
-      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
-    });
-    let refreshes = 0;
-    const inspected = store as unknown as {
-      withGrantLock<T>(
-        grantId: string,
-        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
-      ): Promise<T>;
-    };
-    inspected.withGrantLock = async (_grantId, task) =>
-      await task({
-        refresh: async () => {
-          refreshes += 1;
-          return refreshes === 1;
-        },
-      });
-
-    await assert.rejects(
-      store.revoke(
-        {
-          grantId: created.state.grantId,
-          namespace: "alice",
-          principal: "owner:alice",
-        },
-        async () => undefined,
-      ),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
-    );
-    assert.equal(refreshes, 2);
-    assert.equal(
-      (await store.authenticate(created.state.grantId, created.secret))
-        .revokedAt,
-      undefined,
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [first.state.grantId]
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -920,9 +663,7 @@ test("a helper sees only the selected active card through a valid secret", async
 
 test("grants reject cards owned by another namespace in shared storage", async () => {
   StorageManager.clearAllStaticCaches();
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-card-scope-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-card-scope-"));
   try {
     const storage = new StorageManager(path.join(root, "shared-storage"));
     await storage.ensureDirectories();
@@ -933,10 +674,7 @@ test("grants reject cards owned by another namespace in shared storage", async (
       storage,
     });
     const cardService = new SupportPassportCardService({ resolveOwner, now });
-    const grantStore = new SupportPassportGrantStore({
-      memoryDir: path.join(root, "grants"),
-      now,
-    });
+    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
     const grantService = new SupportPassportGrantService({
       grantStore,
       resolveOwner,
@@ -962,9 +700,7 @@ test("grants reject cards owned by another namespace in shared storage", async (
         cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
         expiresAt: "2026-08-11T13:00:00.000Z",
       }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "invalid_card_status",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
     );
     const forged = await grantStore.create({
       namespace: "bob",
@@ -973,12 +709,8 @@ test("grants reject cards owned by another namespace in shared storage", async (
       expiresAt: "2026-08-11T13:00:00.000Z",
     });
     await assert.rejects(
-      grantService.readGrant({
-        grantId: forged.state.grantId,
-        secret: forged.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_stale",
+      grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
     );
   } finally {
     StorageManager.clearAllStaticCaches();
@@ -988,23 +720,14 @@ test("grants reject cards owned by another namespace in shared storage", async (
 
 test("grants reject cards owned by another principal inside a shared namespace", async () => {
   StorageManager.clearAllStaticCaches();
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-owner-scope-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-scope-"));
   try {
     const storage = new StorageManager(path.join(root, "shared-storage"));
     await storage.ensureDirectories();
     const now = () => new Date("2026-08-11T12:00:00.000Z");
-    const resolveOwner = async (principal: string) => ({
-      principal,
-      namespace: "team",
-      storage,
-    });
+    const resolveOwner = async (principal: string) => ({ principal, namespace: "team", storage });
     const cardService = new SupportPassportCardService({ resolveOwner, now });
-    const grantStore = new SupportPassportGrantStore({
-      memoryDir: path.join(root, "grants"),
-      now,
-    });
+    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
     const grantService = new SupportPassportGrantService({
       grantStore,
       resolveOwner,
@@ -1030,9 +753,7 @@ test("grants reject cards owned by another principal inside a shared namespace",
         cards: [{ cardId: aliceCard.cardId, revision: aliceCard.revision }],
         expiresAt: "2026-08-11T13:00:00.000Z",
       }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "invalid_card_status",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
     );
     const forged = await grantStore.create({
       namespace: "team",
@@ -1041,12 +762,8 @@ test("grants reject cards owned by another principal inside a shared namespace",
       expiresAt: "2026-08-11T13:00:00.000Z",
     });
     await assert.rejects(
-      grantService.readGrant({
-        grantId: forged.state.grantId,
-        secret: forged.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_stale",
+      grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
     );
   } finally {
     StorageManager.clearAllStaticCaches();
@@ -1058,9 +775,7 @@ test("grant creation and card withdrawal cannot interleave", async () => {
   const subject = await makeSubject();
   try {
     const card = await createActiveCard(subject);
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let releaseRead!: () => void;
     let markReadStarted!: () => void;
     const readStarted = new Promise<void>((resolve) => {
@@ -1120,14 +835,9 @@ test("bad secrets return not found, while valid revoked and expired grants revea
     });
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: "x".repeat(43),
-      }),
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: "x".repeat(43) }),
       (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "grant_not_found" &&
-        error.status === 404,
+        error instanceof SupportPassportError && error.code === "grant_not_found" && error.status === 404
     );
 
     await assert.rejects(
@@ -1138,15 +848,10 @@ test("bad secrets return not found, while valid revoked and expired grants revea
         expectedStateVersion: created.grant.stateVersion + 1,
       }),
       (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "state_conflict" &&
-        error.status === 409,
+        error instanceof SupportPassportError && error.code === "state_conflict" && error.status === 409
     );
 
-    const peerStore = new SupportPassportGrantStore({
-      memoryDir: path.join(subject.root, "shared"),
-      now: subject.now,
-    });
+    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
     const peerRevoked = await peerStore.revoke({
       namespace: "alice",
       principal: "owner:alice",
@@ -1162,14 +867,8 @@ test("bad secrets return not found, while valid revoked and expired grants revea
     assert.equal(repeated.stateVersion, peerRevoked.stateVersion);
     assert.equal(repeated.revokedAt, peerRevoked.revokedAt);
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "grant_gone" &&
-        error.status === 410,
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone" && error.status === 410
     );
 
     const second = await subject.grantService.createGrant({
@@ -1179,14 +878,9 @@ test("bad secrets return not found, while valid revoked and expired grants revea
     });
     subject.advance(300_000);
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: second.grant.grantId,
-        secret: second.secret,
-      }),
+      subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret }),
       (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "grant_expired" &&
-        error.status === 410,
+        error instanceof SupportPassportError && error.code === "grant_expired" && error.status === 410
     );
   } finally {
     await subject.cleanup();
@@ -1202,9 +896,7 @@ test("a grant that expires during guide assembly does not return a guide", async
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 300_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let advanced = false;
     subject.aliceStorage.getMemoryById = async (memoryId) => {
       const memory = await getMemoryById(memoryId);
@@ -1216,12 +908,8 @@ test("a grant that expires during guide assembly does not return a guide", async
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_expired",
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_expired"
     );
   } finally {
     await subject.cleanup();
@@ -1239,13 +927,8 @@ test("revocation wins while an optimistic helper card read is still pending", as
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const peerStore = new SupportPassportGrantStore({
-      memoryDir: path.join(subject.root, "shared"),
-      now: subject.now,
-    });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let paused = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
@@ -1273,8 +956,7 @@ test("revocation wins while an optimistic helper card read is still pending", as
     releaseCardRead.resolve();
     await assert.rejects(
       readPromise,
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_gone",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
     );
   } finally {
     releaseCardRead.resolve();
@@ -1300,9 +982,7 @@ test("helper reads for different grants do not block each other", async () => {
     });
     const firstStarted = Promise.withResolvers<void>();
     const secondStarted = Promise.withResolvers<void>();
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
       if (memoryId === firstCard.cardId) {
@@ -1312,25 +992,16 @@ test("helper reads for different grants do not block each other", async () => {
       if (memoryId === secondCard.cardId) secondStarted.resolve();
       return memory;
     };
-    const firstRead = subject.grantService.readGrant({
-      grantId: first.grant.grantId,
-      secret: first.secret,
-    });
+    const firstRead = subject.grantService.readGrant({ grantId: first.grant.grantId, secret: first.secret });
     await firstStarted.promise;
-    const secondRead = subject.grantService.readGrant({
-      grantId: second.grant.grantId,
-      secret: second.secret,
-    });
+    const secondRead = subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret });
     const observedConcurrentRead = await Promise.race([
       secondStarted.promise.then(() => true),
       new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
     ]);
     releaseFirst.resolve();
 
-    const [firstGuide, secondGuide] = await Promise.all([
-      firstRead,
-      secondRead,
-    ]);
+    const [firstGuide, secondGuide] = await Promise.all([firstRead, secondRead]);
     assert.equal(observedConcurrentRead, true);
     assert.equal(firstGuide.cards[0]?.cardId, firstCard.cardId);
     assert.equal(secondGuide.cards[0]?.cardId, secondCard.cardId);
@@ -1342,10 +1013,7 @@ test("helper reads for different grants do not block each other", async () => {
 
 test("helper guide snapshots read selected cards in parallel", async () => {
   const subject = await makeSubject();
-  const pairedReads = [
-    Promise.withResolvers<void>(),
-    Promise.withResolvers<void>(),
-  ];
+  const pairedReads = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
   try {
     const firstCard = await createActiveCard(subject, "First card");
     const secondCard = await createActiveCard(subject, "Second card");
@@ -1357,9 +1025,7 @@ test("helper guide snapshots read selected cards in parallel", async () => {
       ],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let selectedReads = 0;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const selectedRead = selectedReads;
@@ -1369,9 +1035,7 @@ test("helper guide snapshots read selected cards in parallel", async () => {
       else {
         const concurrent = await Promise.race([
           pair?.promise.then(() => true),
-          new Promise<false>((resolve) =>
-            setTimeout(() => resolve(false), 500),
-          ),
+          new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
         ]);
         assert.equal(concurrent, true);
       }
@@ -1385,7 +1049,7 @@ test("helper guide snapshots read selected cards in parallel", async () => {
 
     assert.deepEqual(
       guide.cards.map((card) => card.cardId),
-      [firstCard.cardId, secondCard.cardId],
+      [firstCard.cardId, secondCard.cardId]
     );
     assert.equal(selectedReads, 4);
   } finally {
@@ -1405,9 +1069,7 @@ test("final helper guide assembly blocks card withdrawal", async () => {
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(
-      subject.grantStore,
-    );
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
@@ -1459,9 +1121,7 @@ test("final helper guide assembly blocks owner revocation", async () => {
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(
-      subject.grantStore,
-    );
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
@@ -1511,34 +1171,21 @@ test("helper guide assembly fails when owner-lock ownership is lost", async () =
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(
-      subject.grantStore,
-    );
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
       authentications += 1;
       if (authentications === 2) {
-        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
-          namespace: "alice",
-          principal: "owner:alice",
-        });
-        await writeFile(
-          lockPath,
-          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
-        );
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return state;
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
   } finally {
     await subject.cleanup();
@@ -1554,34 +1201,21 @@ test("helper guide assembly rechecks the owner lock after grant reauthentication
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const authenticate = subject.grantStore.authenticate.bind(
-      subject.grantStore,
-    );
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
     let authentications = 0;
     subject.grantStore.authenticate = async (grantId, secret) => {
       const state = await authenticate(grantId, secret);
       authentications += 1;
       if (authentications === 3) {
-        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
-          namespace: "alice",
-          principal: "owner:alice",
-        });
-        await writeFile(
-          lockPath,
-          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
-        );
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return state;
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(authentications, 3);
   } finally {
@@ -1598,34 +1232,21 @@ test("helper guide assembly refreshes the owner lock after its final card read",
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let reads = 0;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
       reads += 1;
       if (reads === 2) {
-        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
-          namespace: "alice",
-          principal: "owner:alice",
-        });
-        await writeFile(
-          lockPath,
-          `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`,
-        );
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return memory;
     };
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(reads, 2);
   } finally {
@@ -1642,26 +1263,16 @@ test("helper guide assembly rechecks expiry after its final owner-lock refresh",
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 300_000),
     });
-    const withAuthenticatedGrant =
-      subject.grantStore.withAuthenticatedGrant.bind(subject.grantStore);
-    subject.grantStore.withAuthenticatedGrant = async (
-      grantId,
-      secret,
-      task,
-      beforeReturn,
-    ) =>
+    const withAuthenticatedGrant = subject.grantStore.withAuthenticatedGrant.bind(subject.grantStore);
+    subject.grantStore.withAuthenticatedGrant = async (grantId, secret, task, beforeReturn) =>
       await withAuthenticatedGrant(grantId, secret, task, async (state) => {
         subject.advance(300_000);
         await beforeReturn?.(state);
       });
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "grant_expired",
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_expired"
     );
   } finally {
     await subject.cleanup();
@@ -1688,14 +1299,8 @@ test("a changed card makes the whole grant stale without a partial guide", async
     });
 
     await assert.rejects(
-      subject.grantService.readGrant({
-        grantId: created.grant.grantId,
-        secret: created.secret,
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "grant_stale" &&
-        error.status === 410,
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale" && error.status === 410
     );
   } finally {
     await subject.cleanup();
@@ -1711,21 +1316,15 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
       cards: [{ cardId: card.cardId, revision: card.revision }],
       expiresAt: expiryAfter(subject, 3_600_000),
     });
-    const getMemoryById = subject.aliceStorage.getMemoryById.bind(
-      subject.aliceStorage,
-    );
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
     let wroteUnrelated = false;
     subject.aliceStorage.getMemoryById = async (memoryId: string) => {
       const memory = await getMemoryById(memoryId);
       if (!wroteUnrelated) {
         wroteUnrelated = true;
-        await subject.aliceStorage.writeMemory(
-          "fact",
-          "An unrelated memory write.",
-          {
-            source: "support-passport-test",
-          },
-        );
+        await subject.aliceStorage.writeMemory("fact", "An unrelated memory write.", {
+          source: "support-passport-test",
+        });
       }
       return memory;
     };
@@ -1751,12 +1350,9 @@ test("grant creation rejects an approved card with an invalid update timestamp",
       await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(memory, {
         updated: "2026-08-11T12:00:00+99:99",
       }),
-      true,
+      true
     );
-    assert.deepEqual(
-      await subject.cardService.listCards({ principal: "owner:alice" }),
-      [],
-    );
+    assert.deepEqual(await subject.cardService.listCards({ principal: "owner:alice" }), []);
 
     await assert.rejects(
       subject.grantService.createGrant({
@@ -1764,14 +1360,9 @@ test("grant creation rejects an approved card with an invalid update timestamp",
         cards: [{ cardId: card.cardId, revision: card.revision }],
         expiresAt: expiryAfter(subject, 3_600_000),
       }),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "invalid_card_status",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_card_status"
     );
-    assert.deepEqual(
-      await subject.grantService.listGrants({ principal: "owner:alice" }),
-      [],
-    );
+    assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
   } finally {
     await subject.cleanup();
   }
@@ -1783,38 +1374,25 @@ test("public guides compare card update timestamps as instants", async () => {
     const first = await createActiveCard(subject, "Earlier card");
     const second = await createActiveCard(subject, "Later card");
     const firstMemory = await subject.aliceStorage.getMemoryById(first.cardId);
-    const secondMemory = await subject.aliceStorage.getMemoryById(
-      second.cardId,
-    );
+    const secondMemory = await subject.aliceStorage.getMemoryById(second.cardId);
     assert.ok(firstMemory);
     assert.ok(secondMemory);
     assert.equal(
-      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(
-        firstMemory,
-        {
-          updated: "2026-08-11T12:00:00+05:00",
-        },
-      ),
-      true,
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(firstMemory, {
+        updated: "2026-08-11T12:00:00+05:00",
+      }),
+      true
     );
     assert.equal(
-      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(
-        secondMemory,
-        {
-          updated: "2026-08-11T10:00:00Z",
-        },
-      ),
-      true,
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(secondMemory, {
+        updated: "2026-08-11T10:00:00Z",
+      }),
+      true
     );
-    const cards = await subject.cardService.listCards({
-      principal: "owner:alice",
-    });
+    const cards = await subject.cardService.listCards({ principal: "owner:alice" });
     const created = await subject.grantService.createGrant({
       principal: "owner:alice",
-      cards: cards.map((card) => ({
-        cardId: card.cardId,
-        revision: card.revision,
-      })),
+      cards: cards.map((card) => ({ cardId: card.cardId, revision: card.revision })),
       expiresAt: expiryAfter(subject, 3_600_000),
     });
 
@@ -1842,10 +1420,7 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
     const active = await createActiveCard(subject);
 
     for (const input of [
-      {
-        cards: [{ cardId: draft.cardId, revision: draft.revision }],
-        expiresAt: expiryAfter(subject, 3_600_000),
-      },
+      { cards: [{ cardId: draft.cardId, revision: draft.revision }], expiresAt: expiryAfter(subject, 3_600_000) },
       {
         cards: [
           { cardId: active.cardId, revision: active.revision },
@@ -1853,10 +1428,7 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
         ],
         expiresAt: expiryAfter(subject, 3_600_000),
       },
-      {
-        cards: [{ cardId: active.cardId, revision: active.revision }],
-        expiresAt: expiryAfter(subject, 299_999),
-      },
+      { cards: [{ cardId: active.cardId, revision: active.revision }], expiresAt: expiryAfter(subject, 299_999) },
       {
         cards: [{ cardId: active.cardId, revision: active.revision }],
         expiresAt: expiryAfter(subject, 604_800_001),
@@ -1867,11 +1439,8 @@ test("grant creation rejects drafts, duplicate cards, and unsafe durations", asy
       },
     ]) {
       await assert.rejects(
-        subject.grantService.createGrant({
-          principal: "owner:alice",
-          ...input,
-        }),
-        (error: unknown) => error instanceof SupportPassportError,
+        subject.grantService.createGrant({ principal: "owner:alice", ...input }),
+        (error: unknown) => error instanceof SupportPassportError
       );
     }
   } finally {
@@ -1884,14 +1453,9 @@ test("the grant store rejects a symlinked grant directory", async () => {
   try {
     const memoryDir = path.join(root, "memory");
     const outside = path.join(root, "outside");
-    await mkdir(path.join(memoryDir, "state", "support-passport"), {
-      recursive: true,
-    });
+    await mkdir(path.join(memoryDir, "state", "support-passport"), { recursive: true });
     await mkdir(outside);
-    await symlink(
-      outside,
-      path.join(memoryDir, "state", "support-passport", "grants"),
-    );
+    await symlink(outside, path.join(memoryDir, "state", "support-passport", "grants"));
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({ memoryDir, now: () => now });
 
@@ -1902,7 +1466,7 @@ test("the grant store rejects a symlinked grant directory", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: new Date(now.getTime() + 300_000).toISOString(),
       }),
-      /must remain inside the memory directory/,
+      /must remain inside the memory directory/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1911,27 +1475,15 @@ test("the grant store rejects a symlinked grant directory", async () => {
 
 test("private file operations select supported directory access strategies", () => {
   assert.throws(
-    () =>
-      requirePrivateFileDescriptorRoot(
-        "win32",
-        "private file directory cannot be pinned",
-      ),
-    /private file directory cannot be pinned/,
+    () => requirePrivateFileDescriptorRoot("win32", "private file directory cannot be pinned"),
+    /private file directory cannot be pinned/
   );
-  assert.equal(
-    requirePrivateFileDescriptorRoot("linux", "unreachable"),
-    "/proc/self/fd",
-  );
-  assert.equal(
-    requirePrivateFileDescriptorRoot("darwin", "unreachable"),
-    "/dev/fd",
-  );
+  assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
+  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
 });
 
 test("private directory creation syncs every verified parent entry", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-private-directory-sync-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-"));
   try {
     const target = path.join(root, "state", "support-passport", "grants");
     let syncs = 0;
@@ -1939,19 +1491,9 @@ test("private directory creation syncs every verified parent entry", async () =>
       syncs += 1;
     };
 
-    await ensurePrivateDirectoryNoFollow(
-      root,
-      target,
-      "private directory creation failed",
-      syncVerifiedParent,
-    );
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
     assert.equal(syncs, 3);
-    await ensurePrivateDirectoryNoFollow(
-      root,
-      target,
-      "private directory creation failed",
-      syncVerifiedParent,
-    );
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
     assert.equal(syncs, 3);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1959,37 +1501,23 @@ test("private directory creation syncs every verified parent entry", async () =>
 });
 
 test("private directory creation retries a failed parent sync", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-private-directory-sync-retry-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-retry-"));
   try {
     const target = path.join(root, "state", "support-passport", "grants");
     await assert.rejects(
-      ensurePrivateDirectoryNoFollow(
-        root,
-        target,
-        "private directory creation failed",
-        async () => {
-          throw Object.assign(new Error("simulated directory sync failure"), {
-            code: "EIO",
-          });
-        },
-      ),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+      ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
     );
     await assert.rejects(lstat(path.join(root, "state")), (error: unknown) => {
       return (error as NodeJS.ErrnoException).code === "ENOENT";
     });
 
     let retrySyncs = 0;
-    await ensurePrivateDirectoryNoFollow(
-      root,
-      target,
-      "private directory creation failed",
-      async () => {
-        retrySyncs += 1;
-      },
-    );
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+      retrySyncs += 1;
+    });
     assert.equal(retrySyncs, 3);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1997,38 +1525,24 @@ test("private directory creation retries a failed parent sync", async () => {
 });
 
 test("private directory creation retries parent sync when rollback cannot remove the child", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-private-directory-sync-populated-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-populated-"));
   try {
     const target = path.join(root, "state");
     let failed = false;
     await assert.rejects(
-      ensurePrivateDirectoryNoFollow(
-        root,
-        target,
-        "private directory creation failed",
-        async () => {
-          if (failed) return;
-          failed = true;
-          await writeFile(path.join(target, "peer-entry"), "peer");
-          throw Object.assign(new Error("simulated directory sync failure"), {
-            code: "EIO",
-          });
-        },
-      ),
-      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+      ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+        if (failed) return;
+        failed = true;
+        await writeFile(path.join(target, "peer-entry"), "peer");
+        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
     );
 
     let retrySyncs = 0;
-    await ensurePrivateDirectoryNoFollow(
-      root,
-      target,
-      "private directory creation failed",
-      async () => {
-        retrySyncs += 1;
-      },
-    );
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+      retrySyncs += 1;
+    });
     assert.equal(retrySyncs, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2036,20 +1550,14 @@ test("private directory creation retries parent sync when rollback cannot remove
 });
 
 test("private directory tree creation syncs missing memory-root ancestors", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-private-root-sync-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-sync-"));
   try {
     const target = path.join(root, "new-parent", "memory");
     let syncs = 0;
 
-    await ensurePrivateDirectoryTreeNoFollow(
-      target,
-      "private directory creation failed",
-      async () => {
-        syncs += 1;
-      },
-    );
+    await ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed", async () => {
+      syncs += 1;
+    });
 
     assert.equal(syncs, 2);
     assert.equal((await lstat(target)).isDirectory(), true);
@@ -2060,9 +1568,7 @@ test("private directory tree creation syncs missing memory-root ancestors", asyn
 });
 
 test("private directory tree creation rejects a symlink in the ancestor chain", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-private-root-link-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-link-"));
   try {
     const outside = path.join(root, "outside");
     const linked = path.join(root, "linked");
@@ -2071,11 +1577,8 @@ test("private directory tree creation rejects a symlink in the ancestor chain", 
     await symlink(outside, linked);
 
     await assert.rejects(
-      ensurePrivateDirectoryTreeNoFollow(
-        target,
-        "private directory creation failed",
-      ),
-      /private directory creation failed/,
+      ensurePrivateDirectoryTreeNoFollow(target, "private directory creation failed"),
+      /private directory creation failed/
     );
     assert.deepEqual(await readdir(outside), []);
   } finally {
@@ -2084,9 +1587,7 @@ test("private directory tree creation rejects a symlink in the ancestor chain", 
 });
 
 test("configured private directory targets resolve existing symlink aliases once", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-private-root-alias-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-alias-"));
   try {
     const actual = path.join(root, "actual");
     const alias = path.join(root, "alias");
@@ -2094,10 +1595,8 @@ test("configured private directory targets resolve existing symlink aliases once
     await symlink(actual, alias);
 
     assert.equal(
-      await canonicalizePrivateDirectoryTarget(
-        path.join(alias, "new-parent", "memory"),
-      ),
-      path.join(actual, "new-parent", "memory"),
+      await canonicalizePrivateDirectoryTarget(path.join(alias, "new-parent", "memory")),
+      path.join(actual, "new-parent", "memory")
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2105,9 +1604,7 @@ test("configured private directory targets resolve existing symlink aliases once
 });
 
 test("grant cleanup never follows a swapped grant directory", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-cleanup-swap-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cleanup-swap-"));
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -2127,23 +1624,15 @@ test("grant cleanup never follows a swapped grant directory", async () => {
     const outsideDir = path.join(root, "outside");
     const fileName = `${grantId}.json`;
     await mkdir(outsideDir);
-    await writeFile(path.join(outsideDir, fileName), "outside must remain", {
-      mode: 0o600,
-    });
+    await writeFile(path.join(outsideDir, fileName), "outside must remain", { mode: 0o600 });
     renameSync(grantsDir, parkedDir);
     symlinkSync(outsideDir, grantsDir, "dir");
     const inspected = store as unknown as {
       removeGrantStates(grantIds: string[]): Promise<void>;
     };
 
-    await assert.rejects(
-      inspected.removeGrantStates([grantId]),
-      /regular files in a stable directory/,
-    );
-    assert.equal(
-      await readFile(path.join(outsideDir, fileName), "utf8"),
-      "outside must remain",
-    );
+    await assert.rejects(inspected.removeGrantStates([grantId]), /regular files in a stable directory/);
+    assert.equal(await readFile(path.join(outsideDir, fileName), "utf8"), "outside must remain");
     assert.equal((await lstat(path.join(parkedDir, fileName))).isFile(), true);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2155,12 +1644,7 @@ test("grant writes reject a directory swapped after the initial safety check", a
   try {
     const memoryDir = path.join(root, "memory");
     const outside = path.join(root, "outside");
-    const grantsDir = path.join(
-      memoryDir,
-      "state",
-      "support-passport",
-      "grants",
-    );
+    const grantsDir = path.join(memoryDir, "state", "support-passport", "grants");
     const parkedDir = path.join(root, "parked-grants");
     await mkdir(outside, { recursive: true });
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -2180,9 +1664,9 @@ test("grant writes reject a directory swapped after the initial safety check", a
         async () => {
           renameSync(grantsDir, parkedDir);
           symlinkSync(outside, grantsDir, "dir");
-        },
+        }
       ),
-      /regular files in a stable directory/,
+      /regular files in a stable directory/
     );
     assert.deepEqual(await readdir(outside), []);
   } finally {
@@ -2191,9 +1675,7 @@ test("grant writes reject a directory swapped after the initial safety check", a
 });
 
 test("grant writes reject an ancestor swapped after the initial safety check", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-ancestor-swap-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-ancestor-swap-"));
   try {
     const memoryDir = path.join(root, "memory");
     const passportDir = path.join(memoryDir, "state", "support-passport");
@@ -2201,9 +1683,7 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
     const outside = path.join(root, "outside-support-passport");
     await mkdir(path.join(outside, "grants", "owners"), { recursive: true });
     const acceptLock = (async (_lockPath, _options, task) =>
-      await task(true, {
-        refresh: async () => true,
-      })) as typeof withHeldFileLock;
+      await task(true, { refresh: async () => true })) as typeof withHeldFileLock;
     const now = new Date("2026-08-11T12:00:00.000Z");
     const store = new SupportPassportGrantStore({
       memoryDir,
@@ -2224,9 +1704,9 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
         async () => {
           renameSync(passportDir, parkedDir);
           symlinkSync(outside, passportDir, "dir");
-        },
+        }
       ),
-      /regular files in a stable directory/,
+      /regular files in a stable directory/
     );
     assert.deepEqual(await readdir(path.join(outside, "grants")), ["owners"]);
   } finally {
@@ -2235,9 +1715,7 @@ test("grant writes reject an ancestor swapped after the initial safety check", a
 });
 
 test("the grant store fails closed for corrupt and symlinked grant files", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-state-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-"));
   try {
     const firstGrantId = "00000000-0000-4000-8000-000000000001";
     const secondGrantId = "00000000-0000-4000-8000-000000000002";
@@ -2266,10 +1744,7 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
     await writeFile(outsidePath, await readFile(linkedPath), { mode: 0o600 });
     await rm(linkedPath);
     await symlink(outsidePath, linkedPath);
-    await assert.rejects(
-      store.authenticate(secondGrantId, linked.secret),
-      /must be regular files/,
-    );
+    await assert.rejects(store.authenticate(secondGrantId, linked.secret), /must be regular files/);
     await assert.rejects(store.listForOwner("alice", "owner:alice"));
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2277,9 +1752,7 @@ test("the grant store fails closed for corrupt and symlinked grant files", async
 });
 
 test("the grant store rejects a state file whose grant ID does not match its file name", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-identity-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-identity-"));
   try {
     const firstGrantId = "00000000-0000-4000-8000-000000000001";
     const secondGrantId = "00000000-0000-4000-8000-000000000002";
@@ -2302,17 +1775,11 @@ test("the grant store rejects a state file whose grant ID does not match its fil
     await writeFile(
       path.join(grantDir, `${secondGrantId}.json`),
       await readFile(path.join(grantDir, `${firstGrantId}.json`)),
-      { mode: 0o600 },
+      { mode: 0o600 }
     );
 
-    await assert.rejects(
-      store.authenticate(secondGrantId, second.secret),
-      /grant ID must match its file name/,
-    );
-    await assert.rejects(
-      store.listForOwner("alice", "owner:alice"),
-      /grant ID must match its file name/,
-    );
+    await assert.rejects(store.authenticate(secondGrantId, second.secret), /grant ID must match its file name/);
+    await assert.rejects(store.listForOwner("alice", "owner:alice"), /grant ID must match its file name/);
     assert.equal(first.state.grantId, firstGrantId);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2320,17 +1787,11 @@ test("the grant store rejects a state file whose grant ID does not match its fil
 });
 
 test("the grant store rejects unsafe durations and grant ID collisions", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-collision-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-collision-"));
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      makeGrantId: () => grantId,
-      now: () => now,
-    });
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
     const input = {
       namespace: "alice",
       principal: "owner:alice",
@@ -2340,17 +1801,11 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
     await store.create(input);
     await assert.rejects(
       store.create(input),
-      (error: unknown) =>
-        error instanceof SupportPassportError &&
-        error.code === "storage_conflict",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     await assert.rejects(
-      store.create({
-        ...input,
-        expiresAt: new Date(now.getTime() + 299_999).toISOString(),
-      }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "invalid_input",
+      store.create({ ...input, expiresAt: new Date(now.getTime() + 299_999).toISOString() }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2358,9 +1813,7 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
 });
 
 test("the grant store canonicalizes UUID letter case", async () => {
-  const root = await mkdtemp(
-    path.join(tmpdir(), "remnic-support-grant-id-case-"),
-  );
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-id-case-"));
   try {
     const uppercaseGrantId = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA";
     const lowercaseGrantId = uppercaseGrantId.toLowerCase();
@@ -2378,19 +1831,10 @@ test("the grant store canonicalizes UUID letter case", async () => {
     });
 
     assert.equal(created.state.grantId, lowercaseGrantId);
+    assert.equal((await store.authenticate(uppercaseGrantId, created.secret)).grantId, lowercaseGrantId);
     assert.equal(
-      (await store.authenticate(uppercaseGrantId, created.secret)).grantId,
-      lowercaseGrantId,
-    );
-    assert.equal(
-      (
-        await store.revoke({
-          grantId: uppercaseGrantId,
-          namespace: "alice",
-          principal: "owner:alice",
-        })
-      ).grantId,
-      lowercaseGrantId,
+      (await store.revoke({ grantId: uppercaseGrantId, namespace: "alice", principal: "owner:alice" })).grantId,
+      lowercaseGrantId
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2401,10 +1845,7 @@ test("the grant store rejects invalid calendar dates", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-date-"));
   try {
     const now = new Date("2026-02-28T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({
-      memoryDir: root,
-      now: () => now,
-    });
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
 
     await assert.rejects(
       store.create({
@@ -2413,8 +1854,7 @@ test("the grant store rejects invalid calendar dates", async () => {
         cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
         expiresAt: "2026-02-31T12:00:00.000Z",
       }),
-      (error: unknown) =>
-        error instanceof SupportPassportError && error.code === "invalid_input",
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2422,9 +1862,7 @@ test("the grant store rejects invalid calendar dates", async () => {
 });
 
 test("the grant store expands a leading tilde in its memory directory", () => {
-  const store = new SupportPassportGrantStore({
-    memoryDir: "~/support-passport-path-test",
-  });
+  const store = new SupportPassportGrantStore({ memoryDir: "~/support-passport-path-test" });
   const memoryDir = (store as unknown as { memoryDir: string }).memoryDir;
   assert.equal(memoryDir.includes(`${path.sep}~${path.sep}`), false);
   assert.equal(path.basename(memoryDir), "support-passport-path-test");

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -200,10 +200,24 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
       principal: input.principal,
       expectedStateVersion: first.state.stateVersion,
     });
+    const firstGrantPath = path.join(root, "state", "support-passport", "grants", `${first.state.grantId}.json`);
     const inspected = store as unknown as {
       readState(grantId: string): Promise<unknown>;
+      writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
     };
     const readState = inspected.readState.bind(store);
+    const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
+    inspected.writeOwnerIndex = async () => {
+      throw Object.assign(new Error("simulated owner index write failure"), { code: "EIO" });
+    };
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    );
+    inspected.writeOwnerIndex = writeOwnerIndex;
+    assert.equal((await lstat(firstGrantPath)).isFile(), true);
+    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
+
     inspected.readState = async (grantId) => {
       if (grantId === first.state.grantId) {
         throw Object.assign(new Error("simulated indexed grant read failure"), { code: "EIO" });
@@ -222,7 +236,7 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     assert.equal(listed.some((state) => state.grantId === first.state.grantId), false);
     assert.equal(listed.some((state) => state.grantId === replacement.state.grantId), true);
     await assert.rejects(
-      lstat(path.join(root, "state", "support-passport", "grants", `${first.state.grantId}.json`)),
+      lstat(firstGrantPath),
       (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
     );
   } finally {
@@ -613,6 +627,36 @@ test("final helper guide assembly blocks card withdrawal", async () => {
     assert.equal(withdrawalSettled, true);
   } finally {
     releaseFinalAuthentication.resolve();
+    await subject.cleanup();
+  }
+});
+
+test("helper guide assembly fails when owner-lock ownership is lost", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    let authentications = 0;
+    subject.grantStore.authenticate = async (grantId, secret) => {
+      const state = await authenticate(grantId, secret);
+      authentications += 1;
+      if (authentications === 3) {
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+      }
+      return state;
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+  } finally {
     await subject.cleanup();
   }
 });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -687,6 +687,7 @@ test("grant creation revokes its committed link when the owner lock is lost afte
     const card = await createActiveCard(subject);
     const create = subject.grantStore.create.bind(subject.grantStore);
     let committedGrantId = "";
+    let commitNotifications = 0;
     subject.grantStore.create = async (...args) => {
       const created = await create(...args);
       committedGrantId = created.state.grantId;
@@ -699,17 +700,51 @@ test("grant creation revokes its committed link when the owner lock is lost afte
     };
 
     await assert.rejects(
-      subject.grantService.createGrant({
-        principal: "owner:alice",
-        cards: [{ cardId: card.cardId, revision: card.revision }],
-        expiresAt: expiryAfter(subject, 3_600_000),
-      }),
+      subject.grantService.createGrant(
+        {
+          principal: "owner:alice",
+          cards: [{ cardId: card.cardId, revision: card.revision }],
+          expiresAt: expiryAfter(subject, 3_600_000),
+        },
+        {
+          onCommitted: () => {
+            commitNotifications += 1;
+          },
+        }
+      ),
       (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.ok(committedGrantId);
     const [stored] = await subject.grantStore.listForOwner("alice", "owner:alice");
     assert.equal(stored?.grantId, committedGrantId);
     assert.ok(stored?.revokedAt);
+    assert.equal(commitNotifications, 0);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("grant creation reports one commit after its final owner check", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    let commitNotifications = 0;
+
+    const created = await subject.grantService.createGrant(
+      {
+        principal: "owner:alice",
+        cards: [{ cardId: card.cardId, revision: card.revision }],
+        expiresAt: expiryAfter(subject, 3_600_000),
+      },
+      {
+        onCommitted: () => {
+          commitNotifications += 1;
+        },
+      }
+    );
+
+    assert.equal(created.grant.status, "active");
+    assert.equal(commitNotifications, 1);
   } finally {
     await subject.cleanup();
   }
@@ -1283,10 +1318,7 @@ test("grant creation rechecks its mutation lock after the commit callback", asyn
       (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
     );
     assert.equal(refreshes, 2);
-    assert.deepEqual(
-      await readdir(path.join(root, "state", "support-passport", "grants")),
-      ["owners"]
-    );
+    assert.deepEqual(await readdir(path.join(root, "state", "support-passport", "grants")), ["owners"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -220,6 +220,10 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     assert.equal(listed.length, 100);
     assert.equal(listed.some((state) => state.grantId === first.state.grantId), false);
     assert.equal(listed.some((state) => state.grantId === replacement.state.grantId), true);
+    await assert.rejects(
+      lstat(path.join(root, "state", "support-passport", "grants", `${first.state.grantId}.json`)),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -454,6 +454,55 @@ test("grant creation re-syncs an owner index write that committed before its dur
   }
 });
 
+test("grant revocation retries directory durability before reporting an existing revoked state", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-revoke-sync-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    let syncAttempts = 0;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+      syncDirectory: async (directory) => {
+        syncAttempts += 1;
+        if (syncAttempts === 1) {
+          throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+        }
+        await syncDirectoryForDurability(directory);
+      },
+    });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const inspected = store as unknown as {
+      writeState(state: { revokedAt?: string }, requireAbsent?: boolean): Promise<void>;
+    };
+    const writeState = inspected.writeState.bind(store);
+    inspected.writeState = async (state, requireAbsent) => {
+      await writeState(state, requireAbsent);
+      if (state.revokedAt) {
+        throw Object.assign(new Error("simulated post-commit state error"), { code: "EIO" });
+      }
+    };
+    const request = {
+      grantId: created.state.grantId,
+      namespace: "alice",
+      principal: "owner:alice",
+    };
+
+    await assert.rejects(store.revoke(request), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
+    const repeated = await store.revoke(request);
+
+    assert.ok(repeated.revokedAt);
+    assert.equal(repeated.stateVersion, 2);
+    assert.equal(syncAttempts, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("owner grant rollover rejects a foreign grant without deleting it", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-foreign-index-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -233,6 +233,42 @@ test("a revoke during a helper read never returns the old guide", async () => {
   }
 });
 
+test("a revoke during the confirmed card read never returns the old guide", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let reads = 0;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      reads += 1;
+      if (reads === 2) {
+        await peerStore.revoke({
+          namespace: "alice",
+          principal: "owner:alice",
+          grantId: created.grant.grantId,
+          expectedStateVersion: created.grant.stateVersion,
+        });
+      }
+      return memory;
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone"
+    );
+    assert.equal(reads, 2);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("a changed card makes the whole grant stale without a partial guide", async () => {
   const subject = await makeSubject();
   try {
@@ -421,4 +457,12 @@ test("the grant store rejects unsafe durations and grant ID collisions", async (
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("the grant store expands a leading tilde in its memory directory", () => {
+  const store = new SupportPassportGrantStore({ memoryDir: "~/support-passport-path-test" });
+  const memoryDir = (store as unknown as { memoryDir: string }).memoryDir;
+  assert.equal(memoryDir.includes(`${path.sep}~${path.sep}`), false);
+  assert.equal(path.basename(memoryDir), "support-passport-path-test");
+  assert.equal(path.isAbsolute(memoryDir), true);
 });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -9,6 +9,7 @@ import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
+import { withHeldFileLock } from "../utils/serialize-mutations.js";
 
 async function makeSubject() {
   StorageManager.clearAllStaticCaches();
@@ -198,6 +199,22 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
       principal: input.principal,
       expectedStateVersion: first.state.stateVersion,
     });
+    const inspected = store as unknown as {
+      readState(grantId: string): Promise<unknown>;
+    };
+    const readState = inspected.readState.bind(store);
+    inspected.readState = async (grantId) => {
+      if (grantId === first.state.grantId) {
+        throw Object.assign(new Error("simulated indexed grant read failure"), { code: "EIO" });
+      }
+      return await readState(grantId);
+    };
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    );
+    inspected.readState = readState;
+    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
     const replacement = await store.create(input);
     const listed = await store.listForOwner(input.namespace, input.principal);
     assert.equal(listed.length, 100);
@@ -205,6 +222,64 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     assert.equal(listed.some((state) => state.grantId === replacement.state.grantId), true);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant mutations report a storage conflict when the file lock is busy", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-busy-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const rejectLock = (async (_lockPath, _options, task) =>
+      await task(false, { refresh: async () => false, failure: "timeout" })) as typeof withHeldFileLock;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+      withHeldFileLock: rejectLock,
+    });
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation rechecks the owner lock immediately before commit", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const originalRead = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let replacedLock = false;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await originalRead(memoryId);
+      if (!replacedLock) {
+        replacedLock = true;
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+      }
+      return memory;
+    };
+
+    await assert.rejects(
+      subject.grantService.createGrant({
+        principal: "owner:alice",
+        cards: [{ cardId: card.cardId, revision: card.revision }],
+        expiresAt: expiryAfter(subject, 300_000),
+      }),
+      (error: unknown) =>
+        error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
+    );
+    assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
+  } finally {
+    await subject.cleanup();
   }
 });
 

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -849,6 +849,37 @@ test("helper guide assembly fails when owner-lock ownership is lost", async () =
   }
 });
 
+test("helper guide assembly refreshes the owner lock after its final card read", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let reads = 0;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      reads += 1;
+      if (reads === 2) {
+        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+      }
+      return memory;
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+    assert.equal(reads, 2);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("a changed card makes the whole grant stale without a partial guide", async () => {
   const subject = await makeSubject();
   try {
@@ -905,6 +936,74 @@ test("unrelated memory writes do not invalidate an unchanged shared guide", asyn
     });
 
     assert.equal(guide.cards[0]?.cardId, card.cardId);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("grant creation rejects an approved card with an invalid update timestamp", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const memory = await subject.aliceStorage.getMemoryById(card.cardId);
+    assert.ok(memory);
+    assert.equal(
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(memory, {
+        updated: "2026-08-11T12:00:00+99:99",
+      }),
+      true
+    );
+    const [invalidCard] = await subject.cardService.listCards({ principal: "owner:alice" });
+    assert.ok(invalidCard);
+
+    await assert.rejects(
+      subject.grantService.createGrant({
+        principal: "owner:alice",
+        cards: [{ cardId: invalidCard.cardId, revision: invalidCard.revision }],
+        expiresAt: expiryAfter(subject, 3_600_000),
+      }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "card_data_invalid"
+    );
+    assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("public guides compare card update timestamps as instants", async () => {
+  const subject = await makeSubject();
+  try {
+    const first = await createActiveCard(subject, "Earlier card");
+    const second = await createActiveCard(subject, "Later card");
+    const firstMemory = await subject.aliceStorage.getMemoryById(first.cardId);
+    const secondMemory = await subject.aliceStorage.getMemoryById(second.cardId);
+    assert.ok(firstMemory);
+    assert.ok(secondMemory);
+    assert.equal(
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(firstMemory, {
+        updated: "2026-08-11T12:00:00+05:00",
+      }),
+      true
+    );
+    assert.equal(
+      await subject.aliceStorage.writeMemoryFrontmatterIfUnchanged(secondMemory, {
+        updated: "2026-08-11T10:00:00Z",
+      }),
+      true
+    );
+    const cards = await subject.cardService.listCards({ principal: "owner:alice" });
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: cards.map((card) => ({ cardId: card.cardId, revision: card.revision })),
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+
+    const guide = await subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+
+    assert.equal(guide.updatedAt, "2026-08-11T10:00:00Z");
   } finally {
     await subject.cleanup();
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1,17 +1,32 @@
 import assert from "node:assert/strict";
 import { renameSync, symlinkSync } from "node:fs";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  type FileHandle,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
 import { StorageManager } from "../storage.js";
+import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
-import { ensurePrivateDirectoryNoFollow, requirePrivateFileDescriptorRoot } from "./private-file.js";
-import { withHeldFileLock } from "../utils/serialize-mutations.js";
+import {
+  ensurePrivateDirectoryNoFollow,
+  requirePrivateFileDescriptorRoot,
+  resolvePrivateDirectoryPath,
+} from "./private-file.js";
 
 async function makeSubject() {
   StorageManager.clearAllStaticCaches();
@@ -270,6 +285,54 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
   }
 });
 
+test("owner grant rollover rejects a foreign grant without deleting it", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-foreign-index-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    let nextGrantId = 1;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      now: () => now,
+    });
+    const common = {
+      namespace: "shared",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const aliceGrants = [];
+    for (let index = 0; index < 99; index += 1) {
+      aliceGrants.push(await store.create({ ...common, principal: "owner:alice" }));
+    }
+    const bob = await store.create({ ...common, principal: "owner:bob" });
+    await store.revoke({
+      grantId: bob.state.grantId,
+      namespace: common.namespace,
+      principal: "owner:bob",
+    });
+    const inspected = store as unknown as {
+      ownerHash(namespace: string, principalHash: string): string;
+      writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
+    };
+    const firstAliceGrant = aliceGrants[0];
+    assert.ok(firstAliceGrant);
+    const aliceOwnerHash = inspected.ownerHash(common.namespace, firstAliceGrant.state.principalHash);
+    await inspected.writeOwnerIndex(aliceOwnerHash, [
+      ...aliceGrants.map((grant) => grant.state.grantId),
+      bob.state.grantId,
+    ]);
+    const bobGrantPath = path.join(root, "state", "support-passport", "grants", `${bob.state.grantId}.json`);
+
+    await assert.rejects(
+      store.create({ ...common, principal: "owner:alice" }),
+      /owner index references a foreign grant/
+    );
+    assert.equal((await lstat(bobGrantPath)).isFile(), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("owner grant history uses one expiry cutoff while it prunes old links", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cutoff-"));
   try {
@@ -323,8 +386,14 @@ test("owner grant history uses one expiry cutoff while it prunes old links", asy
 
     assert.equal(listed.length, 100);
     assert.equal(new Set(listed.map((state) => state.grantId)).size, 100);
-    assert.equal(listed.some((state) => state.grantId === crossing.state.grantId), true);
-    assert.equal(listed.some((state) => state.grantId === created.state.grantId), true);
+    assert.equal(
+      listed.some((state) => state.grantId === crossing.state.grantId),
+      true
+    );
+    assert.equal(
+      listed.some((state) => state.grantId === created.state.grantId),
+      true
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -653,13 +722,12 @@ test("revocation wins while an optimistic helper card read is still pending", as
       secret: created.secret,
     });
     await cardReadStarted.promise;
-    const revokePromise = peerStore
-      .revoke({
-        namespace: "alice",
-        principal: "owner:alice",
-        grantId: created.grant.grantId,
-        expectedStateVersion: created.grant.stateVersion,
-      });
+    const revokePromise = peerStore.revoke({
+      namespace: "alice",
+      principal: "owner:alice",
+      grantId: created.grant.grantId,
+      expectedStateVersion: created.grant.stateVersion,
+    });
     await revokePromise;
 
     releaseCardRead.resolve();
@@ -1183,13 +1251,26 @@ test("the grant store rejects a symlinked grant directory", async () => {
   }
 });
 
-test("private file operations fail closed without descriptor-relative directory paths", () => {
+test("private file operations select supported directory access strategies", () => {
   assert.throws(
     () => requirePrivateFileDescriptorRoot("win32", "private file directory cannot be pinned"),
     /private file directory cannot be pinned/
   );
   assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
-  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
+  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), null);
+});
+
+test("macOS private files use a verified directory path", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-darwin-"));
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(root, "r");
+    const opened = await handle.stat();
+    assert.equal(await resolvePrivateDirectoryPath(root, handle, opened, "private directory changed", "darwin"), root);
+  } finally {
+    await handle?.close();
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("private directory creation syncs every verified parent entry", async () => {
@@ -1408,10 +1489,7 @@ test("the grant store rejects a state file whose grant ID does not match its fil
     );
 
     await assert.rejects(store.authenticate(secondGrantId, second.secret), /grant ID must match its file name/);
-    await assert.rejects(
-      store.listForOwner("alice", "owner:alice"),
-      /grant ID must match its file name/
-    );
+    await assert.rejects(store.listForOwner("alice", "owner:alice"), /grant ID must match its file name/);
     assert.equal(first.state.grantId, firstGrantId);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -8,7 +8,7 @@ import { StorageManager } from "../storage.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
-import { SupportPassportGrantStore } from "./grant-store.js";
+import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 
 async function makeSubject() {
   StorageManager.clearAllStaticCaches();
@@ -135,6 +135,64 @@ test("owner grant listings read only the indexed owner grants", async () => {
     assert.deepEqual(listed.map((state) => state.grantId), [alice.state.grantId]);
     assert.deepEqual(readGrantIds, [alice.state.grantId]);
     assert.notEqual(alice.state.grantId, bob.state.grantId);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("directory sync ignores only explicit unsupported errors", async () => {
+  const failingOpen = (code: string) => async () => ({
+    sync: async () => {
+      throw Object.assign(new Error(`simulated ${code}`), { code });
+    },
+    close: async () => undefined,
+  });
+
+  await assert.rejects(
+    syncDirectoryForDurability("/unused", failingOpen("EIO")),
+    (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+  );
+  await syncDirectoryForDurability("/unused", failingOpen("EINVAL"));
+});
+
+test("grant creation aborts before replacing an owner index after lock ownership is lost", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-lock-loss-"));
+  try {
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    let refreshes = 0;
+    const inspected = store as unknown as {
+      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+    };
+    inspected.withMutationLock = async (task) =>
+      await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+    assert.equal(refreshes, 2);
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [first.state.grantId]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1192,19 +1192,41 @@ test("private file operations fail closed without descriptor-relative directory 
   assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
 });
 
-test("private directory creation syncs each new parent entry", async () => {
+test("private directory creation syncs every verified parent entry", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-"));
   try {
     const target = path.join(root, "state", "support-passport", "grants");
     let syncs = 0;
-    const syncCreatedParent = async () => {
+    const syncVerifiedParent = async () => {
       syncs += 1;
     };
 
-    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncCreatedParent);
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
     assert.equal(syncs, 3);
-    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncCreatedParent);
-    assert.equal(syncs, 3);
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", syncVerifiedParent);
+    assert.equal(syncs, 6);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("private directory creation retries a failed parent sync", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-directory-sync-retry-"));
+  try {
+    const target = path.join(root, "state", "support-passport", "grants");
+    await assert.rejects(
+      ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    );
+    assert.equal((await lstat(path.join(root, "state"))).isDirectory(), true);
+
+    let retrySyncs = 0;
+    await ensurePrivateDirectoryNoFollow(root, target, "private directory creation failed", async () => {
+      retrySyncs += 1;
+    });
+    assert.equal(retrySyncs, 3);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -843,7 +843,10 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       secretHash: "b".repeat(64),
     };
     const inspected = store as unknown as {
-      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
       writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
     };
@@ -856,15 +859,15 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       await inspected.writeState(peerState, true);
       await writeOwnerIndex(ownerHash, [first.state.grantId, peerGrantId]);
     };
-    let lockRun = 0;
+    let ownerLockRun = 0;
     let firstRunRefreshes = 0;
-    inspected.withMutationLock = async (task) => {
-      lockRun += 1;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRun += 1;
       return await task({
         refresh: async () => {
-          if (lockRun !== 1) return true;
+          if (ownerLockRun !== 1) return true;
           firstRunRefreshes += 1;
-          return firstRunRefreshes !== 4;
+          return firstRunRefreshes !== 2;
         },
       });
     };
@@ -874,8 +877,8 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       (state) => state.grantId,
     ));
 
-    assert.equal(lockRun, 2);
-    assert.equal(firstRunRefreshes, 4);
+    assert.equal(ownerLockRun, 2);
+    assert.equal(firstRunRefreshes, 2);
     assert.deepEqual(listedIds, new Set([first.state.grantId, created.state.grantId, peerGrantId]));
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -907,31 +910,90 @@ test("grant recovery reads only the affected owner's index", async () => {
     await writeFile(path.join(grantsDir, `${unindexedGrantId}.json`), "not valid JSON", {
       mode: 0o600,
     });
-    let lockRun = 0;
+    let ownerLockRun = 0;
     let firstRunRefreshes = 0;
     const inspected = store as unknown as {
-      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
     };
-    inspected.withMutationLock = async (task) => {
-      lockRun += 1;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRun += 1;
       return await task({
         refresh: async () => {
-          if (lockRun !== 1) return true;
+          if (ownerLockRun !== 1) return true;
           firstRunRefreshes += 1;
-          return firstRunRefreshes !== 4;
+          return firstRunRefreshes !== 2;
         },
       });
     };
 
     const created = await store.create(input);
 
-    assert.equal(lockRun, 2);
+    assert.equal(ownerLockRun, 2);
     assert.deepEqual(
       new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
       new Set([first.state.grantId, created.state.grantId]),
     );
     assert.equal(await readFile(path.join(grantsDir, `${unindexedGrantId}.json`), "utf8"), "not valid JSON");
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("one owner's index transaction does not block another owner", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-concurrency-"));
+  const releaseAlice = Promise.withResolvers<void>();
+  try {
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      now: () => now,
+    });
+    const inspected = store as unknown as {
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+    };
+    const withOwnerIndexLock = inspected.withOwnerIndexLock.bind(store);
+    const aliceEntered = Promise.withResolvers<void>();
+    let blockedOwnerHash: string | undefined;
+    inspected.withOwnerIndexLock = async (ownerHash, task) => {
+      if (!blockedOwnerHash) {
+        blockedOwnerHash = ownerHash;
+        return await withOwnerIndexLock(ownerHash, async (lock) => {
+          aliceEntered.resolve();
+          await releaseAlice.promise;
+          return await task(lock);
+        });
+      }
+      return await withOwnerIndexLock(ownerHash, task);
+    };
+    const input = {
+      namespace: "shared",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const alice = store.create({ ...input, principal: "owner:alice" });
+    await aliceEntered.promise;
+    const bob = await Promise.race([
+      store.create({ ...input, principal: "owner:bob" }),
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(() => reject(new Error("another owner was blocked by Alice's index lock")), 1_000),
+      ),
+    ]);
+    assert.equal(bob.state.namespace, "shared");
+    releaseAlice.resolve();
+    await alice;
+  } finally {
+    releaseAlice.resolve();
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -750,6 +750,48 @@ test("grant creation reports one commit after its final owner check", async () =
   }
 });
 
+test("grant revocation reports its committed state when the owner lock is lost after storage", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const revoke = subject.grantStore.revoke.bind(subject.grantStore);
+    subject.grantStore.revoke = async (...args) => {
+      const revoked = await revoke(...args);
+      const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+        namespace: "alice",
+        principal: "owner:alice",
+      });
+      await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
+      return revoked;
+    };
+    let commitNotifications = 0;
+
+    const revoked = await subject.grantService.revokeGrant(
+      {
+        principal: "owner:alice",
+        grantId: created.grant.grantId,
+        expectedStateVersion: created.grant.stateVersion,
+      },
+      {
+        onCommitted: () => {
+          commitNotifications += 1;
+        },
+      }
+    );
+
+    assert.equal(revoked.status, "revoked");
+    assert.ok(revoked.revokedAt);
+    assert.equal(commitNotifications, 1);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("grant creation measures its minimum lifetime from request receipt", async () => {
   const subject = await makeSubject();
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -268,6 +268,15 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
     await assert.rejects(store.create(input), (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO");
     inspected.readState = readState;
     assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
+    const evictedGrantLocks: string[] = [];
+    const lockAwareStore = store as unknown as {
+      withGrantLock<T>(grantId: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+    };
+    const withGrantLock = lockAwareStore.withGrantLock.bind(store);
+    lockAwareStore.withGrantLock = async (grantId, task) => {
+      evictedGrantLocks.push(grantId);
+      return await withGrantLock(grantId, task);
+    };
     const replacement = await store.create(input);
     const listed = await store.listForOwner(input.namespace, input.principal);
     assert.equal(listed.length, 100);
@@ -279,6 +288,7 @@ test("owner grant history stays bounded while an inactive link frees capacity", 
       listed.some((state) => state.grantId === replacement.state.grantId),
       true
     );
+    assert.deepEqual(evictedGrantLocks, [first.state.grantId]);
     await assert.rejects(lstat(firstGrantPath), (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT");
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1252,21 +1262,25 @@ test("the grant store rejects a symlinked grant directory", async () => {
 });
 
 test("private file operations select supported directory access strategies", () => {
-  assert.throws(
-    () => requirePrivateFileDescriptorRoot("win32", "private file directory cannot be pinned"),
-    /private file directory cannot be pinned/
-  );
+  for (const platform of ["win32", "darwin"] as const) {
+    assert.throws(
+      () => requirePrivateFileDescriptorRoot(platform, "private file directory cannot be pinned"),
+      /private file directory cannot be pinned/
+    );
+  }
   assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
-  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), null);
 });
 
-test("macOS private files use a verified directory path", async () => {
+test("macOS private files fail closed without descriptor-relative operations", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-darwin-"));
   let handle: FileHandle | undefined;
   try {
     handle = await open(root, "r");
     const opened = await handle.stat();
-    assert.equal(await resolvePrivateDirectoryPath(root, handle, opened, "private directory changed", "darwin"), root);
+    await assert.rejects(
+      resolvePrivateDirectoryPath(root, handle, opened, "private directory changed", "darwin"),
+      /private directory changed/
+    );
   } finally {
     await handle?.close();
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -882,6 +882,60 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
   }
 });
 
+test("grant recovery reads only the affected owner's index", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-scoped-recovery-"));
+  try {
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
+    const unindexedGrantId = "00000000-0000-4000-8000-000000000003";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000004",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const grantsDir = path.join(root, "state", "support-passport", "grants");
+    await writeFile(path.join(grantsDir, `${unindexedGrantId}.json`), "not valid JSON", {
+      mode: 0o600,
+    });
+    let lockRun = 0;
+    let firstRunRefreshes = 0;
+    const inspected = store as unknown as {
+      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+    };
+    inspected.withMutationLock = async (task) => {
+      lockRun += 1;
+      return await task({
+        refresh: async () => {
+          if (lockRun !== 1) return true;
+          firstRunRefreshes += 1;
+          return firstRunRefreshes !== 4;
+        },
+      });
+    };
+
+    const created = await store.create(input);
+
+    assert.equal(lockRun, 2);
+    assert.deepEqual(
+      new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
+      new Set([first.state.grantId, created.state.grantId]),
+    );
+    assert.equal(await readFile(path.join(grantsDir, `${unindexedGrantId}.json`), "utf8"), "not valid JSON");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("grant creation rechecks its mutation lock after the commit callback", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-callback-lock-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -8,6 +8,7 @@ import { test } from "node:test";
 import { StorageManager } from "../storage.js";
 import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
+import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
@@ -1539,6 +1540,76 @@ test("grants reject cards owned by another principal inside a shared namespace",
     await assert.rejects(
       grantService.readGrant({ grantId: forged.state.grantId, secret: forged.secret }),
       (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale"
+    );
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("helper snapshots ignore colliding card IDs from other owners and reject owned duplicates", async () => {
+  StorageManager.clearAllStaticCaches();
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-snapshot-scope-"));
+  try {
+    const storage = new StorageManager(path.join(root, "shared-storage"));
+    await storage.ensureDirectories();
+    const now = () => new Date("2026-08-11T12:00:00.000Z");
+    const resolveOwner = async (principal: string) => ({ principal, namespace: "team", storage });
+    const cardService = new SupportPassportCardService({ resolveOwner, now });
+    const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "grants"), now });
+    const grantService = new SupportPassportGrantService({
+      grantStore,
+      resolveOwner,
+      resolveNamespace: async () => storage,
+      now,
+    });
+    const draft = await cardService.createManualDraft({
+      principal: "owner:alice",
+      title: "Alice card",
+      statement: "Offer Alice a quiet place.",
+      category: "environment",
+      reviewBy: "2026-09-01T12:00:00.000Z",
+    });
+    const card = await cardService.approveCard({
+      principal: "owner:alice",
+      cardId: draft.cardId,
+      expectedRevision: draft.revision,
+    });
+    const created = await grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: "2026-08-11T13:00:00.000Z",
+    });
+    const originalMemories = await storage.readAllMemories();
+    const aliceMemory = originalMemories.find((memory) => memory.frontmatter.id === card.cardId);
+    assert.ok(aliceMemory);
+    const foreignCollision = {
+      ...aliceMemory,
+      path: path.join(storage.dir, "preferences", "foreign-collision.md"),
+      frontmatter: {
+        ...aliceMemory.frontmatter,
+        structuredAttributes: {
+          ...aliceMemory.frontmatter.structuredAttributes,
+          "support-passport-owner": computeSupportPassportOwnerKey("owner:bob"),
+        },
+      },
+    };
+    storage.readAllMemories = async () => [...originalMemories, foreignCollision];
+
+    const guide = await grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+    assert.deepEqual(guide.cards.map((item) => item.cardId), [card.cardId]);
+
+    const ownedDuplicate = {
+      ...aliceMemory,
+      path: path.join(storage.dir, "preferences", "owned-duplicate.md"),
+    };
+    storage.readAllMemories = async () => [...originalMemories, foreignCollision, ownedDuplicate];
+    await assert.rejects(
+      grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "card_data_invalid",
     );
   } finally {
     StorageManager.clearAllStaticCaches();

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -883,6 +883,7 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       ): Promise<T>;
       writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void>;
       writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof peerState): Promise<void>;
     };
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
     let injectPeer = true;
@@ -890,6 +891,7 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       if (injectPeer) {
         injectPeer = false;
         await inspected.writeState(peerState, true);
+        await inspected.writeOwnerMembership(peerState);
         await writeOwnerIndex(ownerHash, [first.state.grantId, peerGrantId]);
       }
       await writeOwnerIndex(ownerHash, indexedGrantIds);
@@ -915,6 +917,86 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
     assert.equal(ownerLockRun, 2);
     assert.equal(firstRunRefreshes, 2);
     assert.deepEqual(listedIds, new Set([first.state.grantId, created.state.grantId, peerGrantId]));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant recovery propagates transient reads from an owner membership", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-recovery-read-"));
+  try {
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
+    const peerGrantId = "00000000-0000-4000-8000-000000000003";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000004",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const peerState = {
+      ...first.state,
+      grantId: peerGrantId,
+      secretHash: "b".repeat(64),
+    };
+    const inspected = store as unknown as {
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+      writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
+      writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof peerState): Promise<void>;
+      readState(grantId: string): Promise<typeof peerState>;
+    };
+    const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
+    let injectPeer = true;
+    inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
+      if (injectPeer) {
+        injectPeer = false;
+        await inspected.writeState(peerState, true);
+        await inspected.writeOwnerMembership(peerState);
+      }
+      await writeOwnerIndex(ownerHash, indexedGrantIds);
+    };
+    let ownerLockRun = 0;
+    let firstRunRefreshes = 0;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRun += 1;
+      return await task({
+        refresh: async () => {
+          if (ownerLockRun !== 1) return true;
+          firstRunRefreshes += 1;
+          return firstRunRefreshes !== 2;
+        },
+      });
+    };
+    const readState = inspected.readState.bind(store);
+    inspected.readState = async (grantId) => {
+      if (ownerLockRun > 1 && grantId === peerGrantId) {
+        throw Object.assign(new Error("simulated transient owner read"), { code: "EIO" });
+      }
+      return await readState(grantId);
+    };
+
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO",
+    );
+    assert.equal(ownerLockRun, 2);
+    assert.equal(
+      JSON.parse(await readFile(path.join(root, "state", "support-passport", "grants", `${peerGrantId}.json`), "utf8")).grantId,
+      peerGrantId,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1014,7 +1096,14 @@ test("grant recovery ignores malformed unindexed grant files", async () => {
         ownerHash: string,
         task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
       ): Promise<T>;
+      ownerHash(namespace: string, principalHash: string): string;
     };
+    const ownerHash = inspected.ownerHash(first.state.namespace, first.state.principalHash);
+    await writeFile(
+      path.join(grantsDir, "owners", ownerHash, `${unindexedGrantId}.json`),
+      `${JSON.stringify({ schemaVersion: 1, grantId: unindexedGrantId })}\n`,
+      { mode: 0o600 },
+    );
     inspected.withOwnerIndexLock = async (_ownerHash, task) => {
       ownerLockRun += 1;
       return await task({
@@ -1034,6 +1123,63 @@ test("grant recovery ignores malformed unindexed grant files", async () => {
       new Set([first.state.grantId, created.state.grantId]),
     );
     assert.equal(await readFile(path.join(grantsDir, `${unindexedGrantId}.json`), "utf8"), "not valid JSON");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant recovery reads only the affected owner's membership after lock loss", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-owner-scoped-recovery-"));
+  try {
+    const grantIds = Array.from({ length: 8 }, (_, index) =>
+      `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+    );
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000099",
+      now: () => now,
+    });
+    const input = {
+      namespace: "shared",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    await store.create({ ...input, principal: "owner:alice" });
+    const bobGrantIds = new Set<string>();
+    for (let index = 0; index < 5; index += 1) {
+      bobGrantIds.add((await store.create({ ...input, principal: "owner:bob" })).state.grantId);
+    }
+    const inspected = store as unknown as {
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+      readState(grantId: string): Promise<{ grantId: string }>;
+    };
+    let ownerLockRun = 0;
+    let firstRunRefreshes = 0;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRun += 1;
+      return await task({
+        refresh: async () => {
+          if (ownerLockRun !== 1) return true;
+          firstRunRefreshes += 1;
+          return firstRunRefreshes !== 2;
+        },
+      });
+    };
+    const readState = inspected.readState.bind(store);
+    const recoveryReads: string[] = [];
+    inspected.readState = async (grantId) => {
+      if (ownerLockRun === 2) recoveryReads.push(grantId);
+      return await readState(grantId);
+    };
+
+    await store.create({ ...input, principal: "owner:alice" });
+
+    assert.equal(ownerLockRun, 2);
+    assert.equal(recoveryReads.some((grantId) => bobGrantIds.has(grantId)), false);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -887,11 +887,12 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
     let injectPeer = true;
     inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
+      if (injectPeer) {
+        injectPeer = false;
+        await inspected.writeState(peerState, true);
+        await writeOwnerIndex(ownerHash, [first.state.grantId, peerGrantId]);
+      }
       await writeOwnerIndex(ownerHash, indexedGrantIds);
-      if (!injectPeer) return;
-      injectPeer = false;
-      await inspected.writeState(peerState, true);
-      await writeOwnerIndex(ownerHash, [first.state.grantId, peerGrantId]);
     };
     let ownerLockRun = 0;
     let firstRunRefreshes = 0;
@@ -981,7 +982,7 @@ test("grant recovery prunes a stale owner-index entry after lock loss", async ()
   }
 });
 
-test("grant recovery reads only the affected owner's index", async () => {
+test("grant recovery ignores malformed unindexed grant files", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-scoped-recovery-"));
   try {
     const grantIds = [

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -13,10 +13,12 @@ import { computeSupportPassportOwnerLockKey, supportPassportOwnerLockPath } from
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 import {
-  canonicalizePrivateDirectoryTarget,
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
+  readPrivateFileNoFollow,
+  removePrivateFilesNoFollow,
   requirePrivateFileDescriptorRoot,
+  writePrivateFileAtomicallyNoFollow,
 } from "./private-file.js";
 
 async function makeSubject() {
@@ -1806,17 +1808,55 @@ test("private directory tree creation rejects a symlink in the ancestor chain", 
   }
 });
 
-test("configured private directory targets resolve existing symlink aliases once", async () => {
+test("the grant store rejects a symlink alias in the configured memory root", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-root-alias-"));
   try {
     const actual = path.join(root, "actual");
     const alias = path.join(root, "alias");
     await mkdir(actual);
     await symlink(actual, alias);
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: path.join(alias, "memory"),
+      now: () => now,
+    });
 
-    assert.equal(
-      await canonicalizePrivateDirectoryTarget(path.join(alias, "new-parent", "memory")),
-      path.join(actual, "new-parent", "memory")
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+      }),
+      /memory directory must be a stable directory/,
+    );
+    assert.deepEqual(await readdir(actual), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the Windows private-file strategy writes, reads, and removes a private file", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-win32-"));
+  try {
+    const directory = path.join(root, "state", "support-passport", "grants");
+    const filePath = path.join(directory, "grant.json");
+    const errorMessage = "private Windows file operation failed";
+    await ensurePrivateDirectoryNoFollow(root, directory, errorMessage, undefined, true, "win32");
+    await writePrivateFileAtomicallyNoFollow(
+      directory,
+      filePath,
+      '{"ok":true}\n',
+      errorMessage,
+      root,
+      "win32",
+    );
+
+    assert.equal(await readPrivateFileNoFollow(directory, filePath, errorMessage, root, "win32"), '{"ok":true}\n');
+    await removePrivateFilesNoFollow(directory, ["grant.json"], errorMessage, root, "win32");
+    await assert.rejects(
+      readPrivateFileNoFollow(directory, filePath, errorMessage, root, "win32"),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -885,6 +885,68 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
   }
 });
 
+test("grant recovery prunes a stale owner-index entry after lock loss", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-stale-index-recovery-"));
+  try {
+    const grantIds = [
+      "00000000-0000-4000-8000-000000000001",
+      "00000000-0000-4000-8000-000000000002",
+    ];
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const inspected = store as unknown as {
+      withOwnerIndexLock<T>(
+        ownerHash: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+      writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
+    };
+    const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
+    let removeStaleState = true;
+    inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
+      await writeOwnerIndex(ownerHash, indexedGrantIds);
+      if (!removeStaleState) return;
+      removeStaleState = false;
+      await rm(path.join(root, "state", "support-passport", "grants", `${first.state.grantId}.json`));
+    };
+    let ownerLockRun = 0;
+    let firstRunRefreshes = 0;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRun += 1;
+      return await task({
+        refresh: async () => {
+          if (ownerLockRun !== 1) return true;
+          firstRunRefreshes += 1;
+          return firstRunRefreshes !== 2;
+        },
+      });
+    };
+
+    const created = await store.create(input);
+
+    assert.equal(ownerLockRun, 2);
+    assert.equal(firstRunRefreshes, 2);
+    assert.deepEqual(
+      (await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId),
+      [created.state.grantId],
+    );
+    assert.equal((await store.authenticate(created.state.grantId, created.secret)).grantId, created.state.grantId);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("grant recovery reads only the affected owner's index", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-scoped-recovery-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { StorageManager } from "../storage.js";
+import { SupportPassportCardService } from "./card-service.js";
+import { SupportPassportError } from "./errors.js";
+import { SupportPassportGrantService } from "./grant-service.js";
+import { SupportPassportGrantStore } from "./grant-store.js";
+
+async function makeSubject() {
+  StorageManager.clearAllStaticCaches();
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grants-"));
+  const aliceStorage = new StorageManager(path.join(root, "alice"));
+  const bobStorage = new StorageManager(path.join(root, "bob"));
+  await Promise.all([aliceStorage.ensureDirectories(), bobStorage.ensureDirectories()]);
+  let currentTime = Date.parse("2026-08-11T12:00:00.000Z");
+  const now = () => new Date(currentTime);
+  const resolveOwner = async (principal: string) => {
+    if (principal === "owner:alice") return { namespace: "alice", storage: aliceStorage };
+    if (principal === "owner:bob") return { namespace: "bob", storage: bobStorage };
+    throw new Error("unknown test principal");
+  };
+  const cardService = new SupportPassportCardService({ resolveOwner, now });
+  const grantStore = new SupportPassportGrantStore({ memoryDir: path.join(root, "shared"), now });
+  const grantService = new SupportPassportGrantService({
+    grantStore,
+    resolveOwner,
+    resolveNamespace: async (namespace) => {
+      if (namespace === "alice") return aliceStorage;
+      if (namespace === "bob") return bobStorage;
+      throw new Error("unknown test namespace");
+    },
+    now,
+  });
+
+  return {
+    root,
+    cardService,
+    grantService,
+    now,
+    advance: (milliseconds: number) => { currentTime += milliseconds; },
+    cleanup: async () => {
+      StorageManager.clearAllStaticCaches();
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function createActiveCard(subject: Awaited<ReturnType<typeof makeSubject>>, title = "Quiet space") {
+  const draft = await subject.cardService.createManualDraft({
+    principal: "owner:alice",
+    title,
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+  });
+  return await subject.cardService.approveCard({
+    principal: "owner:alice",
+    cardId: draft.cardId,
+    expectedRevision: draft.revision,
+  });
+}
+
+test("a grant stores only hashed credentials with private file permissions", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      durationSeconds: 3_600,
+    });
+
+    assert.match(created.secret, /^[A-Za-z0-9_-]{43}$/);
+    assert.equal(created.grant.stateVersion, 1);
+    const filePath = path.join(
+      subject.root,
+      "shared",
+      "state",
+      "support-passport",
+      "grants",
+      `${created.grant.grantId}.json`,
+    );
+    const body = await readFile(filePath, "utf8");
+    assert.equal(body.includes(created.secret), false);
+    assert.equal(JSON.parse(body).secretHash.length, 64);
+    assert.equal((await lstat(filePath)).mode & 0o777, 0o600);
+    assert.equal((await lstat(path.dirname(filePath))).mode & 0o777, 0o700);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("a helper sees only the selected active card through a valid secret", async () => {
+  const subject = await makeSubject();
+  try {
+    const selected = await createActiveCard(subject, "Selected card");
+    await createActiveCard(subject, "Private card");
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: selected.cardId, revision: selected.revision }],
+      durationSeconds: 3_600,
+    });
+
+    const guide = await subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+    assert.deepEqual(guide.cards, [{
+      cardId: selected.cardId,
+      title: "Selected card",
+      statement: "Offer me a quiet place and time.",
+      category: "environment",
+      updatedAt: selected.updatedAt,
+    }]);
+    assert.equal("revision" in guide.cards[0]!, false);
+    assert.equal("namespace" in guide, false);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("bad secrets return not found, while valid revoked or expired grants return gone", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      durationSeconds: 300,
+    });
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: "x".repeat(43) }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_not_found" && error.status === 404,
+    );
+
+    const peerStore = new SupportPassportGrantStore({ memoryDir: path.join(subject.root, "shared"), now: subject.now });
+    const peerRevoked = await peerStore.revoke({
+      namespace: "alice",
+      principal: "owner:alice",
+      grantId: created.grant.grantId,
+      expectedStateVersion: created.grant.stateVersion,
+    });
+    const repeated = await subject.grantService.revokeGrant({
+      principal: "owner:alice",
+      grantId: created.grant.grantId,
+      expectedStateVersion: created.grant.stateVersion,
+    });
+    assert.equal(peerRevoked.stateVersion, 2);
+    assert.equal(repeated.stateVersion, peerRevoked.stateVersion);
+    assert.equal(repeated.revokedAt, peerRevoked.revokedAt);
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone" && error.status === 410,
+    );
+
+    const second = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      durationSeconds: 300,
+    });
+    subject.advance(300_001);
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: second.grant.grantId, secret: second.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_gone",
+    );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("a changed card makes the whole grant stale without a partial guide", async () => {
+  const subject = await makeSubject();
+  try {
+    const first = await createActiveCard(subject, "First card");
+    const second = await createActiveCard(subject, "Second card");
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [
+        { cardId: first.cardId, revision: first.revision },
+        { cardId: second.cardId, revision: second.revision },
+      ],
+      durationSeconds: 3_600,
+    });
+    await subject.cardService.withdrawCard({
+      principal: "owner:alice",
+      cardId: second.cardId,
+      expectedRevision: second.revision,
+    });
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_stale" && error.status === 410,
+    );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("grant creation rejects drafts, duplicate cards, and unsafe durations", async () => {
+  const subject = await makeSubject();
+  try {
+    const draft = await subject.cardService.createManualDraft({
+      principal: "owner:alice",
+      title: "Draft card",
+      statement: "Give me time to answer.",
+      category: "communication",
+    });
+    const active = await createActiveCard(subject);
+
+    for (const input of [
+      { cards: [{ cardId: draft.cardId, revision: draft.revision }], durationSeconds: 3_600 },
+      { cards: [{ cardId: active.cardId, revision: active.revision }, { cardId: active.cardId, revision: active.revision }], durationSeconds: 3_600 },
+      { cards: [{ cardId: active.cardId, revision: active.revision }], durationSeconds: 299 },
+      { cards: [{ cardId: active.cardId, revision: active.revision }], durationSeconds: 604_801 },
+    ]) {
+      await assert.rejects(
+        subject.grantService.createGrant({ principal: "owner:alice", ...input }),
+        (error: unknown) => error instanceof SupportPassportError,
+      );
+    }
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("the grant store rejects a symlinked grant directory", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-link-"));
+  try {
+    const memoryDir = path.join(root, "memory");
+    const outside = path.join(root, "outside");
+    await mkdir(path.join(memoryDir, "state", "support-passport"), { recursive: true });
+    await mkdir(outside);
+    await symlink(outside, path.join(memoryDir, "state", "support-passport", "grants"));
+    const store = new SupportPassportGrantStore({ memoryDir });
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        durationSeconds: 300,
+      }),
+      /must not be a symbolic link/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the grant store rejects unsafe durations and grant ID collisions", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-collision-"));
+  try {
+    const grantId = "00000000-0000-4000-8000-000000000001";
+    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      durationSeconds: 300,
+    };
+    await store.create(input);
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict",
+    );
+    await assert.rejects(
+      store.create({ ...input, durationSeconds: 299 }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -830,6 +830,39 @@ test("a changed card makes the whole grant stale without a partial guide", async
   }
 });
 
+test("unrelated memory writes do not invalidate an unchanged shared guide", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let wroteUnrelated = false;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      if (!wroteUnrelated) {
+        wroteUnrelated = true;
+        await subject.aliceStorage.writeMemory("An unrelated memory write.", "fact", {
+          source: "support-passport-test",
+        });
+      }
+      return memory;
+    };
+
+    const guide = await subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+
+    assert.equal(guide.cards[0]?.cardId, card.cardId);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("grant creation rejects drafts, duplicate cards, and unsafe durations", async () => {
   const subject = await makeSubject();
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -140,6 +140,74 @@ test("owner grant listings read only the indexed owner grants", async () => {
   }
 });
 
+test("owner grant operations use one trimmed namespace", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-namespace-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const created = await store.create({
+      namespace: " alice ",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+
+    assert.deepEqual(
+      (await store.listForOwner(" alice ", "owner:alice")).map((state) => state.grantId),
+      [created.state.grantId]
+    );
+    const revoked = await store.revoke({
+      grantId: created.state.grantId,
+      namespace: " alice ",
+      principal: "owner:alice",
+      expectedStateVersion: created.state.stateVersion,
+    });
+    assert.ok(revoked.revokedAt);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("owner grant history stays bounded while an inactive link frees capacity", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-history-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    let nextGrantId = 1;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () =>
+        `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    for (let index = 1; index < 100; index += 1) await store.create(input);
+
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+    );
+    await store.revoke({
+      grantId: first.state.grantId,
+      namespace: input.namespace,
+      principal: input.principal,
+      expectedStateVersion: first.state.stateVersion,
+    });
+    const replacement = await store.create(input);
+    const listed = await store.listForOwner(input.namespace, input.principal);
+    assert.equal(listed.length, 100);
+    assert.equal(listed.some((state) => state.grantId === first.state.grantId), false);
+    assert.equal(listed.some((state) => state.grantId === replacement.state.grantId), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("directory sync ignores only explicit unsupported errors", async () => {
   const failingOpen = (code: string) => async () => ({
     sync: async () => {
@@ -413,6 +481,58 @@ test("a revoke during the confirmed card read never returns the old guide", asyn
     );
     assert.equal(reads, 2);
   } finally {
+    await subject.cleanup();
+  }
+});
+
+test("final helper guide assembly blocks card withdrawal", async () => {
+  const subject = await makeSubject();
+  const finalAuthenticationStarted = Promise.withResolvers<void>();
+  const releaseFinalAuthentication = Promise.withResolvers<void>();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    const authenticate = subject.grantStore.authenticate.bind(subject.grantStore);
+    let authentications = 0;
+    subject.grantStore.authenticate = async (grantId, secret) => {
+      const state = await authenticate(grantId, secret);
+      authentications += 1;
+      if (authentications === 3) {
+        finalAuthenticationStarted.resolve();
+        await releaseFinalAuthentication.promise;
+      }
+      return state;
+    };
+
+    const readPromise = subject.grantService.readGrant({
+      grantId: created.grant.grantId,
+      secret: created.secret,
+    });
+    await finalAuthenticationStarted.promise;
+    let withdrawalSettled = false;
+    const withdrawalPromise = subject.cardService
+      .withdrawCard({
+        principal: "owner:alice",
+        cardId: card.cardId,
+        expectedRevision: card.revision,
+      })
+      .finally(() => {
+        withdrawalSettled = true;
+      });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(withdrawalSettled, false);
+
+    releaseFinalAuthentication.resolve();
+    const guide = await readPromise;
+    assert.equal(guide.cards[0]?.cardId, card.cardId);
+    await withdrawalPromise;
+    assert.equal(withdrawalSettled, true);
+  } finally {
+    releaseFinalAuthentication.resolve();
     await subject.cleanup();
   }
 });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -788,6 +788,45 @@ test("the grant store rejects a symlinked grant directory", async () => {
   }
 });
 
+test("grant cleanup never follows a swapped grant directory", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cleanup-swap-"));
+  try {
+    const grantId = "00000000-0000-4000-8000-000000000001";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId,
+      now: () => now,
+    });
+    await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const grantsDir = path.join(root, "state", "support-passport", "grants");
+    const parkedDir = path.join(root, "parked-grants");
+    const outsideDir = path.join(root, "outside");
+    const fileName = `${grantId}.json`;
+    await mkdir(outsideDir);
+    await writeFile(path.join(outsideDir, fileName), "outside must remain", { mode: 0o600 });
+    renameSync(grantsDir, parkedDir);
+    symlinkSync(outsideDir, grantsDir, "dir");
+    const inspected = store as unknown as {
+      removeGrantStates(grantIds: string[]): Promise<void>;
+    };
+
+    await assert.rejects(
+      inspected.removeGrantStates([grantId]),
+      /regular files in a stable directory/
+    );
+    assert.equal(await readFile(path.join(outsideDir, fileName), "utf8"), "outside must remain");
+    assert.equal((await lstat(path.join(parkedDir, fileName))).isFile(), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("grant writes reject a directory swapped after the initial safety check", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-swap-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -173,6 +173,59 @@ test("a helper sees only the selected active card through a valid secret", async
   }
 });
 
+test("grant creation and card withdrawal cannot interleave", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let releaseRead!: () => void;
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    const readReleased = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let pauseRead = true;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      if (pauseRead) {
+        pauseRead = false;
+        markReadStarted();
+        await readReleased;
+      }
+      return memory;
+    };
+
+    const createPromise = subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 3_600_000),
+    });
+    await readStarted;
+    let withdrawalSettled = false;
+    const withdrawalPromise = subject.cardService
+      .withdrawCard({
+        principal: "owner:alice",
+        cardId: card.cardId,
+        expectedRevision: card.revision,
+      })
+      .finally(() => {
+        withdrawalSettled = true;
+      });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(withdrawalSettled, false);
+
+    releaseRead();
+    const created = await createPromise;
+    assert.equal(created.grant.status, "active");
+    await withdrawalPromise;
+    assert.equal(withdrawalSettled, true);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("bad secrets return not found, while valid revoked and expired grants reveal safe lifecycle states", async () => {
   const subject = await makeSubject();
   try {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -886,25 +886,25 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       writeOwnerMembership(state: typeof peerState): Promise<void>;
     };
     const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
-    let injectPeer = true;
+    let ownerIndexWrites = 0;
     inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
-      if (injectPeer) {
-        injectPeer = false;
+      ownerIndexWrites += 1;
+      if (ownerIndexWrites === 2) {
         await inspected.writeState(peerState, true);
         await inspected.writeOwnerMembership(peerState);
-        await writeOwnerIndex(ownerHash, [first.state.grantId, peerGrantId]);
+        await writeOwnerIndex(ownerHash, [...indexedGrantIds, peerGrantId]);
       }
       await writeOwnerIndex(ownerHash, indexedGrantIds);
     };
     let ownerLockRun = 0;
-    let firstRunRefreshes = 0;
+    const refreshesByRun = new Map<number, number>();
     inspected.withOwnerIndexLock = async (_ownerHash, task) => {
       ownerLockRun += 1;
       return await task({
         refresh: async () => {
-          if (ownerLockRun !== 1) return true;
-          firstRunRefreshes += 1;
-          return firstRunRefreshes !== 2;
+          const refreshes = (refreshesByRun.get(ownerLockRun) ?? 0) + 1;
+          refreshesByRun.set(ownerLockRun, refreshes);
+          return ownerLockRun > 2 || refreshes !== 2;
         },
       });
     };
@@ -914,8 +914,9 @@ test("grant creation reconciles peer state when the owner-index lock is lost aft
       (state) => state.grantId,
     ));
 
-    assert.equal(ownerLockRun, 2);
-    assert.equal(firstRunRefreshes, 2);
+    assert.equal(ownerLockRun, 3);
+    assert.equal(refreshesByRun.get(1), 2);
+    assert.equal(refreshesByRun.get(2), 2);
     assert.deepEqual(listedIds, new Set([first.state.grantId, created.state.grantId, peerGrantId]));
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -10,6 +10,7 @@ import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
+import { requirePrivateFileDescriptorRoot } from "./private-file.js";
 import { withHeldFileLock } from "../utils/serialize-mutations.js";
 
 async function makeSubject() {
@@ -508,6 +509,35 @@ test("bad secrets return not found, while valid revoked and expired grants revea
   }
 });
 
+test("a grant that expires during guide assembly does not return a guide", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt: expiryAfter(subject, 300_000),
+    });
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let advanced = false;
+    subject.aliceStorage.getMemoryById = async (memoryId) => {
+      const memory = await getMemoryById(memoryId);
+      if (!advanced) {
+        advanced = true;
+        subject.advance(300_000);
+      }
+      return memory;
+    };
+
+    await assert.rejects(
+      subject.grantService.readGrant({ grantId: created.grant.grantId, secret: created.secret }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "grant_expired"
+    );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
 test("revocation waits until helper guide assembly completes", async () => {
   const subject = await makeSubject();
   const cardReadStarted = Promise.withResolvers<void>();
@@ -740,6 +770,15 @@ test("the grant store rejects a symlinked grant directory", async () => {
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("private file operations fail closed without descriptor-relative directory paths", () => {
+  assert.throws(
+    () => requirePrivateFileDescriptorRoot("win32", "private file directory cannot be pinned"),
+    /private file directory cannot be pinned/
+  );
+  assert.equal(requirePrivateFileDescriptorRoot("linux", "unreachable"), "/proc/self/fd");
+  assert.equal(requirePrivateFileDescriptorRoot("darwin", "unreachable"), "/dev/fd");
 });
 
 test("grant cleanup never follows a swapped grant directory", async () => {

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -19,6 +19,7 @@ import { StorageManager } from "../storage.js";
 import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
+import { supportPassportOwnerLockPath } from "./owner-lock.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 import {
@@ -549,7 +550,10 @@ test("grant creation rechecks the owner lock immediately before commit", async (
       const memory = await originalRead(memoryId);
       if (!replacedLock) {
         replacedLock = true;
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return memory;
@@ -623,6 +627,85 @@ test("grant creation aborts before replacing an owner index after lock ownership
       (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
       [first.state.grantId]
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation rechecks its mutation lock after the commit callback", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-callback-lock-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    let refreshes = 0;
+    const inspected = store as unknown as {
+      withMutationLock<T>(task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+    };
+    inspected.withMutationLock = async (task) =>
+      await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+
+    await assert.rejects(
+      store.create(
+        {
+          namespace: "alice",
+          principal: "owner:alice",
+          cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+          expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+        },
+        async () => undefined
+      ),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+    assert.equal(refreshes, 2);
+    await assert.rejects(
+      lstat(path.join(root, "state", "support-passport", "grants")),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant revocation rechecks its mutation lock after the commit callback", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-revoke-callback-lock-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 300_000).toISOString(),
+    });
+    let refreshes = 0;
+    const inspected = store as unknown as {
+      withGrantLock<T>(
+        grantId: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>
+      ): Promise<T>;
+    };
+    inspected.withGrantLock = async (_grantId, task) =>
+      await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+
+    await assert.rejects(
+      store.revoke(
+        { grantId: created.state.grantId, namespace: "alice", principal: "owner:alice" },
+        async () => undefined
+      ),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+    assert.equal(refreshes, 2);
+    assert.equal((await store.authenticate(created.state.grantId, created.secret)).revokedAt, undefined);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1177,7 +1260,10 @@ test("helper guide assembly fails when owner-lock ownership is lost", async () =
       const state = await authenticate(grantId, secret);
       authentications += 1;
       if (authentications === 2) {
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return state;
@@ -1207,7 +1293,10 @@ test("helper guide assembly rechecks the owner lock after grant reauthentication
       const state = await authenticate(grantId, secret);
       authentications += 1;
       if (authentications === 3) {
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return state;
@@ -1238,7 +1327,10 @@ test("helper guide assembly refreshes the owner lock after its final card read",
       const memory = await getMemoryById(memoryId);
       reads += 1;
       if (reads === 2) {
-        const lockPath = path.join(subject.aliceStorage.dir, "state", "support-passport-cards.lock");
+        const lockPath = supportPassportOwnerLockPath(subject.aliceStorage, {
+          namespace: "alice",
+          principal: "owner:alice",
+        });
         await writeFile(lockPath, `${process.pid} 00000000-0000-4000-8000-000000000000 peer\n`);
       }
       return memory;

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -9,7 +9,7 @@ import { StorageManager } from "../storage.js";
 import type { withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportCardService } from "./card-service.js";
 import { SupportPassportError } from "./errors.js";
-import { supportPassportOwnerLockPath } from "./owner-lock.js";
+import { computeSupportPassportOwnerLockKey, supportPassportOwnerLockPath } from "./owner-lock.js";
 import { SupportPassportGrantService } from "./grant-service.js";
 import { SupportPassportGrantStore, syncDirectoryForDurability } from "./grant-store.js";
 import {
@@ -103,8 +103,15 @@ test("a grant stores only hashed credentials with private file permissions", asy
       `${created.grant.grantId}.json`
     );
     const body = await readFile(filePath, "utf8");
+    const state = JSON.parse(body);
     assert.equal(body.includes(created.secret), false);
-    assert.equal(JSON.parse(body).secretHash.length, 64);
+    assert.equal(body.includes("owner:alice"), false);
+    assert.equal(state.secretHash.length, 64);
+    assert.equal(state.ownerLockKey, computeSupportPassportOwnerLockKey("alice", "owner:alice"));
+    assert.equal(
+      supportPassportOwnerLockPath(subject.aliceStorage, { namespace: "alice", principal: "owner:alice" }),
+      supportPassportOwnerLockPath(subject.aliceStorage, { namespace: "alice", ownerKey: state.ownerLockKey })
+    );
     assert.equal((await lstat(filePath)).mode & 0o777, 0o600);
     assert.equal((await lstat(path.dirname(filePath))).mode & 0o777, 0o700);
   } finally {
@@ -336,7 +343,16 @@ test("grant creation accepts a state write that committed before its durability 
   try {
     const grantId = "00000000-0000-4000-8000-000000000001";
     const now = new Date("2026-08-11T12:00:00.000Z");
-    const store = new SupportPassportGrantStore({ memoryDir: root, makeGrantId: () => grantId, now: () => now });
+    const directorySyncs: string[] = [];
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId,
+      now: () => now,
+      syncDirectory: async (directory) => {
+        directorySyncs.push(directory);
+        await syncDirectoryForDurability(directory);
+      },
+    });
     const inspected = store as unknown as {
       writeState(state: unknown, requireAbsent: boolean): Promise<void>;
     };
@@ -357,6 +373,47 @@ test("grant creation accepts a state write that committed before its durability 
     assert.deepEqual(
       (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
       [grantId]
+    );
+    assert.deepEqual(directorySyncs.map((directory) => path.basename(directory)), ["grants"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("grant creation fails closed when a committed state cannot be re-synced", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-state-sync-"));
+  try {
+    const grantId = "00000000-0000-4000-8000-000000000001";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId,
+      now: () => now,
+      syncDirectory: async () => {
+        throw Object.assign(new Error("simulated directory sync failure"), { code: "EIO" });
+      },
+    });
+    const inspected = store as unknown as {
+      writeState(state: unknown, requireAbsent: boolean): Promise<void>;
+    };
+    const writeState = inspected.writeState.bind(store);
+    inspected.writeState = async (state, requireAbsent) => {
+      await writeState(state, requireAbsent);
+      throw Object.assign(new Error("simulated post-commit state error"), { code: "EIO" });
+    };
+
+    await assert.rejects(
+      store.create({
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "EIO"
+    );
+    await assert.rejects(
+      lstat(path.join(root, "state", "support-passport", "grants", `${grantId}.json`)),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT"
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -565,6 +622,35 @@ test("grant creation rechecks the owner lock immediately before commit", async (
         error instanceof SupportPassportError && error.code === "storage_conflict" && error.status === 409
     );
     assert.deepEqual(await subject.grantService.listGrants({ principal: "owner:alice" }), []);
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("grant creation measures its minimum lifetime from request receipt", async () => {
+  const subject = await makeSubject();
+  try {
+    const card = await createActiveCard(subject);
+    const expiresAt = expiryAfter(subject, 300_000);
+    const getMemoryById = subject.aliceStorage.getMemoryById.bind(subject.aliceStorage);
+    let delayed = false;
+    subject.aliceStorage.getMemoryById = async (memoryId: string) => {
+      const memory = await getMemoryById(memoryId);
+      if (!delayed) {
+        delayed = true;
+        subject.advance(1_000);
+      }
+      return memory;
+    };
+
+    const created = await subject.grantService.createGrant({
+      principal: "owner:alice",
+      cards: [{ cardId: card.cardId, revision: card.revision }],
+      expiresAt,
+    });
+
+    assert.equal(created.grant.expiresAt, expiresAt);
+    assert.equal(created.grant.status, "active");
   } finally {
     await subject.cleanup();
   }

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -39,8 +39,6 @@ interface SupportPassportCardSnapshot {
   cardsById: ReadonlyMap<string, StoredSupportPassportCard>;
 }
 
-const MAX_CARD_SNAPSHOT_AGE_MS = 1_000;
-
 function invalidInput(): SupportPassportError {
   return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
 }
@@ -194,7 +192,8 @@ export class SupportPassportGrantService {
             }
             await requireSupportPassportOwnerLock(ownerLock);
             const currentSnapshot =
-              initialSnapshot.version === this.cardSnapshotVersion(storage) && this.cardSnapshotIsFresh(initialSnapshot)
+              initialSnapshot.version === this.cardSnapshotVersion(storage) &&
+              this.cardSnapshotIsFresh(storage, initialSnapshot)
                 ? initialSnapshot
                 : await this.readStoredCardSnapshot(storage);
             const currentCards = this.readGrantCards(currentSnapshot, finalState);
@@ -240,7 +239,7 @@ export class SupportPassportGrantService {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const before = this.cardSnapshotVersion(storage);
       const cached = this.cardSnapshots.get(storage);
-      if (cached?.version === before && this.cardSnapshotIsFresh(cached)) return cached;
+      if (cached?.version === before && this.cardSnapshotIsFresh(storage, cached)) return cached;
       const cards = (await storage.readAllMemories())
         .map((memory) => projectSupportPassportCard(memory))
         .filter((card): card is StoredSupportPassportCard => card !== null);
@@ -267,12 +266,15 @@ export class SupportPassportGrantService {
     return `${storage.getCorpusScanVersion()}:${storage.hotCacheKeyId()}`;
   }
 
-  private cardSnapshotIsFresh(snapshot: SupportPassportCardSnapshot): boolean {
+  private cardSnapshotIsFresh(storage: StorageManager, snapshot: SupportPassportCardSnapshot): boolean {
+    if (!storage.isHotCacheEnabled()) return false;
     const nowMs = this.now().getTime();
+    const ttlMs = storage.hotCacheTtlMs();
     return (
       Number.isFinite(nowMs) &&
+      Number.isFinite(ttlMs) &&
       nowMs >= snapshot.validatedAtMs &&
-      nowMs - snapshot.validatedAtMs <= MAX_CARD_SNAPSHOT_AGE_MS
+      (ttlMs <= 0 || nowMs - snapshot.validatedAtMs <= ttlMs)
     );
   }
 

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -21,7 +21,7 @@ import {
   type SupportPassportRevokeGrantInput,
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
-import { notifySupportPassportCommitted, type SupportPassportGrantStore } from "./grant-store.js";
+import { type SupportPassportGrantStore, notifySupportPassportCommitted } from "./grant-store.js";
 import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
@@ -153,11 +153,11 @@ export class SupportPassportGrantService {
               options.signal?.throwIfAborted();
               await requireSupportPassportOwnerLock(ownerLock);
             },
-            ...(options.onCommitted ? { onCommitted: options.onCommitted } : {}),
           }
         );
-        await requireSupportPassportOwnerLock(ownerLock);
-        return this.ownerGrant(state);
+        const output = this.ownerGrant(state);
+        notifySupportPassportCommitted(options.onCommitted);
+        return output;
       }
     );
   }

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,5 +1,9 @@
 import type { StorageManager } from "../index.js";
-import { computeSupportPassportOwnerKey, projectSupportPassportCard } from "./card-projection.js";
+import {
+  type StoredSupportPassportCard,
+  computeSupportPassportOwnerKey,
+  projectSupportPassportCard,
+} from "./card-projection.js";
 import { SupportPassportListCardsInputSchema, SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
 import {
@@ -29,6 +33,11 @@ export interface SupportPassportGrantServiceDependencies {
 
 type SupportPassportGrantOwnerScope = Awaited<ReturnType<SupportPassportGrantServiceDependencies["resolveOwner"]>>;
 
+interface SupportPassportCardSnapshot {
+  version: string;
+  cardsById: ReadonlyMap<string, StoredSupportPassportCard>;
+}
+
 function invalidInput(): SupportPassportError {
   return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
 }
@@ -38,6 +47,7 @@ export class SupportPassportGrantService {
   private readonly resolveOwner: SupportPassportGrantServiceDependencies["resolveOwner"];
   private readonly resolveNamespace: SupportPassportGrantServiceDependencies["resolveNamespace"];
   private readonly now: () => Date;
+  private readonly cardSnapshots = new WeakMap<StorageManager, SupportPassportCardSnapshot>();
 
   constructor(dependencies: SupportPassportGrantServiceDependencies) {
     this.grantStore = dependencies.grantStore;
@@ -59,9 +69,11 @@ export class SupportPassportGrantService {
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
       options.signal?.throwIfAborted();
+      const cardsById = new Map(
+        (await this.readStoredCards(owner.storage)).map((card) => [card.card.cardId, card]),
+      );
       for (const cardRef of parsed.data.cards) {
-        const memory = await owner.storage.getMemoryById(cardRef.cardId);
-        const stored = memory ? projectSupportPassportCard(memory) : null;
+        const stored = cardsById.get(cardRef.cardId);
         if (
           !stored ||
           stored.namespace !== owner.namespace ||
@@ -160,7 +172,8 @@ export class SupportPassportGrantService {
   private async readGrantAttempt(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
     const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
     const storage = await this.resolveNamespace(initialState.namespace);
-    const cards = await this.readGrantCards(storage, initialState);
+    const initialSnapshot = await this.readStoredCardSnapshot(storage);
+    const cards = this.readGrantCards(initialSnapshot, initialState);
     const firstCard = cards[0];
     if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
     const updatedAt = cards.reduce((latest, card) => {
@@ -178,7 +191,11 @@ export class SupportPassportGrantService {
             throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
           }
           await requireSupportPassportOwnerLock(ownerLock);
-          const currentCards = await this.readGrantCards(storage, finalState);
+          const currentSnapshot =
+            initialSnapshot.version === this.cardSnapshotVersion(storage)
+              ? initialSnapshot
+              : await this.readStoredCardSnapshot(storage);
+          const currentCards = this.readGrantCards(currentSnapshot, finalState);
           await requireSupportPassportOwnerLock(ownerLock);
           if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
             throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
@@ -197,11 +214,9 @@ export class SupportPassportGrantService {
     );
   }
 
-  private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
-    return await Promise.all(
-      state.cards.map(async (cardRef) => {
-        const memory = await storage.getMemoryById(cardRef.cardId);
-        const stored = memory ? projectSupportPassportCard(memory) : null;
+  private readGrantCards(snapshot: SupportPassportCardSnapshot, state: SupportPassportGrantState) {
+    return state.cards.map((cardRef) => {
+        const stored = snapshot.cardsById.get(cardRef.cardId);
         if (
           !stored ||
           stored.namespace !== state.namespace ||
@@ -216,8 +231,41 @@ export class SupportPassportGrantService {
           throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
         return publicCard.data;
-      })
+      });
+  }
+
+  private async readStoredCardSnapshot(storage: StorageManager): Promise<SupportPassportCardSnapshot> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const before = this.cardSnapshotVersion(storage);
+      const cached = this.cardSnapshots.get(storage);
+      if (cached?.version === before) return cached;
+      const cards = (await storage.readAllMemories())
+        .map((memory) => projectSupportPassportCard(memory))
+        .filter((card): card is StoredSupportPassportCard => card !== null);
+      const after = this.cardSnapshotVersion(storage);
+      if (before !== after) continue;
+      const snapshot = {
+        version: after,
+        cardsById: new Map(cards.map((card) => [card.card.cardId, card])),
+      };
+      this.cardSnapshots.set(storage, snapshot);
+      return snapshot;
+    }
+    throw new SupportPassportError(
+      "storage_conflict",
+      "The support card list changed during review.",
+      409,
     );
+  }
+
+  private async readStoredCards(storage: StorageManager): Promise<StoredSupportPassportCard[]> {
+    return (await storage.readAllMemories())
+      .map((memory) => projectSupportPassportCard(memory))
+      .filter((card): card is StoredSupportPassportCard => card !== null);
+  }
+
+  private cardSnapshotVersion(storage: StorageManager): string {
+    return `${storage.getCorpusScanVersion()}:${storage.hotCacheKeyId()}`;
   }
 
   private async revokeCommittedGrant(

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -35,8 +35,11 @@ type SupportPassportGrantOwnerScope = Awaited<ReturnType<SupportPassportGrantSer
 
 interface SupportPassportCardSnapshot {
   version: string;
+  validatedAtMs: number;
   cardsById: ReadonlyMap<string, StoredSupportPassportCard>;
 }
+
+const MAX_CARD_SNAPSHOT_AGE_MS = 1_000;
 
 function invalidInput(): SupportPassportError {
   return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
@@ -238,7 +241,13 @@ export class SupportPassportGrantService {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const before = this.cardSnapshotVersion(storage);
       const cached = this.cardSnapshots.get(storage);
-      if (cached?.version === before) return cached;
+      const nowMs = this.now().getTime();
+      const cacheIsFresh =
+        cached !== undefined &&
+        Number.isFinite(nowMs) &&
+        nowMs >= cached.validatedAtMs &&
+        nowMs - cached.validatedAtMs <= MAX_CARD_SNAPSHOT_AGE_MS;
+      if (cached?.version === before && cacheIsFresh) return cached;
       const cards = (await storage.readAllMemories())
         .map((memory) => projectSupportPassportCard(memory))
         .filter((card): card is StoredSupportPassportCard => card !== null);
@@ -246,6 +255,7 @@ export class SupportPassportGrantService {
       if (before !== after) continue;
       const snapshot = {
         version: after,
+        validatedAtMs: this.now().getTime(),
         cardsById: new Map(cards.map((card) => [card.card.cardId, card])),
       };
       this.cardSnapshots.set(storage, snapshot);

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -21,7 +21,7 @@ import {
   type SupportPassportRevokeGrantInput,
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
-import type { SupportPassportGrantStore } from "./grant-store.js";
+import { notifySupportPassportCommitted, type SupportPassportGrantStore } from "./grant-store.js";
 import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
@@ -71,54 +71,53 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
-      options.signal?.throwIfAborted();
-      const cardsById = new Map(
-        (await this.readStoredCards(owner.storage)).map((card) => [card.card.cardId, card]),
-      );
-      for (const cardRef of parsed.data.cards) {
-        const stored = cardsById.get(cardRef.cardId);
-        if (
-          !stored ||
-          stored.namespace !== owner.namespace ||
-          stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
-          stored.card.status !== "active"
-        ) {
-          throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
+        options.signal?.throwIfAborted();
+        const cardsById = new Map((await this.readStoredCards(owner.storage)).map((card) => [card.card.cardId, card]));
+        for (const cardRef of parsed.data.cards) {
+          const stored = cardsById.get(cardRef.cardId);
+          if (
+            !stored ||
+            stored.namespace !== owner.namespace ||
+            stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
+            stored.card.status !== "active"
+          ) {
+            throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
+          }
+          if (stored.card.revision !== cardRef.revision) {
+            throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+          }
+          if (!this.publicCard(stored.card).success) {
+            throw new SupportPassportError("card_data_invalid", "The support card data is invalid.", 500);
+          }
         }
-        if (stored.card.revision !== cardRef.revision) {
-          throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+        const created = await this.grantStore.create(
+          {
+            namespace: owner.namespace,
+            principal: owner.principal,
+            cards: parsed.data.cards,
+            expiresAt: parsed.data.expiresAt,
+            requestedAt,
+          },
+          {
+            beforeCommit: async () => await requireSupportPassportOwnerLock(ownerLock),
+          }
+        );
+        try {
+          await requireSupportPassportOwnerLock(ownerLock);
+        } catch (error) {
+          await this.revokeCommittedGrant(created, owner);
+          throw error;
         }
-        if (!this.publicCard(stored.card).success) {
-          throw new SupportPassportError("card_data_invalid", "The support card data is invalid.", 500);
+        if (options.signal?.aborted) {
+          await this.revokeCommittedGrant(created, owner);
+          options.signal.throwIfAborted();
         }
-      }
-      const created = await this.grantStore.create(
-        {
-          namespace: owner.namespace,
-          principal: owner.principal,
-          cards: parsed.data.cards,
-          expiresAt: parsed.data.expiresAt,
-          requestedAt,
-        },
-        {
-          beforeCommit: async () => await requireSupportPassportOwnerLock(ownerLock),
-          ...(options.onCommitted ? { onCommitted: options.onCommitted } : {}),
-        }
-      );
-      try {
-        await requireSupportPassportOwnerLock(ownerLock);
-      } catch (error) {
-        await this.revokeCommittedGrant(created, owner);
-        throw error;
-      }
-      if (options.signal?.aborted) {
-        await this.revokeCommittedGrant(created, owner);
-        options.signal.throwIfAborted();
-      }
-      return SupportPassportCreatedGrantSchema.parse({
-        grant: this.ownerGrant(created.state),
-        secret: created.secret,
-      });
+        const output = SupportPassportCreatedGrantSchema.parse({
+          grant: this.ownerGrant(created.state),
+          secret: created.secret,
+        });
+        notifySupportPassportCommitted(options.onCommitted);
+        return output;
       }
     );
   }
@@ -143,24 +142,24 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
-      options.signal?.throwIfAborted();
-      const state = await this.grantStore.revoke(
-        {
-          grantId: parsed.data.grantId,
-          namespace: owner.namespace,
-          principal: owner.principal,
-          expectedStateVersion: parsed.data.expectedStateVersion,
-        },
-        {
-          beforeCommit: async () => {
-            options.signal?.throwIfAborted();
-            await requireSupportPassportOwnerLock(ownerLock);
+        options.signal?.throwIfAborted();
+        const state = await this.grantStore.revoke(
+          {
+            grantId: parsed.data.grantId,
+            namespace: owner.namespace,
+            principal: owner.principal,
+            expectedStateVersion: parsed.data.expectedStateVersion,
           },
-          ...(options.onCommitted ? { onCommitted: options.onCommitted } : {}),
-        }
-      );
-      await requireSupportPassportOwnerLock(ownerLock);
-      return this.ownerGrant(state);
+          {
+            beforeCommit: async () => {
+              options.signal?.throwIfAborted();
+              await requireSupportPassportOwnerLock(ownerLock);
+            },
+            ...(options.onCommitted ? { onCommitted: options.onCommitted } : {}),
+          }
+        );
+        await requireSupportPassportOwnerLock(ownerLock);
+        return this.ownerGrant(state);
       }
     );
   }
@@ -186,56 +185,55 @@ export class SupportPassportGrantService {
       storage,
       { namespace: initialState.namespace, ownerKey: initialState.ownerLockKey },
       async (ownerLock) => {
-      return await this.grantStore.withAuthenticatedGrant(
-        input.grantId,
-        input.secret,
-        async (finalState) => {
-          if (finalState.namespace !== initialState.namespace) {
-            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-          }
-          await requireSupportPassportOwnerLock(ownerLock);
-          const currentSnapshot =
-            initialSnapshot.version === this.cardSnapshotVersion(storage) &&
-            this.cardSnapshotIsFresh(initialSnapshot)
-              ? initialSnapshot
-              : await this.readStoredCardSnapshot(storage);
-          const currentCards = this.readGrantCards(currentSnapshot, finalState);
-          await requireSupportPassportOwnerLock(ownerLock);
-          if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
-            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-          }
-          return SupportPassportPublicGuideSchema.parse({
-            schemaVersion: 1,
-            grantId: finalState.grantId,
-            expiresAt: finalState.expiresAt,
-            updatedAt,
-            cards,
-          });
-        },
-        async () => await requireSupportPassportOwnerLock(ownerLock)
-      );
+        return await this.grantStore.withAuthenticatedGrant(
+          input.grantId,
+          input.secret,
+          async (finalState) => {
+            if (finalState.namespace !== initialState.namespace) {
+              throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+            }
+            await requireSupportPassportOwnerLock(ownerLock);
+            const currentSnapshot =
+              initialSnapshot.version === this.cardSnapshotVersion(storage) && this.cardSnapshotIsFresh(initialSnapshot)
+                ? initialSnapshot
+                : await this.readStoredCardSnapshot(storage);
+            const currentCards = this.readGrantCards(currentSnapshot, finalState);
+            await requireSupportPassportOwnerLock(ownerLock);
+            if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
+              throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+            }
+            return SupportPassportPublicGuideSchema.parse({
+              schemaVersion: 1,
+              grantId: finalState.grantId,
+              expiresAt: finalState.expiresAt,
+              updatedAt,
+              cards,
+            });
+          },
+          async () => await requireSupportPassportOwnerLock(ownerLock)
+        );
       }
     );
   }
 
   private readGrantCards(snapshot: SupportPassportCardSnapshot, state: SupportPassportGrantState) {
     return state.cards.map((cardRef) => {
-        const stored = snapshot.cardsById.get(cardRef.cardId);
-        if (
-          !stored ||
-          stored.namespace !== state.namespace ||
-          stored.owner !== state.principalHash ||
-          stored.card.status !== "active" ||
-          stored.card.revision !== cardRef.revision
-        ) {
-          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-        }
-        const publicCard = this.publicCard(stored.card);
-        if (!publicCard.success) {
-          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-        }
-        return publicCard.data;
-      });
+      const stored = snapshot.cardsById.get(cardRef.cardId);
+      if (
+        !stored ||
+        stored.namespace !== state.namespace ||
+        stored.owner !== state.principalHash ||
+        stored.card.status !== "active" ||
+        stored.card.revision !== cardRef.revision
+      ) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
+      const publicCard = this.publicCard(stored.card);
+      if (!publicCard.success) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
+      return publicCard.data;
+    });
   }
 
   private async readStoredCardSnapshot(storage: StorageManager): Promise<SupportPassportCardSnapshot> {
@@ -256,11 +254,7 @@ export class SupportPassportGrantService {
       this.cardSnapshots.set(storage, snapshot);
       return snapshot;
     }
-    throw new SupportPassportError(
-      "storage_conflict",
-      "The support card list changed during review.",
-      409,
-    );
+    throw new SupportPassportError("storage_conflict", "The support card list changed during review.", 409);
   }
 
   private async readStoredCards(storage: StorageManager): Promise<StoredSupportPassportCard[]> {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -16,6 +16,7 @@ import {
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
 import type { SupportPassportGrantStore } from "./grant-store.js";
+import { withSupportPassportOwnerLock } from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
@@ -45,26 +46,32 @@ export class SupportPassportGrantService {
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwner(parsed.data.principal);
-    for (const cardRef of parsed.data.cards) {
-      const memory = await owner.storage.getMemoryById(cardRef.cardId);
-      const stored = memory ? projectSupportPassportCard(memory) : null;
-      if (!stored || stored.card.status !== "active") {
-        throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
+    return await withSupportPassportOwnerLock(
+      owner.storage,
+      { namespace: owner.namespace, principal: parsed.data.principal },
+      async () => {
+      for (const cardRef of parsed.data.cards) {
+        const memory = await owner.storage.getMemoryById(cardRef.cardId);
+        const stored = memory ? projectSupportPassportCard(memory) : null;
+        if (!stored || stored.card.status !== "active") {
+          throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
+        }
+        if (stored.card.revision !== cardRef.revision) {
+          throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+        }
       }
-      if (stored.card.revision !== cardRef.revision) {
-        throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+      const created = await this.grantStore.create({
+        namespace: owner.namespace,
+        principal: parsed.data.principal,
+        cards: parsed.data.cards,
+        expiresAt: parsed.data.expiresAt,
+      });
+      return SupportPassportCreatedGrantSchema.parse({
+        grant: this.ownerGrant(created.state),
+        secret: created.secret,
+      });
       }
-    }
-    const created = await this.grantStore.create({
-      namespace: owner.namespace,
-      principal: parsed.data.principal,
-      cards: parsed.data.cards,
-      expiresAt: parsed.data.expiresAt,
-    });
-    return SupportPassportCreatedGrantSchema.parse({
-      grant: this.ownerGrant(created.state),
-      secret: created.secret,
-    });
+    );
   }
 
   async listGrants(input: { principal: string }): Promise<SupportPassportOwnerGrant[]> {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -71,7 +71,9 @@ export class SupportPassportGrantService {
     const parsed = SupportPassportListGrantsInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwner(parsed.data.principal);
-    return (await this.grantStore.listForOwner(owner.namespace, parsed.data.principal)).map((state) => this.ownerGrant(state));
+    return (await this.grantStore.listForOwner(owner.namespace, parsed.data.principal)).map((state) =>
+      this.ownerGrant(state)
+    );
   }
 
   async revokeGrant(input: SupportPassportRevokeGrantInput): Promise<SupportPassportOwnerGrant> {
@@ -108,7 +110,12 @@ export class SupportPassportGrantService {
         updatedAt: stored.card.updatedAt,
       });
     }
-    const updatedAt = cards.reduce((latest, card) => card.updatedAt > latest ? card.updatedAt : latest, cards[0]!.updatedAt);
+    const firstCard = cards[0];
+    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    const updatedAt = cards.reduce(
+      (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
+      firstCard.updatedAt
+    );
     return SupportPassportPublicGuideSchema.parse({
       schemaVersion: 1,
       grantId: state.grantId,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -107,26 +107,28 @@ export class SupportPassportGrantService {
     if (confirmedState.stateVersion !== state.stateVersion) {
       throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
     }
-    const confirmedCards = await this.readGrantCards(storage, confirmedState);
-    if (JSON.stringify(confirmedCards) !== JSON.stringify(cards)) {
-      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    }
-    const finalState = await this.grantStore.authenticate(input.grantId, input.secret);
-    if (finalState.stateVersion !== confirmedState.stateVersion) {
-      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    }
-    const firstCard = confirmedCards[0];
-    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    const updatedAt = confirmedCards.reduce(
-      (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
-      firstCard.updatedAt
-    );
-    return SupportPassportPublicGuideSchema.parse({
-      schemaVersion: 1,
-      grantId: finalState.grantId,
-      expiresAt: finalState.expiresAt,
-      updatedAt,
-      cards: confirmedCards,
+    return await withSupportPassportOwnerLock(storage, async () => {
+      const confirmedCards = await this.readGrantCards(storage, confirmedState);
+      if (JSON.stringify(confirmedCards) !== JSON.stringify(cards)) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
+      const finalState = await this.grantStore.authenticate(input.grantId, input.secret);
+      if (finalState.stateVersion !== confirmedState.stateVersion) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
+      const firstCard = confirmedCards[0];
+      if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      const updatedAt = confirmedCards.reduce(
+        (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
+        firstCard.updatedAt
+      );
+      return SupportPassportPublicGuideSchema.parse({
+        schemaVersion: 1,
+        grantId: finalState.grantId,
+        expiresAt: finalState.expiresAt,
+        updatedAt,
+        cards: confirmedCards,
+      });
     });
   }
 

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,6 +1,12 @@
 import type { StorageManager } from "../index.js";
-import { computeSupportPassportOwnerKey, projectSupportPassportCard } from "./card-projection.js";
-import { SupportPassportListCardsInputSchema, SupportPassportNamespaceSchema } from "./contracts.js";
+import {
+  computeSupportPassportOwnerKey,
+  projectSupportPassportCard,
+} from "./card-projection.js";
+import {
+  SupportPassportListCardsInputSchema,
+  SupportPassportNamespaceSchema,
+} from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
 import {
   type SupportPassportCreateGrantInput,
@@ -18,19 +24,30 @@ import {
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
 import type { SupportPassportGrantStore } from "./grant-store.js";
-import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
+import {
+  requireSupportPassportOwnerLock,
+  withSupportPassportOwnerLock,
+} from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
-  resolveOwner(principal: string): Promise<{ principal: string; namespace: string; storage: StorageManager }>;
+  resolveOwner(
+    principal: string,
+  ): Promise<{ principal: string; namespace: string; storage: StorageManager }>;
   resolveNamespace(namespace: string): Promise<StorageManager>;
   now?: () => Date;
 }
 
-type SupportPassportGrantOwnerScope = Awaited<ReturnType<SupportPassportGrantServiceDependencies["resolveOwner"]>>;
+type SupportPassportGrantOwnerScope = Awaited<
+  ReturnType<SupportPassportGrantServiceDependencies["resolveOwner"]>
+>;
 
 function invalidInput(): SupportPassportError {
-  return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+  return new SupportPassportError(
+    "invalid_input",
+    "The share link request is invalid.",
+    400,
+  );
 }
 
 export class SupportPassportGrantService {
@@ -46,7 +63,9 @@ export class SupportPassportGrantService {
     this.now = dependencies.now ?? (() => new Date());
   }
 
-  async createGrant(input: SupportPassportCreateGrantInput): Promise<SupportPassportCreatedGrant> {
+  async createGrant(
+    input: SupportPassportCreateGrantInput,
+  ): Promise<SupportPassportCreatedGrant> {
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
@@ -54,51 +73,67 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
-      for (const cardRef of parsed.data.cards) {
-        const memory = await owner.storage.getMemoryById(cardRef.cardId);
-        const stored = memory ? projectSupportPassportCard(memory) : null;
-        if (
-          !stored ||
-          stored.namespace !== owner.namespace ||
-          stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
-          stored.card.status !== "active"
-        ) {
-          throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
+        for (const cardRef of parsed.data.cards) {
+          const memory = await owner.storage.getMemoryById(cardRef.cardId);
+          const stored = memory ? projectSupportPassportCard(memory) : null;
+          if (
+            !stored ||
+            stored.namespace !== owner.namespace ||
+            stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
+            stored.card.status !== "active"
+          ) {
+            throw new SupportPassportError(
+              "invalid_card_status",
+              "Only approved support cards can be shared.",
+              409,
+            );
+          }
+          if (stored.card.revision !== cardRef.revision) {
+            throw new SupportPassportError(
+              "revision_conflict",
+              "A support card changed after it was selected.",
+              409,
+            );
+          }
+          if (!this.publicCard(stored.card).success) {
+            throw new SupportPassportError(
+              "card_data_invalid",
+              "The support card data is invalid.",
+              500,
+            );
+          }
         }
-        if (stored.card.revision !== cardRef.revision) {
-          throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
-        }
-        if (!this.publicCard(stored.card).success) {
-          throw new SupportPassportError("card_data_invalid", "The support card data is invalid.", 500);
-        }
-      }
-      const created = await this.grantStore.create(
-        {
-          namespace: owner.namespace,
-          principal: owner.principal,
-          cards: parsed.data.cards,
-          expiresAt: parsed.data.expiresAt,
-        },
-        async () => await requireSupportPassportOwnerLock(ownerLock)
-      );
-      return SupportPassportCreatedGrantSchema.parse({
-        grant: this.ownerGrant(created.state),
-        secret: created.secret,
-      });
-      }
+        const created = await this.grantStore.create(
+          {
+            namespace: owner.namespace,
+            principal: owner.principal,
+            cards: parsed.data.cards,
+            expiresAt: parsed.data.expiresAt,
+          },
+          async () => await requireSupportPassportOwnerLock(ownerLock),
+        );
+        return SupportPassportCreatedGrantSchema.parse({
+          grant: this.ownerGrant(created.state),
+          secret: created.secret,
+        });
+      },
     );
   }
 
-  async listGrants(input: { principal: string }): Promise<SupportPassportOwnerGrant[]> {
+  async listGrants(input: {
+    principal: string;
+  }): Promise<SupportPassportOwnerGrant[]> {
     const parsed = SupportPassportListGrantsInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
-    return (await this.grantStore.listForOwner(owner.namespace, owner.principal)).map((state) =>
-      this.ownerGrant(state)
-    );
+    return (
+      await this.grantStore.listForOwner(owner.namespace, owner.principal)
+    ).map((state) => this.ownerGrant(state));
   }
 
-  async revokeGrant(input: SupportPassportRevokeGrantInput): Promise<SupportPassportOwnerGrant> {
+  async revokeGrant(
+    input: SupportPassportRevokeGrantInput,
+  ): Promise<SupportPassportOwnerGrant> {
     const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
@@ -106,69 +141,107 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
-      const state = await this.grantStore.revoke(
-        {
-          grantId: parsed.data.grantId,
-          namespace: owner.namespace,
-          principal: owner.principal,
-          expectedStateVersion: parsed.data.expectedStateVersion,
-        },
-        async () => await requireSupportPassportOwnerLock(ownerLock)
-      );
-      await requireSupportPassportOwnerLock(ownerLock);
-      return this.ownerGrant(state);
-      }
+        const state = await this.grantStore.revoke(
+          {
+            grantId: parsed.data.grantId,
+            namespace: owner.namespace,
+            principal: owner.principal,
+            expectedStateVersion: parsed.data.expectedStateVersion,
+          },
+          async () => await requireSupportPassportOwnerLock(ownerLock),
+        );
+        await requireSupportPassportOwnerLock(ownerLock);
+        return this.ownerGrant(state);
+      },
     );
   }
 
-  async readGrant(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
-    if (!input || typeof input.grantId !== "string" || typeof input.secret !== "string") {
-      throw new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+  async readGrant(input: {
+    grantId: string;
+    secret: string;
+  }): Promise<SupportPassportPublicGuide> {
+    if (
+      !input ||
+      typeof input.grantId !== "string" ||
+      typeof input.secret !== "string"
+    ) {
+      throw new SupportPassportError(
+        "grant_not_found",
+        "The share link was not found.",
+        404,
+      );
     }
     return await this.readGrantAttempt(input);
   }
 
-  private async readGrantAttempt(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
-    const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
+  private async readGrantAttempt(input: {
+    grantId: string;
+    secret: string;
+  }): Promise<SupportPassportPublicGuide> {
+    const initialState = await this.grantStore.authenticate(
+      input.grantId,
+      input.secret,
+    );
     const storage = await this.resolveNamespace(initialState.namespace);
     const cards = await this.readGrantCards(storage, initialState);
     const firstCard = cards[0];
-    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    if (!firstCard)
+      throw new SupportPassportError(
+        "grant_stale",
+        "The shared support guide has changed.",
+        410,
+      );
     const updatedAt = cards.reduce((latest, card) => {
-      return Date.parse(card.updatedAt) > Date.parse(latest) ? card.updatedAt : latest;
+      return Date.parse(card.updatedAt) > Date.parse(latest)
+        ? card.updatedAt
+        : latest;
     }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(
       storage,
-      { namespace: initialState.namespace, principal: `hash:${initialState.principalHash}` },
+      {
+        namespace: initialState.namespace,
+        ownerKey: initialState.principalHash,
+      },
       async (ownerLock) => {
-      return await this.grantStore.withAuthenticatedGrant(
-        input.grantId,
-        input.secret,
-        async (finalState) => {
-          if (finalState.namespace !== initialState.namespace) {
-            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-          }
-          await requireSupportPassportOwnerLock(ownerLock);
-          const currentCards = await this.readGrantCards(storage, finalState);
-          await requireSupportPassportOwnerLock(ownerLock);
-          if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
-            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-          }
-          return SupportPassportPublicGuideSchema.parse({
-            schemaVersion: 1,
-            grantId: finalState.grantId,
-            expiresAt: finalState.expiresAt,
-            updatedAt,
-            cards,
-          });
-        },
-        async () => await requireSupportPassportOwnerLock(ownerLock)
-      );
-      }
+        return await this.grantStore.withAuthenticatedGrant(
+          input.grantId,
+          input.secret,
+          async (finalState) => {
+            if (finalState.namespace !== initialState.namespace) {
+              throw new SupportPassportError(
+                "grant_stale",
+                "The shared support guide has changed.",
+                410,
+              );
+            }
+            await requireSupportPassportOwnerLock(ownerLock);
+            const currentCards = await this.readGrantCards(storage, finalState);
+            await requireSupportPassportOwnerLock(ownerLock);
+            if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
+              throw new SupportPassportError(
+                "grant_stale",
+                "The shared support guide has changed.",
+                410,
+              );
+            }
+            return SupportPassportPublicGuideSchema.parse({
+              schemaVersion: 1,
+              grantId: finalState.grantId,
+              expiresAt: finalState.expiresAt,
+              updatedAt,
+              cards,
+            });
+          },
+          async () => await requireSupportPassportOwnerLock(ownerLock),
+        );
+      },
     );
   }
 
-  private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
+  private async readGrantCards(
+    storage: StorageManager,
+    state: SupportPassportGrantState,
+  ) {
     return await Promise.all(
       state.cards.map(async (cardRef) => {
         const memory = await storage.getMemoryById(cardRef.cardId);
@@ -180,14 +253,22 @@ export class SupportPassportGrantService {
           stored.card.status !== "active" ||
           stored.card.revision !== cardRef.revision
         ) {
-          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+          throw new SupportPassportError(
+            "grant_stale",
+            "The shared support guide has changed.",
+            410,
+          );
         }
         const publicCard = this.publicCard(stored.card);
         if (!publicCard.success) {
-          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+          throw new SupportPassportError(
+            "grant_stale",
+            "The shared support guide has changed.",
+            410,
+          );
         }
         return publicCard.data;
-      })
+      }),
     );
   }
 
@@ -207,23 +288,39 @@ export class SupportPassportGrantService {
     });
   }
 
-  private async resolveOwnerScope(principal: string): Promise<SupportPassportGrantOwnerScope> {
-    const requestedPrincipal = SupportPassportListCardsInputSchema.safeParse({ principal });
+  private async resolveOwnerScope(
+    principal: string,
+  ): Promise<SupportPassportGrantOwnerScope> {
+    const requestedPrincipal = SupportPassportListCardsInputSchema.safeParse({
+      principal,
+    });
     const owner = await this.resolveOwner(principal);
     const namespace = SupportPassportNamespaceSchema.safeParse(owner.namespace);
-    const ownerPrincipal = SupportPassportListCardsInputSchema.safeParse({ principal: owner.principal });
+    const ownerPrincipal = SupportPassportListCardsInputSchema.safeParse({
+      principal: owner.principal,
+    });
     if (
       !requestedPrincipal.success ||
       !namespace.success ||
       !ownerPrincipal.success ||
       ownerPrincipal.data.principal !== requestedPrincipal.data.principal
     ) {
-      throw new SupportPassportError("card_data_invalid", "The support passport owner scope is invalid.", 500);
+      throw new SupportPassportError(
+        "card_data_invalid",
+        "The support passport owner scope is invalid.",
+        500,
+      );
     }
-    return { ...owner, principal: ownerPrincipal.data.principal, namespace: namespace.data };
+    return {
+      ...owner,
+      principal: ownerPrincipal.data.principal,
+      namespace: namespace.data,
+    };
   }
 
-  private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {
+  private ownerGrant(
+    state: SupportPassportGrantState,
+  ): SupportPassportOwnerGrant {
     const status = state.revokedAt
       ? "revoked"
       : Date.parse(state.expiresAt) <= this.now().getTime()

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -54,7 +54,7 @@ export class SupportPassportGrantService {
       for (const cardRef of parsed.data.cards) {
         const memory = await owner.storage.getMemoryById(cardRef.cardId);
         const stored = memory ? projectSupportPassportCard(memory) : null;
-        if (!stored || stored.card.status !== "active") {
+        if (!stored || stored.namespace !== owner.namespace || stored.card.status !== "active") {
           throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
         }
         if (stored.card.revision !== cardRef.revision) {
@@ -95,12 +95,15 @@ export class SupportPassportGrantService {
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwner(parsed.data.principal);
     return await withSupportPassportOwnerLock(owner.storage, async (ownerLock) => {
-      const state = await this.grantStore.revoke({
-        grantId: parsed.data.grantId,
-        namespace: owner.namespace,
-        principal: owner.principal,
-        expectedStateVersion: parsed.data.expectedStateVersion,
-      }, async () => await requireSupportPassportOwnerLock(ownerLock));
+      const state = await this.grantStore.revoke(
+        {
+          grantId: parsed.data.grantId,
+          namespace: owner.namespace,
+          principal: owner.principal,
+          expectedStateVersion: parsed.data.expectedStateVersion,
+        },
+        async () => await requireSupportPassportOwnerLock(ownerLock)
+      );
       await requireSupportPassportOwnerLock(ownerLock);
       return this.ownerGrant(state);
     });
@@ -150,18 +153,25 @@ export class SupportPassportGrantService {
   }
 
   private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
-    return await Promise.all(state.cards.map(async (cardRef) => {
-      const memory = await storage.getMemoryById(cardRef.cardId);
-      const stored = memory ? projectSupportPassportCard(memory) : null;
-      if (!stored || stored.card.status !== "active" || stored.card.revision !== cardRef.revision) {
-        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-      }
-      const publicCard = this.publicCard(stored.card);
-      if (!publicCard.success) {
-        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-      }
-      return publicCard.data;
-    }));
+    return await Promise.all(
+      state.cards.map(async (cardRef) => {
+        const memory = await storage.getMemoryById(cardRef.cardId);
+        const stored = memory ? projectSupportPassportCard(memory) : null;
+        if (
+          !stored ||
+          stored.namespace !== state.namespace ||
+          stored.card.status !== "active" ||
+          stored.card.revision !== cardRef.revision
+        ) {
+          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+        }
+        const publicCard = this.publicCard(stored.card);
+        if (!publicCard.success) {
+          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+        }
+        return publicCard.data;
+      })
+    );
   }
 
   private publicCard(card: {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -35,7 +35,6 @@ type SupportPassportGrantOwnerScope = Awaited<ReturnType<SupportPassportGrantSer
 
 interface SupportPassportCardSnapshot {
   version: string;
-  validatedAtMs: number;
   cardsById: ReadonlyMap<string, StoredSupportPassportCard>;
 }
 
@@ -48,7 +47,6 @@ export class SupportPassportGrantService {
   private readonly resolveOwner: SupportPassportGrantServiceDependencies["resolveOwner"];
   private readonly resolveNamespace: SupportPassportGrantServiceDependencies["resolveNamespace"];
   private readonly now: () => Date;
-  private readonly cardSnapshots = new WeakMap<StorageManager, SupportPassportCardSnapshot>();
 
   constructor(dependencies: SupportPassportGrantServiceDependencies) {
     this.grantStore = dependencies.grantStore;
@@ -97,7 +95,10 @@ export class SupportPassportGrantService {
             requestedAt,
           },
           {
-            beforeCommit: async () => await requireSupportPassportOwnerLock(ownerLock),
+            beforeCommit: async () => {
+              options.signal?.throwIfAborted();
+              await requireSupportPassportOwnerLock(ownerLock);
+            },
           }
         );
         try {
@@ -191,11 +192,7 @@ export class SupportPassportGrantService {
               throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
             }
             await requireSupportPassportOwnerLock(ownerLock);
-            const currentSnapshot =
-              initialSnapshot.version === this.cardSnapshotVersion(storage) &&
-              this.cardSnapshotIsFresh(storage, initialSnapshot)
-                ? initialSnapshot
-                : await this.readStoredCardSnapshot(storage);
+            const currentSnapshot = await this.readStoredCardSnapshot(storage);
             const currentCards = this.readGrantCards(currentSnapshot, finalState);
             await requireSupportPassportOwnerLock(ownerLock);
             if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
@@ -238,8 +235,6 @@ export class SupportPassportGrantService {
   private async readStoredCardSnapshot(storage: StorageManager): Promise<SupportPassportCardSnapshot> {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const before = this.cardSnapshotVersion(storage);
-      const cached = this.cardSnapshots.get(storage);
-      if (cached?.version === before && this.cardSnapshotIsFresh(storage, cached)) return cached;
       const cards = (await storage.readAllMemories())
         .map((memory) => projectSupportPassportCard(memory))
         .filter((card): card is StoredSupportPassportCard => card !== null);
@@ -247,10 +242,8 @@ export class SupportPassportGrantService {
       if (before !== after) continue;
       const snapshot = {
         version: after,
-        validatedAtMs: this.now().getTime(),
         cardsById: new Map(cards.map((card) => [card.card.cardId, card])),
       };
-      this.cardSnapshots.set(storage, snapshot);
       return snapshot;
     }
     throw new SupportPassportError("storage_conflict", "The support card list changed during review.", 409);
@@ -264,18 +257,6 @@ export class SupportPassportGrantService {
 
   private cardSnapshotVersion(storage: StorageManager): string {
     return `${storage.getCorpusScanVersion()}:${storage.hotCacheKeyId()}`;
-  }
-
-  private cardSnapshotIsFresh(storage: StorageManager, snapshot: SupportPassportCardSnapshot): boolean {
-    if (!storage.isHotCacheEnabled()) return false;
-    const nowMs = this.now().getTime();
-    const ttlMs = storage.hotCacheTtlMs();
-    return (
-      Number.isFinite(nowMs) &&
-      Number.isFinite(ttlMs) &&
-      nowMs >= snapshot.validatedAtMs &&
-      (ttlMs <= 0 || nowMs - snapshot.validatedAtMs <= ttlMs)
-    );
   }
 
   private async revokeCommittedGrant(

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -138,22 +138,20 @@ export class SupportPassportGrantService {
   }
 
   private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
-    const cards = [];
-    for (const cardRef of state.cards) {
+    return await Promise.all(state.cards.map(async (cardRef) => {
       const memory = await storage.getMemoryById(cardRef.cardId);
       const stored = memory ? projectSupportPassportCard(memory) : null;
       if (!stored || stored.card.status !== "active" || stored.card.revision !== cardRef.revision) {
         throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
       }
-      cards.push({
+      return {
         cardId: stored.card.cardId,
         title: stored.card.title,
         statement: stored.card.statement,
         category: stored.card.category,
         updatedAt: stored.card.updatedAt,
-      });
-    }
-    return cards;
+      };
+    }));
   }
 
   private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -139,7 +139,7 @@ export class SupportPassportGrantService {
     }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(
       storage,
-      { namespace: initialState.namespace, principal: `hash:${initialState.principalHash}` },
+      { namespace: initialState.namespace, ownerKey: initialState.principalHash },
       async (ownerLock) => {
       return await this.grantStore.withAuthenticatedGrant(
         input.grantId,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -46,7 +46,10 @@ export class SupportPassportGrantService {
     this.now = dependencies.now ?? (() => new Date());
   }
 
-  async createGrant(input: SupportPassportCreateGrantInput): Promise<SupportPassportCreatedGrant> {
+  async createGrant(
+    input: SupportPassportCreateGrantInput,
+    options: { signal?: AbortSignal; onCommitted?: () => void } = {}
+  ): Promise<SupportPassportCreatedGrant> {
     const requestedAt = this.now();
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
@@ -55,6 +58,7 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
+      options.signal?.throwIfAborted();
       for (const cardRef of parsed.data.cards) {
         const memory = await owner.storage.getMemoryById(cardRef.cardId);
         const stored = memory ? projectSupportPassportCard(memory) : null;
@@ -81,8 +85,21 @@ export class SupportPassportGrantService {
           expiresAt: parsed.data.expiresAt,
           requestedAt,
         },
-        async () => await requireSupportPassportOwnerLock(ownerLock)
+        {
+          beforeCommit: async () => await requireSupportPassportOwnerLock(ownerLock),
+          ...(options.onCommitted ? { onCommitted: options.onCommitted } : {}),
+        }
       );
+      try {
+        await requireSupportPassportOwnerLock(ownerLock);
+      } catch (error) {
+        await this.revokeCommittedGrant(created, owner);
+        throw error;
+      }
+      if (options.signal?.aborted) {
+        await this.revokeCommittedGrant(created, owner);
+        options.signal.throwIfAborted();
+      }
       return SupportPassportCreatedGrantSchema.parse({
         grant: this.ownerGrant(created.state),
         secret: created.secret,
@@ -100,7 +117,10 @@ export class SupportPassportGrantService {
     );
   }
 
-  async revokeGrant(input: SupportPassportRevokeGrantInput): Promise<SupportPassportOwnerGrant> {
+  async revokeGrant(
+    input: SupportPassportRevokeGrantInput,
+    options: { signal?: AbortSignal; onCommitted?: () => void } = {}
+  ): Promise<SupportPassportOwnerGrant> {
     const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
@@ -108,6 +128,7 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
+      options.signal?.throwIfAborted();
       const state = await this.grantStore.revoke(
         {
           grantId: parsed.data.grantId,
@@ -115,7 +136,13 @@ export class SupportPassportGrantService {
           principal: owner.principal,
           expectedStateVersion: parsed.data.expectedStateVersion,
         },
-        async () => await requireSupportPassportOwnerLock(ownerLock)
+        {
+          beforeCommit: async () => {
+            options.signal?.throwIfAborted();
+            await requireSupportPassportOwnerLock(ownerLock);
+          },
+          ...(options.onCommitted ? { onCommitted: options.onCommitted } : {}),
+        }
       );
       await requireSupportPassportOwnerLock(ownerLock);
       return this.ownerGrant(state);
@@ -191,6 +218,26 @@ export class SupportPassportGrantService {
         return publicCard.data;
       })
     );
+  }
+
+  private async revokeCommittedGrant(
+    created: { state: SupportPassportGrantState; secret: string },
+    owner: SupportPassportGrantOwnerScope
+  ): Promise<void> {
+    try {
+      await this.grantStore.revoke({
+        grantId: created.state.grantId,
+        namespace: owner.namespace,
+        principal: owner.principal,
+        expectedStateVersion: created.state.stateVersion,
+      });
+    } catch {
+      throw new SupportPassportError(
+        "storage_conflict",
+        "A share link could not be stopped after owner access changed. Review the active share list.",
+        500
+      );
+    }
   }
 
   private publicCard(card: {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -113,7 +113,7 @@ export class SupportPassportGrantService {
     if (confirmedState.stateVersion !== state.stateVersion) {
       throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
     }
-    return await withSupportPassportOwnerLock(storage, async () => {
+    return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
       const confirmedCards = await this.readGrantCards(storage, confirmedState);
       if (JSON.stringify(confirmedCards) !== JSON.stringify(cards)) {
         throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
@@ -128,6 +128,7 @@ export class SupportPassportGrantService {
         (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
         firstCard.updatedAt
       );
+      await requireSupportPassportOwnerLock(ownerLock);
       return SupportPassportPublicGuideSchema.parse({
         schemaVersion: 1,
         grantId: finalState.grantId,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -95,6 +95,31 @@ export class SupportPassportGrantService {
     }
     const state = await this.grantStore.authenticate(input.grantId, input.secret);
     const storage = await this.resolveNamespace(state.namespace);
+    const cards = await this.readGrantCards(storage, state);
+    const confirmedState = await this.grantStore.authenticate(input.grantId, input.secret);
+    if (confirmedState.stateVersion !== state.stateVersion) {
+      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    }
+    const confirmedCards = await this.readGrantCards(storage, confirmedState);
+    if (JSON.stringify(confirmedCards) !== JSON.stringify(cards)) {
+      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    }
+    const firstCard = confirmedCards[0];
+    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    const updatedAt = confirmedCards.reduce(
+      (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
+      firstCard.updatedAt
+    );
+    return SupportPassportPublicGuideSchema.parse({
+      schemaVersion: 1,
+      grantId: confirmedState.grantId,
+      expiresAt: confirmedState.expiresAt,
+      updatedAt,
+      cards: confirmedCards,
+    });
+  }
+
+  private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
     const cards = [];
     for (const cardRef of state.cards) {
       const memory = await storage.getMemoryById(cardRef.cardId);
@@ -110,23 +135,7 @@ export class SupportPassportGrantService {
         updatedAt: stored.card.updatedAt,
       });
     }
-    const firstCard = cards[0];
-    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    const updatedAt = cards.reduce(
-      (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
-      firstCard.updatedAt
-    );
-    const confirmedState = await this.grantStore.authenticate(input.grantId, input.secret);
-    if (confirmedState.stateVersion !== state.stateVersion) {
-      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    }
-    return SupportPassportPublicGuideSchema.parse({
-      schemaVersion: 1,
-      grantId: state.grantId,
-      expiresAt: state.expiresAt,
-      updatedAt,
-      cards,
-    });
+    return cards;
   }
 
   private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -16,7 +16,10 @@ import {
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
 import type { SupportPassportGrantStore } from "./grant-store.js";
-import { withSupportPassportOwnerLock } from "./owner-lock.js";
+import {
+  requireSupportPassportOwnerLock,
+  withSupportPassportOwnerLock,
+} from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
@@ -49,7 +52,7 @@ export class SupportPassportGrantService {
     return await withSupportPassportOwnerLock(
       owner.storage,
       { namespace: owner.namespace, principal: parsed.data.principal },
-      async () => {
+      async (ownerLock) => {
       for (const cardRef of parsed.data.cards) {
         const memory = await owner.storage.getMemoryById(cardRef.cardId);
         const stored = memory ? projectSupportPassportCard(memory) : null;
@@ -60,12 +63,15 @@ export class SupportPassportGrantService {
           throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
         }
       }
-      const created = await this.grantStore.create({
-        namespace: owner.namespace,
-        principal: parsed.data.principal,
-        cards: parsed.data.cards,
-        expiresAt: parsed.data.expiresAt,
-      });
+      const created = await this.grantStore.create(
+        {
+          namespace: owner.namespace,
+          principal: parsed.data.principal,
+          cards: parsed.data.cards,
+          expiresAt: parsed.data.expiresAt,
+        },
+        async () => await requireSupportPassportOwnerLock(ownerLock)
+      );
       return SupportPassportCreatedGrantSchema.parse({
         grant: this.ownerGrant(created.state),
         secret: created.secret,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -58,7 +58,7 @@ export class SupportPassportGrantService {
 
   async createGrant(
     input: SupportPassportCreateGrantInput,
-    options: { signal?: AbortSignal; onCommitted?: () => void } = {}
+    options: { signal?: AbortSignal; onCommitted?: () => void | Promise<void> } = {}
   ): Promise<SupportPassportCreatedGrant> {
     const requestedAt = this.now();
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
@@ -131,7 +131,7 @@ export class SupportPassportGrantService {
 
   async revokeGrant(
     input: SupportPassportRevokeGrantInput,
-    options: { signal?: AbortSignal; onCommitted?: () => void } = {}
+    options: { signal?: AbortSignal; onCommitted?: () => void | Promise<void> } = {}
   ): Promise<SupportPassportOwnerGrant> {
     const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,12 +1,6 @@
 import type { StorageManager } from "../index.js";
-import {
-  computeSupportPassportOwnerKey,
-  projectSupportPassportCard,
-} from "./card-projection.js";
-import {
-  SupportPassportListCardsInputSchema,
-  SupportPassportNamespaceSchema,
-} from "./contracts.js";
+import { computeSupportPassportOwnerKey, projectSupportPassportCard } from "./card-projection.js";
+import { SupportPassportListCardsInputSchema, SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
 import {
   type SupportPassportCreateGrantInput,
@@ -24,30 +18,19 @@ import {
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
 import type { SupportPassportGrantStore } from "./grant-store.js";
-import {
-  requireSupportPassportOwnerLock,
-  withSupportPassportOwnerLock,
-} from "./owner-lock.js";
+import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
-  resolveOwner(
-    principal: string,
-  ): Promise<{ principal: string; namespace: string; storage: StorageManager }>;
+  resolveOwner(principal: string): Promise<{ principal: string; namespace: string; storage: StorageManager }>;
   resolveNamespace(namespace: string): Promise<StorageManager>;
   now?: () => Date;
 }
 
-type SupportPassportGrantOwnerScope = Awaited<
-  ReturnType<SupportPassportGrantServiceDependencies["resolveOwner"]>
->;
+type SupportPassportGrantOwnerScope = Awaited<ReturnType<SupportPassportGrantServiceDependencies["resolveOwner"]>>;
 
 function invalidInput(): SupportPassportError {
-  return new SupportPassportError(
-    "invalid_input",
-    "The share link request is invalid.",
-    400,
-  );
+  return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
 }
 
 export class SupportPassportGrantService {
@@ -63,9 +46,7 @@ export class SupportPassportGrantService {
     this.now = dependencies.now ?? (() => new Date());
   }
 
-  async createGrant(
-    input: SupportPassportCreateGrantInput,
-  ): Promise<SupportPassportCreatedGrant> {
+  async createGrant(input: SupportPassportCreateGrantInput): Promise<SupportPassportCreatedGrant> {
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
@@ -73,67 +54,51 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
-        for (const cardRef of parsed.data.cards) {
-          const memory = await owner.storage.getMemoryById(cardRef.cardId);
-          const stored = memory ? projectSupportPassportCard(memory) : null;
-          if (
-            !stored ||
-            stored.namespace !== owner.namespace ||
-            stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
-            stored.card.status !== "active"
-          ) {
-            throw new SupportPassportError(
-              "invalid_card_status",
-              "Only approved support cards can be shared.",
-              409,
-            );
-          }
-          if (stored.card.revision !== cardRef.revision) {
-            throw new SupportPassportError(
-              "revision_conflict",
-              "A support card changed after it was selected.",
-              409,
-            );
-          }
-          if (!this.publicCard(stored.card).success) {
-            throw new SupportPassportError(
-              "card_data_invalid",
-              "The support card data is invalid.",
-              500,
-            );
-          }
+      for (const cardRef of parsed.data.cards) {
+        const memory = await owner.storage.getMemoryById(cardRef.cardId);
+        const stored = memory ? projectSupportPassportCard(memory) : null;
+        if (
+          !stored ||
+          stored.namespace !== owner.namespace ||
+          stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
+          stored.card.status !== "active"
+        ) {
+          throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
         }
-        const created = await this.grantStore.create(
-          {
-            namespace: owner.namespace,
-            principal: owner.principal,
-            cards: parsed.data.cards,
-            expiresAt: parsed.data.expiresAt,
-          },
-          async () => await requireSupportPassportOwnerLock(ownerLock),
-        );
-        return SupportPassportCreatedGrantSchema.parse({
-          grant: this.ownerGrant(created.state),
-          secret: created.secret,
-        });
-      },
+        if (stored.card.revision !== cardRef.revision) {
+          throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+        }
+        if (!this.publicCard(stored.card).success) {
+          throw new SupportPassportError("card_data_invalid", "The support card data is invalid.", 500);
+        }
+      }
+      const created = await this.grantStore.create(
+        {
+          namespace: owner.namespace,
+          principal: owner.principal,
+          cards: parsed.data.cards,
+          expiresAt: parsed.data.expiresAt,
+        },
+        async () => await requireSupportPassportOwnerLock(ownerLock)
+      );
+      return SupportPassportCreatedGrantSchema.parse({
+        grant: this.ownerGrant(created.state),
+        secret: created.secret,
+      });
+      }
     );
   }
 
-  async listGrants(input: {
-    principal: string;
-  }): Promise<SupportPassportOwnerGrant[]> {
+  async listGrants(input: { principal: string }): Promise<SupportPassportOwnerGrant[]> {
     const parsed = SupportPassportListGrantsInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
-    return (
-      await this.grantStore.listForOwner(owner.namespace, owner.principal)
-    ).map((state) => this.ownerGrant(state));
+    return (await this.grantStore.listForOwner(owner.namespace, owner.principal)).map((state) =>
+      this.ownerGrant(state)
+    );
   }
 
-  async revokeGrant(
-    input: SupportPassportRevokeGrantInput,
-  ): Promise<SupportPassportOwnerGrant> {
+  async revokeGrant(input: SupportPassportRevokeGrantInput): Promise<SupportPassportOwnerGrant> {
     const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
@@ -141,107 +106,69 @@ export class SupportPassportGrantService {
       owner.storage,
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
-        const state = await this.grantStore.revoke(
-          {
-            grantId: parsed.data.grantId,
-            namespace: owner.namespace,
-            principal: owner.principal,
-            expectedStateVersion: parsed.data.expectedStateVersion,
-          },
-          async () => await requireSupportPassportOwnerLock(ownerLock),
-        );
-        await requireSupportPassportOwnerLock(ownerLock);
-        return this.ownerGrant(state);
-      },
+      const state = await this.grantStore.revoke(
+        {
+          grantId: parsed.data.grantId,
+          namespace: owner.namespace,
+          principal: owner.principal,
+          expectedStateVersion: parsed.data.expectedStateVersion,
+        },
+        async () => await requireSupportPassportOwnerLock(ownerLock)
+      );
+      await requireSupportPassportOwnerLock(ownerLock);
+      return this.ownerGrant(state);
+      }
     );
   }
 
-  async readGrant(input: {
-    grantId: string;
-    secret: string;
-  }): Promise<SupportPassportPublicGuide> {
-    if (
-      !input ||
-      typeof input.grantId !== "string" ||
-      typeof input.secret !== "string"
-    ) {
-      throw new SupportPassportError(
-        "grant_not_found",
-        "The share link was not found.",
-        404,
-      );
+  async readGrant(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
+    if (!input || typeof input.grantId !== "string" || typeof input.secret !== "string") {
+      throw new SupportPassportError("grant_not_found", "The share link was not found.", 404);
     }
     return await this.readGrantAttempt(input);
   }
 
-  private async readGrantAttempt(input: {
-    grantId: string;
-    secret: string;
-  }): Promise<SupportPassportPublicGuide> {
-    const initialState = await this.grantStore.authenticate(
-      input.grantId,
-      input.secret,
-    );
+  private async readGrantAttempt(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
+    const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
     const storage = await this.resolveNamespace(initialState.namespace);
     const cards = await this.readGrantCards(storage, initialState);
     const firstCard = cards[0];
-    if (!firstCard)
-      throw new SupportPassportError(
-        "grant_stale",
-        "The shared support guide has changed.",
-        410,
-      );
+    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
     const updatedAt = cards.reduce((latest, card) => {
-      return Date.parse(card.updatedAt) > Date.parse(latest)
-        ? card.updatedAt
-        : latest;
+      return Date.parse(card.updatedAt) > Date.parse(latest) ? card.updatedAt : latest;
     }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(
       storage,
-      {
-        namespace: initialState.namespace,
-        ownerKey: initialState.principalHash,
-      },
+      { namespace: initialState.namespace, principal: `hash:${initialState.principalHash}` },
       async (ownerLock) => {
-        return await this.grantStore.withAuthenticatedGrant(
-          input.grantId,
-          input.secret,
-          async (finalState) => {
-            if (finalState.namespace !== initialState.namespace) {
-              throw new SupportPassportError(
-                "grant_stale",
-                "The shared support guide has changed.",
-                410,
-              );
-            }
-            await requireSupportPassportOwnerLock(ownerLock);
-            const currentCards = await this.readGrantCards(storage, finalState);
-            await requireSupportPassportOwnerLock(ownerLock);
-            if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
-              throw new SupportPassportError(
-                "grant_stale",
-                "The shared support guide has changed.",
-                410,
-              );
-            }
-            return SupportPassportPublicGuideSchema.parse({
-              schemaVersion: 1,
-              grantId: finalState.grantId,
-              expiresAt: finalState.expiresAt,
-              updatedAt,
-              cards,
-            });
-          },
-          async () => await requireSupportPassportOwnerLock(ownerLock),
-        );
-      },
+      return await this.grantStore.withAuthenticatedGrant(
+        input.grantId,
+        input.secret,
+        async (finalState) => {
+          if (finalState.namespace !== initialState.namespace) {
+            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+          }
+          await requireSupportPassportOwnerLock(ownerLock);
+          const currentCards = await this.readGrantCards(storage, finalState);
+          await requireSupportPassportOwnerLock(ownerLock);
+          if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
+            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+          }
+          return SupportPassportPublicGuideSchema.parse({
+            schemaVersion: 1,
+            grantId: finalState.grantId,
+            expiresAt: finalState.expiresAt,
+            updatedAt,
+            cards,
+          });
+        },
+        async () => await requireSupportPassportOwnerLock(ownerLock)
+      );
+      }
     );
   }
 
-  private async readGrantCards(
-    storage: StorageManager,
-    state: SupportPassportGrantState,
-  ) {
+  private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
     return await Promise.all(
       state.cards.map(async (cardRef) => {
         const memory = await storage.getMemoryById(cardRef.cardId);
@@ -253,22 +180,14 @@ export class SupportPassportGrantService {
           stored.card.status !== "active" ||
           stored.card.revision !== cardRef.revision
         ) {
-          throw new SupportPassportError(
-            "grant_stale",
-            "The shared support guide has changed.",
-            410,
-          );
+          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
         const publicCard = this.publicCard(stored.card);
         if (!publicCard.success) {
-          throw new SupportPassportError(
-            "grant_stale",
-            "The shared support guide has changed.",
-            410,
-          );
+          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
         return publicCard.data;
-      }),
+      })
     );
   }
 
@@ -288,39 +207,23 @@ export class SupportPassportGrantService {
     });
   }
 
-  private async resolveOwnerScope(
-    principal: string,
-  ): Promise<SupportPassportGrantOwnerScope> {
-    const requestedPrincipal = SupportPassportListCardsInputSchema.safeParse({
-      principal,
-    });
+  private async resolveOwnerScope(principal: string): Promise<SupportPassportGrantOwnerScope> {
+    const requestedPrincipal = SupportPassportListCardsInputSchema.safeParse({ principal });
     const owner = await this.resolveOwner(principal);
     const namespace = SupportPassportNamespaceSchema.safeParse(owner.namespace);
-    const ownerPrincipal = SupportPassportListCardsInputSchema.safeParse({
-      principal: owner.principal,
-    });
+    const ownerPrincipal = SupportPassportListCardsInputSchema.safeParse({ principal: owner.principal });
     if (
       !requestedPrincipal.success ||
       !namespace.success ||
       !ownerPrincipal.success ||
       ownerPrincipal.data.principal !== requestedPrincipal.data.principal
     ) {
-      throw new SupportPassportError(
-        "card_data_invalid",
-        "The support passport owner scope is invalid.",
-        500,
-      );
+      throw new SupportPassportError("card_data_invalid", "The support passport owner scope is invalid.", 500);
     }
-    return {
-      ...owner,
-      principal: ownerPrincipal.data.principal,
-      namespace: namespace.data,
-    };
+    return { ...owner, principal: ownerPrincipal.data.principal, namespace: namespace.data };
   }
 
-  private ownerGrant(
-    state: SupportPassportGrantState,
-  ): SupportPassportOwnerGrant {
+  private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {
     const status = state.revokedAt
       ? "revoked"
       : Date.parse(state.expiresAt) <= this.now().getTime()

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,4 +1,5 @@
 import type { StorageManager } from "../index.js";
+import type { MemoryFile } from "../types.js";
 import {
   type StoredSupportPassportCard,
   computeSupportPassportOwnerKey,
@@ -68,13 +69,20 @@ export class SupportPassportGrantService {
       { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
         options.signal?.throwIfAborted();
-        const cardsById = new Map((await this.readStoredCards(owner.storage)).map((card) => [card.card.cardId, card]));
+        const ownerHash = computeSupportPassportOwnerKey(owner.principal);
+        const cardsById = new Map(
+          this.projectOwnedCards(
+            await owner.storage.readAllMemories(),
+            owner.namespace,
+            ownerHash
+          ).map((card) => [card.card.cardId, card])
+        );
         for (const cardRef of parsed.data.cards) {
           const stored = cardsById.get(cardRef.cardId);
           if (
             !stored ||
             stored.namespace !== owner.namespace ||
-            stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
+            stored.owner !== ownerHash ||
             stored.card.status !== "active"
           ) {
             throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
@@ -173,7 +181,11 @@ export class SupportPassportGrantService {
   private async readGrantAttempt(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
     const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
     const storage = await this.resolveNamespace(initialState.namespace);
-    const initialSnapshot = await this.readStoredCardSnapshot(storage);
+    const initialSnapshot = await this.readStoredCardSnapshot(
+      storage,
+      initialState.namespace,
+      initialState.principalHash
+    );
     const cards = this.readGrantCards(initialSnapshot, initialState);
     const firstCard = cards[0];
     if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
@@ -192,7 +204,11 @@ export class SupportPassportGrantService {
               throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
             }
             await requireSupportPassportOwnerLock(ownerLock);
-            const currentSnapshot = await this.readStoredCardSnapshot(storage);
+            const currentSnapshot = await this.readStoredCardSnapshot(
+              storage,
+              finalState.namespace,
+              finalState.principalHash
+            );
             const currentCards = this.readGrantCards(currentSnapshot, finalState);
             await requireSupportPassportOwnerLock(ownerLock);
             if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
@@ -232,14 +248,17 @@ export class SupportPassportGrantService {
     });
   }
 
-  private async readStoredCardSnapshot(storage: StorageManager): Promise<SupportPassportCardSnapshot> {
+  private async readStoredCardSnapshot(
+    storage: StorageManager,
+    namespace: string,
+    owner: string
+  ): Promise<SupportPassportCardSnapshot> {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const before = this.cardSnapshotVersion(storage);
-      const cards = (await storage.readAllMemories())
-        .map((memory) => projectSupportPassportCard(memory))
-        .filter((card): card is StoredSupportPassportCard => card !== null);
+      const memories = await storage.readAllMemories();
       const after = this.cardSnapshotVersion(storage);
       if (before !== after) continue;
+      const cards = this.projectOwnedCards(memories, namespace, owner);
       const snapshot = {
         version: after,
         cardsById: new Map(cards.map((card) => [card.card.cardId, card])),
@@ -249,10 +268,25 @@ export class SupportPassportGrantService {
     throw new SupportPassportError("storage_conflict", "The support card list changed during review.", 409);
   }
 
-  private async readStoredCards(storage: StorageManager): Promise<StoredSupportPassportCard[]> {
-    return (await storage.readAllMemories())
+  private projectOwnedCards(
+    memories: MemoryFile[],
+    namespace: string,
+    owner: string
+  ): StoredSupportPassportCard[] {
+    const cards = memories
       .map((memory) => projectSupportPassportCard(memory))
-      .filter((card): card is StoredSupportPassportCard => card !== null);
+      .filter(
+        (card): card is StoredSupportPassportCard =>
+          card !== null && card.namespace === namespace && card.owner === owner
+      );
+    const cardIds = new Set<string>();
+    for (const card of cards) {
+      if (cardIds.has(card.card.cardId)) {
+        throw new SupportPassportError("card_data_invalid", "Support card IDs must be unique.", 500);
+      }
+      cardIds.add(card.card.cardId);
+    }
+    return cards;
   }
 
   private cardSnapshotVersion(storage: StorageManager): string {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -18,10 +18,6 @@ import {
 import type { SupportPassportGrantStore } from "./grant-store.js";
 import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
 
-const MAX_GUIDE_READ_ATTEMPTS = 3;
-
-class SupportPassportGuideReadChanged extends Error {}
-
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
   resolveOwner(principal: string): Promise<{ principal: string; namespace: string; storage: StorageManager }>;
@@ -107,20 +103,12 @@ export class SupportPassportGrantService {
     if (!input || typeof input.grantId !== "string" || typeof input.secret !== "string") {
       throw new SupportPassportError("grant_not_found", "The share link was not found.", 404);
     }
-    for (let attempt = 0; attempt < MAX_GUIDE_READ_ATTEMPTS; attempt += 1) {
-      try {
-        return await this.readGrantAttempt(input);
-      } catch (error) {
-        if (!(error instanceof SupportPassportGuideReadChanged)) throw error;
-      }
-    }
-    throw new SupportPassportError("storage_conflict", "The support passport changed during the request.", 409);
+    return await this.readGrantAttempt(input);
   }
 
   private async readGrantAttempt(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
     const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
     const storage = await this.resolveNamespace(initialState.namespace);
-    const corpusVersion = storage.getMemoryCorpusVersion();
     const cards = await this.readGrantCards(storage, initialState);
     const firstCard = cards[0];
     if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
@@ -133,8 +121,11 @@ export class SupportPassportGrantService {
         if (finalState.namespace !== initialState.namespace) {
           throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
-        if (storage.getMemoryCorpusVersion() !== corpusVersion) throw new SupportPassportGuideReadChanged();
         await requireSupportPassportOwnerLock(ownerLock);
+        const currentCards = await this.readGrantCards(storage, finalState);
+        if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
+          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+        }
         return SupportPassportPublicGuideSchema.parse({
           schemaVersion: 1,
           grantId: finalState.grantId,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -47,6 +47,7 @@ export class SupportPassportGrantService {
   }
 
   async createGrant(input: SupportPassportCreateGrantInput): Promise<SupportPassportCreatedGrant> {
+    const requestedAt = this.now();
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwnerScope(parsed.data.principal);
@@ -78,6 +79,7 @@ export class SupportPassportGrantService {
           principal: owner.principal,
           cards: parsed.data.cards,
           expiresAt: parsed.data.expiresAt,
+          requestedAt,
         },
         async () => await requireSupportPassportOwnerLock(ownerLock)
       );
@@ -139,7 +141,7 @@ export class SupportPassportGrantService {
     }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(
       storage,
-      { namespace: initialState.namespace, ownerKey: initialState.principalHash },
+      { namespace: initialState.namespace, ownerKey: initialState.ownerLockKey },
       async (ownerLock) => {
       return await this.grantStore.withAuthenticatedGrant(
         input.grantId,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -94,13 +94,16 @@ export class SupportPassportGrantService {
     const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwner(parsed.data.principal);
-    const state = await this.grantStore.revoke({
-      grantId: parsed.data.grantId,
-      namespace: owner.namespace,
-      principal: owner.principal,
-      expectedStateVersion: parsed.data.expectedStateVersion,
+    return await withSupportPassportOwnerLock(owner.storage, async (ownerLock) => {
+      const state = await this.grantStore.revoke({
+        grantId: parsed.data.grantId,
+        namespace: owner.namespace,
+        principal: owner.principal,
+        expectedStateVersion: parsed.data.expectedStateVersion,
+      }, async () => await requireSupportPassportOwnerLock(ownerLock));
+      await requireSupportPassportOwnerLock(ownerLock);
+      return this.ownerGrant(state);
     });
-    return this.ownerGrant(state);
   }
 
   async readGrant(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
@@ -120,26 +123,29 @@ export class SupportPassportGrantService {
       return Date.parse(card.updatedAt) > Date.parse(latest) ? card.updatedAt : latest;
     }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
-      const guide = await this.grantStore.withAuthenticatedGrant(input.grantId, input.secret, async (finalState) => {
-        if (finalState.namespace !== initialState.namespace) {
-          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-        }
-        await requireSupportPassportOwnerLock(ownerLock);
-        const currentCards = await this.readGrantCards(storage, finalState);
-        await requireSupportPassportOwnerLock(ownerLock);
-        if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
-          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-        }
-        return SupportPassportPublicGuideSchema.parse({
-          schemaVersion: 1,
-          grantId: finalState.grantId,
-          expiresAt: finalState.expiresAt,
-          updatedAt,
-          cards,
-        });
-      });
-      await requireSupportPassportOwnerLock(ownerLock);
-      return guide;
+      return await this.grantStore.withAuthenticatedGrant(
+        input.grantId,
+        input.secret,
+        async (finalState) => {
+          if (finalState.namespace !== initialState.namespace) {
+            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+          }
+          await requireSupportPassportOwnerLock(ownerLock);
+          const currentCards = await this.readGrantCards(storage, finalState);
+          await requireSupportPassportOwnerLock(ownerLock);
+          if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
+            throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+          }
+          return SupportPassportPublicGuideSchema.parse({
+            schemaVersion: 1,
+            grantId: finalState.grantId,
+            expiresAt: finalState.expiresAt,
+            updatedAt,
+            cards,
+          });
+        },
+        async () => await requireSupportPassportOwnerLock(ownerLock)
+      );
     });
   }
 

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,0 +1,137 @@
+import type { StorageManager } from "../storage.js";
+import { projectSupportPassportCard } from "./card-projection.js";
+import { SupportPassportError } from "./errors.js";
+import {
+  type SupportPassportCreateGrantInput,
+  SupportPassportCreateGrantInputSchema,
+  type SupportPassportCreatedGrant,
+  SupportPassportCreatedGrantSchema,
+  type SupportPassportGrantState,
+  SupportPassportListGrantsInputSchema,
+  type SupportPassportOwnerGrant,
+  SupportPassportOwnerGrantSchema,
+  type SupportPassportPublicGuide,
+  SupportPassportPublicGuideSchema,
+  type SupportPassportRevokeGrantInput,
+  SupportPassportRevokeGrantInputSchema,
+} from "./grant-contracts.js";
+import type { SupportPassportGrantStore } from "./grant-store.js";
+
+export interface SupportPassportGrantServiceDependencies {
+  grantStore: SupportPassportGrantStore;
+  resolveOwner(principal: string): Promise<{ namespace: string; storage: StorageManager }>;
+  resolveNamespace(namespace: string): Promise<StorageManager>;
+  now?: () => Date;
+}
+
+function invalidInput(): SupportPassportError {
+  return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+}
+
+export class SupportPassportGrantService {
+  private readonly grantStore: SupportPassportGrantStore;
+  private readonly resolveOwner: SupportPassportGrantServiceDependencies["resolveOwner"];
+  private readonly resolveNamespace: SupportPassportGrantServiceDependencies["resolveNamespace"];
+  private readonly now: () => Date;
+
+  constructor(dependencies: SupportPassportGrantServiceDependencies) {
+    this.grantStore = dependencies.grantStore;
+    this.resolveOwner = dependencies.resolveOwner;
+    this.resolveNamespace = dependencies.resolveNamespace;
+    this.now = dependencies.now ?? (() => new Date());
+  }
+
+  async createGrant(input: SupportPassportCreateGrantInput): Promise<SupportPassportCreatedGrant> {
+    const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
+    if (!parsed.success) throw invalidInput();
+    const owner = await this.resolveOwner(parsed.data.principal);
+    for (const cardRef of parsed.data.cards) {
+      const memory = await owner.storage.getMemoryById(cardRef.cardId);
+      const stored = memory ? projectSupportPassportCard(memory) : null;
+      if (!stored || stored.card.status !== "active") {
+        throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
+      }
+      if (stored.card.revision !== cardRef.revision) {
+        throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+      }
+    }
+    const created = await this.grantStore.create({
+      namespace: owner.namespace,
+      principal: parsed.data.principal,
+      cards: parsed.data.cards,
+      durationSeconds: parsed.data.durationSeconds,
+    });
+    return SupportPassportCreatedGrantSchema.parse({
+      grant: this.ownerGrant(created.state),
+      secret: created.secret,
+    });
+  }
+
+  async listGrants(input: { principal: string }): Promise<SupportPassportOwnerGrant[]> {
+    const parsed = SupportPassportListGrantsInputSchema.safeParse(input);
+    if (!parsed.success) throw invalidInput();
+    const owner = await this.resolveOwner(parsed.data.principal);
+    return (await this.grantStore.listForOwner(owner.namespace, parsed.data.principal)).map((state) => this.ownerGrant(state));
+  }
+
+  async revokeGrant(input: SupportPassportRevokeGrantInput): Promise<SupportPassportOwnerGrant> {
+    const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
+    if (!parsed.success) throw invalidInput();
+    const owner = await this.resolveOwner(parsed.data.principal);
+    const state = await this.grantStore.revoke({
+      grantId: parsed.data.grantId,
+      namespace: owner.namespace,
+      principal: parsed.data.principal,
+      expectedStateVersion: parsed.data.expectedStateVersion,
+    });
+    return this.ownerGrant(state);
+  }
+
+  async readGrant(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
+    if (!input || typeof input.grantId !== "string" || typeof input.secret !== "string") {
+      throw new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+    }
+    const state = await this.grantStore.authenticate(input.grantId, input.secret);
+    const storage = await this.resolveNamespace(state.namespace);
+    const cards = [];
+    for (const cardRef of state.cards) {
+      const memory = await storage.getMemoryById(cardRef.cardId);
+      const stored = memory ? projectSupportPassportCard(memory) : null;
+      if (!stored || stored.card.status !== "active" || stored.card.revision !== cardRef.revision) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
+      cards.push({
+        cardId: stored.card.cardId,
+        title: stored.card.title,
+        statement: stored.card.statement,
+        category: stored.card.category,
+        updatedAt: stored.card.updatedAt,
+      });
+    }
+    const updatedAt = cards.reduce((latest, card) => card.updatedAt > latest ? card.updatedAt : latest, cards[0]!.updatedAt);
+    return SupportPassportPublicGuideSchema.parse({
+      schemaVersion: 1,
+      grantId: state.grantId,
+      expiresAt: state.expiresAt,
+      updatedAt,
+      cards,
+    });
+  }
+
+  private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {
+    const status = state.revokedAt
+      ? "revoked"
+      : Date.parse(state.expiresAt) <= this.now().getTime()
+        ? "expired"
+        : "active";
+    return SupportPassportOwnerGrantSchema.parse({
+      grantId: state.grantId,
+      stateVersion: state.stateVersion,
+      cards: state.cards,
+      createdAt: state.createdAt,
+      expiresAt: state.expiresAt,
+      revokedAt: state.revokedAt,
+      status,
+    });
+  }
+}

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -120,7 +120,7 @@ export class SupportPassportGrantService {
       return Date.parse(card.updatedAt) > Date.parse(latest) ? card.updatedAt : latest;
     }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
-      return await this.grantStore.withAuthenticatedGrant(input.grantId, input.secret, async (finalState) => {
+      const guide = await this.grantStore.withAuthenticatedGrant(input.grantId, input.secret, async (finalState) => {
         if (finalState.namespace !== initialState.namespace) {
           throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
@@ -138,6 +138,8 @@ export class SupportPassportGrantService {
           cards,
         });
       });
+      await requireSupportPassportOwnerLock(ownerLock);
+      return guide;
     });
   }
 

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -16,10 +16,7 @@ import {
   SupportPassportRevokeGrantInputSchema,
 } from "./grant-contracts.js";
 import type { SupportPassportGrantStore } from "./grant-store.js";
-import {
-  requireSupportPassportOwnerLock,
-  withSupportPassportOwnerLock,
-} from "./owner-lock.js";
+import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
 
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
@@ -106,35 +103,28 @@ export class SupportPassportGrantService {
     if (!input || typeof input.grantId !== "string" || typeof input.secret !== "string") {
       throw new SupportPassportError("grant_not_found", "The share link was not found.", 404);
     }
-    const state = await this.grantStore.authenticate(input.grantId, input.secret);
-    const storage = await this.resolveNamespace(state.namespace);
-    const cards = await this.readGrantCards(storage, state);
-    const confirmedState = await this.grantStore.authenticate(input.grantId, input.secret);
-    if (confirmedState.stateVersion !== state.stateVersion) {
-      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    }
+    const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
+    const storage = await this.resolveNamespace(initialState.namespace);
     return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
-      const confirmedCards = await this.readGrantCards(storage, confirmedState);
-      if (JSON.stringify(confirmedCards) !== JSON.stringify(cards)) {
-        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-      }
-      const finalState = await this.grantStore.authenticate(input.grantId, input.secret);
-      if (finalState.stateVersion !== confirmedState.stateVersion) {
-        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-      }
-      const firstCard = confirmedCards[0];
-      if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-      const updatedAt = confirmedCards.reduce(
-        (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
-        firstCard.updatedAt
-      );
-      await requireSupportPassportOwnerLock(ownerLock);
-      return SupportPassportPublicGuideSchema.parse({
-        schemaVersion: 1,
-        grantId: finalState.grantId,
-        expiresAt: finalState.expiresAt,
-        updatedAt,
-        cards: confirmedCards,
+      return await this.grantStore.withAuthenticatedGrant(input.grantId, input.secret, async (finalState) => {
+        if (finalState.namespace !== initialState.namespace) {
+          throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+        }
+        const cards = await this.readGrantCards(storage, finalState);
+        const firstCard = cards[0];
+        if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+        const updatedAt = cards.reduce(
+          (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
+          firstCard.updatedAt
+        );
+        await requireSupportPassportOwnerLock(ownerLock);
+        return SupportPassportPublicGuideSchema.parse({
+          schemaVersion: 1,
+          grantId: finalState.grantId,
+          expiresAt: finalState.expiresAt,
+          updatedAt,
+          cards,
+        });
       });
     });
   }

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -10,6 +10,7 @@ import {
   SupportPassportListGrantsInputSchema,
   type SupportPassportOwnerGrant,
   SupportPassportOwnerGrantSchema,
+  SupportPassportPublicCardSchema,
   type SupportPassportPublicGuide,
   SupportPassportPublicGuideSchema,
   type SupportPassportRevokeGrantInput,
@@ -58,6 +59,9 @@ export class SupportPassportGrantService {
         }
         if (stored.card.revision !== cardRef.revision) {
           throw new SupportPassportError("revision_conflict", "A support card changed after it was selected.", 409);
+        }
+        if (!this.publicCard(stored.card).success) {
+          throw new SupportPassportError("card_data_invalid", "The support card data is invalid.", 500);
         }
       }
       const created = await this.grantStore.create(
@@ -112,10 +116,9 @@ export class SupportPassportGrantService {
     const cards = await this.readGrantCards(storage, initialState);
     const firstCard = cards[0];
     if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-    const updatedAt = cards.reduce(
-      (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
-      firstCard.updatedAt
-    );
+    const updatedAt = cards.reduce((latest, card) => {
+      return Date.parse(card.updatedAt) > Date.parse(latest) ? card.updatedAt : latest;
+    }, firstCard.updatedAt);
     return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
       return await this.grantStore.withAuthenticatedGrant(input.grantId, input.secret, async (finalState) => {
         if (finalState.namespace !== initialState.namespace) {
@@ -123,6 +126,7 @@ export class SupportPassportGrantService {
         }
         await requireSupportPassportOwnerLock(ownerLock);
         const currentCards = await this.readGrantCards(storage, finalState);
+        await requireSupportPassportOwnerLock(ownerLock);
         if (JSON.stringify(currentCards) !== JSON.stringify(cards)) {
           throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
@@ -144,14 +148,28 @@ export class SupportPassportGrantService {
       if (!stored || stored.card.status !== "active" || stored.card.revision !== cardRef.revision) {
         throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
       }
-      return {
-        cardId: stored.card.cardId,
-        title: stored.card.title,
-        statement: stored.card.statement,
-        category: stored.card.category,
-        updatedAt: stored.card.updatedAt,
-      };
+      const publicCard = this.publicCard(stored.card);
+      if (!publicCard.success) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
+      return publicCard.data;
     }));
+  }
+
+  private publicCard(card: {
+    cardId: string;
+    title: string;
+    statement: string;
+    category: string;
+    updatedAt: string;
+  }): ReturnType<typeof SupportPassportPublicCardSchema.safeParse> {
+    return SupportPassportPublicCardSchema.safeParse({
+      cardId: card.cardId,
+      title: card.title,
+      statement: card.statement,
+      category: card.category,
+      updatedAt: card.updatedAt,
+    });
   }
 
   private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -116,6 +116,10 @@ export class SupportPassportGrantService {
       (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
       firstCard.updatedAt
     );
+    const confirmedState = await this.grantStore.authenticate(input.grantId, input.secret);
+    if (confirmedState.stateVersion !== state.stateVersion) {
+      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    }
     return SupportPassportPublicGuideSchema.parse({
       schemaVersion: 1,
       grantId: state.grantId,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,5 +1,6 @@
 import type { StorageManager } from "../index.js";
-import { projectSupportPassportCard } from "./card-projection.js";
+import { computeSupportPassportOwnerKey, projectSupportPassportCard } from "./card-projection.js";
+import { SupportPassportListCardsInputSchema, SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
 import {
   type SupportPassportCreateGrantInput,
@@ -26,6 +27,8 @@ export interface SupportPassportGrantServiceDependencies {
   now?: () => Date;
 }
 
+type SupportPassportGrantOwnerScope = Awaited<ReturnType<SupportPassportGrantServiceDependencies["resolveOwner"]>>;
+
 function invalidInput(): SupportPassportError {
   return new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
 }
@@ -46,15 +49,20 @@ export class SupportPassportGrantService {
   async createGrant(input: SupportPassportCreateGrantInput): Promise<SupportPassportCreatedGrant> {
     const parsed = SupportPassportCreateGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
-    const owner = await this.resolveOwner(parsed.data.principal);
+    const owner = await this.resolveOwnerScope(parsed.data.principal);
     return await withSupportPassportOwnerLock(
       owner.storage,
-      { namespace: owner.namespace, principal: parsed.data.principal },
+      { namespace: owner.namespace, principal: owner.principal },
       async (ownerLock) => {
       for (const cardRef of parsed.data.cards) {
         const memory = await owner.storage.getMemoryById(cardRef.cardId);
         const stored = memory ? projectSupportPassportCard(memory) : null;
-        if (!stored || stored.namespace !== owner.namespace || stored.card.status !== "active") {
+        if (
+          !stored ||
+          stored.namespace !== owner.namespace ||
+          stored.owner !== computeSupportPassportOwnerKey(owner.principal) ||
+          stored.card.status !== "active"
+        ) {
           throw new SupportPassportError("invalid_card_status", "Only approved support cards can be shared.", 409);
         }
         if (stored.card.revision !== cardRef.revision) {
@@ -84,7 +92,7 @@ export class SupportPassportGrantService {
   async listGrants(input: { principal: string }): Promise<SupportPassportOwnerGrant[]> {
     const parsed = SupportPassportListGrantsInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
-    const owner = await this.resolveOwner(parsed.data.principal);
+    const owner = await this.resolveOwnerScope(parsed.data.principal);
     return (await this.grantStore.listForOwner(owner.namespace, owner.principal)).map((state) =>
       this.ownerGrant(state)
     );
@@ -93,8 +101,11 @@ export class SupportPassportGrantService {
   async revokeGrant(input: SupportPassportRevokeGrantInput): Promise<SupportPassportOwnerGrant> {
     const parsed = SupportPassportRevokeGrantInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
-    const owner = await this.resolveOwner(parsed.data.principal);
-    return await withSupportPassportOwnerLock(owner.storage, async (ownerLock) => {
+    const owner = await this.resolveOwnerScope(parsed.data.principal);
+    return await withSupportPassportOwnerLock(
+      owner.storage,
+      { namespace: owner.namespace, principal: owner.principal },
+      async (ownerLock) => {
       const state = await this.grantStore.revoke(
         {
           grantId: parsed.data.grantId,
@@ -106,7 +117,8 @@ export class SupportPassportGrantService {
       );
       await requireSupportPassportOwnerLock(ownerLock);
       return this.ownerGrant(state);
-    });
+      }
+    );
   }
 
   async readGrant(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
@@ -125,7 +137,10 @@ export class SupportPassportGrantService {
     const updatedAt = cards.reduce((latest, card) => {
       return Date.parse(card.updatedAt) > Date.parse(latest) ? card.updatedAt : latest;
     }, firstCard.updatedAt);
-    return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
+    return await withSupportPassportOwnerLock(
+      storage,
+      { namespace: initialState.namespace, principal: `hash:${initialState.principalHash}` },
+      async (ownerLock) => {
       return await this.grantStore.withAuthenticatedGrant(
         input.grantId,
         input.secret,
@@ -149,7 +164,8 @@ export class SupportPassportGrantService {
         },
         async () => await requireSupportPassportOwnerLock(ownerLock)
       );
-    });
+      }
+    );
   }
 
   private async readGrantCards(storage: StorageManager, state: SupportPassportGrantState) {
@@ -160,6 +176,7 @@ export class SupportPassportGrantService {
         if (
           !stored ||
           stored.namespace !== state.namespace ||
+          stored.owner !== state.principalHash ||
           stored.card.status !== "active" ||
           stored.card.revision !== cardRef.revision
         ) {
@@ -188,6 +205,22 @@ export class SupportPassportGrantService {
       category: card.category,
       updatedAt: card.updatedAt,
     });
+  }
+
+  private async resolveOwnerScope(principal: string): Promise<SupportPassportGrantOwnerScope> {
+    const requestedPrincipal = SupportPassportListCardsInputSchema.safeParse({ principal });
+    const owner = await this.resolveOwner(principal);
+    const namespace = SupportPassportNamespaceSchema.safeParse(owner.namespace);
+    const ownerPrincipal = SupportPassportListCardsInputSchema.safeParse({ principal: owner.principal });
+    if (
+      !requestedPrincipal.success ||
+      !namespace.success ||
+      !ownerPrincipal.success ||
+      ownerPrincipal.data.principal !== requestedPrincipal.data.principal
+    ) {
+      throw new SupportPassportError("card_data_invalid", "The support passport owner scope is invalid.", 500);
+    }
+    return { ...owner, principal: ownerPrincipal.data.principal, namespace: namespace.data };
   }
 
   private ownerGrant(state: SupportPassportGrantState): SupportPassportOwnerGrant {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -104,6 +104,10 @@ export class SupportPassportGrantService {
     if (JSON.stringify(confirmedCards) !== JSON.stringify(cards)) {
       throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
     }
+    const finalState = await this.grantStore.authenticate(input.grantId, input.secret);
+    if (finalState.stateVersion !== confirmedState.stateVersion) {
+      throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    }
     const firstCard = confirmedCards[0];
     if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
     const updatedAt = confirmedCards.reduce(
@@ -112,8 +116,8 @@ export class SupportPassportGrantService {
     );
     return SupportPassportPublicGuideSchema.parse({
       schemaVersion: 1,
-      grantId: confirmedState.grantId,
-      expiresAt: confirmedState.expiresAt,
+      grantId: finalState.grantId,
+      expiresAt: finalState.expiresAt,
       updatedAt,
       cards: confirmedCards,
     });

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -18,9 +18,13 @@ import {
 import type { SupportPassportGrantStore } from "./grant-store.js";
 import { requireSupportPassportOwnerLock, withSupportPassportOwnerLock } from "./owner-lock.js";
 
+const MAX_GUIDE_READ_ATTEMPTS = 3;
+
+class SupportPassportGuideReadChanged extends Error {}
+
 export interface SupportPassportGrantServiceDependencies {
   grantStore: SupportPassportGrantStore;
-  resolveOwner(principal: string): Promise<{ namespace: string; storage: StorageManager }>;
+  resolveOwner(principal: string): Promise<{ principal: string; namespace: string; storage: StorageManager }>;
   resolveNamespace(namespace: string): Promise<StorageManager>;
   now?: () => Date;
 }
@@ -63,7 +67,7 @@ export class SupportPassportGrantService {
       const created = await this.grantStore.create(
         {
           namespace: owner.namespace,
-          principal: parsed.data.principal,
+          principal: owner.principal,
           cards: parsed.data.cards,
           expiresAt: parsed.data.expiresAt,
         },
@@ -81,7 +85,7 @@ export class SupportPassportGrantService {
     const parsed = SupportPassportListGrantsInputSchema.safeParse(input);
     if (!parsed.success) throw invalidInput();
     const owner = await this.resolveOwner(parsed.data.principal);
-    return (await this.grantStore.listForOwner(owner.namespace, parsed.data.principal)).map((state) =>
+    return (await this.grantStore.listForOwner(owner.namespace, owner.principal)).map((state) =>
       this.ownerGrant(state)
     );
   }
@@ -93,7 +97,7 @@ export class SupportPassportGrantService {
     const state = await this.grantStore.revoke({
       grantId: parsed.data.grantId,
       namespace: owner.namespace,
-      principal: parsed.data.principal,
+      principal: owner.principal,
       expectedStateVersion: parsed.data.expectedStateVersion,
     });
     return this.ownerGrant(state);
@@ -103,20 +107,33 @@ export class SupportPassportGrantService {
     if (!input || typeof input.grantId !== "string" || typeof input.secret !== "string") {
       throw new SupportPassportError("grant_not_found", "The share link was not found.", 404);
     }
+    for (let attempt = 0; attempt < MAX_GUIDE_READ_ATTEMPTS; attempt += 1) {
+      try {
+        return await this.readGrantAttempt(input);
+      } catch (error) {
+        if (!(error instanceof SupportPassportGuideReadChanged)) throw error;
+      }
+    }
+    throw new SupportPassportError("storage_conflict", "The support passport changed during the request.", 409);
+  }
+
+  private async readGrantAttempt(input: { grantId: string; secret: string }): Promise<SupportPassportPublicGuide> {
     const initialState = await this.grantStore.authenticate(input.grantId, input.secret);
     const storage = await this.resolveNamespace(initialState.namespace);
+    const corpusVersion = storage.getMemoryCorpusVersion();
+    const cards = await this.readGrantCards(storage, initialState);
+    const firstCard = cards[0];
+    if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+    const updatedAt = cards.reduce(
+      (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
+      firstCard.updatedAt
+    );
     return await withSupportPassportOwnerLock(storage, async (ownerLock) => {
       return await this.grantStore.withAuthenticatedGrant(input.grantId, input.secret, async (finalState) => {
         if (finalState.namespace !== initialState.namespace) {
           throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
         }
-        const cards = await this.readGrantCards(storage, finalState);
-        const firstCard = cards[0];
-        if (!firstCard) throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
-        const updatedAt = cards.reduce(
-          (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
-          firstCard.updatedAt
-        );
+        if (storage.getMemoryCorpusVersion() !== corpusVersion) throw new SupportPassportGuideReadChanged();
         await requireSupportPassportOwnerLock(ownerLock);
         return SupportPassportPublicGuideSchema.parse({
           schemaVersion: 1,

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -59,7 +59,7 @@ export class SupportPassportGrantService {
       namespace: owner.namespace,
       principal: parsed.data.principal,
       cards: parsed.data.cards,
-      durationSeconds: parsed.data.durationSeconds,
+      expiresAt: parsed.data.expiresAt,
     });
     return SupportPassportCreatedGrantSchema.parse({
       grant: this.ownerGrant(created.state),

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -1,4 +1,4 @@
-import type { StorageManager } from "../storage.js";
+import type { StorageManager } from "../index.js";
 import { projectSupportPassportCard } from "./card-projection.js";
 import { SupportPassportError } from "./errors.js";
 import {

--- a/packages/remnic-core/src/support-passport/grant-service.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.ts
@@ -195,7 +195,8 @@ export class SupportPassportGrantService {
           }
           await requireSupportPassportOwnerLock(ownerLock);
           const currentSnapshot =
-            initialSnapshot.version === this.cardSnapshotVersion(storage)
+            initialSnapshot.version === this.cardSnapshotVersion(storage) &&
+            this.cardSnapshotIsFresh(initialSnapshot)
               ? initialSnapshot
               : await this.readStoredCardSnapshot(storage);
           const currentCards = this.readGrantCards(currentSnapshot, finalState);
@@ -241,13 +242,7 @@ export class SupportPassportGrantService {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const before = this.cardSnapshotVersion(storage);
       const cached = this.cardSnapshots.get(storage);
-      const nowMs = this.now().getTime();
-      const cacheIsFresh =
-        cached !== undefined &&
-        Number.isFinite(nowMs) &&
-        nowMs >= cached.validatedAtMs &&
-        nowMs - cached.validatedAtMs <= MAX_CARD_SNAPSHOT_AGE_MS;
-      if (cached?.version === before && cacheIsFresh) return cached;
+      if (cached?.version === before && this.cardSnapshotIsFresh(cached)) return cached;
       const cards = (await storage.readAllMemories())
         .map((memory) => projectSupportPassportCard(memory))
         .filter((card): card is StoredSupportPassportCard => card !== null);
@@ -276,6 +271,15 @@ export class SupportPassportGrantService {
 
   private cardSnapshotVersion(storage: StorageManager): string {
     return `${storage.getCorpusScanVersion()}:${storage.hotCacheKeyId()}`;
+  }
+
+  private cardSnapshotIsFresh(snapshot: SupportPassportCardSnapshot): boolean {
+    const nowMs = this.now().getTime();
+    return (
+      Number.isFinite(nowMs) &&
+      nowMs >= snapshot.validatedAtMs &&
+      nowMs - snapshot.validatedAtMs <= MAX_CARD_SNAPSHOT_AGE_MS
+    );
   }
 
   private async revokeCommittedGrant(

--- a/packages/remnic-core/src/support-passport/grant-store-commit-hook.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-commit-hook.test.ts
@@ -22,11 +22,12 @@ test("commit notification failures do not orphan grants or hide revocations", as
         expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
       },
       {
-        onCommitted: () => {
+        onCommitted: async () => {
           throw new Error("simulated notification failure");
         },
       },
     );
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     assert.deepEqual(
       (await store.listForOwner("alice", "owner:alice")).map(
@@ -42,11 +43,12 @@ test("commit notification failures do not orphan grants or hide revocations", as
         principal: "owner:alice",
       },
       {
-        onCommitted: () => {
+        onCommitted: async () => {
           throw new Error("simulated notification failure");
         },
       },
     );
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     assert.ok(revoked.revokedAt);
     assert.equal(

--- a/packages/remnic-core/src/support-passport/grant-store-commit-hook.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-commit-hook.test.ts
@@ -25,15 +25,13 @@ test("commit notification failures do not orphan grants or hide revocations", as
         onCommitted: async () => {
           throw new Error("simulated notification failure");
         },
-      },
+      }
     );
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     assert.deepEqual(
-      (await store.listForOwner("alice", "owner:alice")).map(
-        (state) => state.grantId,
-      ),
-      [created.state.grantId],
+      (await store.listForOwner("alice", "owner:alice")).map((state) => state.grantId),
+      [created.state.grantId]
     );
 
     const revoked = await store.revoke(
@@ -46,15 +44,79 @@ test("commit notification failures do not orphan grants or hide revocations", as
         onCommitted: async () => {
           throw new Error("simulated notification failure");
         },
-      },
+      }
     );
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     assert.ok(revoked.revokedAt);
-    assert.equal(
-      (await store.listForOwner("alice", "owner:alice"))[0]?.revokedAt,
-      revoked.revokedAt,
+    assert.equal((await store.listForOwner("alice", "owner:alice"))[0]?.revokedAt, revoked.revokedAt);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("create does not notify before the owner index commits", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-hook-order-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const inspected = store as unknown as {
+      writeOwnerIndex(): Promise<void>;
+    };
+    inspected.writeOwnerIndex = async () => {
+      throw new Error("simulated owner index failure");
+    };
+    let notified = false;
+
+    await assert.rejects(
+      store.create(
+        {
+          namespace: "alice",
+          principal: "owner:alice",
+          cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+          expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+        },
+        {
+          onCommitted: () => {
+            notified = true;
+          },
+        }
+      ),
+      /simulated owner index failure/
     );
+
+    assert.equal(notified, false);
+    assert.deepEqual(await store.listForOwner("alice", "owner:alice"), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("idempotent revoke does not require another directory sync", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-idempotent-revoke-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+      syncDirectory: async () => {
+        throw new Error("simulated directory sync failure");
+      },
+    });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const input = {
+      grantId: created.state.grantId,
+      namespace: "alice",
+      principal: "owner:alice",
+    };
+    const revoked = await store.revoke(input);
+
+    assert.deepEqual(await store.revoke(input), revoked);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-store-commit-hook.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-commit-hook.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { SupportPassportGrantStore } from "./grant-store.js";
+
+test("commit notification failures do not orphan grants or hide revocations", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-hook-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      now: () => now,
+    });
+    const created = await store.create(
+      {
+        namespace: "alice",
+        principal: "owner:alice",
+        cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+        expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+      },
+      {
+        onCommitted: () => {
+          throw new Error("simulated notification failure");
+        },
+      },
+    );
+
+    assert.deepEqual(
+      (await store.listForOwner("alice", "owner:alice")).map(
+        (state) => state.grantId,
+      ),
+      [created.state.grantId],
+    );
+
+    const revoked = await store.revoke(
+      {
+        grantId: created.state.grantId,
+        namespace: "alice",
+        principal: "owner:alice",
+      },
+      {
+        onCommitted: () => {
+          throw new Error("simulated notification failure");
+        },
+      },
+    );
+
+    assert.ok(revoked.revokedAt);
+    assert.equal(
+      (await store.listForOwner("alice", "owner:alice"))[0]?.revokedAt,
+      revoked.revokedAt,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-store-order.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-order.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import type { SupportPassportGrantState } from "./grant-contracts.js";
+import { SupportPassportGrantStore } from "./grant-store.js";
+
+test("grant rollover compares offset timestamps by instant", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-order-"));
+  let nowMs = Date.parse("2026-08-11T06:00:00Z");
+  let nextGrantId = 1;
+  const store = new SupportPassportGrantStore({
+    memoryDir: root,
+    now: () => new Date(nowMs),
+    makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+  });
+  const input = {
+    namespace: "alice",
+    principal: "owner:alice",
+    cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+    expiresAt: "2026-08-11T13:00:00Z",
+  };
+
+  try {
+    const grants = [];
+    for (let index = 0; index < 100; index += 1) grants.push(await store.create(input));
+    nowMs = Date.parse("2026-08-11T11:00:00Z");
+    const older = await store.revoke({
+      grantId: grants[0]!.state.grantId,
+      namespace: input.namespace,
+      principal: input.principal,
+    });
+    const newer = await store.revoke({
+      grantId: grants[1]!.state.grantId,
+      namespace: input.namespace,
+      principal: input.principal,
+    });
+    const inspected = store as unknown as {
+      writeState(state: SupportPassportGrantState): Promise<void>;
+    };
+    await inspected.writeState({ ...older, createdAt: "2026-08-11T12:00:00+05:00" });
+    await inspected.writeState({ ...newer, createdAt: "2026-08-11T10:00:00Z" });
+
+    const replacement = await store.create(input);
+    const ids = new Set((await store.listForOwner(input.namespace, input.principal)).map((grant) => grant.grantId));
+
+    assert.equal(ids.size, 100);
+    assert.equal(ids.has(older.grantId), false);
+    assert.equal(ids.has(newer.grantId), true);
+    assert.equal(ids.has(replacement.state.grantId), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-store-order.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-order.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import type { SupportPassportGrantState } from "./grant-contracts.js";
 import { SupportPassportGrantStore } from "./grant-store.js";
 
-test("grant rollover compares offset timestamps by instant", async () => {
+test("grant rollover stays bounded after cleanup failure and compares offset timestamps by instant", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-order-"));
   let nowMs = Date.parse("2026-08-11T06:00:00Z");
   let nextGrantId = 1;
@@ -39,9 +39,13 @@ test("grant rollover compares offset timestamps by instant", async () => {
     });
     const inspected = store as unknown as {
       writeState(state: SupportPassportGrantState): Promise<void>;
+      removeStoredGrant(state: SupportPassportGrantState): Promise<void>;
     };
     await inspected.writeState({ ...older, createdAt: "2026-08-11T12:00:00+05:00" });
     await inspected.writeState({ ...newer, createdAt: "2026-08-11T10:00:00Z" });
+    inspected.removeStoredGrant = async () => {
+      throw new Error("simulated cleanup failure");
+    };
 
     const replacement = await store.create(input);
     const ids = new Set((await store.listForOwner(input.namespace, input.principal)).map((grant) => grant.grantId));

--- a/packages/remnic-core/src/support-passport/grant-store-path-safety.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-path-safety.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, rename, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { SupportPassportGrantStore } from "./grant-store.js";
+
+test("owner membership setup rejects a swapped memory-directory ancestor before mutation", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-ancestor-"));
+  const liveParent = path.join(root, "live");
+  const memoryDir = path.join(liveParent, "memory");
+  const originalParent = path.join(root, "original");
+  const outsideParent = path.join(root, "outside");
+  try {
+    const store = new SupportPassportGrantStore({ memoryDir });
+    await store.listForOwner("alice", "owner:alice");
+    await mkdir(path.join(outsideParent, "memory"), { recursive: true });
+    await rename(liveParent, originalParent);
+    await symlink(outsideParent, liveParent, "dir");
+
+    await assert.rejects(store.listForOwner("alice", "owner:alice"));
+    await assert.rejects(
+      lstat(path.join(outsideParent, "memory", "state")),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === "ENOENT",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -75,7 +75,7 @@ test("a final stale owner-index write cannot hide a peer grant", async () => {
   }
 });
 
-test("a recovery marker restores owner capacity before another grant is indexed", async () => {
+test("owner membership enforces capacity when the derived index is stale", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cap-recovery-"));
   try {
     const now = new Date("2026-08-11T12:00:00.000Z");
@@ -98,7 +98,6 @@ test("a recovery marker restores owner capacity before another grant is indexed"
       writeState(state: typeof first.state, requireAbsent: boolean): Promise<void>;
       writeOwnerMembership(state: typeof first.state): Promise<void>;
       writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
-      writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void>;
     };
     const states = [first.state];
     for (let index = 2; index <= 100; index += 1) {
@@ -113,7 +112,6 @@ test("a recovery marker restores owner capacity before another grant is indexed"
       ownerHash,
       states.slice(0, 99).map((state) => state.grantId)
     );
-    await inspected.writeOwnerIndexRecoveryMarker(ownerHash, states[99]?.grantId ?? grantId(100));
 
     await assert.rejects(
       store.create(input),
@@ -130,7 +128,7 @@ test("a recovery marker restores owner capacity before another grant is indexed"
   }
 });
 
-test("an owner list retries from membership when a recovery marker appears during its index read", async () => {
+test("an owner list ignores a stale derived index", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-recovery-"));
   try {
     const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
@@ -150,21 +148,10 @@ test("an owner list retries from membership when a recovery marker appears durin
     const second = await store.create(input);
     const inspected = store as unknown as {
       ownerHash(namespace: string, principalHash: string): string;
-      readOwnerIndexByHash(ownerHash: string): Promise<string[]>;
       writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
-      writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void>;
     };
-    const readOwnerIndex = inspected.readOwnerIndexByHash.bind(store);
     const ownerHash = inspected.ownerHash(first.state.namespace, first.state.principalHash);
-    let raced = false;
-    inspected.readOwnerIndexByHash = async (selectedOwnerHash) => {
-      if (!raced) {
-        raced = true;
-        await inspected.writeOwnerIndexRecoveryMarker(ownerHash, second.state.grantId);
-        await inspected.writeOwnerIndex(ownerHash, [first.state.grantId]);
-      }
-      return await readOwnerIndex(selectedOwnerHash);
-    };
+    await inspected.writeOwnerIndex(ownerHash, [first.state.grantId]);
 
     assert.deepEqual(
       new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
@@ -175,8 +162,8 @@ test("an owner list retries from membership when a recovery marker appears durin
   }
 });
 
-test("an index write preserves a late recovery marker that its snapshot does not cover", async () => {
-  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-late-marker-"));
+test("a later create rebuilds the derived index from owner membership", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-index-rebuild-"));
   try {
     const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
     const peerGrantId = "00000000-0000-4000-8000-000000000003";
@@ -199,29 +186,21 @@ test("an index write preserves a late recovery marker that its snapshot does not
       secretHash: "b".repeat(64),
     };
     const inspected = store as unknown as {
-      ownerIndexRecoveryGrantIds(ownerHash: string): Promise<string[]>;
+      ownerHash(namespace: string, principalHash: string): string;
       writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
       writeOwnerMembership(state: typeof peerState): Promise<void>;
-      writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void>;
+      writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
     };
-    const readRecoveryGrantIds = inspected.ownerIndexRecoveryGrantIds.bind(store);
-    let recoveryScans = 0;
-    inspected.ownerIndexRecoveryGrantIds = async (ownerHash) => {
-      recoveryScans += 1;
-      if (recoveryScans === 2) {
-        await inspected.writeState(peerState, true);
-        await inspected.writeOwnerMembership(peerState);
-        await inspected.writeOwnerIndexRecoveryMarker(ownerHash, peerGrantId);
-      }
-      return await readRecoveryGrantIds(ownerHash);
-    };
+    await inspected.writeState(peerState, true);
+    await inspected.writeOwnerMembership(peerState);
+    const ownerHash = inspected.ownerHash(first.state.namespace, first.state.principalHash);
+    await inspected.writeOwnerIndex(ownerHash, [first.state.grantId]);
 
     const second = await store.create(input);
+    const indexPath = path.join(root, "state", "support-passport", "grants", "owners", `${ownerHash}.json`);
+    const derivedIndex = JSON.parse(await readFile(indexPath, "utf8")) as { grantIds: string[] };
 
-    assert.deepEqual(
-      new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
-      new Set([first.state.grantId, second.state.grantId, peerGrantId])
-    );
+    assert.deepEqual(new Set(derivedIndex.grantIds), new Set([first.state.grantId, second.state.grantId, peerGrantId]));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -128,6 +128,152 @@ test("owner membership enforces capacity when the derived index is stale", async
   }
 });
 
+test("an owner can list every active grant while repairing an overflow", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-overflow-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const created = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const states = Array.from({ length: 101 }, (_, index) => ({
+      ...created.state,
+      grantId: `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+    }));
+    const inspected = store as unknown as {
+      readOwnerMembershipStates(namespace: string, principalHash: string): Promise<typeof states>;
+    };
+    inspected.readOwnerMembershipStates = async () => states;
+
+    const listed = await store.listForOwner("alice", "owner:alice");
+
+    assert.equal(listed.length, 101);
+    assert.equal(listed.every((state) => !state.revokedAt), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("overflow recovery locks a committed grant before removing it", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-locked-overflow-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const committed = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const states = Array.from({ length: 101 }, (_, index) => ({
+      ...committed.state,
+      grantId: index === 0
+        ? committed.state.grantId
+        : `00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+    }));
+    const lockedGrantIds: string[] = [];
+    const removedGrantIds: string[] = [];
+    const inspected = store as unknown as {
+      reconcileCommittedGrant(
+        value: typeof committed,
+        ownerHash: string,
+        lock: { refresh(): Promise<boolean> },
+      ): Promise<typeof committed>;
+      readState(grantId: string): Promise<typeof committed.state>;
+      readOwnerMembershipStates(namespace: string, principalHash: string): Promise<typeof states>;
+      withGrantLock<T>(
+        grantId: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+      removeStoredGrant(state: typeof committed.state): Promise<void>;
+      writeOwnerIndexWhileLocked(): Promise<void>;
+    };
+    inspected.readState = async () => committed.state;
+    inspected.readOwnerMembershipStates = async () => states;
+    inspected.withGrantLock = async (grantId, task) => {
+      lockedGrantIds.push(grantId);
+      return await task({ refresh: async () => true });
+    };
+    inspected.removeStoredGrant = async (state) => {
+      removedGrantIds.push(state.grantId);
+    };
+    inspected.writeOwnerIndexWhileLocked = async () => undefined;
+
+    await assert.rejects(
+      inspected.reconcileCommittedGrant(committed, "a".repeat(64), { refresh: async () => true }),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict",
+    );
+
+    assert.deepEqual(lockedGrantIds, [committed.state.grantId]);
+    assert.deepEqual(removedGrantIds, [committed.state.grantId]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("recovery keeps a committed grant when stale history cleanup fails", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cleanup-isolation-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({ memoryDir: root, now: () => now });
+    const committed = await store.create({
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    });
+    const inactiveStates = Array.from({ length: 100 }, (_, index) => ({
+      ...committed.state,
+      grantId: `00000000-0000-4000-8000-${String(index + 2).padStart(12, "0")}`,
+      stateVersion: 2,
+      revokedAt: now.toISOString(),
+    }));
+    const cleanupAttempts: string[] = [];
+    const inspected = store as unknown as {
+      reconcileCommittedGrant(
+        value: typeof committed,
+        ownerHash: string,
+        lock: { refresh(): Promise<boolean> },
+      ): Promise<typeof committed>;
+      readState(grantId: string): Promise<typeof committed.state>;
+      readOwnerMembershipStates(
+        namespace: string,
+        principalHash: string,
+      ): Promise<Array<typeof committed.state>>;
+      withGrantLock<T>(
+        grantId: string,
+        task: (lock: { refresh(): Promise<boolean> }) => Promise<T>,
+      ): Promise<T>;
+      removeStoredGrant(state: typeof committed.state): Promise<void>;
+      writeOwnerIndexWhileLocked(): Promise<void>;
+    };
+    inspected.readState = async () => committed.state;
+    inspected.readOwnerMembershipStates = async () => [committed.state, ...inactiveStates];
+    inspected.withGrantLock = async (grantId, task) => {
+      cleanupAttempts.push(grantId);
+      return await task({ refresh: async () => true });
+    };
+    inspected.removeStoredGrant = async () => {
+      throw new Error("simulated stale history cleanup failure");
+    };
+    inspected.writeOwnerIndexWhileLocked = async () => undefined;
+
+    const result = await inspected.reconcileCommittedGrant(
+      committed,
+      "a".repeat(64),
+      { refresh: async () => true },
+    );
+
+    assert.equal(result.state.grantId, committed.state.grantId);
+    assert.equal(cleanupAttempts.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("an owner list ignores a stale derived index", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-recovery-"));
   try {

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -65,7 +65,7 @@ test("a final stale owner-index write cannot hide a peer grant", async () => {
     );
 
     assert.equal(ownerLockRuns, 4);
-    assert.equal(ownerIndexWrites, 3);
+    assert.equal(ownerIndexWrites, 4);
     assert.deepEqual(
       new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
       new Set([first.state.grantId, peerGrantId])

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -40,7 +40,7 @@ test("a final stale owner-index write cannot hide a peer grant", async () => {
     let ownerIndexWrites = 0;
     inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
       ownerIndexWrites += 1;
-      if (ownerIndexWrites === 4) {
+      if (ownerIndexWrites === 3) {
         await inspected.writeState(peerState, true);
         await inspected.writeOwnerMembership(peerState);
         await writeOwnerIndex(ownerHash, [...indexedGrantIds, peerGrantId]);
@@ -65,7 +65,7 @@ test("a final stale owner-index write cannot hide a peer grant", async () => {
     );
 
     assert.equal(ownerLockRuns, 4);
-    assert.equal(ownerIndexWrites, 4);
+    assert.equal(ownerIndexWrites, 3);
     assert.deepEqual(
       new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
       new Set([first.state.grantId, peerGrantId])
@@ -201,6 +201,101 @@ test("a later create rebuilds the derived index from owner membership", async ()
     const derivedIndex = JSON.parse(await readFile(indexPath, "utf8")) as { grantIds: string[] };
 
     assert.deepEqual(new Set(derivedIndex.grantIds), new Set([first.state.grantId, second.state.grantId, peerGrantId]));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("concurrent owner creates reserve capacity before writing membership", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-concurrent-cap-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    let nextGrantId = 1;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => `00000000-0000-4000-8000-${String(nextGrantId++).padStart(12, "0")}`,
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+
+    const first = await store.create(input);
+    const inspected = store as unknown as {
+      writeState(state: typeof first.state, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof first.state): Promise<void>;
+    };
+    for (let index = 2; index <= 99; index += 1) {
+      const state = {
+        ...first.state,
+        grantId: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      };
+      await inspected.writeState(state, true);
+      await inspected.writeOwnerMembership(state);
+    }
+    nextGrantId = 100;
+
+    const results = await Promise.allSettled([store.create(input), store.create(input)]);
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+
+    assert.equal(fulfilled.length, 1);
+    assert.equal(rejected.length, 1);
+    assert.ok(
+      rejected.every(
+        (result) => result.reason instanceof SupportPassportError && result.reason.code === "invalid_input",
+      ),
+    );
+    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("owner-index recovery removes history entries beyond the retained set", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-overflow-recovery-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => "00000000-0000-4000-8000-000000000001",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const committed = await store.create(input);
+    const inspected = store as unknown as {
+      ownerHash(namespace: string, principalHash: string): string;
+      writeState(state: typeof committed.state, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof committed.state): Promise<void>;
+      reconcileCommittedGrant(
+        value: typeof committed,
+        ownerHash: string,
+        lock: { refresh(): Promise<boolean> },
+      ): Promise<typeof committed>;
+    };
+    for (let index = 2; index <= 101; index += 1) {
+      const state = {
+        ...committed.state,
+        grantId: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        stateVersion: 2,
+        revokedAt: now.toISOString(),
+      };
+      await inspected.writeState(state, true);
+      await inspected.writeOwnerMembership(state);
+    }
+    const ownerHash = inspected.ownerHash(committed.state.namespace, committed.state.principalHash);
+
+    await inspected.reconcileCommittedGrant(committed, ownerHash, { refresh: async () => true });
+
+    assert.equal((await store.listForOwner(input.namespace, input.principal)).length, 100);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -174,3 +174,55 @@ test("an owner list retries from membership when a recovery marker appears durin
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("an index write preserves a late recovery marker that its snapshot does not cover", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-late-marker-"));
+  try {
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const peerGrantId = "00000000-0000-4000-8000-000000000003";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000004",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const peerState = {
+      ...first.state,
+      grantId: peerGrantId,
+      secretHash: "b".repeat(64),
+    };
+    const inspected = store as unknown as {
+      ownerIndexRecoveryGrantIds(ownerHash: string): Promise<string[]>;
+      writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof peerState): Promise<void>;
+      writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void>;
+    };
+    const readRecoveryGrantIds = inspected.ownerIndexRecoveryGrantIds.bind(store);
+    let recoveryScans = 0;
+    inspected.ownerIndexRecoveryGrantIds = async (ownerHash) => {
+      recoveryScans += 1;
+      if (recoveryScans === 2) {
+        await inspected.writeState(peerState, true);
+        await inspected.writeOwnerMembership(peerState);
+        await inspected.writeOwnerIndexRecoveryMarker(ownerHash, peerGrantId);
+      }
+      return await readRecoveryGrantIds(ownerHash);
+    };
+
+    const second = await store.create(input);
+
+    assert.deepEqual(
+      new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
+      new Set([first.state.grantId, second.state.grantId, peerGrantId])
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -74,3 +74,103 @@ test("a final stale owner-index write cannot hide a peer grant", async () => {
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("a recovery marker restores owner capacity before another grant is indexed", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-cap-recovery-"));
+  try {
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    let nextGrantId = 1;
+    const grantId = (value: number) => `00000000-0000-4000-8000-${String(value).padStart(12, "0")}`;
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantId(nextGrantId++),
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const inspected = store as unknown as {
+      ownerHash(namespace: string, principalHash: string): string;
+      writeState(state: typeof first.state, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof first.state): Promise<void>;
+      writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
+      writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void>;
+    };
+    const states = [first.state];
+    for (let index = 2; index <= 100; index += 1) {
+      const state = { ...first.state, grantId: grantId(index) };
+      await inspected.writeState(state, true);
+      await inspected.writeOwnerMembership(state);
+      states.push(state);
+    }
+    nextGrantId = 101;
+    const ownerHash = inspected.ownerHash(first.state.namespace, first.state.principalHash);
+    await inspected.writeOwnerIndex(
+      ownerHash,
+      states.slice(0, 99).map((state) => state.grantId)
+    );
+    await inspected.writeOwnerIndexRecoveryMarker(ownerHash, states[99]?.grantId ?? grantId(100));
+
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "invalid_input"
+    );
+    const listed = await store.listForOwner(input.namespace, input.principal);
+    assert.equal(listed.length, 100);
+    assert.equal(
+      listed.some((state) => state.grantId === grantId(101)),
+      false
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an owner list retries from membership when a recovery marker appears during its index read", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-list-recovery-"));
+  try {
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000003",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const second = await store.create(input);
+    const inspected = store as unknown as {
+      ownerHash(namespace: string, principalHash: string): string;
+      readOwnerIndexByHash(ownerHash: string): Promise<string[]>;
+      writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
+      writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void>;
+    };
+    const readOwnerIndex = inspected.readOwnerIndexByHash.bind(store);
+    const ownerHash = inspected.ownerHash(first.state.namespace, first.state.principalHash);
+    let raced = false;
+    inspected.readOwnerIndexByHash = async (selectedOwnerHash) => {
+      if (!raced) {
+        raced = true;
+        await inspected.writeOwnerIndexRecoveryMarker(ownerHash, second.state.grantId);
+        await inspected.writeOwnerIndex(ownerHash, [first.state.grantId]);
+      }
+      return await readOwnerIndex(selectedOwnerHash);
+    };
+
+    assert.deepEqual(
+      new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
+      new Set([first.state.grantId, second.state.grantId])
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-store-recovery.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { SupportPassportError } from "./errors.js";
+import { SupportPassportGrantStore } from "./grant-store.js";
+
+test("a final stale owner-index write cannot hide a peer grant", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-grant-final-recovery-"));
+  try {
+    const grantIds = ["00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"];
+    const peerGrantId = "00000000-0000-4000-8000-000000000003";
+    const now = new Date("2026-08-11T12:00:00.000Z");
+    const store = new SupportPassportGrantStore({
+      memoryDir: root,
+      makeGrantId: () => grantIds.shift() ?? "00000000-0000-4000-8000-000000000004",
+      now: () => now,
+    });
+    const input = {
+      namespace: "alice",
+      principal: "owner:alice",
+      cards: [{ cardId: "card-1", revision: "a".repeat(64) }],
+      expiresAt: new Date(now.getTime() + 3_600_000).toISOString(),
+    };
+    const first = await store.create(input);
+    const peerState = {
+      ...first.state,
+      grantId: peerGrantId,
+      secretHash: "b".repeat(64),
+    };
+    const inspected = store as unknown as {
+      withOwnerIndexLock<T>(ownerHash: string, task: (lock: { refresh(): Promise<boolean> }) => Promise<T>): Promise<T>;
+      writeOwnerIndex(ownerHash: string, indexedGrantIds: string[]): Promise<void>;
+      writeState(state: typeof peerState, requireAbsent: boolean): Promise<void>;
+      writeOwnerMembership(state: typeof peerState): Promise<void>;
+    };
+    const writeOwnerIndex = inspected.writeOwnerIndex.bind(store);
+    let ownerIndexWrites = 0;
+    inspected.writeOwnerIndex = async (ownerHash, indexedGrantIds) => {
+      ownerIndexWrites += 1;
+      if (ownerIndexWrites === 4) {
+        await inspected.writeState(peerState, true);
+        await inspected.writeOwnerMembership(peerState);
+        await writeOwnerIndex(ownerHash, [...indexedGrantIds, peerGrantId]);
+      }
+      await writeOwnerIndex(ownerHash, indexedGrantIds);
+    };
+    let ownerLockRuns = 0;
+    inspected.withOwnerIndexLock = async (_ownerHash, task) => {
+      ownerLockRuns += 1;
+      let refreshes = 0;
+      return await task({
+        refresh: async () => {
+          refreshes += 1;
+          return refreshes === 1;
+        },
+      });
+    };
+
+    await assert.rejects(
+      store.create(input),
+      (error: unknown) => error instanceof SupportPassportError && error.code === "storage_conflict"
+    );
+
+    assert.equal(ownerLockRuns, 4);
+    assert.equal(ownerIndexWrites, 4);
+    assert.deepEqual(
+      new Set((await store.listForOwner(input.namespace, input.principal)).map((state) => state.grantId)),
+      new Set([first.state.grantId, peerGrantId])
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { log } from "../logger.js";
 import { expandTildePath } from "../utils/path.js";
 import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
 import {
@@ -14,6 +15,7 @@ import {
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
 import {
+  canonicalizePrivateDirectoryTarget,
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
   readPrivateFileNoFollow,
@@ -99,9 +101,10 @@ export async function syncDirectoryForDurability(
 }
 
 export class SupportPassportGrantStore {
-  private readonly memoryDir: string;
-  private readonly grantsDir: string;
-  private readonly ownerIndexesDir: string;
+  private memoryDir: string;
+  private grantsDir: string;
+  private ownerIndexesDir: string;
+  private memoryRootReady?: Promise<void>;
   private readonly now: () => Date;
   private readonly makeSecret: () => Buffer;
   private readonly makeGrantId: () => string;
@@ -149,7 +152,7 @@ export class SupportPassportGrantStore {
         stateVersion: 1,
         grantId,
         namespace,
-        principalHash: sha256("support-passport-principal:v1", parsed.data.principal),
+        principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
         secretHash: sha256("support-passport-secret:v1", secret),
         cards: parsed.data.cards,
         createdAt: createdAt.toISOString(),
@@ -169,11 +172,11 @@ export class SupportPassportGrantStore {
   }
 
   async authenticate(grantId: string, secret: string): Promise<SupportPassportGrantState> {
-    grantId = normalizeGrantId(grantId);
+    const normalizedGrantId = normalizeGrantId(grantId);
     if (typeof secret !== "string" || secret.length > 512) throw grantNotFound();
     let state: SupportPassportGrantState;
     try {
-      state = await this.readState(grantId);
+      state = await this.readState(normalizedGrantId);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
       throw error;
@@ -214,7 +217,7 @@ export class SupportPassportGrantStore {
 
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
-    const principalHash = sha256("support-passport-principal:v1", normalizePrincipal(principal));
+    const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
     const grantIds = await this.readOwnerIndex(normalizedNamespace, principalHash);
     const states: SupportPassportGrantState[] = [];
     for (const grantId of grantIds) {
@@ -245,20 +248,23 @@ export class SupportPassportGrantStore {
     },
     beforeCommit?: () => Promise<void>
   ): Promise<SupportPassportGrantState> {
-    input = { ...input, grantId: normalizeGrantId(input.grantId) };
+    const normalizedInput = { ...input, grantId: normalizeGrantId(input.grantId) };
     const namespace = normalizeNamespace(input.namespace);
-    return await this.withGrantLock(input.grantId, async (lock) => {
+    return await this.withGrantLock(normalizedInput.grantId, async (lock) => {
       let state: SupportPassportGrantState;
       try {
-        state = await this.readState(input.grantId);
+        state = await this.readState(normalizedInput.grantId);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
         throw error;
       }
-      const principalHash = sha256("support-passport-principal:v1", normalizePrincipal(input.principal));
+      const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(input.principal));
       if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
       if (state.revokedAt) return state;
-      if (input.expectedStateVersion !== undefined && input.expectedStateVersion !== state.stateVersion) {
+      if (
+        normalizedInput.expectedStateVersion !== undefined &&
+        normalizedInput.expectedStateVersion !== state.stateVersion
+      ) {
         throw new SupportPassportError("state_conflict", "The share link changed after it was loaded.", 409);
       }
       const revoked = SupportPassportGrantStateSchema.parse({
@@ -274,8 +280,8 @@ export class SupportPassportGrantStore {
   }
 
   private filePath(grantId: string): string {
-    grantId = normalizeGrantId(grantId);
-    return path.join(this.grantsDir, `${grantId}.json`);
+    const normalizedGrantId = normalizeGrantId(grantId);
+    return path.join(this.grantsDir, `${normalizedGrantId}.json`);
   }
 
   private ownerIndexPath(ownerHash: string): string {
@@ -451,15 +457,35 @@ export class SupportPassportGrantStore {
   }
 
   private async ensureSafeDirectories(): Promise<void> {
-    await ensurePrivateDirectoryTreeNoFollow(
-      this.memoryDir,
-      "support passport memory directory must be a stable directory"
-    );
+    await this.ensureMemoryRoot();
     await ensurePrivateDirectoryNoFollow(
       this.memoryDir,
       this.ownerIndexesDir,
       "support passport grant directories must remain inside the memory directory"
     );
+  }
+
+  private async ensureMemoryRoot(): Promise<void> {
+    if (!this.memoryRootReady) {
+      const configuredMemoryDir = this.memoryDir;
+      this.memoryRootReady = (async () => {
+        const canonicalMemoryDir = await canonicalizePrivateDirectoryTarget(configuredMemoryDir);
+        await ensurePrivateDirectoryTreeNoFollow(
+          canonicalMemoryDir,
+          "support passport memory directory must be a stable directory"
+        );
+        this.memoryDir = canonicalMemoryDir;
+        this.grantsDir = path.join(canonicalMemoryDir, "state", "support-passport", "grants");
+        this.ownerIndexesDir = path.join(this.grantsDir, "owners");
+      })();
+    }
+    const currentAttempt = this.memoryRootReady;
+    try {
+      await currentAttempt;
+    } catch (error) {
+      if (this.memoryRootReady === currentAttempt) this.memoryRootReady = undefined;
+      throw error;
+    }
   }
 
   private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
@@ -478,7 +504,7 @@ export class SupportPassportGrantStore {
   }
 
   private async withGrantLock<T>(grantId: string, task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
-    grantId = normalizeGrantId(grantId);
+    const normalizedGrantId = normalizeGrantId(grantId);
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
       this.memoryDir,
@@ -486,8 +512,8 @@ export class SupportPassportGrantStore {
       "support passport grant lock directory must remain inside the memory directory",
       async (pinnedDirectory) =>
         await this.withExclusiveLock(
-          `support-passport-grant:${this.grantsDir}:${grantId}`,
-          path.join(pinnedDirectory, `.${grantId}.lock`),
+          `support-passport-grant:${this.grantsDir}:${normalizedGrantId}`,
+          path.join(pinnedDirectory, `.${normalizedGrantId}.lock`),
           task
         )
     );

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -89,6 +89,14 @@ function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
 }
 
+function notifyCommitted(callback: (() => void) | undefined): void {
+  try {
+    callback?.();
+  } catch (error) {
+    log.warn(`support passport commit notification failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 function normalizeGrantId(grantId: unknown): string {
   if (typeof grantId !== "string" || !UUID_INPUT.test(grantId)) throw grantNotFound();
   return grantId.toLowerCase();
@@ -221,7 +229,7 @@ export class SupportPassportGrantStore {
           throw error;
         }
       }
-      mutationHooks.onCommitted?.();
+      notifyCommitted(mutationHooks.onCommitted);
       return { state, secret };
     });
     const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
@@ -379,7 +387,7 @@ export class SupportPassportGrantStore {
         if (!persisted || !sameGrantState(persisted, revoked)) throw error;
         await this.syncDirectory(this.grantsDir);
       }
-      mutationHooks.onCommitted?.();
+      notifyCommitted(mutationHooks.onCommitted);
       return revoked;
     });
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -16,7 +16,6 @@ import {
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
 import {
-  canonicalizePrivateDirectoryTarget,
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
   readPrivateFileNoFollow,
@@ -407,7 +406,7 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       grantIds.map((grantId) => `${grantId}.json`),
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
   }
 
@@ -424,7 +423,7 @@ export class SupportPassportGrantStore {
         this.ownerIndexesDir,
         filePath,
         "support passport owner indexes must be regular files in a stable directory",
-        this.memoryDir
+        this.memoryDir,
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -465,7 +464,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
       "support passport owner indexes must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
   }
 
@@ -476,7 +475,7 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       filePath,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
     const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
     if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
@@ -500,7 +499,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify(state, null, 2)}\n`,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
   }
 
@@ -511,7 +510,9 @@ export class SupportPassportGrantStore {
         await ensurePrivateDirectoryNoFollow(
           this.memoryDir,
           this.ownerIndexesDir,
-          "support passport grant directories must remain inside the memory directory"
+          "support passport grant directories must remain inside the memory directory",
+          undefined,
+          true,
         );
       })();
     }
@@ -528,13 +529,13 @@ export class SupportPassportGrantStore {
     if (!this.memoryRootReady) {
       const configuredMemoryDir = this.memoryDir;
       this.memoryRootReady = (async () => {
-        const canonicalMemoryDir = await canonicalizePrivateDirectoryTarget(configuredMemoryDir);
         await ensurePrivateDirectoryTreeNoFollow(
-          canonicalMemoryDir,
-          "support passport memory directory must be a stable directory"
+          configuredMemoryDir,
+          "support passport memory directory must be a stable directory",
+          undefined,
         );
-        this.memoryDir = canonicalMemoryDir;
-        this.grantsDir = path.join(canonicalMemoryDir, "state", "support-passport", "grants");
+        this.memoryDir = configuredMemoryDir;
+        this.grantsDir = path.join(configuredMemoryDir, "state", "support-passport", "grants");
         this.ownerIndexesDir = path.join(this.grantsDir, "owners");
       })();
     }
@@ -558,7 +559,7 @@ export class SupportPassportGrantStore {
           `support-passport-grants:${this.grantsDir}`,
           path.join(pinnedDirectory, ".grants.lock"),
           task
-        )
+        ),
     );
   }
 
@@ -574,7 +575,7 @@ export class SupportPassportGrantStore {
           `support-passport-grant:${this.grantsDir}:${normalizedGrantId}`,
           path.join(pinnedDirectory, `.${normalizedGrantId}.lock`),
           task
-        )
+        ),
     );
   }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -112,6 +112,7 @@ export class SupportPassportGrantStore {
   private grantsDir: string;
   private ownerIndexesDir: string;
   private memoryRootReady?: Promise<void>;
+  private safeDirectoriesReady?: Promise<void>;
   private readonly now: () => Date;
   private readonly makeSecret: () => Buffer;
   private readonly makeGrantId: () => string;
@@ -162,6 +163,9 @@ export class SupportPassportGrantStore {
       const grantId = rawGrantId.toLowerCase();
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
+      if (!Number.isFinite(createdAt.getTime()) || Date.parse(parsed.data.expiresAt) <= createdAt.getTime()) {
+        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+      }
       const state = SupportPassportGrantStateSchema.parse({
         schemaVersion: 1,
         stateVersion: 1,
@@ -497,12 +501,23 @@ export class SupportPassportGrantStore {
   }
 
   private async ensureSafeDirectories(): Promise<void> {
-    await this.ensureMemoryRoot();
-    await ensurePrivateDirectoryNoFollow(
-      this.memoryDir,
-      this.ownerIndexesDir,
-      "support passport grant directories must remain inside the memory directory"
-    );
+    if (!this.safeDirectoriesReady) {
+      this.safeDirectoriesReady = (async () => {
+        await this.ensureMemoryRoot();
+        await ensurePrivateDirectoryNoFollow(
+          this.memoryDir,
+          this.ownerIndexesDir,
+          "support passport grant directories must remain inside the memory directory"
+        );
+      })();
+    }
+    const currentAttempt = this.safeDirectoriesReady;
+    try {
+      await currentAttempt;
+    } catch (error) {
+      if (this.safeDirectoriesReady === currentAttempt) this.safeDirectoriesReady = undefined;
+      throw error;
+    }
   }
 
   private async ensureMemoryRoot(): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypt
 import { chmod, lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 
+import { expandTildePath } from "../utils/path.js";
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportError } from "./errors.js";
 import {
@@ -84,7 +85,7 @@ export class SupportPassportGrantStore {
   private readonly makeGrantId: () => string;
 
   constructor(options: SupportPassportGrantStoreOptions) {
-    this.memoryDir = path.resolve(options.memoryDir);
+    this.memoryDir = path.resolve(expandTildePath(options.memoryDir));
     this.grantsDir = path.join(this.memoryDir, "state", "support-passport", "grants");
     this.now = options.now ?? (() => new Date());
     this.makeSecret = options.makeSecret ?? (() => randomBytes(32));

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -308,7 +308,8 @@ export class SupportPassportGrantStore {
     await removePrivateFilesNoFollow(
       this.grantsDir,
       grantIds.map((grantId) => `${grantId}.json`),
-      "support passport grant files must be regular files in a stable directory"
+      "support passport grant files must be regular files in a stable directory",
+      this.memoryDir
     );
   }
 
@@ -324,7 +325,8 @@ export class SupportPassportGrantStore {
       content = await readPrivateFileNoFollow(
         this.ownerIndexesDir,
         filePath,
-        "support passport owner indexes must be regular files in a stable directory"
+        "support passport owner indexes must be regular files in a stable directory",
+        this.memoryDir
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -364,7 +366,8 @@ export class SupportPassportGrantStore {
       this.ownerIndexesDir,
       filePath,
       `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
-      "support passport owner indexes must be regular files in a stable directory"
+      "support passport owner indexes must be regular files in a stable directory",
+      this.memoryDir
     );
   }
 
@@ -374,7 +377,8 @@ export class SupportPassportGrantStore {
     const content = await readPrivateFileNoFollow(
       this.grantsDir,
       filePath,
-      "support passport grant files must be regular files in a stable directory"
+      "support passport grant files must be regular files in a stable directory",
+      this.memoryDir
     );
     const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
     if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
@@ -397,7 +401,8 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       filePath,
       `${JSON.stringify(state, null, 2)}\n`,
-      "support passport grant files must be regular files in a stable directory"
+      "support passport grant files must be regular files in a stable directory",
+      this.memoryDir
     );
   }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -4,7 +4,11 @@ import { chmod, lstat, mkdir, open, rename, rm, type FileHandle } from "node:fs/
 import path from "node:path";
 
 import { expandTildePath } from "../utils/path.js";
-import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import {
+  type HeldFileLockController,
+  serializeMutations,
+  withHeldFileLock,
+} from "../utils/serialize-mutations.js";
 import { SupportPassportError } from "./errors.js";
 import {
   SupportPassportCreateGrantInputSchema,
@@ -18,6 +22,7 @@ const GRANT_LOCK_WAIT_MS = 5_000;
 const GRANT_LOCK_HEARTBEAT_MS = 10_000;
 const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
+const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 
 export interface SupportPassportGrantStoreOptions {
   memoryDir: string;
@@ -47,13 +52,18 @@ function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
 }
 
-async function syncDirectory(directory: string): Promise<void> {
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
+export async function syncDirectoryForDurability(
+  directory: string,
+  openDirectory: (directory: string) => Promise<Pick<FileHandle, "sync" | "close">> = async (target) =>
+    await open(target, "r")
+): Promise<void> {
+  let handle: Pick<FileHandle, "sync" | "close"> | undefined;
   try {
-    handle = await open(directory, "r");
+    handle = await openDirectory(directory);
     await handle.sync();
-  } catch {
-    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!UNSUPPORTED_DIRECTORY_SYNC_ERRORS.has(code ?? "")) throw error;
   } finally {
     await handle?.close().catch(() => undefined);
   }
@@ -113,7 +123,7 @@ async function writePrivateFileAtomically(filePath: string, content: string): Pr
     handle = undefined;
     await rename(tempPath, filePath);
     await chmod(filePath, 0o600);
-    await syncDirectory(directory);
+    await syncDirectoryForDurability(directory);
   } catch (error) {
     await handle?.close().catch(() => undefined);
     await rm(tempPath, { force: true }).catch(() => undefined);
@@ -152,7 +162,7 @@ export class SupportPassportGrantStore {
     ) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
-    return await this.withMutationLock(async () => {
+    return await this.withMutationLock(async (lock) => {
       const secretBytes = this.makeSecret();
       if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
         throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
@@ -176,9 +186,10 @@ export class SupportPassportGrantStore {
         createdAt: createdAt.toISOString(),
         expiresAt: parsed.data.expiresAt,
       });
+      await this.requireMutationLock(lock);
       await this.writeState(state, true);
       try {
-        await this.addToOwnerIndex(state);
+        await this.addToOwnerIndex(state, lock);
       } catch (error) {
         await rm(this.filePath(state.grantId), { force: true }).catch(() => undefined);
         throw error;
@@ -228,7 +239,7 @@ export class SupportPassportGrantStore {
     expectedStateVersion?: number;
   }): Promise<SupportPassportGrantState> {
     if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
-    return await this.withMutationLock(async () => {
+    return await this.withMutationLock(async (lock) => {
       let state: SupportPassportGrantState;
       try {
         state = await this.readState(input.grantId);
@@ -248,6 +259,7 @@ export class SupportPassportGrantStore {
         stateVersion: state.stateVersion + 1,
         revokedAt: this.now().toISOString(),
       });
+      await this.requireMutationLock(lock);
       await this.writeState(revoked);
       return revoked;
     });
@@ -267,11 +279,15 @@ export class SupportPassportGrantStore {
     return sha256("support-passport-owner-index:v1", `${namespace}\0${principalHash}`);
   }
 
-  private async addToOwnerIndex(state: SupportPassportGrantState): Promise<void> {
+  private async addToOwnerIndex(
+    state: SupportPassportGrantState,
+    lock: HeldFileLockController
+  ): Promise<void> {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
     const grantIds = [...current, state.grantId].sort((a, b) => a.localeCompare(b));
+    await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
   }
 
@@ -368,7 +384,7 @@ export class SupportPassportGrantStore {
     await Promise.all(directories.slice(1).map((directory) => chmod(directory, 0o700)));
   }
 
-  private async withMutationLock<T>(task: () => Promise<T>): Promise<T> {
+  private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     await this.ensureSafeDirectories();
     const lockPath = path.join(this.grantsDir, ".grants.lock");
     return await serializeMutations(`support-passport-grants:${this.grantsDir}`, () =>
@@ -379,11 +395,16 @@ export class SupportPassportGrantStore {
           maxWaitMs: GRANT_LOCK_WAIT_MS,
           heartbeatMs: GRANT_LOCK_HEARTBEAT_MS,
         },
-        async (acquired) => {
+        async (acquired, lock) => {
           if (!acquired) throw new Error("could not acquire the support passport grant lock");
-          return await task();
+          return await task(lock);
         }
       )
     );
+  }
+
+  private async requireMutationLock(lock: HeldFileLockController): Promise<void> {
+    if (await lock.refresh()) return;
+    throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
   }
 }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -25,7 +25,8 @@ import {
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
 const GRANT_LOCK_HEARTBEAT_MS = 10_000;
-const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 const MAX_OWNER_GRANT_HISTORY = 100;
@@ -57,6 +58,11 @@ function hashesMatch(left: string, right: string): boolean {
 
 function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+}
+
+function normalizeGrantId(grantId: unknown): string {
+  if (typeof grantId !== "string" || !UUID_INPUT.test(grantId)) throw grantNotFound();
+  return grantId.toLowerCase();
 }
 
 function normalizeNamespace(namespace: unknown): string {
@@ -129,8 +135,9 @@ export class SupportPassportGrantStore {
       if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
         throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
       }
-      const grantId = this.makeGrantId();
-      if (!SAFE_GRANT_ID.test(grantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+      const rawGrantId = this.makeGrantId();
+      if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+      const grantId = rawGrantId.toLowerCase();
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
       const durationMs = Date.parse(parsed.data.expiresAt) - createdAt.getTime();
@@ -162,7 +169,7 @@ export class SupportPassportGrantStore {
   }
 
   async authenticate(grantId: string, secret: string): Promise<SupportPassportGrantState> {
-    if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    grantId = normalizeGrantId(grantId);
     if (typeof secret !== "string" || secret.length > 512) throw grantNotFound();
     let state: SupportPassportGrantState;
     try {
@@ -238,7 +245,7 @@ export class SupportPassportGrantStore {
     },
     beforeCommit?: () => Promise<void>
   ): Promise<SupportPassportGrantState> {
-    if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
+    input = { ...input, grantId: normalizeGrantId(input.grantId) };
     const namespace = normalizeNamespace(input.namespace);
     return await this.withGrantLock(input.grantId, async (lock) => {
       let state: SupportPassportGrantState;
@@ -267,7 +274,7 @@ export class SupportPassportGrantStore {
   }
 
   private filePath(grantId: string): string {
-    if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    grantId = normalizeGrantId(grantId);
     return path.join(this.grantsDir, `${grantId}.json`);
   }
 
@@ -471,7 +478,7 @@ export class SupportPassportGrantStore {
   }
 
   private async withGrantLock<T>(grantId: string, task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
-    if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    grantId = normalizeGrantId(grantId);
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
       this.memoryDir,

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,10 +1,11 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { type FileHandle, lstat, mkdir, open } from "node:fs/promises";
+import { type FileHandle, lstat, open } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
 import { expandTildePath } from "../utils/path.js";
 import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import { SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
 import {
   SupportPassportCreateGrantInputSchema,
@@ -14,6 +15,7 @@ import {
 } from "./grant-contracts.js";
 import {
   ensurePrivateDirectoryNoFollow,
+  ensurePrivateDirectoryTreeNoFollow,
   readPrivateFileNoFollow,
   removePrivateFilesNoFollow,
   withPrivateDirectoryNoFollow,
@@ -58,11 +60,11 @@ function grantNotFound(): SupportPassportError {
 }
 
 function normalizeNamespace(namespace: unknown): string {
-  const normalized = typeof namespace === "string" ? namespace.trim() : "";
-  if (normalized.length < 1 || normalized.length > 256) {
+  const parsed = SupportPassportNamespaceSchema.safeParse(namespace);
+  if (!parsed.success) {
     throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
   }
-  return normalized;
+  return parsed.data;
 }
 
 function normalizePrincipal(principal: unknown): string {
@@ -218,7 +220,13 @@ export class SupportPassportGrantStore {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
     }
-    return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
+    const activeCutoff = this.now().getTime();
+    return states.sort((a, b) => {
+      const aActive = !a.revokedAt && Date.parse(a.expiresAt) > activeCutoff;
+      const bActive = !b.revokedAt && Date.parse(b.expiresAt) > activeCutoff;
+      if (aActive !== bActive) return aActive ? -1 : 1;
+      return b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId);
+    });
   }
 
   async revoke(
@@ -436,7 +444,10 @@ export class SupportPassportGrantStore {
   }
 
   private async ensureSafeDirectories(): Promise<void> {
-    await mkdir(this.memoryDir, { recursive: true, mode: 0o700 });
+    await ensurePrivateDirectoryTreeNoFollow(
+      this.memoryDir,
+      "support passport memory directory must be a stable directory"
+    );
     await ensurePrivateDirectoryNoFollow(
       this.memoryDir,
       this.ownerIndexesDir,

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -4,13 +4,13 @@ import path from "node:path";
 
 import { writeFileAtomically } from "../maintenance/atomic-file.js";
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import { SupportPassportError } from "./errors.js";
 import {
   SupportPassportCreateGrantInputSchema,
-  SupportPassportGrantStateSchema,
   type SupportPassportGrantCardRef,
   type SupportPassportGrantState,
+  SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
-import { SupportPassportError } from "./errors.js";
 
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
@@ -66,7 +66,12 @@ export class SupportPassportGrantStore {
       cards: input.cards,
       durationSeconds: input.durationSeconds,
     });
-    if (!parsed.success || typeof input.namespace !== "string" || input.namespace.trim().length < 1 || input.namespace.trim().length > 256) {
+    if (
+      !parsed.success ||
+      typeof input.namespace !== "string" ||
+      input.namespace.trim().length < 1 ||
+      input.namespace.trim().length > 256
+    ) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
     return await this.withMutationLock(async () => {
@@ -144,7 +149,8 @@ export class SupportPassportGrantStore {
         throw error;
       }
       const principalHash = sha256("support-passport-principal:v1", input.principal);
-      if (state.namespace !== input.namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
+      if (state.namespace !== input.namespace || !hashesMatch(state.principalHash, principalHash))
+        throw grantNotFound();
       if (state.revokedAt) return state;
       if (input.expectedStateVersion !== undefined && input.expectedStateVersion !== state.stateVersion) {
         throw new SupportPassportError("storage_conflict", "The share link changed after it was loaded.", 409);
@@ -168,7 +174,8 @@ export class SupportPassportGrantStore {
     await this.ensureSafeDirectories();
     const filePath = this.filePath(grantId);
     const metadata = await lstat(filePath);
-    if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error("support passport grant files must be regular files");
+    if (metadata.isSymbolicLink() || !metadata.isFile())
+      throw new Error("support passport grant files must be regular files");
     return SupportPassportGrantStateSchema.parse(JSON.parse(await readFile(filePath, "utf8")));
   }
 
@@ -176,7 +183,8 @@ export class SupportPassportGrantStore {
     const filePath = this.filePath(state.grantId);
     try {
       const metadata = await lstat(filePath);
-      if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error("support passport grant files must be regular files");
+      if (metadata.isSymbolicLink() || !metadata.isFile())
+        throw new Error("support passport grant files must be regular files");
       if (requireAbsent) {
         throw new SupportPassportError("storage_conflict", "A new share link could not be allocated.", 409);
       }
@@ -207,14 +215,18 @@ export class SupportPassportGrantStore {
     await this.ensureSafeDirectories();
     const lockPath = path.join(this.grantsDir, ".grants.lock");
     return await serializeMutations(`support-passport-grants:${this.grantsDir}`, () =>
-      withHeldFileLock(lockPath, {
-        staleMs: GRANT_LOCK_STALE_MS,
-        maxWaitMs: GRANT_LOCK_WAIT_MS,
-        heartbeatMs: GRANT_LOCK_HEARTBEAT_MS,
-      }, async (acquired) => {
-        if (!acquired) throw new Error("could not acquire the support passport grant lock");
-        return await task();
-      }),
+      withHeldFileLock(
+        lockPath,
+        {
+          staleMs: GRANT_LOCK_STALE_MS,
+          maxWaitMs: GRANT_LOCK_WAIT_MS,
+          heartbeatMs: GRANT_LOCK_HEARTBEAT_MS,
+        },
+        async (acquired) => {
+          if (!acquired) throw new Error("could not acquire the support passport grant lock");
+          return await task();
+        }
+      )
     );
   }
 }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { type FileHandle, lstat, open } from "node:fs/promises";
+import { type FileHandle, lstat, open, readdir } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
@@ -32,6 +32,13 @@ const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 const MAX_OWNER_GRANT_HISTORY = 100;
+
+class OwnerIndexLockLostError extends Error {
+  constructor(cause: unknown) {
+    super("support passport owner index lock was lost", { cause });
+    this.name = "OwnerIndexLockLostError";
+  }
+}
 
 export interface SupportPassportGrantStoreOptions {
   memoryDir: string;
@@ -156,65 +163,90 @@ export class SupportPassportGrantStore {
     ) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
-    return await this.withMutationLock(async (lock) => {
-      const secretBytes = this.makeSecret();
-      if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
-        throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
-      }
-      const rawGrantId = this.makeGrantId();
-      if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
-      const grantId = rawGrantId.toLowerCase();
-      const secret = secretBytes.toString("base64url");
-      const createdAt = this.now();
-      if (!Number.isFinite(createdAt.getTime()) || Date.parse(parsed.data.expiresAt) <= createdAt.getTime()) {
-        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
-      }
-      const state = SupportPassportGrantStateSchema.parse({
-        schemaVersion: 1,
-        stateVersion: 1,
-        grantId,
-        namespace,
-        principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
-        ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
-        secretHash: sha256("support-passport-secret:v1", secret),
-        cards: parsed.data.cards,
-        createdAt: createdAt.toISOString(),
-        expiresAt: parsed.data.expiresAt,
-      });
-      await this.requireMutationLock(lock);
-      await beforeCommit?.();
-      await this.requireMutationLock(lock);
-      try {
-        await this.writeState(state, true);
-      } catch (error) {
-        const persisted = await this.readState(state.grantId).catch(() => undefined);
-        if (!persisted || !sameGrantState(persisted, state)) throw error;
-        try {
-          await this.syncDirectory(this.grantsDir);
-        } catch {
-          await this.removeGrantStates([state.grantId]).catch(() => undefined);
-          throw error;
+    let recoverableCommit: { state: SupportPassportGrantState; secret: string } | undefined;
+    try {
+      return await this.withMutationLock(async (lock) => {
+        const secretBytes = this.makeSecret();
+        if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
+          throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
         }
-      }
-      try {
-        await this.addToOwnerIndex(state, lock);
-      } catch (error) {
-        const ownerHash = this.ownerHash(state.namespace, state.principalHash);
-        const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
-        if (indexed?.includes(state.grantId)) {
+        const rawGrantId = this.makeGrantId();
+        if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+        const grantId = rawGrantId.toLowerCase();
+        const secret = secretBytes.toString("base64url");
+        const createdAt = this.now();
+        const createdAtMs = createdAt.getTime();
+        const expiresAtMs = Date.parse(parsed.data.expiresAt);
+        if (
+          !Number.isFinite(createdAtMs) ||
+          requestedAt.getTime() > createdAtMs ||
+          expiresAtMs <= createdAtMs ||
+          expiresAtMs - createdAtMs > 604_800_000
+        ) {
+          throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+        }
+        const state = SupportPassportGrantStateSchema.parse({
+          schemaVersion: 1,
+          stateVersion: 1,
+          grantId,
+          namespace,
+          principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
+          ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
+          secretHash: sha256("support-passport-secret:v1", secret),
+          cards: parsed.data.cards,
+          createdAt: createdAt.toISOString(),
+          expiresAt: parsed.data.expiresAt,
+        });
+        recoverableCommit = { state, secret };
+        await this.requireMutationLock(lock);
+        await beforeCommit?.();
+        await this.requireMutationLock(lock);
+        try {
+          await this.writeState(state, true);
+        } catch (error) {
+          const persisted = await this.readState(state.grantId).catch(() => undefined);
+          if (!persisted || !sameGrantState(persisted, state)) throw error;
           try {
-            await this.syncDirectory(this.ownerIndexesDir);
-            return { state, secret };
+            await this.syncDirectory(this.grantsDir);
           } catch {
             await this.removeGrantStates([state.grantId]).catch(() => undefined);
             throw error;
           }
         }
-        await this.removeGrantStates([state.grantId]).catch(() => undefined);
-        throw error;
+        try {
+          await this.addToOwnerIndex(state, lock);
+        } catch (error) {
+          if (error instanceof OwnerIndexLockLostError) throw error;
+          const ownerHash = this.ownerHash(state.namespace, state.principalHash);
+          const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
+          if (indexed?.includes(state.grantId)) {
+            try {
+              await this.syncDirectory(this.ownerIndexesDir);
+            } catch {
+              await this.removeGrantStates([state.grantId]).catch(() => undefined);
+              throw error;
+            }
+            await this.requireOwnerIndexLock(lock);
+            return { state, secret };
+          }
+          await this.removeGrantStates([state.grantId]).catch(() => undefined);
+          throw error;
+        }
+        return { state, secret };
+      });
+    } catch (error) {
+      if (!(error instanceof OwnerIndexLockLostError) || !recoverableCommit) throw error;
+      const committed = recoverableCommit;
+      try {
+        return await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
+      } catch (recoveryError) {
+        await this.withGrantLock(committed.state.grantId, async (lock) => {
+          await this.requireMutationLock(lock);
+          await this.removeGrantStates([committed.state.grantId]);
+        }).catch(() => undefined);
+        throw recoveryError;
       }
-      return { state, secret };
-    });
+    }
   }
 
   async authenticate(grantId: string, secret: string): Promise<SupportPassportGrantState> {
@@ -392,6 +424,7 @@ export class SupportPassportGrantStore {
     const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
+    await this.requireOwnerIndexLock(lock);
     try {
       for (const grantId of evictedGrantIds) {
         await this.withGrantLock(grantId, async (grantLock) => {
@@ -415,8 +448,82 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       grantIds.map((grantId) => `${grantId}.json`),
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir,
+      path.parse(this.memoryDir).root,
     );
+  }
+
+  private async reconcileCreateAfterOwnerIndexLockLoss(
+    committed: { state: SupportPassportGrantState; secret: string },
+  ): Promise<{ state: SupportPassportGrantState; secret: string }> {
+    return await this.withMutationLock(async (lock) => {
+      const persisted = await this.readState(committed.state.grantId).catch(() => undefined);
+      if (!persisted || !sameGrantState(persisted, committed.state)) {
+        throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+      }
+      let ownerStates = await this.readAllOwnerStates(
+        committed.state.namespace,
+        committed.state.principalHash,
+      );
+      const activeCutoff = this.now().getTime();
+      const active = ownerStates.filter(
+        (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
+      );
+      if (active.length > MAX_OWNER_GRANT_HISTORY) {
+        await this.removeGrantStates([committed.state.grantId]);
+        ownerStates = ownerStates.filter((state) => state.grantId !== committed.state.grantId);
+      }
+      const retained = this.retainedOwnerStates(ownerStates, activeCutoff);
+      const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
+      await this.requireMutationLock(lock);
+      await this.writeOwnerIndex(ownerHash, retained.map((state) => state.grantId));
+      await this.requireOwnerIndexLock(lock);
+      if (active.length > MAX_OWNER_GRANT_HISTORY) {
+        throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+      }
+      return committed;
+    });
+  }
+
+  private retainedOwnerStates(
+    states: SupportPassportGrantState[],
+    activeCutoff: number,
+  ): SupportPassportGrantState[] {
+    const active = states.filter(
+      (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
+    );
+    if (active.length > MAX_OWNER_GRANT_HISTORY) {
+      throw new Error("support passport owner has too many active grants");
+    }
+    const inactive = states
+      .filter((state) => state.revokedAt || Date.parse(state.expiresAt) <= activeCutoff)
+      .sort(newestGrantFirst);
+    return [
+      ...active,
+      ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length),
+    ];
+  }
+
+  private async readAllOwnerStates(
+    namespace: string,
+    principalHash: string,
+  ): Promise<SupportPassportGrantState[]> {
+    const grantIds = await withPrivateDirectoryNoFollow(
+      path.parse(this.memoryDir).root,
+      this.grantsDir,
+      "support passport grant files must be regular files in a stable directory",
+      async (pinnedDirectory) => (await readdir(pinnedDirectory, { withFileTypes: true }))
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+        .map((entry) => entry.name.slice(0, -".json".length))
+        .filter((grantId) => SAFE_GRANT_ID.test(grantId)),
+    );
+    const states: SupportPassportGrantState[] = [];
+    for (const grantId of grantIds) {
+      const state = await this.readState(grantId);
+      if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) {
+        states.push(state);
+      }
+    }
+    return states;
   }
 
   private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {
@@ -432,7 +539,7 @@ export class SupportPassportGrantStore {
         this.ownerIndexesDir,
         filePath,
         "support passport owner indexes must be regular files in a stable directory",
-        this.memoryDir,
+        path.parse(this.memoryDir).root,
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -473,7 +580,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
       "support passport owner indexes must be regular files in a stable directory",
-      this.memoryDir,
+      path.parse(this.memoryDir).root,
     );
   }
 
@@ -484,7 +591,7 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       filePath,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir,
+      path.parse(this.memoryDir).root,
     );
     const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
     if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
@@ -508,7 +615,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify(state, null, 2)}\n`,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir,
+      path.parse(this.memoryDir).root,
     );
   }
 
@@ -535,8 +642,8 @@ export class SupportPassportGrantStore {
   }
 
   private async ensureMemoryRoot(): Promise<void> {
+    const configuredMemoryDir = this.memoryDir;
     if (!this.memoryRootReady) {
-      const configuredMemoryDir = this.memoryDir;
       this.memoryRootReady = (async () => {
         await ensurePrivateDirectoryTreeNoFollow(
           configuredMemoryDir,
@@ -560,7 +667,7 @@ export class SupportPassportGrantStore {
   private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
-      this.memoryDir,
+      path.parse(this.memoryDir).root,
       this.grantsDir,
       "support passport grant lock directory must remain inside the memory directory",
       async (pinnedDirectory) =>
@@ -576,7 +683,7 @@ export class SupportPassportGrantStore {
     const normalizedGrantId = normalizeGrantId(grantId);
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
-      this.memoryDir,
+      path.parse(this.memoryDir).root,
       this.grantsDir,
       "support passport grant lock directory must remain inside the memory directory",
       async (pinnedDirectory) =>
@@ -614,6 +721,14 @@ export class SupportPassportGrantStore {
   private async requireMutationLock(lock: HeldFileLockController): Promise<void> {
     if (await lock.refresh()) return;
     throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+  }
+
+  private async requireOwnerIndexLock(lock: HeldFileLockController): Promise<void> {
+    try {
+      await this.requireMutationLock(lock);
+    } catch (error) {
+      throw new OwnerIndexLockLostError(error);
+    }
   }
 
   private requireActiveState(state: SupportPassportGrantState): void {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -291,8 +291,18 @@ export class SupportPassportGrantStore {
       ];
     }
     const grantIds = [...retained, state.grantId];
+    const retainedIds = new Set(grantIds);
+    const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
+    await this.requireMutationLock(lock);
+    await this.removeEvictedGrantStates(evictedGrantIds);
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
+  }
+
+  private async removeEvictedGrantStates(grantIds: string[]): Promise<void> {
+    if (grantIds.length === 0) return;
+    await Promise.all(grantIds.map((grantId) => rm(this.filePath(grantId), { force: true })));
+    await syncDirectoryForDurability(this.grantsDir);
   }
 
   private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { type FileHandle, lstat, open } from "node:fs/promises";
+import { type FileHandle, lstat, open, readdir } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
@@ -494,6 +494,13 @@ export class SupportPassportGrantStore {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
       }
+      const indexedGrantIdSet = new Set(indexedGrantIds);
+      const unindexedOwnerStates = await this.readUnindexedOwnerStates(
+        committed.state.namespace,
+        committed.state.principalHash,
+        indexedGrantIdSet,
+      );
+      ownerStates.push(...unindexedOwnerStates);
       const committedIndex = ownerStates.findIndex(
         (state) => state.grantId === committed.state.grantId,
       );
@@ -542,6 +549,38 @@ export class SupportPassportGrantStore {
 
   private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {
     return await this.readOwnerIndexByHash(this.ownerHash(namespace, principalHash));
+  }
+
+  private async readUnindexedOwnerStates(
+    namespace: string,
+    principalHash: string,
+    indexedGrantIds: ReadonlySet<string>,
+  ): Promise<SupportPassportGrantState[]> {
+    await this.ensureSafeDirectories();
+    const grantIds = await withPrivateDirectoryNoFollow(
+      path.parse(this.memoryDir).root,
+      this.grantsDir,
+      "support passport grant files must be regular files in a stable directory",
+      async (pinnedDirectory) => {
+        const entries = await readdir(pinnedDirectory, { withFileTypes: true });
+        return entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+          .map((entry) => entry.name.slice(0, -5))
+          .filter((grantId) => SAFE_GRANT_ID.test(grantId) && !indexedGrantIds.has(grantId));
+      },
+    );
+    const ownerStates: SupportPassportGrantState[] = [];
+    for (const grantId of grantIds) {
+      try {
+        const state = await this.readState(grantId);
+        if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) {
+          ownerStates.push(state);
+        }
+      } catch {
+        continue;
+      }
+    }
+    return ownerStates;
   }
 
   private async readOwnerIndexByHash(ownerHash: string): Promise<string[]> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,0 +1,220 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { chmod, lstat, mkdir, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { writeFileAtomically } from "../maintenance/atomic-file.js";
+import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import {
+  SupportPassportCreateGrantInputSchema,
+  SupportPassportGrantStateSchema,
+  type SupportPassportGrantCardRef,
+  type SupportPassportGrantState,
+} from "./grant-contracts.js";
+import { SupportPassportError } from "./errors.js";
+
+const GRANT_LOCK_STALE_MS = 30_000;
+const GRANT_LOCK_WAIT_MS = 5_000;
+const GRANT_LOCK_HEARTBEAT_MS = 10_000;
+const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface SupportPassportGrantStoreOptions {
+  memoryDir: string;
+  now?: () => Date;
+  makeSecret?: () => Buffer;
+  makeGrantId?: () => string;
+}
+
+export interface CreateStoredGrantInput {
+  namespace: string;
+  principal: string;
+  cards: SupportPassportGrantCardRef[];
+  durationSeconds: number;
+}
+
+function sha256(domain: string, value: string): string {
+  return createHash("sha256").update(domain).update("\0").update(value).digest("hex");
+}
+
+function hashesMatch(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, "hex");
+  const rightBytes = Buffer.from(right, "hex");
+  return leftBytes.length === 32 && rightBytes.length === 32 && timingSafeEqual(leftBytes, rightBytes);
+}
+
+function grantNotFound(): SupportPassportError {
+  return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+}
+
+export class SupportPassportGrantStore {
+  private readonly memoryDir: string;
+  private readonly grantsDir: string;
+  private readonly now: () => Date;
+  private readonly makeSecret: () => Buffer;
+  private readonly makeGrantId: () => string;
+
+  constructor(options: SupportPassportGrantStoreOptions) {
+    this.memoryDir = path.resolve(options.memoryDir);
+    this.grantsDir = path.join(this.memoryDir, "state", "support-passport", "grants");
+    this.now = options.now ?? (() => new Date());
+    this.makeSecret = options.makeSecret ?? (() => randomBytes(32));
+    this.makeGrantId = options.makeGrantId ?? randomUUID;
+  }
+
+  async create(input: CreateStoredGrantInput): Promise<{ state: SupportPassportGrantState; secret: string }> {
+    const parsed = SupportPassportCreateGrantInputSchema.safeParse({
+      principal: input.principal,
+      cards: input.cards,
+      durationSeconds: input.durationSeconds,
+    });
+    if (!parsed.success || typeof input.namespace !== "string" || input.namespace.trim().length < 1 || input.namespace.trim().length > 256) {
+      throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+    }
+    return await this.withMutationLock(async () => {
+      const secretBytes = this.makeSecret();
+      if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
+        throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
+      }
+      const grantId = this.makeGrantId();
+      if (!SAFE_GRANT_ID.test(grantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+      const secret = secretBytes.toString("base64url");
+      const createdAt = this.now();
+      const state = SupportPassportGrantStateSchema.parse({
+        schemaVersion: 1,
+        stateVersion: 1,
+        grantId,
+        namespace: input.namespace.trim(),
+        principalHash: sha256("support-passport-principal:v1", parsed.data.principal),
+        secretHash: sha256("support-passport-secret:v1", secret),
+        cards: parsed.data.cards,
+        createdAt: createdAt.toISOString(),
+        expiresAt: new Date(createdAt.getTime() + parsed.data.durationSeconds * 1_000).toISOString(),
+      });
+      await this.writeState(state, true);
+      return { state, secret };
+    });
+  }
+
+  async authenticate(grantId: string, secret: string): Promise<SupportPassportGrantState> {
+    if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    if (typeof secret !== "string" || secret.length > 512) throw grantNotFound();
+    let state: SupportPassportGrantState;
+    try {
+      state = await this.readState(grantId);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
+      throw error;
+    }
+    const candidate = sha256("support-passport-secret:v1", secret);
+    if (!hashesMatch(candidate, state.secretHash)) throw grantNotFound();
+    if (state.revokedAt || Date.parse(state.expiresAt) <= this.now().getTime()) {
+      throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
+    }
+    return state;
+  }
+
+  async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
+    await this.ensureSafeDirectories();
+    const entries = await readdir(this.grantsDir, { withFileTypes: true });
+    const principalHash = sha256("support-passport-principal:v1", principal);
+    const states: SupportPassportGrantState[] = [];
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) throw new Error("support passport grant files must not be symbolic links");
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      const grantId = entry.name.slice(0, -5);
+      if (!SAFE_GRANT_ID.test(grantId)) continue;
+      const state = await this.readState(grantId);
+      if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) states.push(state);
+    }
+    return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
+  }
+
+  async revoke(input: {
+    grantId: string;
+    namespace: string;
+    principal: string;
+    expectedStateVersion?: number;
+  }): Promise<SupportPassportGrantState> {
+    if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
+    return await this.withMutationLock(async () => {
+      let state: SupportPassportGrantState;
+      try {
+        state = await this.readState(input.grantId);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
+        throw error;
+      }
+      const principalHash = sha256("support-passport-principal:v1", input.principal);
+      if (state.namespace !== input.namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
+      if (state.revokedAt) return state;
+      if (input.expectedStateVersion !== undefined && input.expectedStateVersion !== state.stateVersion) {
+        throw new SupportPassportError("storage_conflict", "The share link changed after it was loaded.", 409);
+      }
+      const revoked = SupportPassportGrantStateSchema.parse({
+        ...state,
+        stateVersion: state.stateVersion + 1,
+        revokedAt: this.now().toISOString(),
+      });
+      await this.writeState(revoked);
+      return revoked;
+    });
+  }
+
+  private filePath(grantId: string): string {
+    if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    return path.join(this.grantsDir, `${grantId}.json`);
+  }
+
+  private async readState(grantId: string): Promise<SupportPassportGrantState> {
+    await this.ensureSafeDirectories();
+    const filePath = this.filePath(grantId);
+    const metadata = await lstat(filePath);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error("support passport grant files must be regular files");
+    return SupportPassportGrantStateSchema.parse(JSON.parse(await readFile(filePath, "utf8")));
+  }
+
+  private async writeState(state: SupportPassportGrantState, requireAbsent = false): Promise<void> {
+    const filePath = this.filePath(state.grantId);
+    try {
+      const metadata = await lstat(filePath);
+      if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error("support passport grant files must be regular files");
+      if (requireAbsent) {
+        throw new SupportPassportError("storage_conflict", "A new share link could not be allocated.", 409);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    await writeFileAtomically(filePath, `${JSON.stringify(state, null, 2)}\n`);
+    await chmod(filePath, 0o600);
+  }
+
+  private async ensureSafeDirectories(): Promise<void> {
+    const directories = [
+      this.memoryDir,
+      path.join(this.memoryDir, "state"),
+      path.join(this.memoryDir, "state", "support-passport"),
+      this.grantsDir,
+    ];
+    for (const directory of directories) {
+      await mkdir(directory, { recursive: true, mode: 0o700 });
+      const metadata = await lstat(directory);
+      if (metadata.isSymbolicLink()) throw new Error("support passport grant directories must not be a symbolic link");
+      if (!metadata.isDirectory()) throw new Error("support passport grant paths must be directories");
+    }
+    await Promise.all(directories.slice(1).map((directory) => chmod(directory, 0o700)));
+  }
+
+  private async withMutationLock<T>(task: () => Promise<T>): Promise<T> {
+    await this.ensureSafeDirectories();
+    const lockPath = path.join(this.grantsDir, ".grants.lock");
+    return await serializeMutations(`support-passport-grants:${this.grantsDir}`, () =>
+      withHeldFileLock(lockPath, {
+        staleMs: GRANT_LOCK_STALE_MS,
+        maxWaitMs: GRANT_LOCK_WAIT_MS,
+        heartbeatMs: GRANT_LOCK_HEARTBEAT_MS,
+      }, async (acquired) => {
+        if (!acquired) throw new Error("could not acquire the support passport grant lock");
+        return await task();
+      }),
+    );
+  }
+}

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -23,6 +23,7 @@ const GRANT_LOCK_HEARTBEAT_MS = 10_000;
 const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
+const MAX_OWNER_GRANT_HISTORY = 100;
 
 export interface SupportPassportGrantStoreOptions {
   memoryDir: string;
@@ -50,6 +51,14 @@ function hashesMatch(left: string, right: string): boolean {
 
 function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+}
+
+function normalizeNamespace(namespace: unknown): string {
+  const normalized = typeof namespace === "string" ? namespace.trim() : "";
+  if (normalized.length < 1 || normalized.length > 256) {
+    throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+  }
+  return normalized;
 }
 
 export async function syncDirectoryForDurability(
@@ -107,17 +116,13 @@ export class SupportPassportGrantStore {
   }
 
   async create(input: CreateStoredGrantInput): Promise<{ state: SupportPassportGrantState; secret: string }> {
+    const namespace = normalizeNamespace(input.namespace);
     const parsed = SupportPassportCreateGrantInputSchema.safeParse({
       principal: input.principal,
       cards: input.cards,
       expiresAt: input.expiresAt,
     });
-    if (
-      !parsed.success ||
-      typeof input.namespace !== "string" ||
-      input.namespace.trim().length < 1 ||
-      input.namespace.trim().length > 256
-    ) {
+    if (!parsed.success) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
     return await this.withMutationLock(async (lock) => {
@@ -137,7 +142,7 @@ export class SupportPassportGrantStore {
         schemaVersion: 1,
         stateVersion: 1,
         grantId,
-        namespace: input.namespace.trim(),
+        namespace,
         principalHash: sha256("support-passport-principal:v1", parsed.data.principal),
         secretHash: sha256("support-passport-secret:v1", secret),
         cards: parsed.data.cards,
@@ -178,13 +183,16 @@ export class SupportPassportGrantStore {
   }
 
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
+    const normalizedNamespace = normalizeNamespace(namespace);
     const principalHash = sha256("support-passport-principal:v1", principal);
-    const grantIds = await this.readOwnerIndex(namespace, principalHash);
+    const grantIds = await this.readOwnerIndex(normalizedNamespace, principalHash);
     const states: SupportPassportGrantState[] = [];
     for (const grantId of grantIds) {
       try {
         const state = await this.readState(grantId);
-        if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) states.push(state);
+        if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
+          states.push(state);
+        }
       } catch {}
     }
     return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
@@ -197,6 +205,7 @@ export class SupportPassportGrantStore {
     expectedStateVersion?: number;
   }): Promise<SupportPassportGrantState> {
     if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
+    const namespace = normalizeNamespace(input.namespace);
     return await this.withMutationLock(async (lock) => {
       let state: SupportPassportGrantState;
       try {
@@ -206,7 +215,7 @@ export class SupportPassportGrantStore {
         throw error;
       }
       const principalHash = sha256("support-passport-principal:v1", input.principal);
-      if (state.namespace !== input.namespace || !hashesMatch(state.principalHash, principalHash))
+      if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash))
         throw grantNotFound();
       if (state.revokedAt) return state;
       if (input.expectedStateVersion !== undefined && input.expectedStateVersion !== state.stateVersion) {
@@ -244,7 +253,40 @@ export class SupportPassportGrantStore {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
-    const grantIds = [...current, state.grantId].sort((a, b) => a.localeCompare(b));
+    let retained = current;
+    if (current.length >= MAX_OWNER_GRANT_HISTORY) {
+      const indexedStates = (
+        await Promise.all(
+          current.map(async (grantId) => {
+            try {
+              return await this.readState(grantId);
+            } catch {
+              return null;
+            }
+          })
+        )
+      ).filter((item): item is SupportPassportGrantState => item !== null);
+      const active = indexedStates.filter(
+        (item) => !item.revokedAt && Date.parse(item.expiresAt) > this.now().getTime()
+      );
+      if (active.length >= MAX_OWNER_GRANT_HISTORY) {
+        throw new SupportPassportError(
+          "invalid_input",
+          "A support passport can contain at most 100 active share links.",
+          400
+        );
+      }
+      const inactive = indexedStates
+        .filter((item) => item.revokedAt || Date.parse(item.expiresAt) <= this.now().getTime())
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
+      retained = [
+        ...active.map((item) => item.grantId),
+        ...inactive
+          .slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1)
+          .map((item) => item.grantId),
+      ];
+    }
+    const grantIds = [...retained, state.grantId];
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
   }
@@ -281,6 +323,9 @@ export class SupportPassportGrantStore {
     }
     const uniqueGrantIds = new Set(grantIds as string[]);
     if (uniqueGrantIds.size !== grantIds.length) throw new Error("support passport owner index is invalid");
+    if (uniqueGrantIds.size > MAX_OWNER_GRANT_HISTORY) {
+      throw new Error("support passport owner index is invalid");
+    }
     return [...uniqueGrantIds];
   }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { constants as fsConstants, type Stats } from "node:fs";
+import { chmod, lstat, mkdir, open, rename, rm, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import { expandTildePath } from "../utils/path.js";
@@ -55,6 +56,48 @@ async function syncDirectory(directory: string): Promise<void> {
     return;
   } finally {
     await handle?.close().catch(() => undefined);
+  }
+}
+
+function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
+  if (
+    before.isSymbolicLink() ||
+    !before.isDirectory() ||
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    before.dev !== opened.dev ||
+    before.ino !== opened.ino ||
+    after.dev !== opened.dev ||
+    after.ino !== opened.ino
+  ) {
+    throw new Error(errorMessage);
+  }
+}
+
+async function readPrivateFileNoFollow(directory: string, filePath: string, errorMessage: string): Promise<string> {
+  const before = await lstat(directory);
+  let directoryHandle: FileHandle | undefined;
+  let fileHandle: FileHandle | undefined;
+  try {
+    directoryHandle = await open(
+      directory,
+      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW
+    );
+    const opened = await directoryHandle.stat();
+    assertStableDirectory(before, opened, await lstat(directory), errorMessage);
+    try {
+      fileHandle = await open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
+      throw error;
+    }
+    const fileMetadata = await fileHandle.stat();
+    assertStableDirectory(before, opened, await lstat(directory), errorMessage);
+    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
+    return await fileHandle.readFile("utf8");
+  } finally {
+    await fileHandle?.close().catch(() => undefined);
+    await directoryHandle?.close().catch(() => undefined);
   }
 }
 
@@ -241,11 +284,11 @@ export class SupportPassportGrantStore {
     const filePath = this.ownerIndexPath(ownerHash);
     let content: string;
     try {
-      const metadata = await lstat(filePath);
-      if (metadata.isSymbolicLink() || !metadata.isFile()) {
-        throw new Error("support passport owner indexes must be regular files");
-      }
-      content = await readFile(filePath, "utf8");
+      content = await readPrivateFileNoFollow(
+        this.ownerIndexesDir,
+        filePath,
+        "support passport owner indexes must be regular files in a stable directory"
+      );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
       throw error;
@@ -283,10 +326,14 @@ export class SupportPassportGrantStore {
   private async readState(grantId: string): Promise<SupportPassportGrantState> {
     await this.ensureSafeDirectories();
     const filePath = this.filePath(grantId);
-    const metadata = await lstat(filePath);
-    if (metadata.isSymbolicLink() || !metadata.isFile())
-      throw new Error("support passport grant files must be regular files");
-    return SupportPassportGrantStateSchema.parse(JSON.parse(await readFile(filePath, "utf8")));
+    const content = await readPrivateFileNoFollow(
+      this.grantsDir,
+      filePath,
+      "support passport grant files must be regular files in a stable directory"
+    );
+    const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
+    if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
+    return state;
   }
 
   private async writeState(state: SupportPassportGrantState, requireAbsent = false): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -30,8 +30,6 @@ const GRANT_LOCK_HEARTBEAT_MS = 10_000;
 const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
-const SAFE_OWNER_INDEX_RECOVERY_MARKER =
-  /^\.index-recovery-[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 const MAX_OWNER_GRANT_HISTORY = 100;
 const MAX_OWNER_INDEX_RECOVERY_ATTEMPTS = 3;
@@ -248,45 +246,39 @@ export class SupportPassportGrantStore {
         await this.removeStoredGrant(state).catch(() => undefined);
         throw error;
       }
-      notifyCommitted(mutationHooks.onCommitted);
       return { state, secret };
     });
     const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
     try {
-      return await this.withOwnerIndexLock(ownerHash, async (lock) => {
-        try {
-          await this.addToOwnerIndex(committed.state, lock);
-        } catch (error) {
-          if (error instanceof OwnerIndexLockLostError) throw error;
-          const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
-          if (indexed?.includes(committed.state.grantId)) {
+      let finalized: { state: SupportPassportGrantState; secret: string };
+      try {
+        finalized = await this.withOwnerIndexLock(ownerHash, async (lock) => {
+          try {
+            await this.addToOwnerIndex(committed.state, lock);
+          } catch (error) {
+            if (error instanceof OwnerIndexLockLostError) throw error;
+            const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
+            if (!indexed?.includes(committed.state.grantId)) throw error;
             try {
               await this.syncDirectory(this.ownerIndexesDir);
             } catch {
-              await this.removeStoredGrant(committed.state).catch(() => undefined);
               throw error;
             }
             await this.requireOwnerIndexLock(lock);
-            return committed;
           }
-          await this.removeStoredGrant(committed.state).catch(() => undefined);
-          throw error;
-        }
-        return committed;
-      });
-    } catch (error) {
-      if (error instanceof OwnerIndexLockLostError) {
-        try {
-          return await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
-        } catch (recoveryError) {
-          await this.withGrantLock(committed.state.grantId, async (lock) => {
-            await this.requireMutationLock(lock);
-            await this.removeStoredGrant(committed.state);
-          }).catch(() => undefined);
-          throw recoveryError;
-        }
+          return committed;
+        });
+      } catch (error) {
+        if (!(error instanceof OwnerIndexLockLostError)) throw error;
+        finalized = await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
       }
-      await this.removeStoredGrant(committed.state).catch(() => undefined);
+      notifyCommitted(mutationHooks.onCommitted);
+      return finalized;
+    } catch (error) {
+      await this.withGrantLock(committed.state.grantId, async (lock) => {
+        await this.requireMutationLock(lock);
+        await this.removeStoredGrant(committed.state);
+      }).catch(() => undefined);
       throw error;
     }
   }
@@ -338,26 +330,7 @@ export class SupportPassportGrantStore {
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
     const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
-    const ownerHash = this.ownerHash(normalizedNamespace, principalHash);
-    let states: SupportPassportGrantState[];
-    if (await this.ownerIndexRecoveryRequired(ownerHash)) {
-      states = await this.readOwnerMembershipStates(normalizedNamespace, principalHash);
-    } else {
-      states = [];
-      for (const grantId of await this.readOwnerIndexByHash(ownerHash)) {
-        try {
-          const state = await this.readState(grantId);
-          if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
-            states.push(state);
-          }
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-        }
-      }
-      if (await this.ownerIndexRecoveryRequired(ownerHash)) {
-        states = await this.readOwnerMembershipStates(normalizedNamespace, principalHash);
-      }
-    }
+    const states = await this.readOwnerMembershipStates(normalizedNamespace, principalHash);
     const activeCutoff = this.now().getTime();
     return states.sort((a, b) => {
       const aActive = !a.revokedAt && Date.parse(a.expiresAt) > activeCutoff;
@@ -390,7 +363,6 @@ export class SupportPassportGrantStore {
       const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(input.principal));
       if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
       if (state.revokedAt) {
-        await this.syncDirectory(this.grantsDir);
         return state;
       }
       if (
@@ -435,38 +407,14 @@ export class SupportPassportGrantStore {
 
   private async addToOwnerIndex(state: SupportPassportGrantState, lock: HeldFileLockController): Promise<void> {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
-    let recoveredStates: SupportPassportGrantState[] | undefined;
-    let current: string[];
-    if (await this.ownerIndexRecoveryRequired(ownerHash)) {
-      recoveredStates = (await this.readOwnerMembershipStates(state.namespace, state.principalHash))
-        .filter((item) => item.grantId !== state.grantId)
-        .sort(newestGrantFirst);
-      current = recoveredStates.map((item) => item.grantId);
-    } else {
-      current = await this.readOwnerIndexByHash(ownerHash);
-    }
+    const ownerStates = (await this.readOwnerMembershipStates(state.namespace, state.principalHash))
+      .filter((item) => item.grantId !== state.grantId)
+      .sort(newestGrantFirst);
+    const current = ownerStates.map((item) => item.grantId);
     if (current.includes(state.grantId)) return;
     let retained = current;
-    const indexedStates: SupportPassportGrantState[] = [];
+    const indexedStates: SupportPassportGrantState[] = [...ownerStates];
     if (current.length >= MAX_OWNER_GRANT_HISTORY) {
-      if (recoveredStates) {
-        indexedStates.push(...recoveredStates);
-      } else {
-        for (const grantId of current) {
-          try {
-            const indexedState = await this.readState(grantId);
-            if (
-              indexedState.namespace !== state.namespace ||
-              !hashesMatch(indexedState.principalHash, state.principalHash)
-            ) {
-              throw new Error("support passport owner index references a foreign grant");
-            }
-            indexedStates.push(indexedState);
-          } catch (error) {
-            if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-          }
-        }
-      }
       const expiryCutoff = this.now().getTime();
       const active = indexedStates.filter((item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff);
       if (active.length >= MAX_OWNER_GRANT_HISTORY) {
@@ -488,7 +436,7 @@ export class SupportPassportGrantStore {
     const retainedIds = new Set(grantIds);
     const indexedStateById = new Map(indexedStates.map((indexedState) => [indexedState.grantId, indexedState]));
     const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
-    await this.writeOwnerIndexWhileLocked(ownerHash, grantIds, state.grantId, lock);
+    await this.writeOwnerIndexWhileLocked(ownerHash, grantIds, lock);
     try {
       for (const grantId of evictedGrantIds) {
         await this.withGrantLock(grantId, async (grantLock) => {
@@ -561,76 +509,14 @@ export class SupportPassportGrantStore {
     await this.removeOwnerMembership(state);
   }
 
-  private ownerIndexRecoveryMarkerName(grantId: string): string {
-    return `.index-recovery-${normalizeGrantId(grantId)}.json`;
-  }
-
-  private async writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void> {
-    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
-    const fileName = this.ownerIndexRecoveryMarkerName(grantId);
-    await writePrivateFileAtomicallyNoFollow(
-      directory,
-      path.join(directory, fileName),
-      `${JSON.stringify({ schemaVersion: 1, grantId: normalizeGrantId(grantId) })}\n`,
-      "support passport owner recovery markers must be regular files in a stable directory",
-      path.parse(this.memoryDir).root
-    );
-  }
-
-  private async removeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void> {
-    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
-    await removePrivateFilesNoFollow(
-      directory,
-      [this.ownerIndexRecoveryMarkerName(grantId)],
-      "support passport owner recovery markers must be regular files in a stable directory",
-      path.parse(this.memoryDir).root
-    );
-  }
-
-  private async ownerIndexRecoveryRequired(ownerHash: string): Promise<boolean> {
-    return (await this.ownerIndexRecoveryGrantIds(ownerHash)).length > 0;
-  }
-
-  private async ownerIndexRecoveryGrantIds(ownerHash: string): Promise<string[]> {
-    await this.ensureSafeDirectories();
-    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
-    return await withPrivateDirectoryNoFollow(
-      path.parse(this.memoryDir).root,
-      directory,
-      "support passport owner indexes must be regular files in a stable directory",
-      async (pinnedDirectory) => {
-        const grantIds: string[] = [];
-        for (const entry of await readdir(pinnedDirectory, { withFileTypes: true })) {
-          if (!SAFE_OWNER_INDEX_RECOVERY_MARKER.test(entry.name)) continue;
-          if (!entry.isFile()) {
-            throw new Error("support passport owner recovery markers must be regular files");
-          }
-          grantIds.push(entry.name.slice(".index-recovery-".length, -".json".length));
-        }
-        return grantIds.sort();
-      }
-    );
-  }
-
   private async writeOwnerIndexWhileLocked(
     ownerHash: string,
     grantIds: string[],
-    recoveryGrantId: string,
     lock: HeldFileLockController
   ): Promise<void> {
-    const priorRecoveryGrantIds = await this.ownerIndexRecoveryGrantIds(ownerHash);
-    await this.writeOwnerIndexRecoveryMarker(ownerHash, recoveryGrantId);
     await this.requireOwnerIndexLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
-    const indexedGrantIds = new Set(grantIds);
-    const removableRecoveryGrantIds = new Set([
-      recoveryGrantId,
-      ...priorRecoveryGrantIds.filter((grantId) => indexedGrantIds.has(grantId)),
-    ]);
-    for (const markerGrantId of removableRecoveryGrantIds) {
-      await this.requireOwnerIndexLock(lock);
-      await this.removeOwnerIndexRecoveryMarker(ownerHash, markerGrantId);
-    }
+    await this.requireOwnerIndexLock(lock);
   }
 
   private async reconcileCreateAfterOwnerIndexLockLoss(committed: {
@@ -660,25 +546,7 @@ export class SupportPassportGrantStore {
     if (!persisted || !sameGrantState(persisted, committed.state)) {
       throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
     }
-    const indexedGrantIds = await this.readOwnerIndexByHash(ownerHash);
-    const ownerStates: SupportPassportGrantState[] = [];
-    for (const grantId of indexedGrantIds) {
-      try {
-        const state = await this.readState(grantId);
-        if (
-          state.namespace !== committed.state.namespace ||
-          !hashesMatch(state.principalHash, committed.state.principalHash)
-        ) {
-          throw new Error("support passport owner index references a foreign grant");
-        }
-        ownerStates.push(state);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      }
-    }
-    const memberStates = await this.readOwnerMembershipStates(committed.state.namespace, committed.state.principalHash);
-    const indexedGrantIdSet = new Set(ownerStates.map((state) => state.grantId));
-    ownerStates.push(...memberStates.filter((state) => !indexedGrantIdSet.has(state.grantId)));
+    const ownerStates = await this.readOwnerMembershipStates(committed.state.namespace, committed.state.principalHash);
     const committedIndex = ownerStates.findIndex((state) => state.grantId === committed.state.grantId);
     if (committedIndex === -1) ownerStates.push(committed.state);
     else ownerStates[committedIndex] = committed.state;
@@ -693,7 +561,6 @@ export class SupportPassportGrantStore {
     await this.writeOwnerIndexWhileLocked(
       ownerHash,
       retained.map((state) => state.grantId),
-      committed.state.grantId,
       lock
     );
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
@@ -775,8 +642,7 @@ export class SupportPassportGrantStore {
       throw new Error("support passport owner index is invalid");
     }
     const uniqueGrantIds = new Set(grantIds as string[]);
-    if (uniqueGrantIds.size !== grantIds.length) throw new Error("support passport owner index is invalid");
-    if (uniqueGrantIds.size > MAX_OWNER_GRANT_HISTORY) {
+    if (uniqueGrantIds.size !== grantIds.length || uniqueGrantIds.size > MAX_OWNER_GRANT_HISTORY) {
       throw new Error("support passport owner index is invalid");
     }
     return [...uniqueGrantIds];

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, open, type FileHandle } from "node:fs/promises";
+import { lstat, mkdir, open, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
@@ -13,8 +13,10 @@ import {
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
 import {
+  ensurePrivateDirectoryNoFollow,
   readPrivateFileNoFollow,
   removePrivateFilesNoFollow,
+  withPrivateDirectoryNoFollow,
   writePrivateFileAtomicallyNoFollow,
 } from "./private-file.js";
 
@@ -207,7 +209,9 @@ export class SupportPassportGrantStore {
         if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
           states.push(state);
         }
-      } catch {}
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
     }
     return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
   }
@@ -413,26 +417,27 @@ export class SupportPassportGrantStore {
   }
 
   private async ensureSafeDirectories(): Promise<void> {
-    const directories = [
+    await mkdir(this.memoryDir, { recursive: true, mode: 0o700 });
+    await ensurePrivateDirectoryNoFollow(
       this.memoryDir,
-      path.join(this.memoryDir, "state"),
-      path.join(this.memoryDir, "state", "support-passport"),
-      this.grantsDir,
       this.ownerIndexesDir,
-    ];
-    for (const directory of directories) {
-      await mkdir(directory, { recursive: true, mode: 0o700 });
-      const metadata = await lstat(directory);
-      if (metadata.isSymbolicLink()) throw new Error("support passport grant directories must not be a symbolic link");
-      if (!metadata.isDirectory()) throw new Error("support passport grant paths must be directories");
-    }
-    await Promise.all(directories.slice(1).map((directory) => chmod(directory, 0o700)));
+      "support passport grant directories must remain inside the memory directory"
+    );
   }
 
   private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     await this.ensureSafeDirectories();
-    const lockPath = path.join(this.grantsDir, ".grants.lock");
-    return await this.withExclusiveLock(`support-passport-grants:${this.grantsDir}`, lockPath, task);
+    return await withPrivateDirectoryNoFollow(
+      this.memoryDir,
+      this.grantsDir,
+      "support passport grant lock directory must remain inside the memory directory",
+      async (pinnedDirectory) =>
+        await this.withExclusiveLock(
+          `support-passport-grants:${this.grantsDir}`,
+          path.join(pinnedDirectory, ".grants.lock"),
+          task
+        )
+    );
   }
 
   private async withGrantLock<T>(
@@ -441,8 +446,17 @@ export class SupportPassportGrantStore {
   ): Promise<T> {
     if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
     await this.ensureSafeDirectories();
-    const lockPath = path.join(this.grantsDir, `.${grantId}.lock`);
-    return await this.withExclusiveLock(`support-passport-grant:${this.grantsDir}:${grantId}`, lockPath, task);
+    return await withPrivateDirectoryNoFollow(
+      this.memoryDir,
+      this.grantsDir,
+      "support passport grant lock directory must remain inside the memory directory",
+      async (pinnedDirectory) =>
+        await this.withExclusiveLock(
+          `support-passport-grant:${this.grantsDir}:${grantId}`,
+          path.join(pinnedDirectory, `.${grantId}.lock`),
+          task
+        )
+    );
   }
 
   private async withExclusiveLock<T>(

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,8 +1,7 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, readFile, readdir } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 
-import { writeFileAtomically } from "../maintenance/atomic-file.js";
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportError } from "./errors.js";
 import {
@@ -43,6 +42,38 @@ function hashesMatch(left: string, right: string): boolean {
 
 function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(directory, "r");
+    await handle.sync();
+  } catch {
+    return;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function writePrivateFileAtomically(filePath: string, content: string): Promise<void> {
+  const directory = path.dirname(filePath);
+  const tempPath = path.join(directory, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(tempPath, "wx", 0o600);
+    await handle.writeFile(content, "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(tempPath, filePath);
+    await chmod(filePath, 0o600);
+    await syncDirectory(directory);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 export class SupportPassportGrantStore {
@@ -195,8 +226,7 @@ export class SupportPassportGrantStore {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    await writeFileAtomically(filePath, `${JSON.stringify(state, null, 2)}\n`, undefined, { mode: 0o600 });
-    await chmod(filePath, 0o600);
+    await writePrivateFileAtomically(filePath, `${JSON.stringify(state, null, 2)}\n`);
   }
 
   private async ensureSafeDirectories(): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -67,7 +67,7 @@ export interface CreateStoredGrantInput {
 
 export interface SupportPassportGrantMutationHooks {
   beforeCommit?: () => Promise<void>;
-  onCommitted?: () => void;
+  onCommitted?: () => void | Promise<void>;
 }
 
 type SupportPassportGrantCreateHooks =
@@ -97,11 +97,16 @@ function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
 }
 
-function notifyCommitted(callback: (() => void) | undefined): void {
+function warnCommitNotificationFailure(error: unknown): void {
+  log.warn(`support passport commit notification failed: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+function notifyCommitted(callback: (() => void | Promise<void>) | undefined): void {
   try {
-    callback?.();
+    const completion = callback?.();
+    if (completion) void Promise.resolve(completion).catch(warnCommitNotificationFailure);
   } catch (error) {
-    log.warn(`support passport commit notification failed: ${error instanceof Error ? error.message : String(error)}`);
+    warnCommitNotificationFailure(error);
   }
 }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -146,8 +146,11 @@ export class SupportPassportGrantStore {
     }
     const candidate = sha256("support-passport-secret:v1", secret);
     if (!hashesMatch(candidate, state.secretHash)) throw grantNotFound();
-    if (state.revokedAt || Date.parse(state.expiresAt) <= this.now().getTime()) {
+    if (state.revokedAt) {
       throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
+    }
+    if (Date.parse(state.expiresAt) <= this.now().getTime()) {
+      throw new SupportPassportError("grant_expired", "The share link has expired.", 410);
     }
     return state;
   }
@@ -165,9 +168,7 @@ export class SupportPassportGrantStore {
       try {
         const state = await this.readState(grantId);
         if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) states.push(state);
-      } catch {
-        continue;
-      }
+      } catch {}
     }
     return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -306,7 +306,10 @@ export class SupportPassportGrantStore {
       }
       const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(input.principal));
       if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
-      if (state.revokedAt) return state;
+      if (state.revokedAt) {
+        await this.syncDirectory(this.grantsDir);
+        return state;
+      }
       if (
         normalizedInput.expectedStateVersion !== undefined &&
         normalizedInput.expectedStateVersion !== state.stateVersion
@@ -321,7 +324,13 @@ export class SupportPassportGrantStore {
       await this.requireMutationLock(lock);
       await beforeCommit?.();
       await this.requireMutationLock(lock);
-      await this.writeState(revoked);
+      try {
+        await this.writeState(revoked);
+      } catch (error) {
+        const persisted = await this.readState(revoked.grantId).catch(() => undefined);
+        if (!persisted || !sameGrantState(persisted, revoked)) throw error;
+        await this.syncDirectory(this.grantsDir);
+      }
       return revoked;
     });
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, open, rm, type FileHandle } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
@@ -16,7 +16,11 @@ import {
   type SupportPassportGrantState,
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
-import { readPrivateFileNoFollow, writePrivateFileAtomicallyNoFollow } from "./private-file.js";
+import {
+  readPrivateFileNoFollow,
+  removePrivateFilesNoFollow,
+  writePrivateFileAtomicallyNoFollow,
+} from "./private-file.js";
 
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
@@ -150,7 +154,7 @@ export class SupportPassportGrantStore {
       try {
         await this.addToOwnerIndex(state, lock);
       } catch (error) {
-        await rm(this.filePath(state.grantId), { force: true }).catch(() => undefined);
+        await this.removeGrantStates([state.grantId]).catch(() => undefined);
         throw error;
       }
       return { state, secret };
@@ -285,7 +289,7 @@ export class SupportPassportGrantStore {
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
     try {
-      await this.removeEvictedGrantStates(evictedGrantIds);
+      await this.removeGrantStates(evictedGrantIds);
     } catch (error) {
       log.warn(
         `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`
@@ -293,10 +297,16 @@ export class SupportPassportGrantStore {
     }
   }
 
-  private async removeEvictedGrantStates(grantIds: string[]): Promise<void> {
+  private async removeGrantStates(grantIds: string[]): Promise<void> {
     if (grantIds.length === 0) return;
-    await Promise.all(grantIds.map((grantId) => rm(this.filePath(grantId), { force: true })));
-    await syncDirectoryForDurability(this.grantsDir);
+    for (const grantId of grantIds) {
+      if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    }
+    await removePrivateFilesNoFollow(
+      this.grantsDir,
+      grantIds.map((grantId) => `${grantId}.json`),
+      "support passport grant files must be regular files in a stable directory"
+    );
   }
 
   private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -30,6 +30,7 @@ export interface SupportPassportGrantStoreOptions {
   now?: () => Date;
   makeSecret?: () => Buffer;
   makeGrantId?: () => string;
+  withHeldFileLock?: typeof withHeldFileLock;
 }
 
 export interface CreateStoredGrantInput {
@@ -105,6 +106,7 @@ export class SupportPassportGrantStore {
   private readonly now: () => Date;
   private readonly makeSecret: () => Buffer;
   private readonly makeGrantId: () => string;
+  private readonly runWithHeldFileLock: typeof withHeldFileLock;
 
   constructor(options: SupportPassportGrantStoreOptions) {
     this.memoryDir = path.resolve(expandTildePath(options.memoryDir));
@@ -113,9 +115,13 @@ export class SupportPassportGrantStore {
     this.now = options.now ?? (() => new Date());
     this.makeSecret = options.makeSecret ?? (() => randomBytes(32));
     this.makeGrantId = options.makeGrantId ?? randomUUID;
+    this.runWithHeldFileLock = options.withHeldFileLock ?? withHeldFileLock;
   }
 
-  async create(input: CreateStoredGrantInput): Promise<{ state: SupportPassportGrantState; secret: string }> {
+  async create(
+    input: CreateStoredGrantInput,
+    beforeCommit?: () => Promise<void>
+  ): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const namespace = normalizeNamespace(input.namespace);
     const parsed = SupportPassportCreateGrantInputSchema.safeParse({
       principal: input.principal,
@@ -150,6 +156,7 @@ export class SupportPassportGrantStore {
         expiresAt: parsed.data.expiresAt,
       });
       await this.requireMutationLock(lock);
+      await beforeCommit?.();
       await this.writeState(state, true);
       try {
         await this.addToOwnerIndex(state, lock);
@@ -255,17 +262,14 @@ export class SupportPassportGrantStore {
     if (current.includes(state.grantId)) return;
     let retained = current;
     if (current.length >= MAX_OWNER_GRANT_HISTORY) {
-      const indexedStates = (
-        await Promise.all(
-          current.map(async (grantId) => {
-            try {
-              return await this.readState(grantId);
-            } catch {
-              return null;
-            }
-          })
-        )
-      ).filter((item): item is SupportPassportGrantState => item !== null);
+      const indexedStates: SupportPassportGrantState[] = [];
+      for (const grantId of current) {
+        try {
+          indexedStates.push(await this.readState(grantId));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
+      }
       const active = indexedStates.filter(
         (item) => !item.revokedAt && Date.parse(item.expiresAt) > this.now().getTime()
       );
@@ -391,7 +395,7 @@ export class SupportPassportGrantStore {
     await this.ensureSafeDirectories();
     const lockPath = path.join(this.grantsDir, ".grants.lock");
     return await serializeMutations(`support-passport-grants:${this.grantsDir}`, () =>
-      withHeldFileLock(
+      this.runWithHeldFileLock(
         lockPath,
         {
           staleMs: GRANT_LOCK_STALE_MS,
@@ -399,7 +403,9 @@ export class SupportPassportGrantStore {
           heartbeatMs: GRANT_LOCK_HEARTBEAT_MS,
         },
         async (acquired, lock) => {
-          if (!acquired) throw new Error("could not acquire the support passport grant lock");
+          if (!acquired) {
+            throw new SupportPassportError("storage_conflict", "The share link store is busy. Try again.", 409);
+          }
           return await task(lock);
         }
       )

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypt
 import { chmod, lstat, mkdir, open, rm, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
+import { log } from "../logger.js";
 import { expandTildePath } from "../utils/path.js";
 import {
   type HeldFileLockController,
@@ -282,9 +283,14 @@ export class SupportPassportGrantStore {
     const retainedIds = new Set(grantIds);
     const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
     await this.requireMutationLock(lock);
-    await this.removeEvictedGrantStates(evictedGrantIds);
-    await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
+    try {
+      await this.removeEvictedGrantStates(evictedGrantIds);
+    } catch (error) {
+      log.warn(
+        `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
   }
 
   private async removeEvictedGrantStates(grantIds: string[]): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -30,6 +30,8 @@ const GRANT_LOCK_HEARTBEAT_MS = 10_000;
 const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
+const SAFE_OWNER_INDEX_RECOVERY_MARKER =
+  /^\.index-recovery-[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 const MAX_OWNER_GRANT_HISTORY = 100;
 const MAX_OWNER_INDEX_RECOVERY_ATTEMPTS = 3;
@@ -338,16 +340,21 @@ export class SupportPassportGrantStore {
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
     const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
-    const grantIds = await this.readOwnerIndex(normalizedNamespace, principalHash);
-    const states: SupportPassportGrantState[] = [];
-    for (const grantId of grantIds) {
-      try {
-        const state = await this.readState(grantId);
-        if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
-          states.push(state);
+    const ownerHash = this.ownerHash(normalizedNamespace, principalHash);
+    let states: SupportPassportGrantState[];
+    if (await this.ownerIndexRecoveryRequired(ownerHash)) {
+      states = await this.readOwnerMembershipStates(normalizedNamespace, principalHash);
+    } else {
+      states = [];
+      for (const grantId of await this.readOwnerIndexByHash(ownerHash)) {
+        try {
+          const state = await this.readState(grantId);
+          if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
+            states.push(state);
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
     }
     const activeCutoff = this.now().getTime();
@@ -430,7 +437,7 @@ export class SupportPassportGrantStore {
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
     let retained = current;
-    let indexedStates: SupportPassportGrantState[] = [];
+    const indexedStates: SupportPassportGrantState[] = [];
     if (current.length >= MAX_OWNER_GRANT_HISTORY) {
       for (const grantId of current) {
         try {
@@ -467,9 +474,7 @@ export class SupportPassportGrantStore {
     const retainedIds = new Set(grantIds);
     const indexedStateById = new Map(indexedStates.map((indexedState) => [indexedState.grantId, indexedState]));
     const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
-    await this.requireMutationLock(lock);
-    await this.writeOwnerIndex(ownerHash, grantIds);
-    await this.requireOwnerIndexLock(lock);
+    await this.writeOwnerIndexWhileLocked(ownerHash, grantIds, state.grantId, lock);
     try {
       for (const grantId of evictedGrantIds) {
         await this.withGrantLock(grantId, async (grantLock) => {
@@ -542,6 +547,65 @@ export class SupportPassportGrantStore {
     await this.removeOwnerMembership(state);
   }
 
+  private ownerIndexRecoveryMarkerName(grantId: string): string {
+    return `.index-recovery-${normalizeGrantId(grantId)}.json`;
+  }
+
+  private async writeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void> {
+    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
+    const fileName = this.ownerIndexRecoveryMarkerName(grantId);
+    await writePrivateFileAtomicallyNoFollow(
+      directory,
+      path.join(directory, fileName),
+      `${JSON.stringify({ schemaVersion: 1, grantId: normalizeGrantId(grantId) })}\n`,
+      "support passport owner recovery markers must be regular files in a stable directory",
+      path.parse(this.memoryDir).root,
+    );
+  }
+
+  private async removeOwnerIndexRecoveryMarker(ownerHash: string, grantId: string): Promise<void> {
+    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
+    await removePrivateFilesNoFollow(
+      directory,
+      [this.ownerIndexRecoveryMarkerName(grantId)],
+      "support passport owner recovery markers must be regular files in a stable directory",
+      path.parse(this.memoryDir).root,
+    );
+  }
+
+  private async ownerIndexRecoveryRequired(ownerHash: string): Promise<boolean> {
+    await this.ensureSafeDirectories();
+    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
+    return await withPrivateDirectoryNoFollow(
+      path.parse(this.memoryDir).root,
+      directory,
+      "support passport owner indexes must be regular files in a stable directory",
+      async (pinnedDirectory) => {
+        for (const entry of await readdir(pinnedDirectory, { withFileTypes: true })) {
+          if (!SAFE_OWNER_INDEX_RECOVERY_MARKER.test(entry.name)) continue;
+          if (!entry.isFile()) {
+            throw new Error("support passport owner recovery markers must be regular files");
+          }
+          return true;
+        }
+        return false;
+      },
+    );
+  }
+
+  private async writeOwnerIndexWhileLocked(
+    ownerHash: string,
+    grantIds: string[],
+    recoveryGrantId: string,
+    lock: HeldFileLockController,
+  ): Promise<void> {
+    await this.writeOwnerIndexRecoveryMarker(ownerHash, recoveryGrantId);
+    await this.requireOwnerIndexLock(lock);
+    await this.writeOwnerIndex(ownerHash, grantIds);
+    await this.requireOwnerIndexLock(lock);
+    await this.removeOwnerIndexRecoveryMarker(ownerHash, recoveryGrantId);
+  }
+
   private async reconcileCreateAfterOwnerIndexLockLoss(
     committed: { state: SupportPassportGrantState; secret: string },
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
@@ -602,9 +666,12 @@ export class SupportPassportGrantStore {
       if (committedIndex !== -1) ownerStates.splice(committedIndex, 1);
     }
     const retained = this.retainedOwnerStates(ownerStates, activeCutoff);
-    await this.requireMutationLock(lock);
-    await this.writeOwnerIndex(ownerHash, retained.map((state) => state.grantId));
-    await this.requireOwnerIndexLock(lock);
+    await this.writeOwnerIndexWhileLocked(
+      ownerHash,
+      retained.map((state) => state.grantId),
+      committed.state.grantId,
+      lock,
+    );
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
       throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
     }
@@ -628,10 +695,6 @@ export class SupportPassportGrantStore {
       ...active,
       ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length),
     ];
-  }
-
-  private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {
-    return await this.readOwnerIndexByHash(this.ownerHash(namespace, principalHash));
   }
 
   private async readOwnerMembershipStates(

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -622,7 +622,12 @@ export class SupportPassportGrantStore {
     await this.writeOwnerIndexRecoveryMarker(ownerHash, recoveryGrantId);
     await this.requireOwnerIndexLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
-    for (const markerGrantId of new Set([...priorRecoveryGrantIds, recoveryGrantId])) {
+    const indexedGrantIds = new Set(grantIds);
+    const removableRecoveryGrantIds = new Set([
+      recoveryGrantId,
+      ...priorRecoveryGrantIds.filter((grantId) => indexedGrantIds.has(grantId)),
+    ]);
+    for (const markerGrantId of removableRecoveryGrantIds) {
       await this.requireOwnerIndexLock(lock);
       await this.removeOwnerIndexRecoveryMarker(ownerHash, markerGrantId);
     }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,19 +1,10 @@
-import {
-  createHash,
-  randomBytes,
-  randomUUID,
-  timingSafeEqual,
-} from "node:crypto";
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { type FileHandle, lstat, open } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
 import { expandTildePath } from "../utils/path.js";
-import {
-  type HeldFileLockController,
-  serializeMutations,
-  withHeldFileLock,
-} from "../utils/serialize-mutations.js";
+import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
 import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
@@ -36,17 +27,10 @@ import {
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
 const GRANT_LOCK_HEARTBEAT_MS = 10_000;
-const SAFE_GRANT_ID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-const UUID_INPUT =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
-const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set([
-  "EINVAL",
-  "ENOSYS",
-  "ENOTSUP",
-  "EOPNOTSUPP",
-]);
+const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 const MAX_OWNER_GRANT_HISTORY = 100;
 
 export interface SupportPassportGrantStoreOptions {
@@ -65,52 +49,32 @@ export interface CreateStoredGrantInput {
 }
 
 function sha256(domain: string, value: string): string {
-  return createHash("sha256")
-    .update(domain)
-    .update("\0")
-    .update(value)
-    .digest("hex");
+  return createHash("sha256").update(domain).update("\0").update(value).digest("hex");
 }
 
 function hashesMatch(left: string, right: string): boolean {
   const leftBytes = Buffer.from(left, "hex");
   const rightBytes = Buffer.from(right, "hex");
-  return (
-    leftBytes.length === 32 &&
-    rightBytes.length === 32 &&
-    timingSafeEqual(leftBytes, rightBytes)
-  );
+  return leftBytes.length === 32 && rightBytes.length === 32 && timingSafeEqual(leftBytes, rightBytes);
 }
 
-function sameGrantState(
-  left: SupportPassportGrantState,
-  right: SupportPassportGrantState,
-): boolean {
+function sameGrantState(left: SupportPassportGrantState, right: SupportPassportGrantState): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function grantNotFound(): SupportPassportError {
-  return new SupportPassportError(
-    "grant_not_found",
-    "The share link was not found.",
-    404,
-  );
+  return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
 }
 
 function normalizeGrantId(grantId: unknown): string {
-  if (typeof grantId !== "string" || !UUID_INPUT.test(grantId))
-    throw grantNotFound();
+  if (typeof grantId !== "string" || !UUID_INPUT.test(grantId)) throw grantNotFound();
   return grantId.toLowerCase();
 }
 
 function normalizeNamespace(namespace: unknown): string {
   const parsed = SupportPassportNamespaceSchema.safeParse(namespace);
   if (!parsed.success) {
-    throw new SupportPassportError(
-      "invalid_input",
-      "The share link request is invalid.",
-      400,
-    );
+    throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
   }
   return parsed.data;
 }
@@ -118,21 +82,15 @@ function normalizeNamespace(namespace: unknown): string {
 function normalizePrincipal(principal: unknown): string {
   const normalized = typeof principal === "string" ? principal.trim() : "";
   if (normalized.length < 1 || normalized.length > 512) {
-    throw new SupportPassportError(
-      "invalid_input",
-      "The share link request is invalid.",
-      400,
-    );
+    throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
   }
   return normalized;
 }
 
 export async function syncDirectoryForDurability(
   directory: string,
-  openDirectory: (
-    directory: string,
-  ) => Promise<Pick<FileHandle, "sync" | "close">> = async (target) =>
-    await open(target, "r"),
+  openDirectory: (directory: string) => Promise<Pick<FileHandle, "sync" | "close">> = async (target) =>
+    await open(target, "r")
 ): Promise<void> {
   let handle: Pick<FileHandle, "sync" | "close"> | undefined;
   try {
@@ -158,12 +116,7 @@ export class SupportPassportGrantStore {
 
   constructor(options: SupportPassportGrantStoreOptions) {
     this.memoryDir = path.resolve(expandTildePath(options.memoryDir));
-    this.grantsDir = path.join(
-      this.memoryDir,
-      "state",
-      "support-passport",
-      "grants",
-    );
+    this.grantsDir = path.join(this.memoryDir, "state", "support-passport", "grants");
     this.ownerIndexesDir = path.join(this.grantsDir, "owners");
     this.now = options.now ?? (() => new Date());
     this.makeSecret = options.makeSecret ?? (() => randomBytes(32));
@@ -173,7 +126,7 @@ export class SupportPassportGrantStore {
 
   async create(
     input: CreateStoredGrantInput,
-    beforeCommit?: () => Promise<void>,
+    beforeCommit?: () => Promise<void>
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const namespace = normalizeNamespace(input.namespace);
     const parsed = SupportPassportCreateGrantInputSchema.safeParse({
@@ -182,39 +135,21 @@ export class SupportPassportGrantStore {
       expiresAt: input.expiresAt,
     });
     if (!parsed.success) {
-      throw new SupportPassportError(
-        "invalid_input",
-        "The share link request is invalid.",
-        400,
-      );
+      throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
     return await this.withMutationLock(async (lock) => {
       const secretBytes = this.makeSecret();
       if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
-        throw new Error(
-          "SupportPassportGrantStore.makeSecret must return 32 bytes",
-        );
+        throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
       }
       const rawGrantId = this.makeGrantId();
-      if (!UUID_INPUT.test(rawGrantId))
-        throw new Error(
-          "SupportPassportGrantStore.makeGrantId must return a UUID",
-        );
+      if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
       const grantId = rawGrantId.toLowerCase();
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
-      const durationMs =
-        Date.parse(parsed.data.expiresAt) - createdAt.getTime();
-      if (
-        !Number.isFinite(durationMs) ||
-        durationMs < 300_000 ||
-        durationMs > 604_800_000
-      ) {
-        throw new SupportPassportError(
-          "invalid_input",
-          "The share link request is invalid.",
-          400,
-        );
+      const durationMs = Date.parse(parsed.data.expiresAt) - createdAt.getTime();
+      if (!Number.isFinite(durationMs) || durationMs < 300_000 || durationMs > 604_800_000) {
+        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
       }
       const state = SupportPassportGrantStateSchema.parse({
         schemaVersion: 1,
@@ -229,22 +164,17 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
-      await this.requireMutationLock(lock);
       try {
         await this.writeState(state, true);
       } catch (error) {
-        const persisted = await this.readState(state.grantId).catch(
-          () => undefined,
-        );
+        const persisted = await this.readState(state.grantId).catch(() => undefined);
         if (!persisted || !sameGrantState(persisted, state)) throw error;
       }
       try {
         await this.addToOwnerIndex(state, lock);
       } catch (error) {
         const ownerHash = this.ownerHash(state.namespace, state.principalHash);
-        const indexed = await this.readOwnerIndexByHash(ownerHash).catch(
-          () => undefined,
-        );
+        const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
         if (indexed?.includes(state.grantId)) return { state, secret };
         await this.removeGrantStates([state.grantId]).catch(() => undefined);
         throw error;
@@ -253,36 +183,23 @@ export class SupportPassportGrantStore {
     });
   }
 
-  async authenticate(
-    grantId: string,
-    secret: string,
-  ): Promise<SupportPassportGrantState> {
+  async authenticate(grantId: string, secret: string): Promise<SupportPassportGrantState> {
     const normalizedGrantId = normalizeGrantId(grantId);
-    if (typeof secret !== "string" || secret.length > 512)
-      throw grantNotFound();
+    if (typeof secret !== "string" || secret.length > 512) throw grantNotFound();
     let state: SupportPassportGrantState;
     try {
       state = await this.readState(normalizedGrantId);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT")
-        throw grantNotFound();
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
       throw error;
     }
     const candidate = sha256("support-passport-secret:v1", secret);
     if (!hashesMatch(candidate, state.secretHash)) throw grantNotFound();
     if (state.revokedAt) {
-      throw new SupportPassportError(
-        "grant_gone",
-        "The share link is no longer active.",
-        410,
-      );
+      throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
     }
     if (Date.parse(state.expiresAt) <= this.now().getTime()) {
-      throw new SupportPassportError(
-        "grant_expired",
-        "The share link has expired.",
-        410,
-      );
+      throw new SupportPassportError("grant_expired", "The share link has expired.", 410);
     }
     return state;
   }
@@ -291,7 +208,7 @@ export class SupportPassportGrantStore {
     grantId: string,
     secret: string,
     task: (state: SupportPassportGrantState) => Promise<T>,
-    beforeReturn?: (state: SupportPassportGrantState) => Promise<void>,
+    beforeReturn?: (state: SupportPassportGrantState) => Promise<void>
   ): Promise<T> {
     return await this.withGrantLock(grantId, async (lock) => {
       const state = await this.authenticate(grantId, secret);
@@ -300,11 +217,7 @@ export class SupportPassportGrantStore {
       const finalState = await this.authenticate(grantId, secret);
       await this.requireMutationLock(lock);
       if (finalState.stateVersion !== state.stateVersion) {
-        throw new SupportPassportError(
-          "grant_stale",
-          "The shared support guide has changed.",
-          410,
-        );
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
       }
       this.requireActiveState(finalState);
       await beforeReturn?.(finalState);
@@ -314,26 +227,15 @@ export class SupportPassportGrantStore {
     });
   }
 
-  async listForOwner(
-    namespace: string,
-    principal: string,
-  ): Promise<SupportPassportGrantState[]> {
+  async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
-    const principalHash = computeSupportPassportOwnerKey(
-      normalizePrincipal(principal),
-    );
-    const grantIds = await this.readOwnerIndex(
-      normalizedNamespace,
-      principalHash,
-    );
+    const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
+    const grantIds = await this.readOwnerIndex(normalizedNamespace, principalHash);
     const states: SupportPassportGrantState[] = [];
     for (const grantId of grantIds) {
       try {
         const state = await this.readState(grantId);
-        if (
-          state.namespace === normalizedNamespace &&
-          hashesMatch(state.principalHash, principalHash)
-        ) {
+        if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
           states.push(state);
         }
       } catch (error) {
@@ -345,10 +247,7 @@ export class SupportPassportGrantStore {
       const aActive = !a.revokedAt && Date.parse(a.expiresAt) > activeCutoff;
       const bActive = !b.revokedAt && Date.parse(b.expiresAt) > activeCutoff;
       if (aActive !== bActive) return aActive ? -1 : 1;
-      return (
-        b.createdAt.localeCompare(a.createdAt) ||
-        a.grantId.localeCompare(b.grantId)
-      );
+      return b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId);
     });
   }
 
@@ -359,40 +258,26 @@ export class SupportPassportGrantStore {
       principal: string;
       expectedStateVersion?: number;
     },
-    beforeCommit?: () => Promise<void>,
+    beforeCommit?: () => Promise<void>
   ): Promise<SupportPassportGrantState> {
-    const normalizedInput = {
-      ...input,
-      grantId: normalizeGrantId(input.grantId),
-    };
+    const normalizedInput = { ...input, grantId: normalizeGrantId(input.grantId) };
     const namespace = normalizeNamespace(input.namespace);
     return await this.withGrantLock(normalizedInput.grantId, async (lock) => {
       let state: SupportPassportGrantState;
       try {
         state = await this.readState(normalizedInput.grantId);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT")
-          throw grantNotFound();
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
         throw error;
       }
-      const principalHash = computeSupportPassportOwnerKey(
-        normalizePrincipal(input.principal),
-      );
-      if (
-        state.namespace !== namespace ||
-        !hashesMatch(state.principalHash, principalHash)
-      )
-        throw grantNotFound();
+      const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(input.principal));
+      if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
       if (state.revokedAt) return state;
       if (
         normalizedInput.expectedStateVersion !== undefined &&
         normalizedInput.expectedStateVersion !== state.stateVersion
       ) {
-        throw new SupportPassportError(
-          "state_conflict",
-          "The share link changed after it was loaded.",
-          409,
-        );
+        throw new SupportPassportError("state_conflict", "The share link changed after it was loaded.", 409);
       }
       const revoked = SupportPassportGrantStateSchema.parse({
         ...state,
@@ -401,7 +286,6 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
-      await this.requireMutationLock(lock);
       await this.writeState(revoked);
       return revoked;
     });
@@ -413,22 +297,15 @@ export class SupportPassportGrantStore {
   }
 
   private ownerIndexPath(ownerHash: string): string {
-    if (!SAFE_OWNER_INDEX_HASH.test(ownerHash))
-      throw new Error("support passport owner index hash is invalid");
+    if (!SAFE_OWNER_INDEX_HASH.test(ownerHash)) throw new Error("support passport owner index hash is invalid");
     return path.join(this.ownerIndexesDir, `${ownerHash}.json`);
   }
 
   private ownerHash(namespace: string, principalHash: string): string {
-    return sha256(
-      "support-passport-owner-index:v1",
-      `${namespace}\0${principalHash}`,
-    );
+    return sha256("support-passport-owner-index:v1", `${namespace}\0${principalHash}`);
   }
 
-  private async addToOwnerIndex(
-    state: SupportPassportGrantState,
-    lock: HeldFileLockController,
-  ): Promise<void> {
+  private async addToOwnerIndex(state: SupportPassportGrantState, lock: HeldFileLockController): Promise<void> {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
@@ -442,9 +319,7 @@ export class SupportPassportGrantStore {
             indexedState.namespace !== state.namespace ||
             !hashesMatch(indexedState.principalHash, state.principalHash)
           ) {
-            throw new Error(
-              "support passport owner index references a foreign grant",
-            );
+            throw new Error("support passport owner index references a foreign grant");
           }
           indexedStates.push(indexedState);
         } catch (error) {
@@ -452,38 +327,25 @@ export class SupportPassportGrantStore {
         }
       }
       const expiryCutoff = this.now().getTime();
-      const active = indexedStates.filter(
-        (item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff,
-      );
+      const active = indexedStates.filter((item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff);
       if (active.length >= MAX_OWNER_GRANT_HISTORY) {
         throw new SupportPassportError(
           "invalid_input",
           "A support passport can contain at most 100 active share links.",
-          400,
+          400
         );
       }
       const inactive = indexedStates
-        .filter(
-          (item) =>
-            item.revokedAt || Date.parse(item.expiresAt) <= expiryCutoff,
-        )
-        .sort(
-          (a, b) =>
-            b.createdAt.localeCompare(a.createdAt) ||
-            a.grantId.localeCompare(b.grantId),
-        );
+        .filter((item) => item.revokedAt || Date.parse(item.expiresAt) <= expiryCutoff)
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
       retained = [
         ...active.map((item) => item.grantId),
-        ...inactive
-          .slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1)
-          .map((item) => item.grantId),
+        ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1).map((item) => item.grantId),
       ];
     }
     const grantIds = [...retained, state.grantId];
     const retainedIds = new Set(grantIds);
-    const evictedGrantIds = current.filter(
-      (grantId) => !retainedIds.has(grantId),
-    );
+    const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
     try {
@@ -495,7 +357,7 @@ export class SupportPassportGrantStore {
       }
     } catch (error) {
       log.warn(
-        `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`,
+        `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
@@ -509,17 +371,12 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       grantIds.map((grantId) => `${grantId}.json`),
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir,
+      this.memoryDir
     );
   }
 
-  private async readOwnerIndex(
-    namespace: string,
-    principalHash: string,
-  ): Promise<string[]> {
-    return await this.readOwnerIndexByHash(
-      this.ownerHash(namespace, principalHash),
-    );
+  private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {
+    return await this.readOwnerIndexByHash(this.ownerHash(namespace, principalHash));
   }
 
   private async readOwnerIndexByHash(ownerHash: string): Promise<string[]> {
@@ -531,7 +388,7 @@ export class SupportPassportGrantStore {
         this.ownerIndexesDir,
         filePath,
         "support passport owner indexes must be regular files in a stable directory",
-        this.memoryDir,
+        this.memoryDir
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -543,34 +400,21 @@ export class SupportPassportGrantStore {
     }
     const record = parsed as Record<string, unknown>;
     const grantIds = record.grantIds;
-    if (
-      record.schemaVersion !== 1 ||
-      record.ownerHash !== ownerHash ||
-      !Array.isArray(grantIds)
-    ) {
+    if (record.schemaVersion !== 1 || record.ownerHash !== ownerHash || !Array.isArray(grantIds)) {
       throw new Error("support passport owner index is invalid");
     }
-    if (
-      grantIds.some(
-        (grantId) =>
-          typeof grantId !== "string" || !SAFE_GRANT_ID.test(grantId),
-      )
-    ) {
+    if (grantIds.some((grantId) => typeof grantId !== "string" || !SAFE_GRANT_ID.test(grantId))) {
       throw new Error("support passport owner index is invalid");
     }
     const uniqueGrantIds = new Set(grantIds as string[]);
-    if (uniqueGrantIds.size !== grantIds.length)
-      throw new Error("support passport owner index is invalid");
+    if (uniqueGrantIds.size !== grantIds.length) throw new Error("support passport owner index is invalid");
     if (uniqueGrantIds.size > MAX_OWNER_GRANT_HISTORY) {
       throw new Error("support passport owner index is invalid");
     }
     return [...uniqueGrantIds];
   }
 
-  private async writeOwnerIndex(
-    ownerHash: string,
-    grantIds: string[],
-  ): Promise<void> {
+  private async writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void> {
     const filePath = this.ownerIndexPath(ownerHash);
     try {
       const metadata = await lstat(filePath);
@@ -585,7 +429,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
       "support passport owner indexes must be regular files in a stable directory",
-      this.memoryDir,
+      this.memoryDir
     );
   }
 
@@ -596,29 +440,21 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       filePath,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir,
+      this.memoryDir
     );
     const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
-    if (state.grantId !== grantId)
-      throw new Error("support passport grant ID must match its file name");
+    if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
     return state;
   }
 
-  private async writeState(
-    state: SupportPassportGrantState,
-    requireAbsent = false,
-  ): Promise<void> {
+  private async writeState(state: SupportPassportGrantState, requireAbsent = false): Promise<void> {
     const filePath = this.filePath(state.grantId);
     try {
       const metadata = await lstat(filePath);
       if (metadata.isSymbolicLink() || !metadata.isFile())
         throw new Error("support passport grant files must be regular files");
       if (requireAbsent) {
-        throw new SupportPassportError(
-          "storage_conflict",
-          "A new share link could not be allocated.",
-          409,
-        );
+        throw new SupportPassportError("storage_conflict", "A new share link could not be allocated.", 409);
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -628,7 +464,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify(state, null, 2)}\n`,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir,
+      this.memoryDir
     );
   }
 
@@ -637,7 +473,7 @@ export class SupportPassportGrantStore {
     await ensurePrivateDirectoryNoFollow(
       this.memoryDir,
       this.ownerIndexesDir,
-      "support passport grant directories must remain inside the memory directory",
+      "support passport grant directories must remain inside the memory directory"
     );
   }
 
@@ -645,19 +481,13 @@ export class SupportPassportGrantStore {
     if (!this.memoryRootReady) {
       const configuredMemoryDir = this.memoryDir;
       this.memoryRootReady = (async () => {
-        const canonicalMemoryDir =
-          await canonicalizePrivateDirectoryTarget(configuredMemoryDir);
+        const canonicalMemoryDir = await canonicalizePrivateDirectoryTarget(configuredMemoryDir);
         await ensurePrivateDirectoryTreeNoFollow(
           canonicalMemoryDir,
-          "support passport memory directory must be a stable directory",
+          "support passport memory directory must be a stable directory"
         );
         this.memoryDir = canonicalMemoryDir;
-        this.grantsDir = path.join(
-          canonicalMemoryDir,
-          "state",
-          "support-passport",
-          "grants",
-        );
+        this.grantsDir = path.join(canonicalMemoryDir, "state", "support-passport", "grants");
         this.ownerIndexesDir = path.join(this.grantsDir, "owners");
       })();
     }
@@ -665,15 +495,12 @@ export class SupportPassportGrantStore {
     try {
       await currentAttempt;
     } catch (error) {
-      if (this.memoryRootReady === currentAttempt)
-        this.memoryRootReady = undefined;
+      if (this.memoryRootReady === currentAttempt) this.memoryRootReady = undefined;
       throw error;
     }
   }
 
-  private async withMutationLock<T>(
-    task: (lock: HeldFileLockController) => Promise<T>,
-  ): Promise<T> {
+  private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
       this.memoryDir,
@@ -683,15 +510,12 @@ export class SupportPassportGrantStore {
         await this.withExclusiveLock(
           `support-passport-grants:${this.grantsDir}`,
           path.join(pinnedDirectory, ".grants.lock"),
-          task,
-        ),
+          task
+        )
     );
   }
 
-  private async withGrantLock<T>(
-    grantId: string,
-    task: (lock: HeldFileLockController) => Promise<T>,
-  ): Promise<T> {
+  private async withGrantLock<T>(grantId: string, task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     const normalizedGrantId = normalizeGrantId(grantId);
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
@@ -702,15 +526,15 @@ export class SupportPassportGrantStore {
         await this.withExclusiveLock(
           `support-passport-grant:${this.grantsDir}:${normalizedGrantId}`,
           path.join(pinnedDirectory, `.${normalizedGrantId}.lock`),
-          task,
-        ),
+          task
+        )
     );
   }
 
   private async withExclusiveLock<T>(
     serializationKey: string,
     lockPath: string,
-    task: (lock: HeldFileLockController) => Promise<T>,
+    task: (lock: HeldFileLockController) => Promise<T>
   ): Promise<T> {
     return await serializeMutations(serializationKey, () =>
       this.runWithHeldFileLock(
@@ -722,43 +546,25 @@ export class SupportPassportGrantStore {
         },
         async (acquired, lock) => {
           if (!acquired) {
-            throw new SupportPassportError(
-              "storage_conflict",
-              "The share link store is busy. Try again.",
-              409,
-            );
+            throw new SupportPassportError("storage_conflict", "The share link store is busy. Try again.", 409);
           }
           return await task(lock);
-        },
-      ),
+        }
+      )
     );
   }
 
-  private async requireMutationLock(
-    lock: HeldFileLockController,
-  ): Promise<void> {
+  private async requireMutationLock(lock: HeldFileLockController): Promise<void> {
     if (await lock.refresh()) return;
-    throw new SupportPassportError(
-      "storage_conflict",
-      "The share link store changed during the request.",
-      409,
-    );
+    throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
   }
 
   private requireActiveState(state: SupportPassportGrantState): void {
     if (state.revokedAt) {
-      throw new SupportPassportError(
-        "grant_gone",
-        "The share link is no longer active.",
-        410,
-      );
+      throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
     }
     if (Date.parse(state.expiresAt) <= this.now().getTime()) {
-      throw new SupportPassportError(
-        "grant_expired",
-        "The share link has expired.",
-        410,
-      );
+      throw new SupportPassportError("grant_expired", "The share link has expired.", 410);
     }
   }
 }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -4,11 +4,7 @@ import path from "node:path";
 
 import { log } from "../logger.js";
 import { expandTildePath } from "../utils/path.js";
-import {
-  type HeldFileLockController,
-  serializeMutations,
-  withHeldFileLock,
-} from "../utils/serialize-mutations.js";
+import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportError } from "./errors.js";
 import {
   SupportPassportCreateGrantInputSchema,
@@ -182,6 +178,19 @@ export class SupportPassportGrantStore {
     return state;
   }
 
+  async withAuthenticatedGrant<T>(
+    grantId: string,
+    secret: string,
+    task: (state: SupportPassportGrantState) => Promise<T>
+  ): Promise<T> {
+    return await this.withMutationLock(async (lock) => {
+      const state = await this.authenticate(grantId, secret);
+      const result = await task(state);
+      await this.requireMutationLock(lock);
+      return result;
+    });
+  }
+
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
     const principalHash = sha256("support-passport-principal:v1", normalizePrincipal(principal));
@@ -215,8 +224,7 @@ export class SupportPassportGrantStore {
         throw error;
       }
       const principalHash = sha256("support-passport-principal:v1", normalizePrincipal(input.principal));
-      if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash))
-        throw grantNotFound();
+      if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
       if (state.revokedAt) return state;
       if (input.expectedStateVersion !== undefined && input.expectedStateVersion !== state.stateVersion) {
         throw new SupportPassportError("state_conflict", "The share link changed after it was loaded.", 409);
@@ -246,10 +254,7 @@ export class SupportPassportGrantStore {
     return sha256("support-passport-owner-index:v1", `${namespace}\0${principalHash}`);
   }
 
-  private async addToOwnerIndex(
-    state: SupportPassportGrantState,
-    lock: HeldFileLockController
-  ): Promise<void> {
+  private async addToOwnerIndex(state: SupportPassportGrantState, lock: HeldFileLockController): Promise<void> {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
@@ -278,9 +283,7 @@ export class SupportPassportGrantStore {
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
       retained = [
         ...active.map((item) => item.grantId),
-        ...inactive
-          .slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1)
-          .map((item) => item.grantId),
+        ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1).map((item) => item.grantId),
       ];
     }
     const grantIds = [...retained, state.grantId];

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -540,58 +540,68 @@ export class SupportPassportGrantStore {
     committed: { state: SupportPassportGrantState; secret: string },
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
-    return await this.withOwnerIndexLock(ownerHash, async (lock) => {
-      const persisted = await this.readState(committed.state.grantId).catch(() => undefined);
-      if (!persisted || !sameGrantState(persisted, committed.state)) {
-        throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
-      }
-      const indexedGrantIds = await this.readOwnerIndexByHash(ownerHash);
-      const ownerStates: SupportPassportGrantState[] = [];
-      for (const grantId of indexedGrantIds) {
-        try {
-          const state = await this.readState(grantId);
-          if (
-            state.namespace !== committed.state.namespace ||
-            !hashesMatch(state.principalHash, committed.state.principalHash)
-          ) {
-            throw new Error("support passport owner index references a foreign grant");
-          }
-          ownerStates.push(state);
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-        }
-      }
-      const memberStates = await this.readOwnerMembershipStates(
-        committed.state.namespace,
-        committed.state.principalHash,
-      );
-      const indexedGrantIdSet = new Set(ownerStates.map((state) => state.grantId));
-      ownerStates.push(...memberStates.filter((state) => !indexedGrantIdSet.has(state.grantId)));
-      const committedIndex = ownerStates.findIndex(
-        (state) => state.grantId === committed.state.grantId,
-      );
-      if (committedIndex === -1) ownerStates.push(committed.state);
-      else ownerStates[committedIndex] = committed.state;
-      const activeCutoff = this.now().getTime();
-      const active = ownerStates.filter(
-        (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
-      );
-      if (active.length > MAX_OWNER_GRANT_HISTORY) {
-        await this.removeStoredGrant(committed.state);
-        const committedIndex = ownerStates.findIndex(
-          (state) => state.grantId === committed.state.grantId,
+    while (true) {
+      try {
+        return await this.withOwnerIndexLock(ownerHash, async (lock) =>
+          await this.reconcileCommittedGrant(committed, ownerHash, lock)
         );
-        if (committedIndex !== -1) ownerStates.splice(committedIndex, 1);
+      } catch (error) {
+        if (!(error instanceof OwnerIndexLockLostError)) throw error;
       }
-      const retained = this.retainedOwnerStates(ownerStates, activeCutoff);
-      await this.requireMutationLock(lock);
-      await this.writeOwnerIndex(ownerHash, retained.map((state) => state.grantId));
-      await this.requireOwnerIndexLock(lock);
-      if (active.length > MAX_OWNER_GRANT_HISTORY) {
-        throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+    }
+  }
+
+  private async reconcileCommittedGrant(
+    committed: { state: SupportPassportGrantState; secret: string },
+    ownerHash: string,
+    lock: HeldFileLockController,
+  ): Promise<{ state: SupportPassportGrantState; secret: string }> {
+    const persisted = await this.readState(committed.state.grantId).catch(() => undefined);
+    if (!persisted || !sameGrantState(persisted, committed.state)) {
+      throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+    }
+    const indexedGrantIds = await this.readOwnerIndexByHash(ownerHash);
+    const ownerStates: SupportPassportGrantState[] = [];
+    for (const grantId of indexedGrantIds) {
+      try {
+        const state = await this.readState(grantId);
+        if (
+          state.namespace !== committed.state.namespace ||
+          !hashesMatch(state.principalHash, committed.state.principalHash)
+        ) {
+          throw new Error("support passport owner index references a foreign grant");
+        }
+        ownerStates.push(state);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
-      return committed;
-    });
+    }
+    const memberStates = await this.readOwnerMembershipStates(
+      committed.state.namespace,
+      committed.state.principalHash,
+    );
+    const indexedGrantIdSet = new Set(ownerStates.map((state) => state.grantId));
+    ownerStates.push(...memberStates.filter((state) => !indexedGrantIdSet.has(state.grantId)));
+    const committedIndex = ownerStates.findIndex((state) => state.grantId === committed.state.grantId);
+    if (committedIndex === -1) ownerStates.push(committed.state);
+    else ownerStates[committedIndex] = committed.state;
+    const activeCutoff = this.now().getTime();
+    const active = ownerStates.filter(
+      (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
+    );
+    if (active.length > MAX_OWNER_GRANT_HISTORY) {
+      await this.removeStoredGrant(committed.state);
+      const committedIndex = ownerStates.findIndex((state) => state.grantId === committed.state.grantId);
+      if (committedIndex !== -1) ownerStates.splice(committedIndex, 1);
+    }
+    const retained = this.retainedOwnerStates(ownerStates, activeCutoff);
+    await this.requireMutationLock(lock);
+    await this.writeOwnerIndex(ownerHash, retained.map((state) => state.grantId));
+    await this.requireOwnerIndexLock(lock);
+    if (active.length > MAX_OWNER_GRANT_HISTORY) {
+      throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+    }
+    return committed;
   }
 
   private retainedOwnerStates(

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,10 +1,19 @@
-import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
 import { type FileHandle, lstat, open } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
 import { expandTildePath } from "../utils/path.js";
-import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import {
+  type HeldFileLockController,
+  serializeMutations,
+  withHeldFileLock,
+} from "../utils/serialize-mutations.js";
 import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
@@ -27,10 +36,17 @@ import {
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
 const GRANT_LOCK_HEARTBEAT_MS = 10_000;
-const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_GRANT_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID_INPUT =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
-const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
+const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set([
+  "EINVAL",
+  "ENOSYS",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+]);
 const MAX_OWNER_GRANT_HISTORY = 100;
 
 export interface SupportPassportGrantStoreOptions {
@@ -49,32 +65,52 @@ export interface CreateStoredGrantInput {
 }
 
 function sha256(domain: string, value: string): string {
-  return createHash("sha256").update(domain).update("\0").update(value).digest("hex");
+  return createHash("sha256")
+    .update(domain)
+    .update("\0")
+    .update(value)
+    .digest("hex");
 }
 
 function hashesMatch(left: string, right: string): boolean {
   const leftBytes = Buffer.from(left, "hex");
   const rightBytes = Buffer.from(right, "hex");
-  return leftBytes.length === 32 && rightBytes.length === 32 && timingSafeEqual(leftBytes, rightBytes);
+  return (
+    leftBytes.length === 32 &&
+    rightBytes.length === 32 &&
+    timingSafeEqual(leftBytes, rightBytes)
+  );
 }
 
-function sameGrantState(left: SupportPassportGrantState, right: SupportPassportGrantState): boolean {
+function sameGrantState(
+  left: SupportPassportGrantState,
+  right: SupportPassportGrantState,
+): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function grantNotFound(): SupportPassportError {
-  return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
+  return new SupportPassportError(
+    "grant_not_found",
+    "The share link was not found.",
+    404,
+  );
 }
 
 function normalizeGrantId(grantId: unknown): string {
-  if (typeof grantId !== "string" || !UUID_INPUT.test(grantId)) throw grantNotFound();
+  if (typeof grantId !== "string" || !UUID_INPUT.test(grantId))
+    throw grantNotFound();
   return grantId.toLowerCase();
 }
 
 function normalizeNamespace(namespace: unknown): string {
   const parsed = SupportPassportNamespaceSchema.safeParse(namespace);
   if (!parsed.success) {
-    throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+    throw new SupportPassportError(
+      "invalid_input",
+      "The share link request is invalid.",
+      400,
+    );
   }
   return parsed.data;
 }
@@ -82,15 +118,21 @@ function normalizeNamespace(namespace: unknown): string {
 function normalizePrincipal(principal: unknown): string {
   const normalized = typeof principal === "string" ? principal.trim() : "";
   if (normalized.length < 1 || normalized.length > 512) {
-    throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+    throw new SupportPassportError(
+      "invalid_input",
+      "The share link request is invalid.",
+      400,
+    );
   }
   return normalized;
 }
 
 export async function syncDirectoryForDurability(
   directory: string,
-  openDirectory: (directory: string) => Promise<Pick<FileHandle, "sync" | "close">> = async (target) =>
-    await open(target, "r")
+  openDirectory: (
+    directory: string,
+  ) => Promise<Pick<FileHandle, "sync" | "close">> = async (target) =>
+    await open(target, "r"),
 ): Promise<void> {
   let handle: Pick<FileHandle, "sync" | "close"> | undefined;
   try {
@@ -116,7 +158,12 @@ export class SupportPassportGrantStore {
 
   constructor(options: SupportPassportGrantStoreOptions) {
     this.memoryDir = path.resolve(expandTildePath(options.memoryDir));
-    this.grantsDir = path.join(this.memoryDir, "state", "support-passport", "grants");
+    this.grantsDir = path.join(
+      this.memoryDir,
+      "state",
+      "support-passport",
+      "grants",
+    );
     this.ownerIndexesDir = path.join(this.grantsDir, "owners");
     this.now = options.now ?? (() => new Date());
     this.makeSecret = options.makeSecret ?? (() => randomBytes(32));
@@ -126,7 +173,7 @@ export class SupportPassportGrantStore {
 
   async create(
     input: CreateStoredGrantInput,
-    beforeCommit?: () => Promise<void>
+    beforeCommit?: () => Promise<void>,
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const namespace = normalizeNamespace(input.namespace);
     const parsed = SupportPassportCreateGrantInputSchema.safeParse({
@@ -135,21 +182,39 @@ export class SupportPassportGrantStore {
       expiresAt: input.expiresAt,
     });
     if (!parsed.success) {
-      throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+      throw new SupportPassportError(
+        "invalid_input",
+        "The share link request is invalid.",
+        400,
+      );
     }
     return await this.withMutationLock(async (lock) => {
       const secretBytes = this.makeSecret();
       if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
-        throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
+        throw new Error(
+          "SupportPassportGrantStore.makeSecret must return 32 bytes",
+        );
       }
       const rawGrantId = this.makeGrantId();
-      if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+      if (!UUID_INPUT.test(rawGrantId))
+        throw new Error(
+          "SupportPassportGrantStore.makeGrantId must return a UUID",
+        );
       const grantId = rawGrantId.toLowerCase();
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
-      const durationMs = Date.parse(parsed.data.expiresAt) - createdAt.getTime();
-      if (!Number.isFinite(durationMs) || durationMs < 300_000 || durationMs > 604_800_000) {
-        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+      const durationMs =
+        Date.parse(parsed.data.expiresAt) - createdAt.getTime();
+      if (
+        !Number.isFinite(durationMs) ||
+        durationMs < 300_000 ||
+        durationMs > 604_800_000
+      ) {
+        throw new SupportPassportError(
+          "invalid_input",
+          "The share link request is invalid.",
+          400,
+        );
       }
       const state = SupportPassportGrantStateSchema.parse({
         schemaVersion: 1,
@@ -164,17 +229,22 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
+      await this.requireMutationLock(lock);
       try {
         await this.writeState(state, true);
       } catch (error) {
-        const persisted = await this.readState(state.grantId).catch(() => undefined);
+        const persisted = await this.readState(state.grantId).catch(
+          () => undefined,
+        );
         if (!persisted || !sameGrantState(persisted, state)) throw error;
       }
       try {
         await this.addToOwnerIndex(state, lock);
       } catch (error) {
         const ownerHash = this.ownerHash(state.namespace, state.principalHash);
-        const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
+        const indexed = await this.readOwnerIndexByHash(ownerHash).catch(
+          () => undefined,
+        );
         if (indexed?.includes(state.grantId)) return { state, secret };
         await this.removeGrantStates([state.grantId]).catch(() => undefined);
         throw error;
@@ -183,23 +253,36 @@ export class SupportPassportGrantStore {
     });
   }
 
-  async authenticate(grantId: string, secret: string): Promise<SupportPassportGrantState> {
+  async authenticate(
+    grantId: string,
+    secret: string,
+  ): Promise<SupportPassportGrantState> {
     const normalizedGrantId = normalizeGrantId(grantId);
-    if (typeof secret !== "string" || secret.length > 512) throw grantNotFound();
+    if (typeof secret !== "string" || secret.length > 512)
+      throw grantNotFound();
     let state: SupportPassportGrantState;
     try {
       state = await this.readState(normalizedGrantId);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
+      if ((error as NodeJS.ErrnoException).code === "ENOENT")
+        throw grantNotFound();
       throw error;
     }
     const candidate = sha256("support-passport-secret:v1", secret);
     if (!hashesMatch(candidate, state.secretHash)) throw grantNotFound();
     if (state.revokedAt) {
-      throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
+      throw new SupportPassportError(
+        "grant_gone",
+        "The share link is no longer active.",
+        410,
+      );
     }
     if (Date.parse(state.expiresAt) <= this.now().getTime()) {
-      throw new SupportPassportError("grant_expired", "The share link has expired.", 410);
+      throw new SupportPassportError(
+        "grant_expired",
+        "The share link has expired.",
+        410,
+      );
     }
     return state;
   }
@@ -208,7 +291,7 @@ export class SupportPassportGrantStore {
     grantId: string,
     secret: string,
     task: (state: SupportPassportGrantState) => Promise<T>,
-    beforeReturn?: (state: SupportPassportGrantState) => Promise<void>
+    beforeReturn?: (state: SupportPassportGrantState) => Promise<void>,
   ): Promise<T> {
     return await this.withGrantLock(grantId, async (lock) => {
       const state = await this.authenticate(grantId, secret);
@@ -217,7 +300,11 @@ export class SupportPassportGrantStore {
       const finalState = await this.authenticate(grantId, secret);
       await this.requireMutationLock(lock);
       if (finalState.stateVersion !== state.stateVersion) {
-        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+        throw new SupportPassportError(
+          "grant_stale",
+          "The shared support guide has changed.",
+          410,
+        );
       }
       this.requireActiveState(finalState);
       await beforeReturn?.(finalState);
@@ -227,15 +314,26 @@ export class SupportPassportGrantStore {
     });
   }
 
-  async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
+  async listForOwner(
+    namespace: string,
+    principal: string,
+  ): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
-    const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
-    const grantIds = await this.readOwnerIndex(normalizedNamespace, principalHash);
+    const principalHash = computeSupportPassportOwnerKey(
+      normalizePrincipal(principal),
+    );
+    const grantIds = await this.readOwnerIndex(
+      normalizedNamespace,
+      principalHash,
+    );
     const states: SupportPassportGrantState[] = [];
     for (const grantId of grantIds) {
       try {
         const state = await this.readState(grantId);
-        if (state.namespace === normalizedNamespace && hashesMatch(state.principalHash, principalHash)) {
+        if (
+          state.namespace === normalizedNamespace &&
+          hashesMatch(state.principalHash, principalHash)
+        ) {
           states.push(state);
         }
       } catch (error) {
@@ -247,7 +345,10 @@ export class SupportPassportGrantStore {
       const aActive = !a.revokedAt && Date.parse(a.expiresAt) > activeCutoff;
       const bActive = !b.revokedAt && Date.parse(b.expiresAt) > activeCutoff;
       if (aActive !== bActive) return aActive ? -1 : 1;
-      return b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId);
+      return (
+        b.createdAt.localeCompare(a.createdAt) ||
+        a.grantId.localeCompare(b.grantId)
+      );
     });
   }
 
@@ -258,26 +359,40 @@ export class SupportPassportGrantStore {
       principal: string;
       expectedStateVersion?: number;
     },
-    beforeCommit?: () => Promise<void>
+    beforeCommit?: () => Promise<void>,
   ): Promise<SupportPassportGrantState> {
-    const normalizedInput = { ...input, grantId: normalizeGrantId(input.grantId) };
+    const normalizedInput = {
+      ...input,
+      grantId: normalizeGrantId(input.grantId),
+    };
     const namespace = normalizeNamespace(input.namespace);
     return await this.withGrantLock(normalizedInput.grantId, async (lock) => {
       let state: SupportPassportGrantState;
       try {
         state = await this.readState(normalizedInput.grantId);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
+        if ((error as NodeJS.ErrnoException).code === "ENOENT")
+          throw grantNotFound();
         throw error;
       }
-      const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(input.principal));
-      if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash)) throw grantNotFound();
+      const principalHash = computeSupportPassportOwnerKey(
+        normalizePrincipal(input.principal),
+      );
+      if (
+        state.namespace !== namespace ||
+        !hashesMatch(state.principalHash, principalHash)
+      )
+        throw grantNotFound();
       if (state.revokedAt) return state;
       if (
         normalizedInput.expectedStateVersion !== undefined &&
         normalizedInput.expectedStateVersion !== state.stateVersion
       ) {
-        throw new SupportPassportError("state_conflict", "The share link changed after it was loaded.", 409);
+        throw new SupportPassportError(
+          "state_conflict",
+          "The share link changed after it was loaded.",
+          409,
+        );
       }
       const revoked = SupportPassportGrantStateSchema.parse({
         ...state,
@@ -286,6 +401,7 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
+      await this.requireMutationLock(lock);
       await this.writeState(revoked);
       return revoked;
     });
@@ -297,15 +413,22 @@ export class SupportPassportGrantStore {
   }
 
   private ownerIndexPath(ownerHash: string): string {
-    if (!SAFE_OWNER_INDEX_HASH.test(ownerHash)) throw new Error("support passport owner index hash is invalid");
+    if (!SAFE_OWNER_INDEX_HASH.test(ownerHash))
+      throw new Error("support passport owner index hash is invalid");
     return path.join(this.ownerIndexesDir, `${ownerHash}.json`);
   }
 
   private ownerHash(namespace: string, principalHash: string): string {
-    return sha256("support-passport-owner-index:v1", `${namespace}\0${principalHash}`);
+    return sha256(
+      "support-passport-owner-index:v1",
+      `${namespace}\0${principalHash}`,
+    );
   }
 
-  private async addToOwnerIndex(state: SupportPassportGrantState, lock: HeldFileLockController): Promise<void> {
+  private async addToOwnerIndex(
+    state: SupportPassportGrantState,
+    lock: HeldFileLockController,
+  ): Promise<void> {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
@@ -319,7 +442,9 @@ export class SupportPassportGrantStore {
             indexedState.namespace !== state.namespace ||
             !hashesMatch(indexedState.principalHash, state.principalHash)
           ) {
-            throw new Error("support passport owner index references a foreign grant");
+            throw new Error(
+              "support passport owner index references a foreign grant",
+            );
           }
           indexedStates.push(indexedState);
         } catch (error) {
@@ -327,25 +452,38 @@ export class SupportPassportGrantStore {
         }
       }
       const expiryCutoff = this.now().getTime();
-      const active = indexedStates.filter((item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff);
+      const active = indexedStates.filter(
+        (item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff,
+      );
       if (active.length >= MAX_OWNER_GRANT_HISTORY) {
         throw new SupportPassportError(
           "invalid_input",
           "A support passport can contain at most 100 active share links.",
-          400
+          400,
         );
       }
       const inactive = indexedStates
-        .filter((item) => item.revokedAt || Date.parse(item.expiresAt) <= expiryCutoff)
-        .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
+        .filter(
+          (item) =>
+            item.revokedAt || Date.parse(item.expiresAt) <= expiryCutoff,
+        )
+        .sort(
+          (a, b) =>
+            b.createdAt.localeCompare(a.createdAt) ||
+            a.grantId.localeCompare(b.grantId),
+        );
       retained = [
         ...active.map((item) => item.grantId),
-        ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1).map((item) => item.grantId),
+        ...inactive
+          .slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1)
+          .map((item) => item.grantId),
       ];
     }
     const grantIds = [...retained, state.grantId];
     const retainedIds = new Set(grantIds);
-    const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
+    const evictedGrantIds = current.filter(
+      (grantId) => !retainedIds.has(grantId),
+    );
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
     try {
@@ -357,7 +495,7 @@ export class SupportPassportGrantStore {
       }
     } catch (error) {
       log.warn(
-        `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`
+        `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
@@ -371,12 +509,17 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       grantIds.map((grantId) => `${grantId}.json`),
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
   }
 
-  private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {
-    return await this.readOwnerIndexByHash(this.ownerHash(namespace, principalHash));
+  private async readOwnerIndex(
+    namespace: string,
+    principalHash: string,
+  ): Promise<string[]> {
+    return await this.readOwnerIndexByHash(
+      this.ownerHash(namespace, principalHash),
+    );
   }
 
   private async readOwnerIndexByHash(ownerHash: string): Promise<string[]> {
@@ -388,7 +531,7 @@ export class SupportPassportGrantStore {
         this.ownerIndexesDir,
         filePath,
         "support passport owner indexes must be regular files in a stable directory",
-        this.memoryDir
+        this.memoryDir,
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -400,21 +543,34 @@ export class SupportPassportGrantStore {
     }
     const record = parsed as Record<string, unknown>;
     const grantIds = record.grantIds;
-    if (record.schemaVersion !== 1 || record.ownerHash !== ownerHash || !Array.isArray(grantIds)) {
+    if (
+      record.schemaVersion !== 1 ||
+      record.ownerHash !== ownerHash ||
+      !Array.isArray(grantIds)
+    ) {
       throw new Error("support passport owner index is invalid");
     }
-    if (grantIds.some((grantId) => typeof grantId !== "string" || !SAFE_GRANT_ID.test(grantId))) {
+    if (
+      grantIds.some(
+        (grantId) =>
+          typeof grantId !== "string" || !SAFE_GRANT_ID.test(grantId),
+      )
+    ) {
       throw new Error("support passport owner index is invalid");
     }
     const uniqueGrantIds = new Set(grantIds as string[]);
-    if (uniqueGrantIds.size !== grantIds.length) throw new Error("support passport owner index is invalid");
+    if (uniqueGrantIds.size !== grantIds.length)
+      throw new Error("support passport owner index is invalid");
     if (uniqueGrantIds.size > MAX_OWNER_GRANT_HISTORY) {
       throw new Error("support passport owner index is invalid");
     }
     return [...uniqueGrantIds];
   }
 
-  private async writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void> {
+  private async writeOwnerIndex(
+    ownerHash: string,
+    grantIds: string[],
+  ): Promise<void> {
     const filePath = this.ownerIndexPath(ownerHash);
     try {
       const metadata = await lstat(filePath);
@@ -429,7 +585,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
       "support passport owner indexes must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
   }
 
@@ -440,21 +596,29 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       filePath,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
     const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
-    if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
+    if (state.grantId !== grantId)
+      throw new Error("support passport grant ID must match its file name");
     return state;
   }
 
-  private async writeState(state: SupportPassportGrantState, requireAbsent = false): Promise<void> {
+  private async writeState(
+    state: SupportPassportGrantState,
+    requireAbsent = false,
+  ): Promise<void> {
     const filePath = this.filePath(state.grantId);
     try {
       const metadata = await lstat(filePath);
       if (metadata.isSymbolicLink() || !metadata.isFile())
         throw new Error("support passport grant files must be regular files");
       if (requireAbsent) {
-        throw new SupportPassportError("storage_conflict", "A new share link could not be allocated.", 409);
+        throw new SupportPassportError(
+          "storage_conflict",
+          "A new share link could not be allocated.",
+          409,
+        );
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -464,7 +628,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify(state, null, 2)}\n`,
       "support passport grant files must be regular files in a stable directory",
-      this.memoryDir
+      this.memoryDir,
     );
   }
 
@@ -473,7 +637,7 @@ export class SupportPassportGrantStore {
     await ensurePrivateDirectoryNoFollow(
       this.memoryDir,
       this.ownerIndexesDir,
-      "support passport grant directories must remain inside the memory directory"
+      "support passport grant directories must remain inside the memory directory",
     );
   }
 
@@ -481,13 +645,19 @@ export class SupportPassportGrantStore {
     if (!this.memoryRootReady) {
       const configuredMemoryDir = this.memoryDir;
       this.memoryRootReady = (async () => {
-        const canonicalMemoryDir = await canonicalizePrivateDirectoryTarget(configuredMemoryDir);
+        const canonicalMemoryDir =
+          await canonicalizePrivateDirectoryTarget(configuredMemoryDir);
         await ensurePrivateDirectoryTreeNoFollow(
           canonicalMemoryDir,
-          "support passport memory directory must be a stable directory"
+          "support passport memory directory must be a stable directory",
         );
         this.memoryDir = canonicalMemoryDir;
-        this.grantsDir = path.join(canonicalMemoryDir, "state", "support-passport", "grants");
+        this.grantsDir = path.join(
+          canonicalMemoryDir,
+          "state",
+          "support-passport",
+          "grants",
+        );
         this.ownerIndexesDir = path.join(this.grantsDir, "owners");
       })();
     }
@@ -495,12 +665,15 @@ export class SupportPassportGrantStore {
     try {
       await currentAttempt;
     } catch (error) {
-      if (this.memoryRootReady === currentAttempt) this.memoryRootReady = undefined;
+      if (this.memoryRootReady === currentAttempt)
+        this.memoryRootReady = undefined;
       throw error;
     }
   }
 
-  private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
+  private async withMutationLock<T>(
+    task: (lock: HeldFileLockController) => Promise<T>,
+  ): Promise<T> {
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
       this.memoryDir,
@@ -510,12 +683,15 @@ export class SupportPassportGrantStore {
         await this.withExclusiveLock(
           `support-passport-grants:${this.grantsDir}`,
           path.join(pinnedDirectory, ".grants.lock"),
-          task
-        )
+          task,
+        ),
     );
   }
 
-  private async withGrantLock<T>(grantId: string, task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
+  private async withGrantLock<T>(
+    grantId: string,
+    task: (lock: HeldFileLockController) => Promise<T>,
+  ): Promise<T> {
     const normalizedGrantId = normalizeGrantId(grantId);
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
@@ -526,15 +702,15 @@ export class SupportPassportGrantStore {
         await this.withExclusiveLock(
           `support-passport-grant:${this.grantsDir}:${normalizedGrantId}`,
           path.join(pinnedDirectory, `.${normalizedGrantId}.lock`),
-          task
-        )
+          task,
+        ),
     );
   }
 
   private async withExclusiveLock<T>(
     serializationKey: string,
     lockPath: string,
-    task: (lock: HeldFileLockController) => Promise<T>
+    task: (lock: HeldFileLockController) => Promise<T>,
   ): Promise<T> {
     return await serializeMutations(serializationKey, () =>
       this.runWithHeldFileLock(
@@ -546,25 +722,43 @@ export class SupportPassportGrantStore {
         },
         async (acquired, lock) => {
           if (!acquired) {
-            throw new SupportPassportError("storage_conflict", "The share link store is busy. Try again.", 409);
+            throw new SupportPassportError(
+              "storage_conflict",
+              "The share link store is busy. Try again.",
+              409,
+            );
           }
           return await task(lock);
-        }
-      )
+        },
+      ),
     );
   }
 
-  private async requireMutationLock(lock: HeldFileLockController): Promise<void> {
+  private async requireMutationLock(
+    lock: HeldFileLockController,
+  ): Promise<void> {
     if (await lock.refresh()) return;
-    throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+    throw new SupportPassportError(
+      "storage_conflict",
+      "The share link store changed during the request.",
+      409,
+    );
   }
 
   private requireActiveState(state: SupportPassportGrantState): void {
     if (state.revokedAt) {
-      throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
+      throw new SupportPassportError(
+        "grant_gone",
+        "The share link is no longer active.",
+        410,
+      );
     }
     if (Date.parse(state.expiresAt) <= this.now().getTime()) {
-      throw new SupportPassportError("grant_expired", "The share link has expired.", 410);
+      throw new SupportPassportError(
+        "grant_expired",
+        "The share link has expired.",
+        410,
+      );
     }
   }
 }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -467,14 +467,18 @@ export class SupportPassportGrantStore {
       const indexedGrantIds = await this.readOwnerIndexByHash(ownerHash);
       const ownerStates: SupportPassportGrantState[] = [];
       for (const grantId of indexedGrantIds) {
-        const state = await this.readState(grantId);
-        if (
-          state.namespace !== committed.state.namespace ||
-          !hashesMatch(state.principalHash, committed.state.principalHash)
-        ) {
-          throw new Error("support passport owner index references a foreign grant");
+        try {
+          const state = await this.readState(grantId);
+          if (
+            state.namespace !== committed.state.namespace ||
+            !hashesMatch(state.principalHash, committed.state.principalHash)
+          ) {
+            throw new Error("support passport owner index references a foreign grant");
+          }
+          ownerStates.push(state);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
-        ownerStates.push(state);
       }
       const committedIndex = ownerStates.findIndex(
         (state) => state.grantId === committed.state.grantId,

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -183,7 +183,8 @@ export class SupportPassportGrantStore {
   async withAuthenticatedGrant<T>(
     grantId: string,
     secret: string,
-    task: (state: SupportPassportGrantState) => Promise<T>
+    task: (state: SupportPassportGrantState) => Promise<T>,
+    beforeReturn?: (state: SupportPassportGrantState) => Promise<void>
   ): Promise<T> {
     return await this.withGrantLock(grantId, async (lock) => {
       const state = await this.authenticate(grantId, secret);
@@ -194,6 +195,10 @@ export class SupportPassportGrantStore {
       if (finalState.stateVersion !== state.stateVersion) {
         throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
       }
+      this.requireActiveState(finalState);
+      await beforeReturn?.(finalState);
+      await this.requireMutationLock(lock);
+      this.requireActiveState(finalState);
       return result;
     });
   }
@@ -221,7 +226,7 @@ export class SupportPassportGrantStore {
     namespace: string;
     principal: string;
     expectedStateVersion?: number;
-  }): Promise<SupportPassportGrantState> {
+  }, beforeCommit?: () => Promise<void>): Promise<SupportPassportGrantState> {
     if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
     const namespace = normalizeNamespace(input.namespace);
     return await this.withGrantLock(input.grantId, async (lock) => {
@@ -244,6 +249,7 @@ export class SupportPassportGrantStore {
         revokedAt: this.now().toISOString(),
       });
       await this.requireMutationLock(lock);
+      await beforeCommit?.();
       await this.writeState(revoked);
       return revoked;
     });
@@ -485,5 +491,14 @@ export class SupportPassportGrantStore {
   private async requireMutationLock(lock: HeldFileLockController): Promise<void> {
     if (await lock.refresh()) return;
     throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
+  }
+
+  private requireActiveState(state: SupportPassportGrantState): void {
+    if (state.revokedAt) {
+      throw new SupportPassportError("grant_gone", "The share link is no longer active.", 410);
+    }
+    if (Date.parse(state.expiresAt) <= this.now().getTime()) {
+      throw new SupportPassportError("grant_expired", "The share link has expired.", 410);
+    }
   }
 }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { type FileHandle, lstat, open, readdir } from "node:fs/promises";
+import { type FileHandle, lstat, open } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
@@ -460,20 +460,36 @@ export class SupportPassportGrantStore {
       if (!persisted || !sameGrantState(persisted, committed.state)) {
         throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
       }
-      let ownerStates = await this.readAllOwnerStates(
-        committed.state.namespace,
-        committed.state.principalHash,
+      const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
+      const indexedGrantIds = await this.readOwnerIndexByHash(ownerHash);
+      const ownerStates: SupportPassportGrantState[] = [];
+      for (const grantId of indexedGrantIds) {
+        const state = await this.readState(grantId);
+        if (
+          state.namespace !== committed.state.namespace ||
+          !hashesMatch(state.principalHash, committed.state.principalHash)
+        ) {
+          throw new Error("support passport owner index references a foreign grant");
+        }
+        ownerStates.push(state);
+      }
+      const committedIndex = ownerStates.findIndex(
+        (state) => state.grantId === committed.state.grantId,
       );
+      if (committedIndex === -1) ownerStates.push(committed.state);
+      else ownerStates[committedIndex] = committed.state;
       const activeCutoff = this.now().getTime();
       const active = ownerStates.filter(
         (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
       );
       if (active.length > MAX_OWNER_GRANT_HISTORY) {
         await this.removeGrantStates([committed.state.grantId]);
-        ownerStates = ownerStates.filter((state) => state.grantId !== committed.state.grantId);
+        const committedIndex = ownerStates.findIndex(
+          (state) => state.grantId === committed.state.grantId,
+        );
+        if (committedIndex !== -1) ownerStates.splice(committedIndex, 1);
       }
       const retained = this.retainedOwnerStates(ownerStates, activeCutoff);
-      const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
       await this.requireMutationLock(lock);
       await this.writeOwnerIndex(ownerHash, retained.map((state) => state.grantId));
       await this.requireOwnerIndexLock(lock);
@@ -501,29 +517,6 @@ export class SupportPassportGrantStore {
       ...active,
       ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length),
     ];
-  }
-
-  private async readAllOwnerStates(
-    namespace: string,
-    principalHash: string,
-  ): Promise<SupportPassportGrantState[]> {
-    const grantIds = await withPrivateDirectoryNoFollow(
-      path.parse(this.memoryDir).root,
-      this.grantsDir,
-      "support passport grant files must be regular files in a stable directory",
-      async (pinnedDirectory) => (await readdir(pinnedDirectory, { withFileTypes: true }))
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-        .map((entry) => entry.name.slice(0, -".json".length))
-        .filter((grantId) => SAFE_GRANT_ID.test(grantId)),
-    );
-    const states: SupportPassportGrantState[] = [];
-    for (const grantId of grantIds) {
-      const state = await this.readState(grantId);
-      if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) {
-        states.push(state);
-      }
-    }
-    return states;
   }
 
   private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -164,6 +164,7 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
+      await this.requireMutationLock(lock);
       try {
         await this.writeState(state, true);
       } catch (error) {
@@ -286,6 +287,7 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
+      await this.requireMutationLock(lock);
       await this.writeState(revoked);
       return revoked;
     });

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import path from "node:path";
 
 import { expandTildePath } from "../utils/path.js";
@@ -16,6 +16,7 @@ const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
 const GRANT_LOCK_HEARTBEAT_MS = 10_000;
 const SAFE_GRANT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
 
 export interface SupportPassportGrantStoreOptions {
   memoryDir: string;
@@ -80,6 +81,7 @@ async function writePrivateFileAtomically(filePath: string, content: string): Pr
 export class SupportPassportGrantStore {
   private readonly memoryDir: string;
   private readonly grantsDir: string;
+  private readonly ownerIndexesDir: string;
   private readonly now: () => Date;
   private readonly makeSecret: () => Buffer;
   private readonly makeGrantId: () => string;
@@ -87,6 +89,7 @@ export class SupportPassportGrantStore {
   constructor(options: SupportPassportGrantStoreOptions) {
     this.memoryDir = path.resolve(expandTildePath(options.memoryDir));
     this.grantsDir = path.join(this.memoryDir, "state", "support-passport", "grants");
+    this.ownerIndexesDir = path.join(this.grantsDir, "owners");
     this.now = options.now ?? (() => new Date());
     this.makeSecret = options.makeSecret ?? (() => randomBytes(32));
     this.makeGrantId = options.makeGrantId ?? randomUUID;
@@ -131,6 +134,12 @@ export class SupportPassportGrantStore {
         expiresAt: parsed.data.expiresAt,
       });
       await this.writeState(state, true);
+      try {
+        await this.addToOwnerIndex(state);
+      } catch (error) {
+        await rm(this.filePath(state.grantId), { force: true }).catch(() => undefined);
+        throw error;
+      }
       return { state, secret };
     });
   }
@@ -157,15 +166,10 @@ export class SupportPassportGrantStore {
   }
 
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
-    await this.ensureSafeDirectories();
-    const entries = await readdir(this.grantsDir, { withFileTypes: true });
     const principalHash = sha256("support-passport-principal:v1", principal);
+    const grantIds = await this.readOwnerIndex(namespace, principalHash);
     const states: SupportPassportGrantState[] = [];
-    for (const entry of entries) {
-      if (entry.isSymbolicLink()) continue;
-      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-      const grantId = entry.name.slice(0, -5);
-      if (!SAFE_GRANT_ID.test(grantId)) continue;
+    for (const grantId of grantIds) {
       try {
         const state = await this.readState(grantId);
         if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) states.push(state);
@@ -211,6 +215,71 @@ export class SupportPassportGrantStore {
     return path.join(this.grantsDir, `${grantId}.json`);
   }
 
+  private ownerIndexPath(ownerHash: string): string {
+    if (!SAFE_OWNER_INDEX_HASH.test(ownerHash)) throw new Error("support passport owner index hash is invalid");
+    return path.join(this.ownerIndexesDir, `${ownerHash}.json`);
+  }
+
+  private ownerHash(namespace: string, principalHash: string): string {
+    return sha256("support-passport-owner-index:v1", `${namespace}\0${principalHash}`);
+  }
+
+  private async addToOwnerIndex(state: SupportPassportGrantState): Promise<void> {
+    const ownerHash = this.ownerHash(state.namespace, state.principalHash);
+    const current = await this.readOwnerIndexByHash(ownerHash);
+    if (current.includes(state.grantId)) return;
+    const grantIds = [...current, state.grantId].sort((a, b) => a.localeCompare(b));
+    await this.writeOwnerIndex(ownerHash, grantIds);
+  }
+
+  private async readOwnerIndex(namespace: string, principalHash: string): Promise<string[]> {
+    return await this.readOwnerIndexByHash(this.ownerHash(namespace, principalHash));
+  }
+
+  private async readOwnerIndexByHash(ownerHash: string): Promise<string[]> {
+    await this.ensureSafeDirectories();
+    const filePath = this.ownerIndexPath(ownerHash);
+    let content: string;
+    try {
+      const metadata = await lstat(filePath);
+      if (metadata.isSymbolicLink() || !metadata.isFile()) {
+        throw new Error("support passport owner indexes must be regular files");
+      }
+      content = await readFile(filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const parsed: unknown = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("support passport owner index is invalid");
+    }
+    const record = parsed as Record<string, unknown>;
+    const grantIds = record.grantIds;
+    if (record.schemaVersion !== 1 || record.ownerHash !== ownerHash || !Array.isArray(grantIds)) {
+      throw new Error("support passport owner index is invalid");
+    }
+    if (grantIds.some((grantId) => typeof grantId !== "string" || !SAFE_GRANT_ID.test(grantId))) {
+      throw new Error("support passport owner index is invalid");
+    }
+    const uniqueGrantIds = new Set(grantIds as string[]);
+    if (uniqueGrantIds.size !== grantIds.length) throw new Error("support passport owner index is invalid");
+    return [...uniqueGrantIds];
+  }
+
+  private async writeOwnerIndex(ownerHash: string, grantIds: string[]): Promise<void> {
+    const filePath = this.ownerIndexPath(ownerHash);
+    try {
+      const metadata = await lstat(filePath);
+      if (metadata.isSymbolicLink() || !metadata.isFile()) {
+        throw new Error("support passport owner indexes must be regular files");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    await writePrivateFileAtomically(filePath, `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`);
+  }
+
   private async readState(grantId: string): Promise<SupportPassportGrantState> {
     await this.ensureSafeDirectories();
     const filePath = this.filePath(grantId);
@@ -241,6 +310,7 @@ export class SupportPassportGrantStore {
       path.join(this.memoryDir, "state"),
       path.join(this.memoryDir, "state", "support-passport"),
       this.grantsDir,
+      this.ownerIndexesDir,
     ];
     for (const directory of directories) {
       await mkdir(directory, { recursive: true, mode: 0o700 });

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -72,9 +72,7 @@ export interface SupportPassportGrantMutationHooks {
   onCommitted?: () => void | Promise<void>;
 }
 
-type SupportPassportGrantCreateHooks =
-  | SupportPassportGrantMutationHooks
-  | (() => Promise<void>);
+type SupportPassportGrantCreateHooks = SupportPassportGrantMutationHooks | (() => Promise<void>);
 type SupportPassportGrantRevokeHooks = SupportPassportGrantMutationHooks | (() => Promise<void>);
 
 function sha256(domain: string, value: string): string {
@@ -356,6 +354,9 @@ export class SupportPassportGrantStore {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
       }
+      if (await this.ownerIndexRecoveryRequired(ownerHash)) {
+        states = await this.readOwnerMembershipStates(normalizedNamespace, principalHash);
+      }
     }
     const activeCutoff = this.now().getTime();
     return states.sort((a, b) => {
@@ -434,23 +435,36 @@ export class SupportPassportGrantStore {
 
   private async addToOwnerIndex(state: SupportPassportGrantState, lock: HeldFileLockController): Promise<void> {
     const ownerHash = this.ownerHash(state.namespace, state.principalHash);
-    const current = await this.readOwnerIndexByHash(ownerHash);
+    let recoveredStates: SupportPassportGrantState[] | undefined;
+    let current: string[];
+    if (await this.ownerIndexRecoveryRequired(ownerHash)) {
+      recoveredStates = (await this.readOwnerMembershipStates(state.namespace, state.principalHash))
+        .filter((item) => item.grantId !== state.grantId)
+        .sort(newestGrantFirst);
+      current = recoveredStates.map((item) => item.grantId);
+    } else {
+      current = await this.readOwnerIndexByHash(ownerHash);
+    }
     if (current.includes(state.grantId)) return;
     let retained = current;
     const indexedStates: SupportPassportGrantState[] = [];
     if (current.length >= MAX_OWNER_GRANT_HISTORY) {
-      for (const grantId of current) {
-        try {
-          const indexedState = await this.readState(grantId);
-          if (
-            indexedState.namespace !== state.namespace ||
-            !hashesMatch(indexedState.principalHash, state.principalHash)
-          ) {
-            throw new Error("support passport owner index references a foreign grant");
+      if (recoveredStates) {
+        indexedStates.push(...recoveredStates);
+      } else {
+        for (const grantId of current) {
+          try {
+            const indexedState = await this.readState(grantId);
+            if (
+              indexedState.namespace !== state.namespace ||
+              !hashesMatch(indexedState.principalHash, state.principalHash)
+            ) {
+              throw new Error("support passport owner index references a foreign grant");
+            }
+            indexedStates.push(indexedState);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
           }
-          indexedStates.push(indexedState);
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
       }
       const expiryCutoff = this.now().getTime();
@@ -500,7 +514,7 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       grantIds.map((grantId) => `${grantId}.json`),
       "support passport grant files must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
@@ -514,7 +528,7 @@ export class SupportPassportGrantStore {
     await ensurePrivateDirectoryNoFollow(
       this.memoryDir,
       directory,
-      "support passport owner membership must remain inside the memory directory",
+      "support passport owner membership must remain inside the memory directory"
     );
     return directory;
   }
@@ -527,7 +541,7 @@ export class SupportPassportGrantStore {
       path.join(directory, `${state.grantId}.json`),
       `${JSON.stringify({ schemaVersion: 1, grantId: state.grantId })}\n`,
       "support passport owner membership must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
@@ -538,7 +552,7 @@ export class SupportPassportGrantStore {
       directory,
       [`${state.grantId}.json`],
       "support passport owner membership must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
@@ -559,7 +573,7 @@ export class SupportPassportGrantStore {
       path.join(directory, fileName),
       `${JSON.stringify({ schemaVersion: 1, grantId: normalizeGrantId(grantId) })}\n`,
       "support passport owner recovery markers must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
@@ -569,11 +583,15 @@ export class SupportPassportGrantStore {
       directory,
       [this.ownerIndexRecoveryMarkerName(grantId)],
       "support passport owner recovery markers must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
   private async ownerIndexRecoveryRequired(ownerHash: string): Promise<boolean> {
+    return (await this.ownerIndexRecoveryGrantIds(ownerHash)).length > 0;
+  }
+
+  private async ownerIndexRecoveryGrantIds(ownerHash: string): Promise<string[]> {
     await this.ensureSafeDirectories();
     const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
     return await withPrivateDirectoryNoFollow(
@@ -581,15 +599,16 @@ export class SupportPassportGrantStore {
       directory,
       "support passport owner indexes must be regular files in a stable directory",
       async (pinnedDirectory) => {
+        const grantIds: string[] = [];
         for (const entry of await readdir(pinnedDirectory, { withFileTypes: true })) {
           if (!SAFE_OWNER_INDEX_RECOVERY_MARKER.test(entry.name)) continue;
           if (!entry.isFile()) {
             throw new Error("support passport owner recovery markers must be regular files");
           }
-          return true;
+          grantIds.push(entry.name.slice(".index-recovery-".length, -".json".length));
         }
-        return false;
-      },
+        return grantIds.sort();
+      }
     );
   }
 
@@ -597,23 +616,28 @@ export class SupportPassportGrantStore {
     ownerHash: string,
     grantIds: string[],
     recoveryGrantId: string,
-    lock: HeldFileLockController,
+    lock: HeldFileLockController
   ): Promise<void> {
+    const priorRecoveryGrantIds = await this.ownerIndexRecoveryGrantIds(ownerHash);
     await this.writeOwnerIndexRecoveryMarker(ownerHash, recoveryGrantId);
     await this.requireOwnerIndexLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
-    await this.requireOwnerIndexLock(lock);
-    await this.removeOwnerIndexRecoveryMarker(ownerHash, recoveryGrantId);
+    for (const markerGrantId of new Set([...priorRecoveryGrantIds, recoveryGrantId])) {
+      await this.requireOwnerIndexLock(lock);
+      await this.removeOwnerIndexRecoveryMarker(ownerHash, markerGrantId);
+    }
   }
 
-  private async reconcileCreateAfterOwnerIndexLockLoss(
-    committed: { state: SupportPassportGrantState; secret: string },
-  ): Promise<{ state: SupportPassportGrantState; secret: string }> {
+  private async reconcileCreateAfterOwnerIndexLockLoss(committed: {
+    state: SupportPassportGrantState;
+    secret: string;
+  }): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
     for (let attempt = 1; attempt <= MAX_OWNER_INDEX_RECOVERY_ATTEMPTS; attempt += 1) {
       try {
-        return await this.withOwnerIndexLock(ownerHash, async (lock) =>
-          await this.reconcileCommittedGrant(committed, ownerHash, lock)
+        return await this.withOwnerIndexLock(
+          ownerHash,
+          async (lock) => await this.reconcileCommittedGrant(committed, ownerHash, lock)
         );
       } catch (error) {
         if (!(error instanceof OwnerIndexLockLostError)) throw error;
@@ -625,7 +649,7 @@ export class SupportPassportGrantStore {
   private async reconcileCommittedGrant(
     committed: { state: SupportPassportGrantState; secret: string },
     ownerHash: string,
-    lock: HeldFileLockController,
+    lock: HeldFileLockController
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const persisted = await this.readState(committed.state.grantId).catch(() => undefined);
     if (!persisted || !sameGrantState(persisted, committed.state)) {
@@ -647,19 +671,14 @@ export class SupportPassportGrantStore {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       }
     }
-    const memberStates = await this.readOwnerMembershipStates(
-      committed.state.namespace,
-      committed.state.principalHash,
-    );
+    const memberStates = await this.readOwnerMembershipStates(committed.state.namespace, committed.state.principalHash);
     const indexedGrantIdSet = new Set(ownerStates.map((state) => state.grantId));
     ownerStates.push(...memberStates.filter((state) => !indexedGrantIdSet.has(state.grantId)));
     const committedIndex = ownerStates.findIndex((state) => state.grantId === committed.state.grantId);
     if (committedIndex === -1) ownerStates.push(committed.state);
     else ownerStates[committedIndex] = committed.state;
     const activeCutoff = this.now().getTime();
-    const active = ownerStates.filter(
-      (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
-    );
+    const active = ownerStates.filter((state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff);
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
       await this.removeStoredGrant(committed.state);
       const committedIndex = ownerStates.findIndex((state) => state.grantId === committed.state.grantId);
@@ -670,7 +689,7 @@ export class SupportPassportGrantStore {
       ownerHash,
       retained.map((state) => state.grantId),
       committed.state.grantId,
-      lock,
+      lock
     );
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
       throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
@@ -678,28 +697,20 @@ export class SupportPassportGrantStore {
     return committed;
   }
 
-  private retainedOwnerStates(
-    states: SupportPassportGrantState[],
-    activeCutoff: number,
-  ): SupportPassportGrantState[] {
-    const active = states.filter(
-      (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
-    );
+  private retainedOwnerStates(states: SupportPassportGrantState[], activeCutoff: number): SupportPassportGrantState[] {
+    const active = states.filter((state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff);
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
       throw new Error("support passport owner has too many active grants");
     }
     const inactive = states
       .filter((state) => state.revokedAt || Date.parse(state.expiresAt) <= activeCutoff)
       .sort(newestGrantFirst);
-    return [
-      ...active,
-      ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length),
-    ];
+    return [...active, ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length)];
   }
 
   private async readOwnerMembershipStates(
     namespace: string,
-    principalHash: string,
+    principalHash: string
   ): Promise<SupportPassportGrantState[]> {
     await this.ensureSafeDirectories();
     const ownerHash = this.ownerHash(namespace, principalHash);
@@ -714,7 +725,7 @@ export class SupportPassportGrantStore {
           .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
           .map((entry) => entry.name.slice(0, -5))
           .filter((grantId) => SAFE_GRANT_ID.test(grantId));
-      },
+      }
     );
     const ownerStates: SupportPassportGrantState[] = [];
     for (const grantId of grantIds) {
@@ -740,7 +751,7 @@ export class SupportPassportGrantStore {
         this.ownerIndexesDir,
         filePath,
         "support passport owner indexes must be regular files in a stable directory",
-        path.parse(this.memoryDir).root,
+        path.parse(this.memoryDir).root
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -781,7 +792,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
       "support passport owner indexes must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
@@ -792,7 +803,7 @@ export class SupportPassportGrantStore {
       this.grantsDir,
       filePath,
       "support passport grant files must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
     try {
       const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
@@ -826,7 +837,7 @@ export class SupportPassportGrantStore {
       filePath,
       `${JSON.stringify(state, null, 2)}\n`,
       "support passport grant files must be regular files in a stable directory",
-      path.parse(this.memoryDir).root,
+      path.parse(this.memoryDir).root
     );
   }
 
@@ -839,7 +850,7 @@ export class SupportPassportGrantStore {
           this.ownerIndexesDir,
           "support passport grant directories must remain inside the memory directory",
           undefined,
-          true,
+          true
         );
       })();
     }
@@ -859,7 +870,7 @@ export class SupportPassportGrantStore {
         await ensurePrivateDirectoryTreeNoFollow(
           configuredMemoryDir,
           "support passport memory directory must be a stable directory",
-          undefined,
+          undefined
         );
         this.memoryDir = configuredMemoryDir;
         this.grantsDir = path.join(configuredMemoryDir, "state", "support-passport", "grants");
@@ -886,7 +897,7 @@ export class SupportPassportGrantStore {
           `support-passport-grants:${this.grantsDir}`,
           path.join(pinnedDirectory, ".grants.lock"),
           task
-        ),
+        )
     );
   }
 
@@ -902,13 +913,13 @@ export class SupportPassportGrantStore {
           `support-passport-grant:${this.grantsDir}:${normalizedGrantId}`,
           path.join(pinnedDirectory, `.${normalizedGrantId}.lock`),
           task
-        ),
+        )
     );
   }
 
   private async withOwnerIndexLock<T>(
     ownerHash: string,
-    task: (lock: HeldFileLockController) => Promise<T>,
+    task: (lock: HeldFileLockController) => Promise<T>
   ): Promise<T> {
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(
@@ -919,8 +930,8 @@ export class SupportPassportGrantStore {
         await this.withExclusiveLock(
           `support-passport-owner:${this.ownerIndexesDir}:${ownerHash}`,
           path.join(pinnedDirectory, `.${ownerHash}.lock`),
-          task,
-        ),
+          task
+        )
     );
   }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -176,7 +176,15 @@ export class SupportPassportGrantStore {
       } catch (error) {
         const ownerHash = this.ownerHash(state.namespace, state.principalHash);
         const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
-        if (indexed?.includes(state.grantId)) return { state, secret };
+        if (indexed?.includes(state.grantId)) {
+          try {
+            await syncDirectoryForDurability(this.ownerIndexesDir);
+            return { state, secret };
+          } catch {
+            await this.removeGrantStates([state.grantId]).catch(() => undefined);
+            throw error;
+          }
+        }
         await this.removeGrantStates([state.grantId]).catch(() => undefined);
         throw error;
       }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,4 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { constants as fsConstants, type Stats } from "node:fs";
 import { chmod, lstat, mkdir, open, rename, rm, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
@@ -16,6 +15,7 @@ import {
   type SupportPassportGrantState,
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
+import { readPrivateFileNoFollow } from "./private-file.js";
 
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
@@ -66,48 +66,6 @@ export async function syncDirectoryForDurability(
     if (!UNSUPPORTED_DIRECTORY_SYNC_ERRORS.has(code ?? "")) throw error;
   } finally {
     await handle?.close().catch(() => undefined);
-  }
-}
-
-function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
-  if (
-    before.isSymbolicLink() ||
-    !before.isDirectory() ||
-    after.isSymbolicLink() ||
-    !after.isDirectory() ||
-    before.dev !== opened.dev ||
-    before.ino !== opened.ino ||
-    after.dev !== opened.dev ||
-    after.ino !== opened.ino
-  ) {
-    throw new Error(errorMessage);
-  }
-}
-
-async function readPrivateFileNoFollow(directory: string, filePath: string, errorMessage: string): Promise<string> {
-  const before = await lstat(directory);
-  let directoryHandle: FileHandle | undefined;
-  let fileHandle: FileHandle | undefined;
-  try {
-    directoryHandle = await open(
-      directory,
-      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW
-    );
-    const opened = await directoryHandle.stat();
-    assertStableDirectory(before, opened, await lstat(directory), errorMessage);
-    try {
-      fileHandle = await open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
-      throw error;
-    }
-    const fileMetadata = await fileHandle.stat();
-    assertStableDirectory(before, opened, await lstat(directory), errorMessage);
-    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
-    return await fileHandle.readFile("utf8");
-  } finally {
-    await fileHandle?.close().catch(() => undefined);
-    await directoryHandle?.close().catch(() => undefined);
   }
 }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -340,7 +340,7 @@ export class SupportPassportGrantStore {
     const normalizedNamespace = normalizeNamespace(namespace);
     const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
     const activeCutoff = this.now().getTime();
-    const states = this.retainedOwnerStates(
+    const states = this.listedOwnerStates(
       await this.readOwnerMembershipStates(normalizedNamespace, principalHash),
       activeCutoff
     );
@@ -563,7 +563,10 @@ export class SupportPassportGrantStore {
     const activeCutoff = this.now().getTime();
     const active = ownerStates.filter((state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff);
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
-      await this.removeStoredGrant(committed.state);
+      await this.withGrantLock(committed.state.grantId, async (grantLock) => {
+        await this.requireMutationLock(grantLock);
+        await this.removeStoredGrant(committed.state);
+      });
       const committedIndex = ownerStates.findIndex((state) => state.grantId === committed.state.grantId);
       if (committedIndex !== -1) ownerStates.splice(committedIndex, 1);
     }
@@ -576,10 +579,16 @@ export class SupportPassportGrantStore {
     const retainedIds = new Set(retained.map((state) => state.grantId));
     for (const state of ownerStates) {
       if (retainedIds.has(state.grantId)) continue;
-      await this.withGrantLock(state.grantId, async (grantLock) => {
-        await this.requireMutationLock(grantLock);
-        await this.removeStoredGrant(state);
-      });
+      try {
+        await this.withGrantLock(state.grantId, async (grantLock) => {
+          await this.requireMutationLock(grantLock);
+          await this.removeStoredGrant(state);
+        });
+      } catch (error) {
+        log.warn(
+          `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
     }
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
       throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
@@ -590,12 +599,20 @@ export class SupportPassportGrantStore {
   private retainedOwnerStates(states: SupportPassportGrantState[], activeCutoff: number): SupportPassportGrantState[] {
     const active = states.filter((state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff);
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
-      throw new Error("support passport owner has too many active grants");
+      throw new SupportPassportError("storage_conflict", "The share link store contains too many active links.", 409);
     }
     const inactive = states
       .filter((state) => state.revokedAt || Date.parse(state.expiresAt) <= activeCutoff)
       .sort(newestGrantFirst);
     return [...active, ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length)];
+  }
+
+  private listedOwnerStates(states: SupportPassportGrantState[], activeCutoff: number): SupportPassportGrantState[] {
+    const active = states.filter((state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff);
+    const inactive = states
+      .filter((state) => state.revokedAt || Date.parse(state.expiresAt) <= activeCutoff)
+      .sort(newestGrantFirst);
+    return [...active, ...inactive.slice(0, Math.max(0, MAX_OWNER_GRANT_HISTORY - active.length))];
   }
 
   private async requireAvailableOwnerGrantSlot(namespace: string, principalHash: string): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -65,6 +65,10 @@ function sameGrantState(left: SupportPassportGrantState, right: SupportPassportG
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function newestGrantFirst(left: SupportPassportGrantState, right: SupportPassportGrantState): number {
+  return Date.parse(right.createdAt) - Date.parse(left.createdAt) || left.grantId.localeCompare(right.grantId);
+}
+
 function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
 }
@@ -278,7 +282,7 @@ export class SupportPassportGrantStore {
       const aActive = !a.revokedAt && Date.parse(a.expiresAt) > activeCutoff;
       const bActive = !b.revokedAt && Date.parse(b.expiresAt) > activeCutoff;
       if (aActive !== bActive) return aActive ? -1 : 1;
-      return b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId);
+      return newestGrantFirst(a, b);
     });
   }
 
@@ -369,7 +373,7 @@ export class SupportPassportGrantStore {
       }
       const inactive = indexedStates
         .filter((item) => item.revokedAt || Date.parse(item.expiresAt) <= expiryCutoff)
-        .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
+        .sort(newestGrantFirst);
       retained = [
         ...active.map((item) => item.grantId),
         ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length - 1).map((item) => item.grantId),

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -316,7 +316,12 @@ export class SupportPassportGrantStore {
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
     try {
-      await this.removeGrantStates(evictedGrantIds);
+      for (const grantId of evictedGrantIds) {
+        await this.withGrantLock(grantId, async (grantLock) => {
+          await this.requireMutationLock(grantLock);
+          await this.removeGrantStates([grantId]);
+        });
+      }
     } catch (error) {
       log.warn(
         `support passport could not remove inactive grant state: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -99,7 +99,7 @@ function warnCommitNotificationFailure(error: unknown): void {
   log.warn(`support passport commit notification failed: ${error instanceof Error ? error.message : String(error)}`);
 }
 
-function notifyCommitted(callback: (() => void | Promise<void>) | undefined): void {
+export function notifySupportPassportCommitted(callback: (() => void | Promise<void>) | undefined): void {
   try {
     const completion = callback?.();
     if (completion) void Promise.resolve(completion).catch(warnCommitNotificationFailure);
@@ -279,7 +279,7 @@ export class SupportPassportGrantStore {
         if (!(error instanceof OwnerIndexLockLostError) || !committed) throw error;
         finalized = await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
       }
-      notifyCommitted(mutationHooks.onCommitted);
+      notifySupportPassportCommitted(mutationHooks.onCommitted);
       return finalized;
     } catch (error) {
       if (committed) {
@@ -395,7 +395,7 @@ export class SupportPassportGrantStore {
         if (!persisted || !sameGrantState(persisted, revoked)) throw error;
         await this.syncDirectory(this.grantsDir);
       }
-      notifyCommitted(mutationHooks.onCommitted);
+      notifySupportPassportCommitted(mutationHooks.onCommitted);
       return revoked;
     });
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -8,6 +8,7 @@ import { type HeldFileLockController, serializeMutations, withHeldFileLock } fro
 import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
+import { computeSupportPassportOwnerLockKey } from "./owner-lock.js";
 import {
   SupportPassportCreateGrantInputSchema,
   type SupportPassportGrantCardRef,
@@ -39,6 +40,7 @@ export interface SupportPassportGrantStoreOptions {
   makeSecret?: () => Buffer;
   makeGrantId?: () => string;
   withHeldFileLock?: typeof withHeldFileLock;
+  syncDirectory?: typeof syncDirectoryForDurability;
 }
 
 export interface CreateStoredGrantInput {
@@ -46,6 +48,7 @@ export interface CreateStoredGrantInput {
   principal: string;
   cards: SupportPassportGrantCardRef[];
   expiresAt: string;
+  requestedAt?: Date;
 }
 
 function sha256(domain: string, value: string): string {
@@ -113,6 +116,7 @@ export class SupportPassportGrantStore {
   private readonly makeSecret: () => Buffer;
   private readonly makeGrantId: () => string;
   private readonly runWithHeldFileLock: typeof withHeldFileLock;
+  private readonly syncDirectory: typeof syncDirectoryForDurability;
 
   constructor(options: SupportPassportGrantStoreOptions) {
     this.memoryDir = path.resolve(expandTildePath(options.memoryDir));
@@ -122,6 +126,7 @@ export class SupportPassportGrantStore {
     this.makeSecret = options.makeSecret ?? (() => randomBytes(32));
     this.makeGrantId = options.makeGrantId ?? randomUUID;
     this.runWithHeldFileLock = options.withHeldFileLock ?? withHeldFileLock;
+    this.syncDirectory = options.syncDirectory ?? syncDirectoryForDurability;
   }
 
   async create(
@@ -137,6 +142,16 @@ export class SupportPassportGrantStore {
     if (!parsed.success) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
+    const requestedAt = input.requestedAt ?? this.now();
+    const durationMs = Date.parse(parsed.data.expiresAt) - requestedAt.getTime();
+    if (
+      !Number.isFinite(requestedAt.getTime()) ||
+      !Number.isFinite(durationMs) ||
+      durationMs < 300_000 ||
+      durationMs > 604_800_000
+    ) {
+      throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+    }
     return await this.withMutationLock(async (lock) => {
       const secretBytes = this.makeSecret();
       if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
@@ -147,16 +162,13 @@ export class SupportPassportGrantStore {
       const grantId = rawGrantId.toLowerCase();
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
-      const durationMs = Date.parse(parsed.data.expiresAt) - createdAt.getTime();
-      if (!Number.isFinite(durationMs) || durationMs < 300_000 || durationMs > 604_800_000) {
-        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
-      }
       const state = SupportPassportGrantStateSchema.parse({
         schemaVersion: 1,
         stateVersion: 1,
         grantId,
         namespace,
         principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
+        ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
         secretHash: sha256("support-passport-secret:v1", secret),
         cards: parsed.data.cards,
         createdAt: createdAt.toISOString(),
@@ -170,6 +182,12 @@ export class SupportPassportGrantStore {
       } catch (error) {
         const persisted = await this.readState(state.grantId).catch(() => undefined);
         if (!persisted || !sameGrantState(persisted, state)) throw error;
+        try {
+          await this.syncDirectory(this.grantsDir);
+        } catch {
+          await this.removeGrantStates([state.grantId]).catch(() => undefined);
+          throw error;
+        }
       }
       try {
         await this.addToOwnerIndex(state, lock);
@@ -178,7 +196,7 @@ export class SupportPassportGrantStore {
         const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
         if (indexed?.includes(state.grantId)) {
           try {
-            await syncDirectoryForDurability(this.ownerIndexesDir);
+            await this.syncDirectory(this.ownerIndexesDir);
             return { state, secret };
           } catch {
             await this.removeGrantStates([state.grantId]).catch(() => undefined);

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -187,6 +187,11 @@ export class SupportPassportGrantStore {
       const state = await this.authenticate(grantId, secret);
       const result = await task(state);
       await this.requireMutationLock(lock);
+      const finalState = await this.authenticate(grantId, secret);
+      await this.requireMutationLock(lock);
+      if (finalState.stateVersion !== state.stateVersion) {
+        throw new SupportPassportError("grant_stale", "The shared support guide has changed.", 410);
+      }
       return result;
     });
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { lstat, mkdir, open, type FileHandle } from "node:fs/promises";
+import { type FileHandle, lstat, mkdir, open } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "../logger.js";
@@ -221,12 +221,15 @@ export class SupportPassportGrantStore {
     return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
   }
 
-  async revoke(input: {
-    grantId: string;
-    namespace: string;
-    principal: string;
-    expectedStateVersion?: number;
-  }, beforeCommit?: () => Promise<void>): Promise<SupportPassportGrantState> {
+  async revoke(
+    input: {
+      grantId: string;
+      namespace: string;
+      principal: string;
+      expectedStateVersion?: number;
+    },
+    beforeCommit?: () => Promise<void>
+  ): Promise<SupportPassportGrantState> {
     if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
     const namespace = normalizeNamespace(input.namespace);
     return await this.withGrantLock(input.grantId, async (lock) => {
@@ -278,15 +281,20 @@ export class SupportPassportGrantStore {
       const indexedStates: SupportPassportGrantState[] = [];
       for (const grantId of current) {
         try {
-          indexedStates.push(await this.readState(grantId));
+          const indexedState = await this.readState(grantId);
+          if (
+            indexedState.namespace !== state.namespace ||
+            !hashesMatch(indexedState.principalHash, state.principalHash)
+          ) {
+            throw new Error("support passport owner index references a foreign grant");
+          }
+          indexedStates.push(indexedState);
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
       }
       const expiryCutoff = this.now().getTime();
-      const active = indexedStates.filter(
-        (item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff
-      );
+      const active = indexedStates.filter((item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff);
       if (active.length >= MAX_OWNER_GRANT_HISTORY) {
         throw new SupportPassportError(
           "invalid_input",
@@ -446,10 +454,7 @@ export class SupportPassportGrantStore {
     );
   }
 
-  private async withGrantLock<T>(
-    grantId: string,
-    task: (lock: HeldFileLockController) => Promise<T>
-  ): Promise<T> {
+  private async withGrantLock<T>(grantId: string, task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
     await this.ensureSafeDirectories();
     return await withPrivateDirectoryNoFollow(

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -57,6 +57,16 @@ export interface CreateStoredGrantInput {
   requestedAt?: Date;
 }
 
+export interface SupportPassportGrantMutationHooks {
+  beforeCommit?: () => Promise<void>;
+  onCommitted?: () => void;
+}
+
+type SupportPassportGrantCreateHooks =
+  | SupportPassportGrantMutationHooks
+  | (() => Promise<void>);
+type SupportPassportGrantRevokeHooks = SupportPassportGrantMutationHooks | (() => Promise<void>);
+
 function sha256(domain: string, value: string): string {
   return createHash("sha256").update(domain).update("\0").update(value).digest("hex");
 }
@@ -142,8 +152,9 @@ export class SupportPassportGrantStore {
 
   async create(
     input: CreateStoredGrantInput,
-    beforeCommit?: () => Promise<void>
+    hooks: SupportPassportGrantCreateHooks = {}
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
+    const mutationHooks = typeof hooks === "function" ? { beforeCommit: hooks } : hooks;
     const namespace = normalizeNamespace(input.namespace);
     const parsed = SupportPassportCreateGrantInputSchema.safeParse({
       principal: input.principal,
@@ -196,7 +207,7 @@ export class SupportPassportGrantStore {
         expiresAt: parsed.data.expiresAt,
       });
       await this.requireMutationLock(lock);
-      await beforeCommit?.();
+      await mutationHooks.beforeCommit?.();
       await this.requireMutationLock(lock);
       try {
         await this.writeState(state, true);
@@ -210,6 +221,7 @@ export class SupportPassportGrantStore {
           throw error;
         }
       }
+      mutationHooks.onCommitted?.();
       return { state, secret };
     });
     const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
@@ -327,8 +339,9 @@ export class SupportPassportGrantStore {
       principal: string;
       expectedStateVersion?: number;
     },
-    beforeCommit?: () => Promise<void>
+    hooks: SupportPassportGrantRevokeHooks = {}
   ): Promise<SupportPassportGrantState> {
+    const mutationHooks = typeof hooks === "function" ? { beforeCommit: hooks } : hooks;
     const normalizedInput = { ...input, grantId: normalizeGrantId(input.grantId) };
     const namespace = normalizeNamespace(input.namespace);
     return await this.withGrantLock(normalizedInput.grantId, async (lock) => {
@@ -357,7 +370,7 @@ export class SupportPassportGrantStore {
         revokedAt: this.now().toISOString(),
       });
       await this.requireMutationLock(lock);
-      await beforeCommit?.();
+      await mutationHooks.beforeCommit?.();
       await this.requireMutationLock(lock);
       try {
         await this.writeState(revoked);
@@ -366,6 +379,7 @@ export class SupportPassportGrantStore {
         if (!persisted || !sameGrantState(persisted, revoked)) throw error;
         await this.syncDirectory(this.grantsDir);
       }
+      mutationHooks.onCommitted?.();
       return revoked;
     });
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -115,7 +115,7 @@ export class SupportPassportGrantStore {
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
       const durationMs = Date.parse(parsed.data.expiresAt) - createdAt.getTime();
-      if (durationMs < 300_000 || durationMs > 604_800_000) {
+      if (!Number.isFinite(durationMs) || durationMs < 300_000 || durationMs > 604_800_000) {
         throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
       }
       const state = SupportPassportGrantStateSchema.parse({
@@ -158,12 +158,16 @@ export class SupportPassportGrantStore {
     const principalHash = sha256("support-passport-principal:v1", principal);
     const states: SupportPassportGrantState[] = [];
     for (const entry of entries) {
-      if (entry.isSymbolicLink()) throw new Error("support passport grant files must not be symbolic links");
+      if (entry.isSymbolicLink()) continue;
       if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
       const grantId = entry.name.slice(0, -5);
       if (!SAFE_GRANT_ID.test(grantId)) continue;
-      const state = await this.readState(grantId);
-      if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) states.push(state);
+      try {
+        const state = await this.readState(grantId);
+        if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) states.push(state);
+      } catch {
+        continue;
+      }
     }
     return states.sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -183,7 +183,7 @@ export class SupportPassportGrantStore {
     secret: string,
     task: (state: SupportPassportGrantState) => Promise<T>
   ): Promise<T> {
-    return await this.withMutationLock(async (lock) => {
+    return await this.withGrantLock(grantId, async (lock) => {
       const state = await this.authenticate(grantId, secret);
       const result = await task(state);
       await this.requireMutationLock(lock);
@@ -220,7 +220,7 @@ export class SupportPassportGrantStore {
   }): Promise<SupportPassportGrantState> {
     if (!SAFE_GRANT_ID.test(input.grantId)) throw grantNotFound();
     const namespace = normalizeNamespace(input.namespace);
-    return await this.withMutationLock(async (lock) => {
+    return await this.withGrantLock(input.grantId, async (lock) => {
       let state: SupportPassportGrantState;
       try {
         state = await this.readState(input.grantId);
@@ -273,8 +273,9 @@ export class SupportPassportGrantStore {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
       }
+      const expiryCutoff = this.now().getTime();
       const active = indexedStates.filter(
-        (item) => !item.revokedAt && Date.parse(item.expiresAt) > this.now().getTime()
+        (item) => !item.revokedAt && Date.parse(item.expiresAt) > expiryCutoff
       );
       if (active.length >= MAX_OWNER_GRANT_HISTORY) {
         throw new SupportPassportError(
@@ -284,7 +285,7 @@ export class SupportPassportGrantStore {
         );
       }
       const inactive = indexedStates
-        .filter((item) => item.revokedAt || Date.parse(item.expiresAt) <= this.now().getTime())
+        .filter((item) => item.revokedAt || Date.parse(item.expiresAt) <= expiryCutoff)
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.grantId.localeCompare(b.grantId));
       retained = [
         ...active.map((item) => item.grantId),
@@ -431,7 +432,25 @@ export class SupportPassportGrantStore {
   private async withMutationLock<T>(task: (lock: HeldFileLockController) => Promise<T>): Promise<T> {
     await this.ensureSafeDirectories();
     const lockPath = path.join(this.grantsDir, ".grants.lock");
-    return await serializeMutations(`support-passport-grants:${this.grantsDir}`, () =>
+    return await this.withExclusiveLock(`support-passport-grants:${this.grantsDir}`, lockPath, task);
+  }
+
+  private async withGrantLock<T>(
+    grantId: string,
+    task: (lock: HeldFileLockController) => Promise<T>
+  ): Promise<T> {
+    if (!SAFE_GRANT_ID.test(grantId)) throw grantNotFound();
+    await this.ensureSafeDirectories();
+    const lockPath = path.join(this.grantsDir, `.${grantId}.lock`);
+    return await this.withExclusiveLock(`support-passport-grant:${this.grantsDir}:${grantId}`, lockPath, task);
+  }
+
+  private async withExclusiveLock<T>(
+    serializationKey: string,
+    lockPath: string,
+    task: (lock: HeldFileLockController) => Promise<T>
+  ): Promise<T> {
+    return await serializeMutations(serializationKey, () =>
       this.runWithHeldFileLock(
         lockPath,
         {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -153,7 +153,7 @@ export class SupportPassportGrantStore {
         throw grantNotFound();
       if (state.revokedAt) return state;
       if (input.expectedStateVersion !== undefined && input.expectedStateVersion !== state.stateVersion) {
-        throw new SupportPassportError("storage_conflict", "The share link changed after it was loaded.", 409);
+        throw new SupportPassportError("state_conflict", "The share link changed after it was loaded.", 409);
       }
       const revoked = SupportPassportGrantStateSchema.parse({
         ...state,
@@ -191,7 +191,7 @@ export class SupportPassportGrantStore {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    await writeFileAtomically(filePath, `${JSON.stringify(state, null, 2)}\n`);
+    await writeFileAtomically(filePath, `${JSON.stringify(state, null, 2)}\n`, undefined, { mode: 0o600 });
     await chmod(filePath, 0o600);
   }
 

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -40,6 +40,13 @@ class OwnerIndexLockLostError extends Error {
   }
 }
 
+class MalformedGrantStateError extends Error {
+  constructor(message = "support passport grant state is invalid", cause?: unknown) {
+    super(message, { cause });
+    this.name = "MalformedGrantStateError";
+  }
+}
+
 export interface SupportPassportGrantStoreOptions {
   memoryDir: string;
   now?: () => Date;
@@ -229,6 +236,12 @@ export class SupportPassportGrantStore {
           throw error;
         }
       }
+      try {
+        await this.writeOwnerMembership(state);
+      } catch (error) {
+        await this.removeStoredGrant(state).catch(() => undefined);
+        throw error;
+      }
       notifyCommitted(mutationHooks.onCommitted);
       return { state, secret };
     });
@@ -244,13 +257,13 @@ export class SupportPassportGrantStore {
             try {
               await this.syncDirectory(this.ownerIndexesDir);
             } catch {
-              await this.removeGrantStates([committed.state.grantId]).catch(() => undefined);
+              await this.removeStoredGrant(committed.state).catch(() => undefined);
               throw error;
             }
             await this.requireOwnerIndexLock(lock);
             return committed;
           }
-          await this.removeGrantStates([committed.state.grantId]).catch(() => undefined);
+          await this.removeStoredGrant(committed.state).catch(() => undefined);
           throw error;
         }
         return committed;
@@ -262,12 +275,12 @@ export class SupportPassportGrantStore {
         } catch (recoveryError) {
           await this.withGrantLock(committed.state.grantId, async (lock) => {
             await this.requireMutationLock(lock);
-            await this.removeGrantStates([committed.state.grantId]);
+            await this.removeStoredGrant(committed.state);
           }).catch(() => undefined);
           throw recoveryError;
         }
       }
-      await this.removeGrantStates([committed.state.grantId]).catch(() => undefined);
+      await this.removeStoredGrant(committed.state).catch(() => undefined);
       throw error;
     }
   }
@@ -411,8 +424,8 @@ export class SupportPassportGrantStore {
     const current = await this.readOwnerIndexByHash(ownerHash);
     if (current.includes(state.grantId)) return;
     let retained = current;
+    let indexedStates: SupportPassportGrantState[] = [];
     if (current.length >= MAX_OWNER_GRANT_HISTORY) {
-      const indexedStates: SupportPassportGrantState[] = [];
       for (const grantId of current) {
         try {
           const indexedState = await this.readState(grantId);
@@ -446,6 +459,7 @@ export class SupportPassportGrantStore {
     }
     const grantIds = [...retained, state.grantId];
     const retainedIds = new Set(grantIds);
+    const indexedStateById = new Map(indexedStates.map((indexedState) => [indexedState.grantId, indexedState]));
     const evictedGrantIds = current.filter((grantId) => !retainedIds.has(grantId));
     await this.requireMutationLock(lock);
     await this.writeOwnerIndex(ownerHash, grantIds);
@@ -454,7 +468,9 @@ export class SupportPassportGrantStore {
       for (const grantId of evictedGrantIds) {
         await this.withGrantLock(grantId, async (grantLock) => {
           await this.requireMutationLock(grantLock);
-          await this.removeGrantStates([grantId]);
+          const evictedState = indexedStateById.get(grantId);
+          if (evictedState) await this.removeStoredGrant(evictedState);
+          else await this.removeGrantStates([grantId]);
         });
       }
     } catch (error) {
@@ -475,6 +491,49 @@ export class SupportPassportGrantStore {
       "support passport grant files must be regular files in a stable directory",
       path.parse(this.memoryDir).root,
     );
+  }
+
+  private ownerMembershipDirectory(ownerHash: string): string {
+    if (!SAFE_OWNER_INDEX_HASH.test(ownerHash)) throw new Error("support passport owner index hash is invalid");
+    return path.join(this.ownerIndexesDir, ownerHash);
+  }
+
+  private async ensureOwnerMembershipDirectory(ownerHash: string): Promise<string> {
+    const directory = this.ownerMembershipDirectory(ownerHash);
+    await ensurePrivateDirectoryNoFollow(
+      this.memoryDir,
+      directory,
+      "support passport owner membership must remain inside the memory directory",
+    );
+    return directory;
+  }
+
+  private async writeOwnerMembership(state: SupportPassportGrantState): Promise<void> {
+    const ownerHash = this.ownerHash(state.namespace, state.principalHash);
+    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
+    await writePrivateFileAtomicallyNoFollow(
+      directory,
+      path.join(directory, `${state.grantId}.json`),
+      `${JSON.stringify({ schemaVersion: 1, grantId: state.grantId })}\n`,
+      "support passport owner membership must be regular files in a stable directory",
+      path.parse(this.memoryDir).root,
+    );
+  }
+
+  private async removeOwnerMembership(state: SupportPassportGrantState): Promise<void> {
+    const ownerHash = this.ownerHash(state.namespace, state.principalHash);
+    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
+    await removePrivateFilesNoFollow(
+      directory,
+      [`${state.grantId}.json`],
+      "support passport owner membership must be regular files in a stable directory",
+      path.parse(this.memoryDir).root,
+    );
+  }
+
+  private async removeStoredGrant(state: SupportPassportGrantState): Promise<void> {
+    await this.removeGrantStates([state.grantId]);
+    await this.removeOwnerMembership(state);
   }
 
   private async reconcileCreateAfterOwnerIndexLockLoss(
@@ -502,13 +561,12 @@ export class SupportPassportGrantStore {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
       }
-      const indexedGrantIdSet = new Set(indexedGrantIds);
-      const unindexedOwnerStates = await this.readUnindexedOwnerStates(
+      const memberStates = await this.readOwnerMembershipStates(
         committed.state.namespace,
         committed.state.principalHash,
-        indexedGrantIdSet,
       );
-      ownerStates.push(...unindexedOwnerStates);
+      const indexedGrantIdSet = new Set(ownerStates.map((state) => state.grantId));
+      ownerStates.push(...memberStates.filter((state) => !indexedGrantIdSet.has(state.grantId)));
       const committedIndex = ownerStates.findIndex(
         (state) => state.grantId === committed.state.grantId,
       );
@@ -519,7 +577,7 @@ export class SupportPassportGrantStore {
         (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff,
       );
       if (active.length > MAX_OWNER_GRANT_HISTORY) {
-        await this.removeGrantStates([committed.state.grantId]);
+        await this.removeStoredGrant(committed.state);
         const committedIndex = ownerStates.findIndex(
           (state) => state.grantId === committed.state.grantId,
         );
@@ -559,22 +617,23 @@ export class SupportPassportGrantStore {
     return await this.readOwnerIndexByHash(this.ownerHash(namespace, principalHash));
   }
 
-  private async readUnindexedOwnerStates(
+  private async readOwnerMembershipStates(
     namespace: string,
     principalHash: string,
-    indexedGrantIds: ReadonlySet<string>,
   ): Promise<SupportPassportGrantState[]> {
     await this.ensureSafeDirectories();
+    const ownerHash = this.ownerHash(namespace, principalHash);
+    const directory = await this.ensureOwnerMembershipDirectory(ownerHash);
     const grantIds = await withPrivateDirectoryNoFollow(
       path.parse(this.memoryDir).root,
-      this.grantsDir,
-      "support passport grant files must be regular files in a stable directory",
+      directory,
+      "support passport owner membership must be regular files in a stable directory",
       async (pinnedDirectory) => {
         const entries = await readdir(pinnedDirectory, { withFileTypes: true });
         return entries
           .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
           .map((entry) => entry.name.slice(0, -5))
-          .filter((grantId) => SAFE_GRANT_ID.test(grantId) && !indexedGrantIds.has(grantId));
+          .filter((grantId) => SAFE_GRANT_ID.test(grantId));
       },
     );
     const ownerStates: SupportPassportGrantState[] = [];
@@ -584,8 +643,9 @@ export class SupportPassportGrantStore {
         if (state.namespace === namespace && hashesMatch(state.principalHash, principalHash)) {
           ownerStates.push(state);
         }
-      } catch {
-        continue;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT" || error instanceof MalformedGrantStateError) continue;
+        throw error;
       }
     }
     return ownerStates;
@@ -654,9 +714,19 @@ export class SupportPassportGrantStore {
       "support passport grant files must be regular files in a stable directory",
       path.parse(this.memoryDir).root,
     );
-    const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
-    if (state.grantId !== grantId) throw new Error("support passport grant ID must match its file name");
-    return state;
+    try {
+      const state = SupportPassportGrantStateSchema.parse(JSON.parse(content));
+      if (state.grantId !== grantId) {
+        throw new MalformedGrantStateError("support passport grant ID must match its file name");
+      }
+      return state;
+    } catch (error) {
+      if (error instanceof MalformedGrantStateError) throw error;
+      if (error instanceof SyntaxError || (error as Error).name === "ZodError") {
+        throw new MalformedGrantStateError(undefined, error);
+      }
+      throw error;
+    }
   }
 
   private async writeState(state: SupportPassportGrantState, requireAbsent = false): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -8,13 +8,13 @@ import { type HeldFileLockController, serializeMutations, withHeldFileLock } fro
 import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportNamespaceSchema } from "./contracts.js";
 import { SupportPassportError } from "./errors.js";
-import { computeSupportPassportOwnerLockKey } from "./owner-lock.js";
 import {
   SupportPassportCreateGrantInputSchema,
   type SupportPassportGrantCardRef,
   type SupportPassportGrantState,
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
+import { computeSupportPassportOwnerLockKey } from "./owner-lock.js";
 import {
   ensurePrivateDirectoryNoFollow,
   ensurePrivateDirectoryTreeNoFollow,
@@ -163,89 +163,92 @@ export class SupportPassportGrantStore {
     ) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
-    let recoverableCommit: { state: SupportPassportGrantState; secret: string } | undefined;
-    try {
-      return await this.withMutationLock(async (lock) => {
-        const secretBytes = this.makeSecret();
-        if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
-          throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
-        }
-        const rawGrantId = this.makeGrantId();
-        if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
-        const grantId = rawGrantId.toLowerCase();
-        const secret = secretBytes.toString("base64url");
-        const createdAt = this.now();
-        const createdAtMs = createdAt.getTime();
-        const expiresAtMs = Date.parse(parsed.data.expiresAt);
-        if (
-          !Number.isFinite(createdAtMs) ||
-          requestedAt.getTime() > createdAtMs ||
-          expiresAtMs <= createdAtMs ||
-          expiresAtMs - createdAtMs > 604_800_000
-        ) {
-          throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
-        }
-        const state = SupportPassportGrantStateSchema.parse({
-          schemaVersion: 1,
-          stateVersion: 1,
-          grantId,
-          namespace,
-          principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
-          ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
-          secretHash: sha256("support-passport-secret:v1", secret),
-          cards: parsed.data.cards,
-          createdAt: createdAt.toISOString(),
-          expiresAt: parsed.data.expiresAt,
-        });
-        recoverableCommit = { state, secret };
-        await this.requireMutationLock(lock);
-        await beforeCommit?.();
-        await this.requireMutationLock(lock);
+    const committed = await this.withMutationLock(async (lock) => {
+      const secretBytes = this.makeSecret();
+      if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
+        throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
+      }
+      const rawGrantId = this.makeGrantId();
+      if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+      const grantId = rawGrantId.toLowerCase();
+      const secret = secretBytes.toString("base64url");
+      const createdAt = this.now();
+      const createdAtMs = createdAt.getTime();
+      const expiresAtMs = Date.parse(parsed.data.expiresAt);
+      if (
+        !Number.isFinite(createdAtMs) ||
+        requestedAt.getTime() > createdAtMs ||
+        expiresAtMs <= createdAtMs ||
+        expiresAtMs - createdAtMs > 604_800_000
+      ) {
+        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+      }
+      const state = SupportPassportGrantStateSchema.parse({
+        schemaVersion: 1,
+        stateVersion: 1,
+        grantId,
+        namespace,
+        principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
+        ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
+        secretHash: sha256("support-passport-secret:v1", secret),
+        cards: parsed.data.cards,
+        createdAt: createdAt.toISOString(),
+        expiresAt: parsed.data.expiresAt,
+      });
+      await this.requireMutationLock(lock);
+      await beforeCommit?.();
+      await this.requireMutationLock(lock);
+      try {
+        await this.writeState(state, true);
+      } catch (error) {
+        const persisted = await this.readState(state.grantId).catch(() => undefined);
+        if (!persisted || !sameGrantState(persisted, state)) throw error;
         try {
-          await this.writeState(state, true);
-        } catch (error) {
-          const persisted = await this.readState(state.grantId).catch(() => undefined);
-          if (!persisted || !sameGrantState(persisted, state)) throw error;
-          try {
-            await this.syncDirectory(this.grantsDir);
-          } catch {
-            await this.removeGrantStates([state.grantId]).catch(() => undefined);
-            throw error;
-          }
-        }
-        try {
-          await this.addToOwnerIndex(state, lock);
-        } catch (error) {
-          if (error instanceof OwnerIndexLockLostError) throw error;
-          const ownerHash = this.ownerHash(state.namespace, state.principalHash);
-          const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
-          if (indexed?.includes(state.grantId)) {
-            try {
-              await this.syncDirectory(this.ownerIndexesDir);
-            } catch {
-              await this.removeGrantStates([state.grantId]).catch(() => undefined);
-              throw error;
-            }
-            await this.requireOwnerIndexLock(lock);
-            return { state, secret };
-          }
+          await this.syncDirectory(this.grantsDir);
+        } catch {
           await this.removeGrantStates([state.grantId]).catch(() => undefined);
           throw error;
         }
-        return { state, secret };
+      }
+      return { state, secret };
+    });
+    const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
+    try {
+      return await this.withOwnerIndexLock(ownerHash, async (lock) => {
+        try {
+          await this.addToOwnerIndex(committed.state, lock);
+        } catch (error) {
+          if (error instanceof OwnerIndexLockLostError) throw error;
+          const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
+          if (indexed?.includes(committed.state.grantId)) {
+            try {
+              await this.syncDirectory(this.ownerIndexesDir);
+            } catch {
+              await this.removeGrantStates([committed.state.grantId]).catch(() => undefined);
+              throw error;
+            }
+            await this.requireOwnerIndexLock(lock);
+            return committed;
+          }
+          await this.removeGrantStates([committed.state.grantId]).catch(() => undefined);
+          throw error;
+        }
+        return committed;
       });
     } catch (error) {
-      if (!(error instanceof OwnerIndexLockLostError) || !recoverableCommit) throw error;
-      const committed = recoverableCommit;
-      try {
-        return await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
-      } catch (recoveryError) {
-        await this.withGrantLock(committed.state.grantId, async (lock) => {
-          await this.requireMutationLock(lock);
-          await this.removeGrantStates([committed.state.grantId]);
-        }).catch(() => undefined);
-        throw recoveryError;
+      if (error instanceof OwnerIndexLockLostError) {
+        try {
+          return await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
+        } catch (recoveryError) {
+          await this.withGrantLock(committed.state.grantId, async (lock) => {
+            await this.requireMutationLock(lock);
+            await this.removeGrantStates([committed.state.grantId]);
+          }).catch(() => undefined);
+          throw recoveryError;
+        }
       }
+      await this.removeGrantStates([committed.state.grantId]).catch(() => undefined);
+      throw error;
     }
   }
 
@@ -455,12 +458,12 @@ export class SupportPassportGrantStore {
   private async reconcileCreateAfterOwnerIndexLockLoss(
     committed: { state: SupportPassportGrantState; secret: string },
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
-    return await this.withMutationLock(async (lock) => {
+    const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
+    return await this.withOwnerIndexLock(ownerHash, async (lock) => {
       const persisted = await this.readState(committed.state.grantId).catch(() => undefined);
       if (!persisted || !sameGrantState(persisted, committed.state)) {
         throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
       }
-      const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
       const indexedGrantIds = await this.readOwnerIndexByHash(ownerHash);
       const ownerStates: SupportPassportGrantState[] = [];
       for (const grantId of indexedGrantIds) {
@@ -684,6 +687,24 @@ export class SupportPassportGrantStore {
           `support-passport-grant:${this.grantsDir}:${normalizedGrantId}`,
           path.join(pinnedDirectory, `.${normalizedGrantId}.lock`),
           task
+        ),
+    );
+  }
+
+  private async withOwnerIndexLock<T>(
+    ownerHash: string,
+    task: (lock: HeldFileLockController) => Promise<T>,
+  ): Promise<T> {
+    await this.ensureSafeDirectories();
+    return await withPrivateDirectoryNoFollow(
+      path.parse(this.memoryDir).root,
+      this.ownerIndexesDir,
+      "support passport owner lock directory must remain inside the memory directory",
+      async (pinnedDirectory) =>
+        await this.withExclusiveLock(
+          `support-passport-owner:${this.ownerIndexesDir}:${ownerHash}`,
+          path.join(pinnedDirectory, `.${ownerHash}.lock`),
+          task,
         ),
     );
   }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, open, rename, rm, type FileHandle } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, rm, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import { expandTildePath } from "../utils/path.js";
@@ -15,7 +15,7 @@ import {
   type SupportPassportGrantState,
   SupportPassportGrantStateSchema,
 } from "./grant-contracts.js";
-import { readPrivateFileNoFollow } from "./private-file.js";
+import { readPrivateFileNoFollow, writePrivateFileAtomicallyNoFollow } from "./private-file.js";
 
 const GRANT_LOCK_STALE_MS = 30_000;
 const GRANT_LOCK_WAIT_MS = 5_000;
@@ -62,6 +62,14 @@ function normalizeNamespace(namespace: unknown): string {
   return normalized;
 }
 
+function normalizePrincipal(principal: unknown): string {
+  const normalized = typeof principal === "string" ? principal.trim() : "";
+  if (normalized.length < 1 || normalized.length > 512) {
+    throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+  }
+  return normalized;
+}
+
 export async function syncDirectoryForDurability(
   directory: string,
   openDirectory: (directory: string) => Promise<Pick<FileHandle, "sync" | "close">> = async (target) =>
@@ -76,26 +84,6 @@ export async function syncDirectoryForDurability(
     if (!UNSUPPORTED_DIRECTORY_SYNC_ERRORS.has(code ?? "")) throw error;
   } finally {
     await handle?.close().catch(() => undefined);
-  }
-}
-
-async function writePrivateFileAtomically(filePath: string, content: string): Promise<void> {
-  const directory = path.dirname(filePath);
-  const tempPath = path.join(directory, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
-  try {
-    handle = await open(tempPath, "wx", 0o600);
-    await handle.writeFile(content, "utf8");
-    await handle.sync();
-    await handle.close();
-    handle = undefined;
-    await rename(tempPath, filePath);
-    await chmod(filePath, 0o600);
-    await syncDirectoryForDurability(directory);
-  } catch (error) {
-    await handle?.close().catch(() => undefined);
-    await rm(tempPath, { force: true }).catch(() => undefined);
-    throw error;
   }
 }
 
@@ -191,7 +179,7 @@ export class SupportPassportGrantStore {
 
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
-    const principalHash = sha256("support-passport-principal:v1", principal);
+    const principalHash = sha256("support-passport-principal:v1", normalizePrincipal(principal));
     const grantIds = await this.readOwnerIndex(normalizedNamespace, principalHash);
     const states: SupportPassportGrantState[] = [];
     for (const grantId of grantIds) {
@@ -221,7 +209,7 @@ export class SupportPassportGrantStore {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") throw grantNotFound();
         throw error;
       }
-      const principalHash = sha256("support-passport-principal:v1", input.principal);
+      const principalHash = sha256("support-passport-principal:v1", normalizePrincipal(input.principal));
       if (state.namespace !== namespace || !hashesMatch(state.principalHash, principalHash))
         throw grantNotFound();
       if (state.revokedAt) return state;
@@ -353,7 +341,12 @@ export class SupportPassportGrantStore {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    await writePrivateFileAtomically(filePath, `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`);
+    await writePrivateFileAtomicallyNoFollow(
+      this.ownerIndexesDir,
+      filePath,
+      `${JSON.stringify({ schemaVersion: 1, ownerHash, grantIds }, null, 2)}\n`,
+      "support passport owner indexes must be regular files in a stable directory"
+    );
   }
 
   private async readState(grantId: string): Promise<SupportPassportGrantState> {
@@ -381,7 +374,12 @@ export class SupportPassportGrantStore {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
-    await writePrivateFileAtomically(filePath, `${JSON.stringify(state, null, 2)}\n`);
+    await writePrivateFileAtomicallyNoFollow(
+      this.grantsDir,
+      filePath,
+      `${JSON.stringify(state, null, 2)}\n`,
+      "support passport grant files must be regular files in a stable directory"
+    );
   }
 
   private async ensureSafeDirectories(): Promise<void> {

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -28,7 +28,7 @@ export interface CreateStoredGrantInput {
   namespace: string;
   principal: string;
   cards: SupportPassportGrantCardRef[];
-  durationSeconds: number;
+  expiresAt: string;
 }
 
 function sha256(domain: string, value: string): string {
@@ -64,7 +64,7 @@ export class SupportPassportGrantStore {
     const parsed = SupportPassportCreateGrantInputSchema.safeParse({
       principal: input.principal,
       cards: input.cards,
-      durationSeconds: input.durationSeconds,
+      expiresAt: input.expiresAt,
     });
     if (
       !parsed.success ||
@@ -83,6 +83,10 @@ export class SupportPassportGrantStore {
       if (!SAFE_GRANT_ID.test(grantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
       const secret = secretBytes.toString("base64url");
       const createdAt = this.now();
+      const durationMs = Date.parse(parsed.data.expiresAt) - createdAt.getTime();
+      if (durationMs < 300_000 || durationMs > 604_800_000) {
+        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+      }
       const state = SupportPassportGrantStateSchema.parse({
         schemaVersion: 1,
         stateVersion: 1,
@@ -92,7 +96,7 @@ export class SupportPassportGrantStore {
         secretHash: sha256("support-passport-secret:v1", secret),
         cards: parsed.data.cards,
         createdAt: createdAt.toISOString(),
-        expiresAt: new Date(createdAt.getTime() + parsed.data.durationSeconds * 1_000).toISOString(),
+        expiresAt: parsed.data.expiresAt,
       });
       await this.writeState(state, true);
       return { state, secret };

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -339,8 +339,11 @@ export class SupportPassportGrantStore {
   async listForOwner(namespace: string, principal: string): Promise<SupportPassportGrantState[]> {
     const normalizedNamespace = normalizeNamespace(namespace);
     const principalHash = computeSupportPassportOwnerKey(normalizePrincipal(principal));
-    const states = await this.readOwnerMembershipStates(normalizedNamespace, principalHash);
     const activeCutoff = this.now().getTime();
+    const states = this.retainedOwnerStates(
+      await this.readOwnerMembershipStates(normalizedNamespace, principalHash),
+      activeCutoff
+    );
     return states.sort((a, b) => {
       const aActive = !a.revokedAt && Date.parse(a.expiresAt) > activeCutoff;
       const bActive = !b.revokedAt && Date.parse(b.expiresAt) > activeCutoff;

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -193,66 +193,73 @@ export class SupportPassportGrantStore {
     ) {
       throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
     }
-    const committed = await this.withMutationLock(async (lock) => {
-      const secretBytes = this.makeSecret();
-      if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
-        throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
-      }
-      const rawGrantId = this.makeGrantId();
-      if (!UUID_INPUT.test(rawGrantId)) throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
-      const grantId = rawGrantId.toLowerCase();
-      const secret = secretBytes.toString("base64url");
-      const createdAt = this.now();
-      const createdAtMs = createdAt.getTime();
-      const expiresAtMs = Date.parse(parsed.data.expiresAt);
-      if (
-        !Number.isFinite(createdAtMs) ||
-        requestedAt.getTime() > createdAtMs ||
-        expiresAtMs <= createdAtMs ||
-        expiresAtMs - createdAtMs > 604_800_000
-      ) {
-        throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
-      }
-      const state = SupportPassportGrantStateSchema.parse({
-        schemaVersion: 1,
-        stateVersion: 1,
-        grantId,
-        namespace,
-        principalHash: computeSupportPassportOwnerKey(parsed.data.principal),
-        ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
-        secretHash: sha256("support-passport-secret:v1", secret),
-        cards: parsed.data.cards,
-        createdAt: createdAt.toISOString(),
-        expiresAt: parsed.data.expiresAt,
-      });
-      await this.requireMutationLock(lock);
-      await mutationHooks.beforeCommit?.();
-      await this.requireMutationLock(lock);
-      try {
-        await this.writeState(state, true);
-      } catch (error) {
-        const persisted = await this.readState(state.grantId).catch(() => undefined);
-        if (!persisted || !sameGrantState(persisted, state)) throw error;
-        try {
-          await this.syncDirectory(this.grantsDir);
-        } catch {
-          await this.removeGrantStates([state.grantId]).catch(() => undefined);
-          throw error;
-        }
-      }
-      try {
-        await this.writeOwnerMembership(state);
-      } catch (error) {
-        await this.removeStoredGrant(state).catch(() => undefined);
-        throw error;
-      }
-      return { state, secret };
-    });
-    const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
+    const principalHash = computeSupportPassportOwnerKey(parsed.data.principal);
+    const ownerHash = this.ownerHash(namespace, principalHash);
+    let committed: { state: SupportPassportGrantState; secret: string } | undefined;
     try {
       let finalized: { state: SupportPassportGrantState; secret: string };
       try {
         finalized = await this.withOwnerIndexLock(ownerHash, async (lock) => {
+          await this.requireAvailableOwnerGrantSlot(namespace, principalHash);
+          committed = await this.withMutationLock(async (mutationLock) => {
+            const secretBytes = this.makeSecret();
+            if (!Buffer.isBuffer(secretBytes) || secretBytes.length !== 32) {
+              throw new Error("SupportPassportGrantStore.makeSecret must return 32 bytes");
+            }
+            const rawGrantId = this.makeGrantId();
+            if (!UUID_INPUT.test(rawGrantId)) {
+              throw new Error("SupportPassportGrantStore.makeGrantId must return a UUID");
+            }
+            const grantId = rawGrantId.toLowerCase();
+            const secret = secretBytes.toString("base64url");
+            const createdAt = this.now();
+            const createdAtMs = createdAt.getTime();
+            const expiresAtMs = Date.parse(parsed.data.expiresAt);
+            if (
+              !Number.isFinite(createdAtMs) ||
+              requestedAt.getTime() > createdAtMs ||
+              expiresAtMs <= createdAtMs ||
+              expiresAtMs - createdAtMs > 604_800_000
+            ) {
+              throw new SupportPassportError("invalid_input", "The share link request is invalid.", 400);
+            }
+            const state = SupportPassportGrantStateSchema.parse({
+              schemaVersion: 1,
+              stateVersion: 1,
+              grantId,
+              namespace,
+              principalHash,
+              ownerLockKey: computeSupportPassportOwnerLockKey(namespace, parsed.data.principal),
+              secretHash: sha256("support-passport-secret:v1", secret),
+              cards: parsed.data.cards,
+              createdAt: createdAt.toISOString(),
+              expiresAt: parsed.data.expiresAt,
+            });
+            await this.requireMutationLock(mutationLock);
+            await mutationHooks.beforeCommit?.();
+            await this.requireMutationLock(mutationLock);
+            try {
+              await this.writeState(state, true);
+            } catch (error) {
+              const persisted = await this.readState(state.grantId).catch(() => undefined);
+              if (!persisted || !sameGrantState(persisted, state)) throw error;
+              try {
+                await this.syncDirectory(this.grantsDir);
+              } catch {
+                await this.removeGrantStates([state.grantId]).catch(() => undefined);
+                throw error;
+              }
+            }
+            try {
+              await this.writeOwnerMembership(state);
+            } catch (error) {
+              await this.removeStoredGrant(state).catch(() => undefined);
+              throw error;
+            }
+            const persisted = { state, secret };
+            committed = persisted;
+            return persisted;
+          });
           try {
             await this.addToOwnerIndex(committed.state, lock);
           } catch (error) {
@@ -269,16 +276,18 @@ export class SupportPassportGrantStore {
           return committed;
         });
       } catch (error) {
-        if (!(error instanceof OwnerIndexLockLostError)) throw error;
+        if (!(error instanceof OwnerIndexLockLostError) || !committed) throw error;
         finalized = await this.reconcileCreateAfterOwnerIndexLockLoss(committed);
       }
       notifyCommitted(mutationHooks.onCommitted);
       return finalized;
     } catch (error) {
-      await this.withGrantLock(committed.state.grantId, async (lock) => {
-        await this.requireMutationLock(lock);
-        await this.removeStoredGrant(committed.state);
-      }).catch(() => undefined);
+      if (committed) {
+        await this.withGrantLock(committed.state.grantId, async (lock) => {
+          await this.requireMutationLock(lock);
+          await this.removeStoredGrant(committed!.state);
+        }).catch(() => undefined);
+      }
       throw error;
     }
   }
@@ -411,7 +420,6 @@ export class SupportPassportGrantStore {
       .filter((item) => item.grantId !== state.grantId)
       .sort(newestGrantFirst);
     const current = ownerStates.map((item) => item.grantId);
-    if (current.includes(state.grantId)) return;
     let retained = current;
     const indexedStates: SupportPassportGrantState[] = [...ownerStates];
     if (current.length >= MAX_OWNER_GRANT_HISTORY) {
@@ -473,8 +481,7 @@ export class SupportPassportGrantStore {
 
   private async ensureOwnerMembershipDirectory(ownerHash: string): Promise<string> {
     const directory = this.ownerMembershipDirectory(ownerHash);
-    await ensurePrivateDirectoryNoFollow(
-      this.memoryDir,
+    await ensurePrivateDirectoryTreeNoFollow(
       directory,
       "support passport owner membership must remain inside the memory directory"
     );
@@ -563,6 +570,14 @@ export class SupportPassportGrantStore {
       retained.map((state) => state.grantId),
       lock
     );
+    const retainedIds = new Set(retained.map((state) => state.grantId));
+    for (const state of ownerStates) {
+      if (retainedIds.has(state.grantId)) continue;
+      await this.withGrantLock(state.grantId, async (grantLock) => {
+        await this.requireMutationLock(grantLock);
+        await this.removeStoredGrant(state);
+      });
+    }
     if (active.length > MAX_OWNER_GRANT_HISTORY) {
       throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
     }
@@ -578,6 +593,20 @@ export class SupportPassportGrantStore {
       .filter((state) => state.revokedAt || Date.parse(state.expiresAt) <= activeCutoff)
       .sort(newestGrantFirst);
     return [...active, ...inactive.slice(0, MAX_OWNER_GRANT_HISTORY - active.length)];
+  }
+
+  private async requireAvailableOwnerGrantSlot(namespace: string, principalHash: string): Promise<void> {
+    const activeCutoff = this.now().getTime();
+    const active = (await this.readOwnerMembershipStates(namespace, principalHash)).filter(
+      (state) => !state.revokedAt && Date.parse(state.expiresAt) > activeCutoff
+    );
+    if (active.length >= MAX_OWNER_GRANT_HISTORY) {
+      throw new SupportPassportError(
+        "invalid_input",
+        "A support passport can contain at most 100 active share links.",
+        400
+      );
+    }
   }
 
   private async readOwnerMembershipStates(

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -58,6 +58,10 @@ function hashesMatch(left: string, right: string): boolean {
   return leftBytes.length === 32 && rightBytes.length === 32 && timingSafeEqual(leftBytes, rightBytes);
 }
 
+function sameGrantState(left: SupportPassportGrantState, right: SupportPassportGrantState): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 function grantNotFound(): SupportPassportError {
   return new SupportPassportError("grant_not_found", "The share link was not found.", 404);
 }
@@ -160,10 +164,18 @@ export class SupportPassportGrantStore {
       });
       await this.requireMutationLock(lock);
       await beforeCommit?.();
-      await this.writeState(state, true);
+      try {
+        await this.writeState(state, true);
+      } catch (error) {
+        const persisted = await this.readState(state.grantId).catch(() => undefined);
+        if (!persisted || !sameGrantState(persisted, state)) throw error;
+      }
       try {
         await this.addToOwnerIndex(state, lock);
       } catch (error) {
+        const ownerHash = this.ownerHash(state.namespace, state.principalHash);
+        const indexed = await this.readOwnerIndexByHash(ownerHash).catch(() => undefined);
+        if (indexed?.includes(state.grantId)) return { state, secret };
         await this.removeGrantStates([state.grantId]).catch(() => undefined);
         throw error;
       }

--- a/packages/remnic-core/src/support-passport/grant-store.ts
+++ b/packages/remnic-core/src/support-passport/grant-store.ts
@@ -32,6 +32,7 @@ const UUID_INPUT = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-
 const SAFE_OWNER_INDEX_HASH = /^[0-9a-f]{64}$/;
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 const MAX_OWNER_GRANT_HISTORY = 100;
+const MAX_OWNER_INDEX_RECOVERY_ATTEMPTS = 3;
 
 class OwnerIndexLockLostError extends Error {
   constructor(cause: unknown) {
@@ -540,7 +541,7 @@ export class SupportPassportGrantStore {
     committed: { state: SupportPassportGrantState; secret: string },
   ): Promise<{ state: SupportPassportGrantState; secret: string }> {
     const ownerHash = this.ownerHash(committed.state.namespace, committed.state.principalHash);
-    while (true) {
+    for (let attempt = 1; attempt <= MAX_OWNER_INDEX_RECOVERY_ATTEMPTS; attempt += 1) {
       try {
         return await this.withOwnerIndexLock(ownerHash, async (lock) =>
           await this.reconcileCommittedGrant(committed, ownerHash, lock)
@@ -549,6 +550,7 @@ export class SupportPassportGrantStore {
         if (!(error instanceof OwnerIndexLockLostError)) throw error;
       }
     }
+    throw new SupportPassportError("storage_conflict", "The share link store changed during the request.", 409);
   }
 
   private async reconcileCommittedGrant(

--- a/packages/remnic-core/src/support-passport/index.ts
+++ b/packages/remnic-core/src/support-passport/index.ts
@@ -2,3 +2,6 @@ export * from "./card-projection.js";
 export * from "./card-service.js";
 export * from "./contracts.js";
 export * from "./errors.js";
+export * from "./grant-contracts.js";
+export * from "./grant-service.js";
+export * from "./grant-store.js";

--- a/packages/remnic-core/src/support-passport/owner-lock.ts
+++ b/packages/remnic-core/src/support-passport/owner-lock.ts
@@ -3,21 +3,25 @@ import path from "node:path";
 
 import type { StorageManager } from "../index.js";
 import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportError } from "./errors.js";
 
 const CARD_MUTATION_LOCK_STALE_MS = 60_000;
 const CARD_MUTATION_LOCK_MAX_WAIT_MS = 30_000;
 
-export interface SupportPassportOwnerLockScope {
-  namespace: string;
-  principal: string;
-}
+export type SupportPassportOwnerLockScope =
+  | { namespace: string; principal: string; ownerKey?: never }
+  | { namespace: string; ownerKey: string; principal?: never };
 
 export function supportPassportOwnerLockPath(
   storage: StorageManager,
   scope: SupportPassportOwnerLockScope
 ): string {
-  const scopeKey = createHash("sha256").update(JSON.stringify([scope.namespace, scope.principal])).digest("hex");
+  const ownerKey = scope.ownerKey ?? computeSupportPassportOwnerKey(scope.principal);
+  if (!/^[a-f0-9]{64}$/.test(ownerKey)) {
+    throw new SupportPassportError("card_data_invalid", "The support passport owner scope is invalid.", 500);
+  }
+  const scopeKey = createHash("sha256").update(JSON.stringify([scope.namespace, ownerKey])).digest("hex");
   return path.join(storage.dir, "state", `support-passport-cards-${scopeKey}.lock`);
 }
 

--- a/packages/remnic-core/src/support-passport/owner-lock.ts
+++ b/packages/remnic-core/src/support-passport/owner-lock.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 
 import type { StorageManager } from "../index.js";
 import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
-import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportError } from "./errors.js";
 
 const CARD_MUTATION_LOCK_STALE_MS = 60_000;
@@ -13,16 +12,19 @@ export type SupportPassportOwnerLockScope =
   | { namespace: string; principal: string; ownerKey?: never }
   | { namespace: string; ownerKey: string; principal?: never };
 
+export function computeSupportPassportOwnerLockKey(namespace: string, principal: string): string {
+  return createHash("sha256").update(JSON.stringify([namespace, principal])).digest("hex");
+}
+
 export function supportPassportOwnerLockPath(
   storage: StorageManager,
   scope: SupportPassportOwnerLockScope
 ): string {
-  const ownerKey = scope.ownerKey ?? computeSupportPassportOwnerKey(scope.principal);
-  if (!/^[a-f0-9]{64}$/.test(ownerKey)) {
+  const ownerLockKey = scope.ownerKey ?? computeSupportPassportOwnerLockKey(scope.namespace, scope.principal);
+  if (!/^[a-f0-9]{64}$/.test(ownerLockKey)) {
     throw new SupportPassportError("card_data_invalid", "The support passport owner scope is invalid.", 500);
   }
-  const scopeKey = createHash("sha256").update(JSON.stringify([scope.namespace, ownerKey])).digest("hex");
-  return path.join(storage.dir, "state", `support-passport-cards-${scopeKey}.lock`);
+  return path.join(storage.dir, "state", `support-passport-cards-${ownerLockKey}.lock`);
 }
 
 export async function withSupportPassportOwnerLock<T>(

--- a/packages/remnic-core/src/support-passport/owner-lock.ts
+++ b/packages/remnic-core/src/support-passport/owner-lock.ts
@@ -2,78 +2,46 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 
 import type { StorageManager } from "../index.js";
-import {
-  type HeldFileLockController,
-  serializeMutations,
-  withHeldFileLock,
-} from "../utils/serialize-mutations.js";
-import { computeSupportPassportOwnerKey } from "./card-projection.js";
+import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
 import { SupportPassportError } from "./errors.js";
 
 const CARD_MUTATION_LOCK_STALE_MS = 60_000;
 const CARD_MUTATION_LOCK_MAX_WAIT_MS = 30_000;
 
-export type SupportPassportOwnerLockScope =
-  | { namespace: string; principal: string; ownerKey?: never }
-  | { namespace: string; ownerKey: string; principal?: never };
+export interface SupportPassportOwnerLockScope {
+  namespace: string;
+  principal: string;
+}
 
 export function supportPassportOwnerLockPath(
   storage: StorageManager,
-  scope: SupportPassportOwnerLockScope,
+  scope: SupportPassportOwnerLockScope
 ): string {
-  const ownerKey =
-    scope.ownerKey ?? computeSupportPassportOwnerKey(scope.principal);
-  if (!/^[a-f0-9]{64}$/.test(ownerKey)) {
-    throw new SupportPassportError(
-      "card_data_invalid",
-      "The support passport owner scope is invalid.",
-      500,
-    );
-  }
-  const scopeKey = createHash("sha256")
-    .update(JSON.stringify([scope.namespace, ownerKey]))
-    .digest("hex");
-  return path.join(
-    storage.dir,
-    "state",
-    `support-passport-cards-${scopeKey}.lock`,
-  );
+  const scopeKey = createHash("sha256").update(JSON.stringify([scope.namespace, scope.principal])).digest("hex");
+  return path.join(storage.dir, "state", `support-passport-cards-${scopeKey}.lock`);
 }
 
 export async function withSupportPassportOwnerLock<T>(
   storage: StorageManager,
   scope: SupportPassportOwnerLockScope,
-  task: (lock: HeldFileLockController) => Promise<T>,
+  task: (lock: HeldFileLockController) => Promise<T>
 ): Promise<T> {
   const lockPath = supportPassportOwnerLockPath(storage, scope);
   return await serializeMutations(lockPath, () =>
     withHeldFileLock(
       lockPath,
-      {
-        staleMs: CARD_MUTATION_LOCK_STALE_MS,
-        maxWaitMs: CARD_MUTATION_LOCK_MAX_WAIT_MS,
-      },
+      { staleMs: CARD_MUTATION_LOCK_STALE_MS, maxWaitMs: CARD_MUTATION_LOCK_MAX_WAIT_MS },
       async (acquired, lock) => {
         if (!acquired) {
-          throw new SupportPassportError(
-            "storage_conflict",
-            "The support passport is busy. Try again.",
-            409,
-          );
+          throw new SupportPassportError("storage_conflict", "The support passport is busy. Try again.", 409);
         }
         return await task(lock);
-      },
-    ),
+      }
+    )
   );
 }
 
-export async function requireSupportPassportOwnerLock(
-  lock: HeldFileLockController,
-): Promise<void> {
+export async function requireSupportPassportOwnerLock(lock: HeldFileLockController): Promise<void> {
   if (await lock.refresh()) return;
-  throw new SupportPassportError(
-    "storage_conflict",
-    "The support passport changed during the request.",
-    409,
-  );
+  throw new SupportPassportError("storage_conflict", "The support passport changed during the request.", 409);
 }

--- a/packages/remnic-core/src/support-passport/owner-lock.ts
+++ b/packages/remnic-core/src/support-passport/owner-lock.ts
@@ -2,46 +2,78 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 
 import type { StorageManager } from "../index.js";
-import { type HeldFileLockController, serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
+import {
+  type HeldFileLockController,
+  serializeMutations,
+  withHeldFileLock,
+} from "../utils/serialize-mutations.js";
+import { computeSupportPassportOwnerKey } from "./card-projection.js";
 import { SupportPassportError } from "./errors.js";
 
 const CARD_MUTATION_LOCK_STALE_MS = 60_000;
 const CARD_MUTATION_LOCK_MAX_WAIT_MS = 30_000;
 
-export interface SupportPassportOwnerLockScope {
-  namespace: string;
-  principal: string;
-}
+export type SupportPassportOwnerLockScope =
+  | { namespace: string; principal: string; ownerKey?: never }
+  | { namespace: string; ownerKey: string; principal?: never };
 
 export function supportPassportOwnerLockPath(
   storage: StorageManager,
-  scope: SupportPassportOwnerLockScope
+  scope: SupportPassportOwnerLockScope,
 ): string {
-  const scopeKey = createHash("sha256").update(JSON.stringify([scope.namespace, scope.principal])).digest("hex");
-  return path.join(storage.dir, "state", `support-passport-cards-${scopeKey}.lock`);
+  const ownerKey =
+    scope.ownerKey ?? computeSupportPassportOwnerKey(scope.principal);
+  if (!/^[a-f0-9]{64}$/.test(ownerKey)) {
+    throw new SupportPassportError(
+      "card_data_invalid",
+      "The support passport owner scope is invalid.",
+      500,
+    );
+  }
+  const scopeKey = createHash("sha256")
+    .update(JSON.stringify([scope.namespace, ownerKey]))
+    .digest("hex");
+  return path.join(
+    storage.dir,
+    "state",
+    `support-passport-cards-${scopeKey}.lock`,
+  );
 }
 
 export async function withSupportPassportOwnerLock<T>(
   storage: StorageManager,
   scope: SupportPassportOwnerLockScope,
-  task: (lock: HeldFileLockController) => Promise<T>
+  task: (lock: HeldFileLockController) => Promise<T>,
 ): Promise<T> {
   const lockPath = supportPassportOwnerLockPath(storage, scope);
   return await serializeMutations(lockPath, () =>
     withHeldFileLock(
       lockPath,
-      { staleMs: CARD_MUTATION_LOCK_STALE_MS, maxWaitMs: CARD_MUTATION_LOCK_MAX_WAIT_MS },
+      {
+        staleMs: CARD_MUTATION_LOCK_STALE_MS,
+        maxWaitMs: CARD_MUTATION_LOCK_MAX_WAIT_MS,
+      },
       async (acquired, lock) => {
         if (!acquired) {
-          throw new SupportPassportError("storage_conflict", "The support passport is busy. Try again.", 409);
+          throw new SupportPassportError(
+            "storage_conflict",
+            "The support passport is busy. Try again.",
+            409,
+          );
         }
         return await task(lock);
-      }
-    )
+      },
+    ),
   );
 }
 
-export async function requireSupportPassportOwnerLock(lock: HeldFileLockController): Promise<void> {
+export async function requireSupportPassportOwnerLock(
+  lock: HeldFileLockController,
+): Promise<void> {
   if (await lock.refresh()) return;
-  throw new SupportPassportError("storage_conflict", "The support passport changed during the request.", 409);
+  throw new SupportPassportError(
+    "storage_conflict",
+    "The support passport changed during the request.",
+    409,
+  );
 }

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { type Stats, constants as fsConstants } from "node:fs";
-import { type FileHandle, lstat, mkdir, open, realpath, rename, rm, rmdir, stat } from "node:fs/promises";
+import { type FileHandle, lstat, mkdir, open, realpath, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
-const pendingDirectoryParentSyncs = new Set<string>();
 
 function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
   if (
@@ -137,7 +136,6 @@ export async function ensurePrivateDirectoryNoFollow(
     for (const component of components) {
       const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
       const childPath = path.join(pinnedParent, component);
-      const stableChildPath = path.join(currentPath, component);
       let created = false;
       try {
         await mkdir(childPath, { mode: 0o700 });
@@ -145,22 +143,7 @@ export async function ensurePrivateDirectoryNoFollow(
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
-      if (created) {
-        try {
-          await syncVerifiedParent(current.handle);
-          pendingDirectoryParentSyncs.delete(stableChildPath);
-        } catch (error) {
-          try {
-            await rmdir(childPath);
-          } catch {
-            pendingDirectoryParentSyncs.add(stableChildPath);
-          }
-          throw error;
-        }
-      } else if (pendingDirectoryParentSyncs.has(stableChildPath)) {
-        await syncVerifiedParent(current.handle);
-        pendingDirectoryParentSyncs.delete(stableChildPath);
-      }
+      await syncVerifiedParent(current.handle);
       const child = await openDirectoryNoFollow(childPath, errorMessage);
       handles.push(child.handle);
       if (created || (hardenExistingChildren && (child.opened.mode & 0o777) !== 0o700)) {

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants, type Stats } from "node:fs";
-import { lstat, open, rename, rm, stat, type FileHandle } from "node:fs/promises";
+import { lstat, mkdir, open, rename, rm, stat, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
@@ -106,6 +106,63 @@ async function openStableDirectoryFromRoot(
   } catch (error) {
     await closeDirectoryHandles(handles);
     throw error;
+  }
+}
+
+export async function ensurePrivateDirectoryNoFollow(
+  trustedRoot: string,
+  directory: string,
+  errorMessage: string
+): Promise<void> {
+  const root = path.resolve(trustedRoot);
+  const target = path.resolve(directory);
+  const relative = path.relative(root, target);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(errorMessage);
+  }
+  const components = relative === "" ? [] : relative.split(path.sep);
+  const handles: FileHandle[] = [];
+  let currentPath = root;
+  try {
+    let current = await openDirectoryNoFollow(root, errorMessage);
+    handles.push(current.handle);
+    for (const component of components) {
+      const pinnedParent = await pinnedDirectoryPath(current.handle, current.opened, errorMessage);
+      const childPath = path.join(pinnedParent, component);
+      try {
+        await mkdir(childPath, { mode: 0o700 });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+      const child = await openDirectoryNoFollow(childPath, errorMessage);
+      handles.push(child.handle);
+      await child.handle.chmod(0o700);
+      assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
+      currentPath = path.join(currentPath, component);
+      current = child;
+    }
+    assertStableDirectory(current.before, current.opened, await lstat(target), errorMessage);
+  } finally {
+    await closeDirectoryHandles(handles);
+  }
+}
+
+export async function withPrivateDirectoryNoFollow<T>(
+  trustedRoot: string,
+  directory: string,
+  errorMessage: string,
+  task: (pinnedDirectory: string) => Promise<T>
+): Promise<T> {
+  let directoryHandles: FileHandle[] = [];
+  try {
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    directoryHandles = stableDirectory.handles;
+    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const result = await task(pinnedDirectory);
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
+    return result;
+  } finally {
+    await closeDirectoryHandles(directoryHandles);
   }
 }
 

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -4,6 +4,7 @@ import { type FileHandle, lstat, mkdir, open, realpath, rename, rm, rmdir, stat 
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
+const pendingDirectoryParentSyncs = new Set<string>();
 
 function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
   if (
@@ -72,6 +73,7 @@ export async function resolvePrivateDirectoryPath(
 
 export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, errorMessage: string): string {
   if (platform === "linux") return "/proc/self/fd";
+  if (platform === "darwin" || platform === "freebsd" || platform === "openbsd") return "/dev/fd";
   throw new Error(errorMessage);
 }
 
@@ -135,6 +137,7 @@ export async function ensurePrivateDirectoryNoFollow(
     for (const component of components) {
       const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
       const childPath = path.join(pinnedParent, component);
+      const stableChildPath = path.join(currentPath, component);
       let created = false;
       try {
         await mkdir(childPath, { mode: 0o700 });
@@ -145,10 +148,18 @@ export async function ensurePrivateDirectoryNoFollow(
       if (created) {
         try {
           await syncVerifiedParent(current.handle);
+          pendingDirectoryParentSyncs.delete(stableChildPath);
         } catch (error) {
-          await rmdir(childPath).catch(() => undefined);
+          try {
+            await rmdir(childPath);
+          } catch {
+            pendingDirectoryParentSyncs.add(stableChildPath);
+          }
           throw error;
         }
+      } else if (pendingDirectoryParentSyncs.has(stableChildPath)) {
+        await syncVerifiedParent(current.handle);
+        pendingDirectoryParentSyncs.delete(stableChildPath);
       }
       const child = await openDirectoryNoFollow(childPath, errorMessage);
       handles.push(child.handle);

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -112,7 +112,8 @@ async function openStableDirectoryFromRoot(
 export async function ensurePrivateDirectoryNoFollow(
   trustedRoot: string,
   directory: string,
-  errorMessage: string
+  errorMessage: string,
+  syncCreatedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
 ): Promise<void> {
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
@@ -129,14 +130,17 @@ export async function ensurePrivateDirectoryNoFollow(
     for (const component of components) {
       const pinnedParent = await pinnedDirectoryPath(current.handle, current.opened, errorMessage);
       const childPath = path.join(pinnedParent, component);
+      let created = false;
       try {
         await mkdir(childPath, { mode: 0o700 });
+        created = true;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
       const child = await openDirectoryNoFollow(childPath, errorMessage);
       handles.push(child.handle);
       await child.handle.chmod(0o700);
+      if (created) await syncCreatedParent(current.handle);
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
       currentPath = path.join(currentPath, component);
       current = child;

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -178,3 +178,30 @@ export async function writePrivateFileAtomicallyNoFollow(
     await directoryHandle?.close().catch(() => undefined);
   }
 }
+
+export async function removePrivateFilesNoFollow(
+  directory: string,
+  fileNames: string[],
+  errorMessage: string
+): Promise<void> {
+  if (
+    fileNames.some(
+      (fileName) => fileName.length === 0 || fileName === "." || fileName === ".." || path.basename(fileName) !== fileName
+    )
+  ) {
+    throw new Error(errorMessage);
+  }
+  let directoryHandle: FileHandle | undefined;
+  try {
+    const stableDirectory = await openStableDirectory(directory, errorMessage);
+    directoryHandle = stableDirectory.handle;
+    const pinnedDirectory = await pinnedDirectoryPath(directory, directoryHandle, stableDirectory.opened, errorMessage);
+    for (const fileName of fileNames) {
+      await rm(path.join(pinnedDirectory, fileName), { force: true });
+    }
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
+    await syncDirectoryHandle(directoryHandle);
+  } finally {
+    await directoryHandle?.close().catch(() => undefined);
+  }
+}

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants, type Stats } from "node:fs";
-import { lstat, mkdir, open, rename, rm, stat, type FileHandle } from "node:fs/promises";
+import { type Stats, constants as fsConstants } from "node:fs";
+import { type FileHandle, lstat, mkdir, open, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
@@ -20,7 +20,10 @@ function assertStableDirectory(before: Stats, opened: Stats, after: Stats, error
   }
 }
 
-async function openDirectoryNoFollow(directory: string, errorMessage: string): Promise<{
+async function openDirectoryNoFollow(
+  directory: string,
+  errorMessage: string
+): Promise<{
   before: Stats;
   opened: Stats;
   handle: FileHandle;
@@ -51,12 +54,26 @@ async function syncDirectoryHandle(handle: FileHandle): Promise<void> {
   }
 }
 
-async function pinnedDirectoryPath(
+export async function resolvePrivateDirectoryPath(
+  directory: string,
   handle: FileHandle,
   opened: Stats,
-  errorMessage: string
+  errorMessage: string,
+  platform: NodeJS.Platform = process.platform
 ): Promise<string> {
-  const descriptorRoot = requirePrivateFileDescriptorRoot(process.platform, errorMessage);
+  const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
+  if (descriptorRoot === null) {
+    const current = await lstat(directory);
+    if (
+      current.isSymbolicLink() ||
+      !current.isDirectory() ||
+      current.dev !== opened.dev ||
+      current.ino !== opened.ino
+    ) {
+      throw new Error(errorMessage);
+    }
+    return directory;
+  }
   const pinnedPath = path.join(descriptorRoot, String(handle.fd));
   const metadata = await stat(pinnedPath);
   if (!metadata.isDirectory() || metadata.dev !== opened.dev || metadata.ino !== opened.ino) {
@@ -65,9 +82,9 @@ async function pinnedDirectoryPath(
   return pinnedPath;
 }
 
-export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, errorMessage: string): string {
+export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, errorMessage: string): string | null {
   if (platform === "linux") return "/proc/self/fd";
-  if (platform === "darwin") return "/dev/fd";
+  if (platform === "darwin") return null;
   throw new Error(errorMessage);
 }
 
@@ -94,7 +111,7 @@ async function openStableDirectoryFromRoot(
     let current = await openDirectoryNoFollow(root, errorMessage);
     handles.push(current.handle);
     for (const component of components) {
-      const pinnedParent = await pinnedDirectoryPath(current.handle, current.opened, errorMessage);
+      const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
       const child = await openDirectoryNoFollow(path.join(pinnedParent, component), errorMessage);
       handles.push(child.handle);
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
@@ -128,7 +145,7 @@ export async function ensurePrivateDirectoryNoFollow(
     let current = await openDirectoryNoFollow(root, errorMessage);
     handles.push(current.handle);
     for (const component of components) {
-      const pinnedParent = await pinnedDirectoryPath(current.handle, current.opened, errorMessage);
+      const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
       const childPath = path.join(pinnedParent, component);
       try {
         await mkdir(childPath, { mode: 0o700 });
@@ -159,7 +176,12 @@ export async function withPrivateDirectoryNoFollow<T>(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await resolvePrivateDirectoryPath(
+      directory,
+      stableDirectory.handle,
+      stableDirectory.opened,
+      errorMessage
+    );
     const result = await task(pinnedDirectory);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     return result;
@@ -181,7 +203,12 @@ export async function readPrivateFileNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await resolvePrivateDirectoryPath(
+      directory,
+      stableDirectory.handle,
+      stableDirectory.opened,
+      errorMessage
+    );
     try {
       fileHandle = await open(path.join(pinnedDirectory, targetName), fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
     } catch (error) {
@@ -189,12 +216,7 @@ export async function readPrivateFileNoFollow(
       throw error;
     }
     const fileMetadata = await fileHandle.stat();
-    assertStableDirectory(
-      stableDirectory.before,
-      stableDirectory.opened,
-      await lstat(directory),
-      errorMessage
-    );
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
     return await fileHandle.readFile("utf8");
   } finally {
@@ -217,7 +239,12 @@ export async function appendPrivateFileNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await resolvePrivateDirectoryPath(
+      directory,
+      stableDirectory.handle,
+      stableDirectory.opened,
+      errorMessage
+    );
     try {
       fileHandle = await open(
         path.join(pinnedDirectory, targetName),
@@ -229,12 +256,7 @@ export async function appendPrivateFileNoFollow(
       throw error;
     }
     const fileMetadata = await fileHandle.stat();
-    assertStableDirectory(
-      stableDirectory.before,
-      stableDirectory.opened,
-      await lstat(directory),
-      errorMessage
-    );
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
     await fileHandle.chmod(0o600);
     await fileHandle.appendFile(content, "utf8");
@@ -261,7 +283,12 @@ export async function writePrivateFileAtomicallyNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await resolvePrivateDirectoryPath(
+      directory,
+      stableDirectory.handle,
+      stableDirectory.opened,
+      errorMessage
+    );
     tempPath = path.join(pinnedDirectory, tempName);
     const targetPath = path.join(pinnedDirectory, targetName);
     try {
@@ -301,7 +328,8 @@ export async function removePrivateFilesNoFollow(
 ): Promise<void> {
   if (
     fileNames.some(
-      (fileName) => fileName.length === 0 || fileName === "." || fileName === ".." || path.basename(fileName) !== fileName
+      (fileName) =>
+        fileName.length === 0 || fileName === "." || fileName === ".." || path.basename(fileName) !== fileName
     )
   ) {
     throw new Error(errorMessage);
@@ -310,7 +338,12 @@ export async function removePrivateFilesNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await resolvePrivateDirectoryPath(
+      directory,
+      stableDirectory.handle,
+      stableDirectory.opened,
+      errorMessage
+    );
     for (const fileName of fileNames) {
       await rm(path.join(pinnedDirectory, fileName), { force: true });
     }

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -153,6 +153,28 @@ export async function ensurePrivateDirectoryNoFollow(
   }
 }
 
+export async function ensurePrivateDirectoryTreeNoFollow(
+  directory: string,
+  errorMessage: string,
+  syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
+): Promise<void> {
+  const target = path.resolve(directory);
+  let existingAncestor = target;
+  while (true) {
+    try {
+      const metadata = await lstat(existingAncestor);
+      if (metadata.isSymbolicLink() || !metadata.isDirectory()) throw new Error(errorMessage);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) throw error;
+      existingAncestor = parent;
+    }
+  }
+  await ensurePrivateDirectoryNoFollow(existingAncestor, target, errorMessage, syncVerifiedParent);
+}
+
 export async function withPrivateDirectoryNoFollow<T>(
   trustedRoot: string,
   directory: string,

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -4,6 +4,7 @@ import { type FileHandle, lstat, mkdir, open, rename, rm, stat } from "node:fs/p
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
+const NON_WRITABLE_ANCESTOR_SYNC_ERRORS = new Set(["EROFS", "EPERM", "EACCES"]);
 
 function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
   if (
@@ -209,11 +210,28 @@ export async function ensurePrivateDirectoryTreeNoFollow(
   platform: NodeJS.Platform = process.platform,
 ): Promise<void> {
   const target = path.resolve(directory);
+  const filesystemRoot = path.parse(target).root;
+  const rootMetadata = await stat(filesystemRoot);
   await ensurePrivateDirectoryNoFollow(
-    path.parse(target).root,
+    filesystemRoot,
     target,
     errorMessage,
-    syncVerifiedParent,
+    async (handle) => {
+      try {
+        await syncVerifiedParent(handle);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        const metadata = await handle.stat();
+        if (
+          metadata.ino === rootMetadata.ino &&
+          metadata.dev === rootMetadata.dev &&
+          NON_WRITABLE_ANCESTOR_SYNC_ERRORS.has(code ?? "")
+        ) {
+          return;
+        }
+        throw error;
+      }
+    },
     false,
     platform,
   );

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -62,18 +62,6 @@ export async function resolvePrivateDirectoryPath(
   platform: NodeJS.Platform = process.platform
 ): Promise<string> {
   const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
-  if (descriptorRoot === null) {
-    const current = await lstat(directory);
-    if (
-      current.isSymbolicLink() ||
-      !current.isDirectory() ||
-      current.dev !== opened.dev ||
-      current.ino !== opened.ino
-    ) {
-      throw new Error(errorMessage);
-    }
-    return directory;
-  }
   const pinnedPath = path.join(descriptorRoot, String(handle.fd));
   const metadata = await stat(pinnedPath);
   if (!metadata.isDirectory() || metadata.dev !== opened.dev || metadata.ino !== opened.ino) {
@@ -82,9 +70,8 @@ export async function resolvePrivateDirectoryPath(
   return pinnedPath;
 }
 
-export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, errorMessage: string): string | null {
+export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, errorMessage: string): string {
   if (platform === "linux") return "/proc/self/fd";
-  if (platform === "darwin") return null;
   throw new Error(errorMessage);
 }
 

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -20,7 +20,7 @@ function assertStableDirectory(before: Stats, opened: Stats, after: Stats, error
   }
 }
 
-async function openStableDirectory(directory: string, errorMessage: string): Promise<{
+async function openDirectoryNoFollow(directory: string, errorMessage: string): Promise<{
   before: Stats;
   opened: Stats;
   handle: FileHandle;
@@ -36,6 +36,10 @@ async function openStableDirectory(directory: string, errorMessage: string): Pro
     await handle.close().catch(() => undefined);
     throw error;
   }
+}
+
+async function closeDirectoryHandles(handles: FileHandle[]): Promise<void> {
+  for (const handle of handles.reverse()) await handle.close().catch(() => undefined);
 }
 
 async function syncDirectoryHandle(handle: FileHandle): Promise<void> {
@@ -64,18 +68,60 @@ async function pinnedDirectoryPath(
   return pinnedPath;
 }
 
+async function openStableDirectoryFromRoot(
+  trustedRoot: string,
+  directory: string,
+  errorMessage: string
+): Promise<{
+  before: Stats;
+  opened: Stats;
+  handle: FileHandle;
+  handles: FileHandle[];
+}> {
+  const root = path.resolve(trustedRoot);
+  const target = path.resolve(directory);
+  const relative = path.relative(root, target);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(errorMessage);
+  }
+  const components = relative === "" ? [] : relative.split(path.sep);
+  const handles: FileHandle[] = [];
+  let currentPath = root;
+  try {
+    let current = await openDirectoryNoFollow(root, errorMessage);
+    handles.push(current.handle);
+    for (const component of components) {
+      const pinnedParent = await pinnedDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
+      const child = await openDirectoryNoFollow(path.join(pinnedParent, component), errorMessage);
+      handles.push(child.handle);
+      assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
+      currentPath = path.join(currentPath, component);
+      current = child;
+    }
+    assertStableDirectory(current.before, current.opened, await lstat(target), errorMessage);
+    return { ...current, handles };
+  } catch (error) {
+    await closeDirectoryHandles(handles);
+    throw error;
+  }
+}
+
 export async function readPrivateFileNoFollow(
   directory: string,
   filePath: string,
-  errorMessage: string
+  errorMessage: string,
+  trustedRoot = directory
 ): Promise<string> {
-  let directoryHandle: FileHandle | undefined;
+  if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
+  const targetName = path.basename(filePath);
+  let directoryHandles: FileHandle[] = [];
   let fileHandle: FileHandle | undefined;
   try {
-    const stableDirectory = await openStableDirectory(directory, errorMessage);
-    directoryHandle = stableDirectory.handle;
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    directoryHandles = stableDirectory.handles;
+    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
     try {
-      fileHandle = await open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      fileHandle = await open(path.join(pinnedDirectory, targetName), fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
       throw error;
@@ -91,7 +137,7 @@ export async function readPrivateFileNoFollow(
     return await fileHandle.readFile("utf8");
   } finally {
     await fileHandle?.close().catch(() => undefined);
-    await directoryHandle?.close().catch(() => undefined);
+    await closeDirectoryHandles(directoryHandles);
   }
 }
 
@@ -99,16 +145,20 @@ export async function appendPrivateFileNoFollow(
   directory: string,
   filePath: string,
   content: string,
-  errorMessage: string
+  errorMessage: string,
+  trustedRoot = directory
 ): Promise<void> {
-  let directoryHandle: FileHandle | undefined;
+  if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
+  const targetName = path.basename(filePath);
+  let directoryHandles: FileHandle[] = [];
   let fileHandle: FileHandle | undefined;
   try {
-    const stableDirectory = await openStableDirectory(directory, errorMessage);
-    directoryHandle = stableDirectory.handle;
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    directoryHandles = stableDirectory.handles;
+    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
     try {
       fileHandle = await open(
-        filePath,
+        path.join(pinnedDirectory, targetName),
         fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW,
         0o600
       );
@@ -126,9 +176,10 @@ export async function appendPrivateFileNoFollow(
     if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
     await fileHandle.chmod(0o600);
     await fileHandle.appendFile(content, "utf8");
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
   } finally {
     await fileHandle?.close().catch(() => undefined);
-    await directoryHandle?.close().catch(() => undefined);
+    await closeDirectoryHandles(directoryHandles);
   }
 }
 
@@ -136,18 +187,19 @@ export async function writePrivateFileAtomicallyNoFollow(
   directory: string,
   filePath: string,
   content: string,
-  errorMessage: string
+  errorMessage: string,
+  trustedRoot = directory
 ): Promise<void> {
   if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
   const targetName = path.basename(filePath);
   const tempName = `.${targetName}.${randomUUID()}.tmp`;
-  let tempPath = path.join(directory, tempName);
-  let directoryHandle: FileHandle | undefined;
+  let tempPath: string | undefined;
+  let directoryHandles: FileHandle[] = [];
   let fileHandle: FileHandle | undefined;
   try {
-    const stableDirectory = await openStableDirectory(directory, errorMessage);
-    directoryHandle = stableDirectory.handle;
-    const pinnedDirectory = await pinnedDirectoryPath(directory, directoryHandle, stableDirectory.opened, errorMessage);
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    directoryHandles = stableDirectory.handles;
+    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
     tempPath = path.join(pinnedDirectory, tempName);
     const targetPath = path.join(pinnedDirectory, targetName);
     try {
@@ -171,18 +223,19 @@ export async function writePrivateFileAtomicallyNoFollow(
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     await rename(tempPath, targetPath);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    await syncDirectoryHandle(directoryHandle);
+    await syncDirectoryHandle(stableDirectory.handle);
   } finally {
     await fileHandle?.close().catch(() => undefined);
-    await rm(tempPath, { force: true }).catch(() => undefined);
-    await directoryHandle?.close().catch(() => undefined);
+    if (tempPath) await rm(tempPath, { force: true }).catch(() => undefined);
+    await closeDirectoryHandles(directoryHandles);
   }
 }
 
 export async function removePrivateFilesNoFollow(
   directory: string,
   fileNames: string[],
-  errorMessage: string
+  errorMessage: string,
+  trustedRoot = directory
 ): Promise<void> {
   if (
     fileNames.some(
@@ -191,17 +244,17 @@ export async function removePrivateFilesNoFollow(
   ) {
     throw new Error(errorMessage);
   }
-  let directoryHandle: FileHandle | undefined;
+  let directoryHandles: FileHandle[] = [];
   try {
-    const stableDirectory = await openStableDirectory(directory, errorMessage);
-    directoryHandle = stableDirectory.handle;
-    const pinnedDirectory = await pinnedDirectoryPath(directory, directoryHandle, stableDirectory.opened, errorMessage);
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    directoryHandles = stableDirectory.handles;
+    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
     for (const fileName of fileNames) {
       await rm(path.join(pinnedDirectory, fileName), { force: true });
     }
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    await syncDirectoryHandle(directoryHandle);
+    await syncDirectoryHandle(stableDirectory.handle);
   } finally {
-    await directoryHandle?.close().catch(() => undefined);
+    await closeDirectoryHandles(directoryHandles);
   }
 }

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,5 +1,9 @@
+import { randomUUID } from "node:crypto";
 import { constants as fsConstants, type Stats } from "node:fs";
-import { lstat, open, type FileHandle } from "node:fs/promises";
+import { lstat, open, rename, rm, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+
+const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 
 function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
   if (
@@ -22,6 +26,7 @@ async function openStableDirectory(directory: string, errorMessage: string): Pro
   handle: FileHandle;
 }> {
   const before = await lstat(directory);
+  if (before.isSymbolicLink() || !before.isDirectory()) throw new Error(errorMessage);
   const handle = await open(directory, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
   try {
     const opened = await handle.stat();
@@ -30,6 +35,15 @@ async function openStableDirectory(directory: string, errorMessage: string): Pro
   } catch (error) {
     await handle.close().catch(() => undefined);
     throw error;
+  }
+}
+
+async function syncDirectoryHandle(handle: FileHandle): Promise<void> {
+  try {
+    await handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!UNSUPPORTED_DIRECTORY_SYNC_ERRORS.has(code ?? "")) throw error;
   }
 }
 
@@ -97,6 +111,48 @@ export async function appendPrivateFileNoFollow(
     await fileHandle.appendFile(content, "utf8");
   } finally {
     await fileHandle?.close().catch(() => undefined);
+    await directoryHandle?.close().catch(() => undefined);
+  }
+}
+
+export async function writePrivateFileAtomicallyNoFollow(
+  directory: string,
+  filePath: string,
+  content: string,
+  errorMessage: string
+): Promise<void> {
+  if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
+  const tempPath = path.join(directory, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+  let directoryHandle: FileHandle | undefined;
+  let fileHandle: FileHandle | undefined;
+  try {
+    const stableDirectory = await openStableDirectory(directory, errorMessage);
+    directoryHandle = stableDirectory.handle;
+    try {
+      fileHandle = await open(
+        tempPath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+        0o600
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
+      throw error;
+    }
+    const fileMetadata = await fileHandle.stat();
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
+    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
+    await fileHandle.chmod(0o600);
+    await fileHandle.writeFile(content, "utf8");
+    await fileHandle.sync();
+    await fileHandle.close();
+    fileHandle = undefined;
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
+    await rename(tempPath, filePath);
+    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
+    await syncDirectoryHandle(directoryHandle);
+  } finally {
+    await fileHandle?.close().catch(() => undefined);
+    await rm(tempPath, { force: true }).catch(() => undefined);
     await directoryHandle?.close().catch(() => undefined);
   }
 }

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type Stats, constants as fsConstants } from "node:fs";
-import { type FileHandle, lstat, mkdir, open, realpath, rename, rm, stat } from "node:fs/promises";
+import { type FileHandle, lstat, mkdir, open, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
@@ -20,6 +20,50 @@ function assertStableDirectory(before: Stats, opened: Stats, after: Stats, error
   }
 }
 
+function assertStableRegularFile(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
+  if (
+    before.isSymbolicLink() ||
+    !before.isFile() ||
+    after.isSymbolicLink() ||
+    !after.isFile() ||
+    before.dev !== opened.dev ||
+    before.ino !== opened.ino ||
+    after.dev !== opened.dev ||
+    after.ino !== opened.ino ||
+    opened.nlink !== 1
+  ) {
+    throw new Error(errorMessage);
+  }
+}
+
+function openFlags(...flags: Array<number | undefined>): number {
+  let combined = 0;
+  for (const flag of flags) combined |= typeof flag === "number" ? flag : 0;
+  return combined;
+}
+
+function assertContainedPath(trustedRoot: string, directory: string, errorMessage: string): void {
+  const relative = path.relative(path.resolve(trustedRoot), path.resolve(directory));
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(errorMessage);
+  }
+}
+
+async function assertAbsoluteDirectoryChainNoFollow(directory: string, errorMessage: string): Promise<Stats> {
+  const target = path.resolve(directory);
+  const root = path.parse(target).root;
+  const components = path.relative(root, target).split(path.sep).filter(Boolean);
+  let current = root;
+  let metadata = await lstat(current);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) throw new Error(errorMessage);
+  for (const component of components) {
+    current = path.join(current, component);
+    metadata = await lstat(current);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) throw new Error(errorMessage);
+  }
+  return metadata;
+}
+
 async function openDirectoryNoFollow(
   directory: string,
   errorMessage: string
@@ -30,7 +74,10 @@ async function openDirectoryNoFollow(
 }> {
   const before = await lstat(directory);
   if (before.isSymbolicLink() || !before.isDirectory()) throw new Error(errorMessage);
-  const handle = await open(directory, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
+  const handle = await open(
+    directory,
+    openFlags(fsConstants.O_RDONLY, fsConstants.O_DIRECTORY, fsConstants.O_NOFOLLOW),
+  );
   try {
     const opened = await handle.stat();
     assertStableDirectory(before, opened, await lstat(directory), errorMessage);
@@ -61,6 +108,10 @@ export async function resolvePrivateDirectoryPath(
   errorMessage: string,
   platform: NodeJS.Platform = process.platform
 ): Promise<string> {
+  if (platform === "win32") {
+    assertStableDirectory(opened, opened, await lstat(directory), errorMessage);
+    return path.resolve(directory);
+  }
   const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
   const pinnedPath = path.join(descriptorRoot, String(handle.fd));
   const metadata = await stat(pinnedPath);
@@ -79,19 +130,23 @@ export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, erro
 async function openStableDirectoryFromRoot(
   trustedRoot: string,
   directory: string,
-  errorMessage: string
+  errorMessage: string,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<{
   before: Stats;
   opened: Stats;
-  handle: FileHandle;
+  handle?: FileHandle;
   handles: FileHandle[];
+  pinnedDirectory: string;
 }> {
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
-  const relative = path.relative(root, target);
-  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
-    throw new Error(errorMessage);
+  assertContainedPath(root, target, errorMessage);
+  if (platform === "win32") {
+    const opened = await assertAbsoluteDirectoryChainNoFollow(target, errorMessage);
+    return { before: opened, opened, handles: [], pinnedDirectory: target };
   }
+  const relative = path.relative(root, target);
   const components = relative === "" ? [] : relative.split(path.sep);
   const handles: FileHandle[] = [];
   let currentPath = root;
@@ -107,7 +162,17 @@ async function openStableDirectoryFromRoot(
       current = child;
     }
     assertStableDirectory(current.before, current.opened, await lstat(target), errorMessage);
-    return { ...current, handles };
+    return {
+      ...current,
+      handles,
+      pinnedDirectory: await resolvePrivateDirectoryPath(
+        target,
+        current.handle,
+        current.opened,
+        errorMessage,
+        platform,
+      ),
+    };
   } catch (error) {
     await closeDirectoryHandles(handles);
     throw error;
@@ -119,13 +184,39 @@ export async function ensurePrivateDirectoryNoFollow(
   directory: string,
   errorMessage: string,
   syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle,
-  hardenExistingChildren = true
+  hardenExistingChildren = true,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<void> {
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
+  assertContainedPath(root, target, errorMessage);
   const relative = path.relative(root, target);
-  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
-    throw new Error(errorMessage);
+  if (platform === "win32") {
+    await assertAbsoluteDirectoryChainNoFollow(root, errorMessage);
+    let currentPath = root;
+    for (const component of relative === "" ? [] : relative.split(path.sep)) {
+      const childPath = path.join(currentPath, component);
+      let created = false;
+      try {
+        await mkdir(childPath, { mode: 0o700 });
+        created = true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+      const child = await lstat(childPath);
+      if (child.isSymbolicLink() || !child.isDirectory()) throw new Error(errorMessage);
+      if (created || (hardenExistingChildren && (child.mode & 0o777) !== 0o700)) {
+        const childHandle = await open(childPath, openFlags(fsConstants.O_RDONLY));
+        try {
+          await childHandle.chmod(0o700);
+        } finally {
+          await childHandle.close();
+        }
+      }
+      currentPath = childPath;
+    }
+    await assertAbsoluteDirectoryChainNoFollow(target, errorMessage);
+    return;
   }
   const components = relative === "" ? [] : relative.split(path.sep);
   const handles: FileHandle[] = [];
@@ -159,50 +250,36 @@ export async function ensurePrivateDirectoryNoFollow(
   }
 }
 
-export async function canonicalizePrivateDirectoryTarget(directory: string): Promise<string> {
-  const target = path.resolve(directory);
-  const missingComponents: string[] = [];
-  let existing = target;
-  while (true) {
-    try {
-      const canonicalExisting = await realpath(existing);
-      return path.join(canonicalExisting, ...missingComponents);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      const parent = path.dirname(existing);
-      if (parent === existing) throw error;
-      missingComponents.unshift(path.basename(existing));
-      existing = parent;
-    }
-  }
-}
-
 export async function ensurePrivateDirectoryTreeNoFollow(
   directory: string,
   errorMessage: string,
-  syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
+  syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<void> {
   const target = path.resolve(directory);
-  await ensurePrivateDirectoryNoFollow(path.parse(target).root, target, errorMessage, syncVerifiedParent, false);
+  await ensurePrivateDirectoryNoFollow(
+    path.parse(target).root,
+    target,
+    errorMessage,
+    syncVerifiedParent,
+    false,
+    platform,
+  );
 }
 
 export async function withPrivateDirectoryNoFollow<T>(
   trustedRoot: string,
   directory: string,
   errorMessage: string,
-  task: (pinnedDirectory: string) => Promise<T>
+  task: (pinnedDirectory: string) => Promise<T>,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<T> {
   let directoryHandles: FileHandle[] = [];
   try {
-    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage, platform);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await resolvePrivateDirectoryPath(
-      directory,
-      stableDirectory.handle,
-      stableDirectory.opened,
-      errorMessage
-    );
-    const result = await task(pinnedDirectory);
+    const result = await task(stableDirectory.pinnedDirectory);
+    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     return result;
   } finally {
@@ -214,30 +291,30 @@ export async function readPrivateFileNoFollow(
   directory: string,
   filePath: string,
   errorMessage: string,
-  trustedRoot = directory
+  trustedRoot = directory,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<string> {
   if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
   const targetName = path.basename(filePath);
   let directoryHandles: FileHandle[] = [];
   let fileHandle: FileHandle | undefined;
   try {
-    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage, platform);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await resolvePrivateDirectoryPath(
-      directory,
-      stableDirectory.handle,
-      stableDirectory.opened,
-      errorMessage
-    );
+    const pinnedDirectory = stableDirectory.pinnedDirectory;
+    const targetPath = path.join(pinnedDirectory, targetName);
+    const before = await lstat(targetPath);
+    if (before.isSymbolicLink() || !before.isFile()) throw new Error(errorMessage);
     try {
-      fileHandle = await open(path.join(pinnedDirectory, targetName), fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      fileHandle = await open(targetPath, openFlags(fsConstants.O_RDONLY, fsConstants.O_NOFOLLOW));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
       throw error;
     }
     const fileMetadata = await fileHandle.stat();
+    assertStableRegularFile(before, fileMetadata, await lstat(targetPath), errorMessage);
+    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
     return await fileHandle.readFile("utf8");
   } finally {
     await fileHandle?.close().catch(() => undefined);
@@ -250,7 +327,8 @@ export async function writePrivateFileAtomicallyNoFollow(
   filePath: string,
   content: string,
   errorMessage: string,
-  trustedRoot = directory
+  trustedRoot = directory,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<void> {
   if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
   const targetName = path.basename(filePath);
@@ -259,20 +337,15 @@ export async function writePrivateFileAtomicallyNoFollow(
   let directoryHandles: FileHandle[] = [];
   let fileHandle: FileHandle | undefined;
   try {
-    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage, platform);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await resolvePrivateDirectoryPath(
-      directory,
-      stableDirectory.handle,
-      stableDirectory.opened,
-      errorMessage
-    );
+    const pinnedDirectory = stableDirectory.pinnedDirectory;
     tempPath = path.join(pinnedDirectory, tempName);
     const targetPath = path.join(pinnedDirectory, targetName);
     try {
       fileHandle = await open(
         tempPath,
-        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+        openFlags(fsConstants.O_WRONLY, fsConstants.O_CREAT, fsConstants.O_EXCL, fsConstants.O_NOFOLLOW),
         0o600
       );
     } catch (error) {
@@ -280,17 +353,20 @@ export async function writePrivateFileAtomicallyNoFollow(
       throw error;
     }
     const fileMetadata = await fileHandle.stat();
+    const tempMetadata = await lstat(tempPath);
+    assertStableRegularFile(tempMetadata, fileMetadata, await lstat(tempPath), errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
     await fileHandle.chmod(0o600);
     await fileHandle.writeFile(content, "utf8");
     await fileHandle.sync();
     await fileHandle.close();
     fileHandle = undefined;
+    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     await rename(tempPath, targetPath);
+    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    await syncDirectoryHandle(stableDirectory.handle);
+    if (stableDirectory.handle) await syncDirectoryHandle(stableDirectory.handle);
   } finally {
     await fileHandle?.close().catch(() => undefined);
     if (tempPath) await rm(tempPath, { force: true }).catch(() => undefined);
@@ -302,7 +378,8 @@ export async function removePrivateFilesNoFollow(
   directory: string,
   fileNames: string[],
   errorMessage: string,
-  trustedRoot = directory
+  trustedRoot = directory,
+  platform: NodeJS.Platform = process.platform,
 ): Promise<void> {
   if (
     fileNames.some(
@@ -314,19 +391,15 @@ export async function removePrivateFilesNoFollow(
   }
   let directoryHandles: FileHandle[] = [];
   try {
-    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
+    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage, platform);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await resolvePrivateDirectoryPath(
-      directory,
-      stableDirectory.handle,
-      stableDirectory.opened,
-      errorMessage
-    );
+    const pinnedDirectory = stableDirectory.pinnedDirectory;
     for (const fileName of fileNames) {
       await rm(path.join(pinnedDirectory, fileName), { force: true });
     }
+    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    await syncDirectoryHandle(stableDirectory.handle);
+    if (stableDirectory.handle) await syncDirectoryHandle(stableDirectory.handle);
   } finally {
     await closeDirectoryHandles(directoryHandles);
   }

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants, type Stats } from "node:fs";
-import { lstat, open, rename, rm, type FileHandle } from "node:fs/promises";
+import { lstat, open, rename, rm, stat, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
@@ -45,6 +45,23 @@ async function syncDirectoryHandle(handle: FileHandle): Promise<void> {
     const code = (error as NodeJS.ErrnoException).code;
     if (!UNSUPPORTED_DIRECTORY_SYNC_ERRORS.has(code ?? "")) throw error;
   }
+}
+
+async function pinnedDirectoryPath(
+  directory: string,
+  handle: FileHandle,
+  opened: Stats,
+  errorMessage: string
+): Promise<string> {
+  const descriptorRoot =
+    process.platform === "linux" ? "/proc/self/fd" : process.platform === "darwin" ? "/dev/fd" : null;
+  if (!descriptorRoot) return directory;
+  const pinnedPath = path.join(descriptorRoot, String(handle.fd));
+  const metadata = await stat(pinnedPath);
+  if (!metadata.isDirectory() || metadata.dev !== opened.dev || metadata.ino !== opened.ino) {
+    throw new Error(errorMessage);
+  }
+  return pinnedPath;
 }
 
 export async function readPrivateFileNoFollow(
@@ -122,12 +139,17 @@ export async function writePrivateFileAtomicallyNoFollow(
   errorMessage: string
 ): Promise<void> {
   if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
-  const tempPath = path.join(directory, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+  const targetName = path.basename(filePath);
+  const tempName = `.${targetName}.${randomUUID()}.tmp`;
+  let tempPath = path.join(directory, tempName);
   let directoryHandle: FileHandle | undefined;
   let fileHandle: FileHandle | undefined;
   try {
     const stableDirectory = await openStableDirectory(directory, errorMessage);
     directoryHandle = stableDirectory.handle;
+    const pinnedDirectory = await pinnedDirectoryPath(directory, directoryHandle, stableDirectory.opened, errorMessage);
+    tempPath = path.join(pinnedDirectory, tempName);
+    const targetPath = path.join(pinnedDirectory, targetName);
     try {
       fileHandle = await open(
         tempPath,
@@ -147,7 +169,7 @@ export async function writePrivateFileAtomicallyNoFollow(
     await fileHandle.close();
     fileHandle = undefined;
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    await rename(tempPath, filePath);
+    await rename(tempPath, targetPath);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     await syncDirectoryHandle(directoryHandle);
   } finally {

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,0 +1,102 @@
+import { constants as fsConstants, type Stats } from "node:fs";
+import { lstat, open, type FileHandle } from "node:fs/promises";
+
+function assertStableDirectory(before: Stats, opened: Stats, after: Stats, errorMessage: string): void {
+  if (
+    before.isSymbolicLink() ||
+    !before.isDirectory() ||
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    before.dev !== opened.dev ||
+    before.ino !== opened.ino ||
+    after.dev !== opened.dev ||
+    after.ino !== opened.ino
+  ) {
+    throw new Error(errorMessage);
+  }
+}
+
+async function openStableDirectory(directory: string, errorMessage: string): Promise<{
+  before: Stats;
+  opened: Stats;
+  handle: FileHandle;
+}> {
+  const before = await lstat(directory);
+  const handle = await open(directory, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
+  try {
+    const opened = await handle.stat();
+    assertStableDirectory(before, opened, await lstat(directory), errorMessage);
+    return { before, opened, handle };
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function readPrivateFileNoFollow(
+  directory: string,
+  filePath: string,
+  errorMessage: string
+): Promise<string> {
+  let directoryHandle: FileHandle | undefined;
+  let fileHandle: FileHandle | undefined;
+  try {
+    const stableDirectory = await openStableDirectory(directory, errorMessage);
+    directoryHandle = stableDirectory.handle;
+    try {
+      fileHandle = await open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
+      throw error;
+    }
+    const fileMetadata = await fileHandle.stat();
+    assertStableDirectory(
+      stableDirectory.before,
+      stableDirectory.opened,
+      await lstat(directory),
+      errorMessage
+    );
+    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
+    return await fileHandle.readFile("utf8");
+  } finally {
+    await fileHandle?.close().catch(() => undefined);
+    await directoryHandle?.close().catch(() => undefined);
+  }
+}
+
+export async function appendPrivateFileNoFollow(
+  directory: string,
+  filePath: string,
+  content: string,
+  errorMessage: string
+): Promise<void> {
+  let directoryHandle: FileHandle | undefined;
+  let fileHandle: FileHandle | undefined;
+  try {
+    const stableDirectory = await openStableDirectory(directory, errorMessage);
+    directoryHandle = stableDirectory.handle;
+    try {
+      fileHandle = await open(
+        filePath,
+        fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW,
+        0o600
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
+      throw error;
+    }
+    const fileMetadata = await fileHandle.stat();
+    assertStableDirectory(
+      stableDirectory.before,
+      stableDirectory.opened,
+      await lstat(directory),
+      errorMessage
+    );
+    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
+    await fileHandle.chmod(0o600);
+    await fileHandle.appendFile(content, "utf8");
+  } finally {
+    await fileHandle?.close().catch(() => undefined);
+    await directoryHandle?.close().catch(() => undefined);
+  }
+}

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -49,21 +49,6 @@ function assertContainedPath(trustedRoot: string, directory: string, errorMessag
   }
 }
 
-async function assertAbsoluteDirectoryChainNoFollow(directory: string, errorMessage: string): Promise<Stats> {
-  const target = path.resolve(directory);
-  const root = path.parse(target).root;
-  const components = path.relative(root, target).split(path.sep).filter(Boolean);
-  let current = root;
-  let metadata = await lstat(current);
-  if (metadata.isSymbolicLink() || !metadata.isDirectory()) throw new Error(errorMessage);
-  for (const component of components) {
-    current = path.join(current, component);
-    metadata = await lstat(current);
-    if (metadata.isSymbolicLink() || !metadata.isDirectory()) throw new Error(errorMessage);
-  }
-  return metadata;
-}
-
 async function openDirectoryNoFollow(
   directory: string,
   errorMessage: string
@@ -108,10 +93,6 @@ export async function resolvePrivateDirectoryPath(
   errorMessage: string,
   platform: NodeJS.Platform = process.platform
 ): Promise<string> {
-  if (platform === "win32") {
-    assertStableDirectory(opened, opened, await lstat(directory), errorMessage);
-    return path.resolve(directory);
-  }
   const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
   const pinnedPath = path.join(descriptorRoot, String(handle.fd));
   const metadata = await stat(pinnedPath);
@@ -142,10 +123,7 @@ async function openStableDirectoryFromRoot(
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
   assertContainedPath(root, target, errorMessage);
-  if (platform === "win32") {
-    const opened = await assertAbsoluteDirectoryChainNoFollow(target, errorMessage);
-    return { before: opened, opened, handles: [], pinnedDirectory: target };
-  }
+  requirePrivateFileDescriptorRoot(platform, errorMessage);
   const relative = path.relative(root, target);
   const components = relative === "" ? [] : relative.split(path.sep);
   const handles: FileHandle[] = [];
@@ -191,33 +169,7 @@ export async function ensurePrivateDirectoryNoFollow(
   const target = path.resolve(directory);
   assertContainedPath(root, target, errorMessage);
   const relative = path.relative(root, target);
-  if (platform === "win32") {
-    await assertAbsoluteDirectoryChainNoFollow(root, errorMessage);
-    let currentPath = root;
-    for (const component of relative === "" ? [] : relative.split(path.sep)) {
-      const childPath = path.join(currentPath, component);
-      let created = false;
-      try {
-        await mkdir(childPath, { mode: 0o700 });
-        created = true;
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      }
-      const child = await lstat(childPath);
-      if (child.isSymbolicLink() || !child.isDirectory()) throw new Error(errorMessage);
-      if (created || (hardenExistingChildren && (child.mode & 0o777) !== 0o700)) {
-        const childHandle = await open(childPath, openFlags(fsConstants.O_RDONLY));
-        try {
-          await childHandle.chmod(0o700);
-        } finally {
-          await childHandle.close();
-        }
-      }
-      currentPath = childPath;
-    }
-    await assertAbsoluteDirectoryChainNoFollow(target, errorMessage);
-    return;
-  }
+  requirePrivateFileDescriptorRoot(platform, errorMessage);
   const components = relative === "" ? [] : relative.split(path.sep);
   const handles: FileHandle[] = [];
   let currentPath = root;
@@ -279,7 +231,6 @@ export async function withPrivateDirectoryNoFollow<T>(
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage, platform);
     directoryHandles = stableDirectory.handles;
     const result = await task(stableDirectory.pinnedDirectory);
-    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     return result;
   } finally {
@@ -313,7 +264,6 @@ export async function readPrivateFileNoFollow(
     }
     const fileMetadata = await fileHandle.stat();
     assertStableRegularFile(before, fileMetadata, await lstat(targetPath), errorMessage);
-    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     return await fileHandle.readFile("utf8");
   } finally {
@@ -361,10 +311,8 @@ export async function writePrivateFileAtomicallyNoFollow(
     await fileHandle.sync();
     await fileHandle.close();
     fileHandle = undefined;
-    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     await rename(tempPath, targetPath);
-    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     if (stableDirectory.handle) await syncDirectoryHandle(stableDirectory.handle);
   } finally {
@@ -397,7 +345,6 @@ export async function removePrivateFilesNoFollow(
     for (const fileName of fileNames) {
       await rm(path.join(pinnedDirectory, fileName), { force: true });
     }
-    if (platform === "win32") await assertAbsoluteDirectoryChainNoFollow(directory, errorMessage);
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     if (stableDirectory.handle) await syncDirectoryHandle(stableDirectory.handle);
   } finally {

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -52,20 +52,23 @@ async function syncDirectoryHandle(handle: FileHandle): Promise<void> {
 }
 
 async function pinnedDirectoryPath(
-  directory: string,
   handle: FileHandle,
   opened: Stats,
   errorMessage: string
 ): Promise<string> {
-  const descriptorRoot =
-    process.platform === "linux" ? "/proc/self/fd" : process.platform === "darwin" ? "/dev/fd" : null;
-  if (!descriptorRoot) return directory;
+  const descriptorRoot = requirePrivateFileDescriptorRoot(process.platform, errorMessage);
   const pinnedPath = path.join(descriptorRoot, String(handle.fd));
   const metadata = await stat(pinnedPath);
   if (!metadata.isDirectory() || metadata.dev !== opened.dev || metadata.ino !== opened.ino) {
     throw new Error(errorMessage);
   }
   return pinnedPath;
+}
+
+export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, errorMessage: string): string {
+  if (platform === "linux") return "/proc/self/fd";
+  if (platform === "darwin") return "/dev/fd";
+  throw new Error(errorMessage);
 }
 
 async function openStableDirectoryFromRoot(
@@ -91,7 +94,7 @@ async function openStableDirectoryFromRoot(
     let current = await openDirectoryNoFollow(root, errorMessage);
     handles.push(current.handle);
     for (const component of components) {
-      const pinnedParent = await pinnedDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
+      const pinnedParent = await pinnedDirectoryPath(current.handle, current.opened, errorMessage);
       const child = await openDirectoryNoFollow(path.join(pinnedParent, component), errorMessage);
       handles.push(child.handle);
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
@@ -119,7 +122,7 @@ export async function readPrivateFileNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
     try {
       fileHandle = await open(path.join(pinnedDirectory, targetName), fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
     } catch (error) {
@@ -155,7 +158,7 @@ export async function appendPrivateFileNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
     try {
       fileHandle = await open(
         path.join(pinnedDirectory, targetName),
@@ -199,7 +202,7 @@ export async function writePrivateFileAtomicallyNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
     tempPath = path.join(pinnedDirectory, tempName);
     const targetPath = path.join(pinnedDirectory, targetName);
     try {
@@ -248,7 +251,7 @@ export async function removePrivateFilesNoFollow(
   try {
     const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
     directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await pinnedDirectoryPath(directory, stableDirectory.handle, stableDirectory.opened, errorMessage);
+    const pinnedDirectory = await pinnedDirectoryPath(stableDirectory.handle, stableDirectory.opened, errorMessage);
     for (const fileName of fileNames) {
       await rm(path.join(pinnedDirectory, fileName), { force: true });
     }

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -113,7 +113,7 @@ export async function ensurePrivateDirectoryNoFollow(
   trustedRoot: string,
   directory: string,
   errorMessage: string,
-  syncCreatedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
+  syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
 ): Promise<void> {
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
@@ -130,17 +130,15 @@ export async function ensurePrivateDirectoryNoFollow(
     for (const component of components) {
       const pinnedParent = await pinnedDirectoryPath(current.handle, current.opened, errorMessage);
       const childPath = path.join(pinnedParent, component);
-      let created = false;
       try {
         await mkdir(childPath, { mode: 0o700 });
-        created = true;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
+      await syncVerifiedParent(current.handle);
       const child = await openDirectoryNoFollow(childPath, errorMessage);
       handles.push(child.handle);
       await child.handle.chmod(0o700);
-      if (created) await syncCreatedParent(current.handle);
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
       currentPath = path.join(currentPath, component);
       current = child;

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type Stats, constants as fsConstants } from "node:fs";
-import { type FileHandle, lstat, mkdir, open, rename, rm, stat } from "node:fs/promises";
+import { type FileHandle, lstat, mkdir, open, realpath, rename, rm, rmdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 const UNSUPPORTED_DIRECTORY_SYNC_ERRORS = new Set(["EINVAL", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
@@ -142,10 +142,19 @@ export async function ensurePrivateDirectoryNoFollow(
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
-      await syncVerifiedParent(current.handle);
+      if (created) {
+        try {
+          await syncVerifiedParent(current.handle);
+        } catch (error) {
+          await rmdir(childPath).catch(() => undefined);
+          throw error;
+        }
+      }
       const child = await openDirectoryNoFollow(childPath, errorMessage);
       handles.push(child.handle);
-      if (created || hardenExistingChildren) await child.handle.chmod(0o700);
+      if (created || (hardenExistingChildren && (child.opened.mode & 0o777) !== 0o700)) {
+        await child.handle.chmod(0o700);
+      }
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
       currentPath = path.join(currentPath, component);
       current = child;
@@ -153,6 +162,24 @@ export async function ensurePrivateDirectoryNoFollow(
     assertStableDirectory(current.before, current.opened, await lstat(target), errorMessage);
   } finally {
     await closeDirectoryHandles(handles);
+  }
+}
+
+export async function canonicalizePrivateDirectoryTarget(directory: string): Promise<string> {
+  const target = path.resolve(directory);
+  const missingComponents: string[] = [];
+  let existing = target;
+  while (true) {
+    try {
+      const canonicalExisting = await realpath(existing);
+      return path.join(canonicalExisting, ...missingComponents);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existing);
+      if (parent === existing) throw error;
+      missingComponents.unshift(path.basename(existing));
+      existing = parent;
+    }
   }
 }
 

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -117,7 +117,8 @@ export async function ensurePrivateDirectoryNoFollow(
   trustedRoot: string,
   directory: string,
   errorMessage: string,
-  syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
+  syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle,
+  hardenExistingChildren = true
 ): Promise<void> {
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
@@ -134,15 +135,17 @@ export async function ensurePrivateDirectoryNoFollow(
     for (const component of components) {
       const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
       const childPath = path.join(pinnedParent, component);
+      let created = false;
       try {
         await mkdir(childPath, { mode: 0o700 });
+        created = true;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       }
       await syncVerifiedParent(current.handle);
       const child = await openDirectoryNoFollow(childPath, errorMessage);
       handles.push(child.handle);
-      await child.handle.chmod(0o700);
+      if (created || hardenExistingChildren) await child.handle.chmod(0o700);
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
       currentPath = path.join(currentPath, component);
       current = child;
@@ -159,20 +162,7 @@ export async function ensurePrivateDirectoryTreeNoFollow(
   syncVerifiedParent: (handle: FileHandle) => Promise<void> = syncDirectoryHandle
 ): Promise<void> {
   const target = path.resolve(directory);
-  let existingAncestor = target;
-  while (true) {
-    try {
-      const metadata = await lstat(existingAncestor);
-      if (metadata.isSymbolicLink() || !metadata.isDirectory()) throw new Error(errorMessage);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      const parent = path.dirname(existingAncestor);
-      if (parent === existingAncestor) throw error;
-      existingAncestor = parent;
-    }
-  }
-  await ensurePrivateDirectoryNoFollow(existingAncestor, target, errorMessage, syncVerifiedParent);
+  await ensurePrivateDirectoryNoFollow(path.parse(target).root, target, errorMessage, syncVerifiedParent, false);
 }
 
 export async function withPrivateDirectoryNoFollow<T>(
@@ -228,48 +218,6 @@ export async function readPrivateFileNoFollow(
     assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
     if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
     return await fileHandle.readFile("utf8");
-  } finally {
-    await fileHandle?.close().catch(() => undefined);
-    await closeDirectoryHandles(directoryHandles);
-  }
-}
-
-export async function appendPrivateFileNoFollow(
-  directory: string,
-  filePath: string,
-  content: string,
-  errorMessage: string,
-  trustedRoot = directory
-): Promise<void> {
-  if (path.dirname(filePath) !== path.resolve(directory)) throw new Error(errorMessage);
-  const targetName = path.basename(filePath);
-  let directoryHandles: FileHandle[] = [];
-  let fileHandle: FileHandle | undefined;
-  try {
-    const stableDirectory = await openStableDirectoryFromRoot(trustedRoot, directory, errorMessage);
-    directoryHandles = stableDirectory.handles;
-    const pinnedDirectory = await resolvePrivateDirectoryPath(
-      directory,
-      stableDirectory.handle,
-      stableDirectory.opened,
-      errorMessage
-    );
-    try {
-      fileHandle = await open(
-        path.join(pinnedDirectory, targetName),
-        fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW,
-        0o600
-      );
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(errorMessage);
-      throw error;
-    }
-    const fileMetadata = await fileHandle.stat();
-    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
-    if (!fileMetadata.isFile() || fileMetadata.nlink !== 1) throw new Error(errorMessage);
-    await fileHandle.chmod(0o600);
-    await fileHandle.appendFile(content, "utf8");
-    assertStableDirectory(stableDirectory.before, stableDirectory.opened, await lstat(directory), errorMessage);
   } finally {
     await fileHandle?.close().catch(() => undefined);
     await closeDirectoryHandles(directoryHandles);


### PR DESCRIPTION
## Summary

Add exact-version, time-limited Support Passport grants for issue #2355.

Owners share selected approved card revisions. Helpers receive only the public card projection. Revocation, expiry, stale cards, bad secrets, and corrupt state fail closed.

Grant secrets use 32 random bytes. Remnic stores only hashes with owner-only permissions and atomic, lock-protected writes.

## Validation

- [x] Tests prove secrets never reach files, logs, or owner grant lists.
- [x] Tests cover guessed secrets, exact expiry, stale revisions, state races, symlinks, corruption, and cross-process revocation.
- [x] `npm test`
- [x] `npm run preflight:quick`
- [x] `npm run test:entity-hardening`
- [x] `npm run build`
- [x] No secrets or tokens were added.
- [x] Cursor CLI was unavailable locally. GitHub review gates are active.

## Stack

This is layer 2 of 7. It depends on https://github.com/joshuaswarren/remnic/pull/2360.

Part of #2355.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New security-sensitive sharing layer (secrets, timing-safe auth, cross-namespace isolation) plus complex filesystem locking and recovery; mistakes could leak cards or accept stale/forged grants.
> 
> **Overview**
> Adds **time-limited share links** so owners can grant helpers read-only access to selected **approved support card revisions**, without exposing raw secrets or full owner identity on disk.
> 
> **`SupportPassportGrantService`** orchestrates create/list/revoke for owners and **`readGrant`** for helpers: it validates card ownership and revision pins under the **owner lock**, coordinates with **`SupportPassportGrantStore`**, and assembles a **public guide** (title/statement/category only) with re-authentication, corpus snapshot consistency, and **`grant_stale`** / **`grant_expired`** / **`grant_gone`** semantics when cards, locks, or lifecycle change mid-read.
> 
> **`SupportPassportGrantStore`** persists grant state as private JSON (secret and principal **hashed**), maintains per-owner indexes with a **100-link cap** and eviction, uses **file locks** and durability sync, and includes recovery paths for index/lock races. New **Zod grant contracts** and **error codes** (`grant_*`, `state_conflict`) support the API surface.
> 
> **`owner-lock`** now accepts an **`ownerKey`** scope (aligned with stored `ownerLockKey`) so helper reads can serialize with card mutations without the principal string. Package **exports** and a large **test suite** cover security, concurrency, symlinks, cache freshness, and cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447a4428583bff38d401af9a564c30a570c7d5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->