### PR TITLE
feat(ui): add the What Helps Me support passport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ docs/research/failure-gate/RESUME-HANDOFF.md
 # packages/bench/profiles/h6-example.json and edit it locally.
 packages/bench/profiles/h6-*.json
 !packages/bench/profiles/h6-example.json
+
+# Browser test artifacts
+.playwright-cli/
+output/playwright/

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -855,9 +855,9 @@
       return;
     }
     const choice = document.querySelector('input[name="duration"]:checked')?.value ?? "2h";
-    let expiresAt;
+    let expiry;
     try {
-      expiresAt = model.expiryForChoice(choice, byId("customTimeInput").value);
+      expiry = model.expiryForChoice(choice, byId("customTimeInput").value);
     } catch (error) {
       setError("shareError", errorMessage(error, "Choose a valid share time."));
       return;
@@ -871,7 +871,7 @@
     try {
       let created;
       try {
-        created = model.parseCreatedGrant(await api.createGrant({ cardIds, cardRevisions, expiresAt }));
+        created = model.parseCreatedGrant(await api.createGrant({ cardIds, cardRevisions, ...expiry }));
       } catch (error) {
         if (error?.code !== "request_timeout") {
           setError("shareError", errorMessage(error, "The share link was not created."));

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -679,7 +679,7 @@
         ...state.selectedNotes,
         {
           memoryId,
-          content: model.stripAttributesSuffix(preview.memory.content),
+          content: preview.memory.content,
           revision: preview.memory.revision,
         },
       ];

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -717,41 +717,47 @@
       return;
     }
     const button = event.currentTarget.querySelector('button[type="submit"]');
-    let created;
+    const priorLabel = button.textContent;
+    button.disabled = true;
+    button.textContent = "Creating link…";
     try {
-      created = model.parseCreatedGrant(
-        await withBusy(button, "Creating link…", () => api.createGrant({ cardIds, cardRevisions, expiresAt }))
-      );
-    } catch (error) {
-      if (error?.code !== "request_timeout") {
-        setError("shareError", errorMessage(error, "The share link was not created."));
+      let created;
+      try {
+        created = model.parseCreatedGrant(await api.createGrant({ cardIds, cardRevisions, expiresAt }));
+      } catch (error) {
+        if (error?.code !== "request_timeout") {
+          setError("shareError", errorMessage(error, "The share link was not created."));
+          return;
+        }
+        let refreshed = false;
+        try {
+          await loadOwnerState();
+          refreshed = true;
+        } catch {}
+        setError(
+          "shareError",
+          refreshed
+            ? "The server did not confirm whether it created a link. Review the live share list and stop any link you do not recognize before creating another."
+            : "The server did not confirm whether it created a link. Refresh the guide and review live shares before creating another."
+        );
         return;
       }
-      let refreshed = false;
+      const url = model.buildShareUrl(window.location.href, created.grantId, created.secret, replayMode);
+      byId("shareLinkInput").value = url;
+      byId("openLinkButton").href = url;
+      byId("newLinkPanel").hidden = false;
+      const message = `Share link created. It ends ${model.formatDate(created.expiresAt)}.`;
+      toast(message);
+      announce(message);
+      byId("newLinkPanel").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "nearest" });
       try {
         await loadOwnerState();
-        refreshed = true;
-      } catch {}
-      setError(
-        "shareError",
-        refreshed
-          ? "The server did not confirm whether it created a link. Review the live share list and stop any link you do not recognize before creating another."
-          : "The server did not confirm whether it created a link. Refresh the guide and review live shares before creating another."
-      );
-      return;
-    }
-    const url = model.buildShareUrl(window.location.href, created.grantId, created.secret, replayMode);
-    byId("shareLinkInput").value = url;
-    byId("openLinkButton").href = url;
-    byId("newLinkPanel").hidden = false;
-    const message = `Share link created. It ends ${model.formatDate(created.expiresAt)}.`;
-    toast(message);
-    announce(message);
-    byId("newLinkPanel").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "nearest" });
-    try {
-      await loadOwnerState();
-    } catch {
-      setError("shareError", "The share link was created, but the share list did not refresh. Use the link above.");
+      } catch {
+        setError("shareError", "The share link was created, but the share list did not refresh. Use the link above.");
+      }
+    } finally {
+      button.disabled = false;
+      button.textContent = priorLabel;
     }
   }
 

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -1,0 +1,1085 @@
+(function startWhatHelpsMe() {
+  const model = window.WhatHelpsMeModel;
+  if (!model) throw new Error("What Helps Me model did not load.");
+
+  const byId = (id) => document.getElementById(id);
+  const params = new URLSearchParams(window.location.search);
+  const replayMode = params.get("mode") === "replay";
+  const grantId = params.get("grant") ?? "";
+  const hasSecretFragment = new URLSearchParams(window.location.hash.slice(1)).has("secret");
+  const secret = model.parseSecret(window.location.hash);
+  if (hasSecretFragment) {
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  }
+  const replayStore = replayMode ? model.createReplayStore() : null;
+  const replayChannel =
+    replayMode && "BroadcastChannel" in window ? new BroadcastChannel("remnic-what-helps-me-replay") : null;
+  const HELPER_REVALIDATION_MS = 30_000;
+  const HELPER_REVALIDATION_MAX_MS = 5 * 60_000;
+  const HELPER_READ_TIMEOUT_MS = 10_000;
+  const HELPER_QUESTION_TIMEOUT_MS = 60_000;
+  const OWNER_READ_TIMEOUT_MS = 30_000;
+  const OWNER_WRITE_TIMEOUT_MS = 60_000;
+  const OWNER_MODEL_WRITE_TIMEOUT_MS = 15 * 60_000;
+  const OWNER_RECONCILIATION_ATTEMPTS = 4;
+  const OWNER_RECONCILIATION_DELAY_MS = 250;
+  const MAX_VISIBLE_GRANTS = 100;
+  const MAX_SHARED_CARDS = 8;
+  const PAGE_HIDDEN_ABORT = new Error("The helper page was hidden.");
+  const SCROLL_BEHAVIOR = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+  const TERMINAL_HELPER_ERROR_CODES = new Set([
+    "grant_expired",
+    "grant_gone",
+    "grant_not_found",
+    "grant_stale",
+    "missing_link",
+  ]);
+
+  const state = {
+    token: "",
+    cards: [],
+    grants: [],
+    selectedNotes: [],
+    guide: null,
+    helperSecret: secret,
+    helperGrantId: grantId,
+    helperServerOffsetMs: null,
+    helperExpiryTimer: null,
+    helperLoadController: null,
+    helperQuestionController: null,
+    helperRevalidationController: null,
+    helperRevalidationTimer: null,
+    helperRevalidationDelayMs: HELPER_REVALIDATION_MS,
+    helperLifecyclePaused: false,
+    toastTimer: null,
+  };
+
+  function element(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function clear(node) {
+    node.replaceChildren();
+  }
+
+  function setError(id, message = "") {
+    byId(id).textContent = message;
+  }
+
+  function announce(message) {
+    byId("announcer").textContent = "";
+    window.setTimeout(() => {
+      byId("announcer").textContent = message;
+    }, 10);
+  }
+
+  function toast(message) {
+    const node = byId("toast");
+    window.clearTimeout(state.toastTimer);
+    node.textContent = message;
+    node.classList.add("visible");
+    state.toastTimer = window.setTimeout(() => node.classList.remove("visible"), 3_600);
+  }
+
+  function errorMessage(error, fallback) {
+    if (error instanceof Error && error.message.trim()) return error.message;
+    return fallback;
+  }
+
+  async function withBusy(button, label, run) {
+    const prior = button.textContent;
+    button.disabled = true;
+    button.textContent = label;
+    try {
+      return await run();
+    } finally {
+      button.disabled = false;
+      button.textContent = prior;
+    }
+  }
+
+  async function fetchJson(path, options = {}) {
+    const method = options.method ?? "GET";
+    const timeoutMs =
+      options.timeoutMs ??
+      (options.owner ? (method === "GET" ? OWNER_READ_TIMEOUT_MS : OWNER_WRITE_TIMEOUT_MS) : undefined);
+    const controller = Number.isFinite(timeoutMs) ? new AbortController() : null;
+    let timedOut = false;
+    let timeout;
+    let removeCallerAbort = () => {};
+    if (controller && options.signal) {
+      const abortFromCaller = () => controller.abort(options.signal.reason);
+      if (options.signal.aborted) abortFromCaller();
+      else options.signal.addEventListener("abort", abortFromCaller, { once: true });
+      removeCallerAbort = () => options.signal.removeEventListener("abort", abortFromCaller);
+    }
+    if (controller) {
+      timeout = window.setTimeout(() => {
+        timedOut = true;
+        controller.abort(new Error("The request took too long."));
+      }, timeoutMs);
+    }
+    const headers = new Headers(options.headers ?? {});
+    headers.set("accept", "application/json");
+    if (options.owner) headers.set("authorization", `Bearer ${state.token}`);
+    if (options.secret) headers.set("authorization", `SupportPassport ${options.secret}`);
+    let body;
+    if (options.body !== undefined) {
+      headers.set("content-type", "application/json");
+      body = JSON.stringify(options.body);
+    }
+    try {
+      const response = await fetch(path, {
+        method,
+        headers,
+        body,
+        cache: "no-store",
+        signal: controller?.signal ?? options.signal,
+      });
+      let payload = {};
+      try {
+        payload = await response.json();
+      } catch {
+        if (!response.ok) throw new Error(`The server returned HTTP ${response.status}.`);
+      }
+      if (!response.ok) {
+        const error = new Error(
+          typeof payload.error === "string" ? payload.error : `The server returned HTTP ${response.status}.`
+        );
+        error.code = typeof payload.code === "string" ? payload.code : "request_failed";
+        error.status = response.status;
+        throw error;
+      }
+      if (!options.captureServerTime) return payload;
+      const serverNowMs = Date.parse(response.headers.get("date") ?? "");
+      return {
+        payload,
+        serverOffsetMs: Number.isFinite(serverNowMs) ? serverNowMs - Date.now() : null,
+      };
+    } catch (error) {
+      if (!timedOut) throw error;
+      const timeoutError = new Error(options.timeoutMessage ?? "The owner request took too long. Try again.");
+      timeoutError.code = "request_timeout";
+      throw timeoutError;
+    } finally {
+      if (timeout) window.clearTimeout(timeout);
+      removeCallerAbort();
+    }
+  }
+
+  const liveApi = {
+    listCards: () => fetchJson("/engram/v1/support-passport/cards", { owner: true }),
+    listGrants: () => fetchJson("/engram/v1/support-passport/grants", { owner: true }),
+    fetchMemory: (memoryId) =>
+      fetchJson(`/engram/v1/support-passport/memories/${encodeURIComponent(memoryId)}`, { owner: true }),
+    createManualDraft: (input) =>
+      fetchJson("/engram/v1/support-passport/drafts", { owner: true, method: "POST", body: input }),
+    generateDrafts: (input) =>
+      fetchJson("/engram/v1/support-passport/drafts/generate", {
+        owner: true,
+        method: "POST",
+        body: input,
+        timeoutMs: OWNER_MODEL_WRITE_TIMEOUT_MS,
+        timeoutMessage: "Drafting timed out.",
+      }),
+    replaceCard: (cardId, input) =>
+      fetchJson(`/engram/v1/support-passport/cards/${encodeURIComponent(cardId)}`, {
+        owner: true,
+        method: "PUT",
+        body: input,
+      }),
+    mutateCard: (cardId, input, action) =>
+      fetchJson(`/engram/v1/support-passport/cards/${encodeURIComponent(cardId)}/${action}`, {
+        owner: true,
+        method: "POST",
+        body: input,
+      }),
+    createGrant: (input) =>
+      fetchJson("/engram/v1/support-passport/grants", { owner: true, method: "POST", body: input }),
+    revokeGrant: (id, input) =>
+      fetchJson(`/engram/v1/support-passport/grants/${encodeURIComponent(id)}/revoke`, {
+        owner: true,
+        method: "POST",
+        body: input,
+      }),
+    readGrant: (id, helperSecret, signal) =>
+      fetchJson(`/engram/v1/support-passport/public/grants/${encodeURIComponent(id)}`, {
+        secret: helperSecret,
+        signal,
+        captureServerTime: true,
+      }),
+    askGrant: (id, helperSecret, question, signal) =>
+      fetchJson(`/engram/v1/support-passport/public/grants/${encodeURIComponent(id)}/ask`, {
+        secret: helperSecret,
+        method: "POST",
+        body: { question },
+        signal,
+      }),
+  };
+
+  const replayApi = replayStore && {
+    ...replayStore,
+    async fetchMemory(memoryId) {
+      const note = replayStore.notes.find((candidate) => candidate.memoryId === memoryId);
+      if (!note) return { found: false };
+      return { found: true, memory: { id: note.memoryId, content: note.content, revision: note.revision } };
+    },
+  };
+  const api = replayMode ? replayApi : liveApi;
+
+  function showOwner() {
+    byId("connectPanel").hidden = true;
+    byId("helperView").remove();
+    byId("lockedView").remove();
+    byId("ownerView").hidden = false;
+    byId("viewMarkerText").textContent = replayMode ? "Owner replay" : "Owner view";
+  }
+
+  function renderSelectedNotes() {
+    const list = byId("noteList");
+    clear(list);
+    byId("notesEmpty").hidden = state.selectedNotes.length > 0;
+    byId("noteCount").textContent = `${state.selectedNotes.length} selected`;
+    for (const note of state.selectedNotes) {
+      const item = element("li", "note-item");
+      const copy = element("div");
+      copy.append(element("code", "", note.memoryId), element("p", "", note.content));
+      const remove = element("button", "button button-quiet", "Remove");
+      remove.type = "button";
+      remove.setAttribute("aria-label", `Remove selected note ${note.memoryId}`);
+      remove.addEventListener("click", () => {
+        state.selectedNotes = state.selectedNotes.filter((candidate) => candidate.memoryId !== note.memoryId);
+        byId("consentInput").checked = false;
+        renderSelectedNotes();
+        announce("Selected note removed. Consent cleared.");
+      });
+      item.append(copy, remove);
+      list.append(item);
+    }
+  }
+
+  function statusLabel(card) {
+    return card.status === "active" ? "Approved" : "Draft";
+  }
+
+  function cardButton(label, className, handler) {
+    const button = element("button", `button ${className}`, label);
+    button.type = "button";
+    button.addEventListener("click", handler);
+    return button;
+  }
+
+  async function mutateCard(card, action, button) {
+    setError("generateError");
+    const verbs = { approve: "Approving…", reject: "Rejecting…", withdraw: "Stopping…" };
+    let ownerStateFresh = false;
+    try {
+      await withBusy(button, verbs[action], () =>
+        api.mutateCard(
+          card.cardId,
+          {
+            expectedRevision: card.revision,
+            reasonCode:
+              action === "approve"
+                ? "owner-approved-ui"
+                : action === "reject"
+                  ? "owner-rejected-ui"
+                  : "owner-withdrew-ui",
+          },
+          action
+        )
+      );
+    } catch (error) {
+      if (error?.code !== "request_timeout") {
+        setError("generateError", errorMessage(error, "The support card did not change."));
+        return;
+      }
+      const reconciled = await reconcileOwnerState(() => {
+        const current = state.cards.find((candidate) => candidate.cardId === card.cardId);
+        if (action === "approve") {
+          return current?.status === "active" && current.revision !== card.revision ? current : null;
+        }
+        return current ? null : card;
+      });
+      if (!reconciled.matched) {
+        setError(
+          "generateError",
+          reconciled.refreshed
+            ? "The request stopped without a confirmed change. Review the current guide before trying again."
+            : "The request stopped without a confirmed change. Refresh the guide before trying again."
+        );
+        return;
+      }
+      ownerStateFresh = true;
+    }
+    const message =
+      action === "approve"
+        ? `Approved ${card.title}. It can now be shared.`
+        : action === "reject"
+          ? `Rejected ${card.title}. It stays private.`
+          : `Withdrew ${card.title}. Existing links will lock.`;
+    toast(message);
+    announce(message);
+    try {
+      if (!ownerStateFresh) await loadOwnerState();
+    } catch {
+      const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
+      setError("generateError", warning);
+      announce(warning);
+    }
+  }
+
+  function renderCards() {
+    const list = byId("cardList");
+    clear(list);
+    byId("cardsEmpty").hidden = state.cards.length > 0;
+    const drafts = state.cards.filter((card) => card.status === "pending_review").length;
+    const approved = state.cards.filter((card) => card.status === "active").length;
+    byId("draftCount").textContent = String(drafts);
+    byId("approvedCount").textContent = String(approved);
+
+    for (const card of state.cards) {
+      const article = element("article", "support-card");
+      article.dataset.category = card.category;
+      const top = element("div", "card-topline");
+      const status = element(
+        "span",
+        `status-pill ${card.status === "active" ? "approved" : "draft"}`,
+        statusLabel(card)
+      );
+      const category = element("span", "category-pill", model.CATEGORY_LABELS[card.category]);
+      top.append(status, category);
+      const title = element("h3", "", card.title);
+      const statement = element("blockquote", "", card.statement);
+      const dates = element("div", "card-dates");
+      dates.append(
+        element("span", "", `Updated ${model.formatDate(card.updatedAt)}`),
+        element("span", "", `Review by ${model.formatDate(card.reviewBy)}`)
+      );
+      const actions = element("div", "card-actions");
+      actions.append(cardButton("Edit", "button-quiet", () => openCardDialog(card)));
+      if (card.status === "pending_review") {
+        const approve = cardButton("Approve", "button-primary", (event) =>
+          mutateCard(card, "approve", event.currentTarget)
+        );
+        const reject = cardButton("Reject", "button-danger", (event) =>
+          mutateCard(card, "reject", event.currentTarget)
+        );
+        actions.append(approve, reject);
+      } else {
+        actions.append(
+          cardButton("Withdraw", "button-danger", (event) => mutateCard(card, "withdraw", event.currentTarget))
+        );
+      }
+      article.append(top, title, statement, dates, actions);
+      list.append(article);
+    }
+  }
+
+  function renderShareCards() {
+    const list = byId("shareCardList");
+    clear(list);
+    const approved = state.cards.filter((card) => card.status === "active");
+    byId("shareCardsEmpty").hidden = approved.length > 0;
+    for (const card of approved) {
+      const label = element("label", "card-choice");
+      const input = document.createElement("input");
+      input.type = "checkbox";
+      input.name = "shareCard";
+      input.value = card.cardId;
+      input.dataset.revision = card.revision;
+      input.addEventListener("change", updateShareCardChoices);
+      const copy = element("span");
+      copy.append(element("strong", "", card.title), element("small", "", card.statement));
+      label.append(input, copy);
+      list.append(label);
+    }
+    updateShareCardChoices();
+  }
+
+  function updateShareCardChoices() {
+    const choices = [...document.querySelectorAll('input[name="shareCard"]')];
+    const selectedCount = choices.filter((input) => input.checked).length;
+    for (const input of choices) input.disabled = !input.checked && selectedCount >= MAX_SHARED_CARDS;
+  }
+
+  function delay(milliseconds) {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+
+  async function reconcileOwnerState(match) {
+    let refreshed = false;
+    for (let attempt = 0; attempt < OWNER_RECONCILIATION_ATTEMPTS; attempt += 1) {
+      try {
+        await loadOwnerState();
+        refreshed = true;
+        const value = match();
+        if (value) return { matched: true, value };
+      } catch {}
+      if (attempt + 1 < OWNER_RECONCILIATION_ATTEMPTS) {
+        await delay(OWNER_RECONCILIATION_DELAY_MS);
+      }
+    }
+    return { matched: false, refreshed };
+  }
+
+  function sameCardDraft(card, input) {
+    return (
+      card.status === "pending_review" &&
+      card.title === input.title &&
+      card.statement === input.statement &&
+      card.category === input.category &&
+      card.reviewBy === input.reviewBy
+    );
+  }
+
+  function renderGrants() {
+    const list = byId("grantList");
+    clear(list);
+    byId("grantsEmpty").hidden = state.grants.length > 0;
+    for (const grant of state.grants) {
+      const article = element("article", "grant-card");
+      const stateText =
+        grant.status === "active" ? "Live share" : grant.status === "revoked" ? "Sharing stopped" : "Share time ended";
+      article.append(
+        element("p", "", stateText),
+        element(
+          "div",
+          "grant-meta",
+          `${grant.cards.length} card${grant.cards.length === 1 ? "" : "s"} · Ends ${model.formatDate(grant.expiresAt)}`
+        )
+      );
+      if (grant.status === "active") {
+        const stop = cardButton("Stop sharing", "button-danger", async (event) => {
+          let ownerStateFresh = false;
+          try {
+            await withBusy(event.currentTarget, "Stopping sharing…", () =>
+              api.revokeGrant(grant.grantId, { expectedVersion: grant.stateVersion })
+            );
+          } catch (error) {
+            if (error?.code !== "request_timeout") {
+              setError("shareError", errorMessage(error, "The share link did not stop."));
+              return;
+            }
+            const reconciled = await reconcileOwnerState(() => {
+              const current = state.grants.find((candidate) => candidate.grantId === grant.grantId);
+              return !current || current.status === "revoked" ? grant : null;
+            });
+            if (!reconciled.matched) {
+              setError(
+                "shareError",
+                "The server did not confirm that sharing stopped. Refresh the guide and check this link."
+              );
+              return;
+            }
+            ownerStateFresh = true;
+          }
+          replayChannel?.postMessage({ type: "grant-revoked", grantId: grant.grantId });
+          const message = "Sharing stopped. The helper link is now locked.";
+          toast(message);
+          announce(message);
+          try {
+            if (!ownerStateFresh) await loadOwnerState();
+          } catch {
+            const warning = `${message} The share list did not refresh. Refresh the guide before another change.`;
+            setError("shareError", warning);
+            announce(warning);
+          }
+        });
+        article.append(stop);
+      }
+      list.append(article);
+    }
+  }
+
+  async function loadOwnerState() {
+    const [cardPayload, grantPayload] = await Promise.all([api.listCards(), api.listGrants()]);
+    state.cards = model.parseCardList(cardPayload);
+    state.grants = model.parseGrantList(grantPayload).slice(0, MAX_VISIBLE_GRANTS);
+    renderCards();
+    renderShareCards();
+    renderGrants();
+  }
+
+  function toLocalInputValue(date) {
+    const offset = date.getTimezoneOffset() * 60_000;
+    return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+  }
+
+  function openCardDialog(card = null) {
+    byId("cardDialogTitle").textContent = card ? "Edit this support card" : "Write a support card";
+    byId("cardSaveButton").textContent = "Save draft";
+    byId("cardIdInput").value = card?.cardId ?? "";
+    byId("cardRevisionInput").value = card?.revision ?? "";
+    byId("cardTitleInput").value = card?.title ?? "";
+    byId("cardStatementInput").value = card?.statement ?? "";
+    byId("cardCategoryInput").value = card?.category ?? "communication";
+    byId("cardReviewInput").value = toLocalInputValue(
+      card ? new Date(card.reviewBy) : new Date(Date.now() + 180 * 24 * 60 * 60_000)
+    );
+    setError("cardError");
+    byId("cardDialog").showModal();
+    byId("cardTitleInput").focus();
+  }
+
+  function closeCardDialog() {
+    byId("cardDialog").close();
+  }
+
+  async function saveCard(event) {
+    event.preventDefault();
+    setError("cardError");
+    const cardId = byId("cardIdInput").value;
+    const expectedRevision = byId("cardRevisionInput").value;
+    const reviewValue = byId("cardReviewInput").value;
+    const reviewDate = new Date(reviewValue);
+    const existingCard = state.cards.find((card) => card.cardId === cardId);
+    const keepsExistingReminder =
+      existingCard && reviewValue === toLocalInputValue(new Date(existingCard.reviewBy));
+    if (
+      !Number.isFinite(reviewDate.getTime()) ||
+      (reviewDate.getTime() <= Date.now() && !keepsExistingReminder)
+    ) {
+      setError("cardError", "Choose a future review reminder.");
+      return;
+    }
+    const input = {
+      title: byId("cardTitleInput").value.trim(),
+      statement: byId("cardStatementInput").value.trim(),
+      category: byId("cardCategoryInput").value,
+      reviewBy: keepsExistingReminder ? existingCard.reviewBy : reviewDate.toISOString(),
+      ...(cardId ? { expectedRevision } : {}),
+    };
+    const priorCardIds = new Set(state.cards.map((card) => card.cardId));
+    let ownerStateFresh = false;
+    try {
+      await withBusy(byId("cardSaveButton"), "Saving draft…", () =>
+        cardId ? api.replaceCard(cardId, input) : api.createManualDraft(input)
+      );
+    } catch (error) {
+      if (error?.code !== "request_timeout") {
+        setError("cardError", errorMessage(error, "The draft did not save."));
+        return;
+      }
+      const reconciled = await reconcileOwnerState(() =>
+        state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input))
+      );
+      if (!reconciled.matched) {
+        setError(
+          "cardError",
+          reconciled.refreshed
+            ? "The request stopped before the draft saved. Review the current guide before trying again."
+            : "The server did not confirm whether the draft saved. Refresh the guide before saving it again."
+        );
+        return;
+      }
+      ownerStateFresh = true;
+    }
+    closeCardDialog();
+    const message = "Draft saved. Review and approve it before sharing.";
+    toast(message);
+    announce(message);
+    try {
+      if (!ownerStateFresh) await loadOwnerState();
+    } catch {
+      const warning = "The draft was saved, but the card list did not refresh. Refresh the guide before editing it.";
+      setError("generateError", warning);
+      announce(warning);
+    }
+  }
+
+  async function addMemory(event) {
+    event.preventDefault();
+    setError("memoryError");
+    const memoryId = byId("memoryIdInput").value.trim();
+    if (state.selectedNotes.some((note) => note.memoryId === memoryId)) {
+      setError("memoryError", "That note is already selected.");
+      return;
+    }
+    if (state.selectedNotes.length >= 20) {
+      setError("memoryError", "Select no more than 20 notes.");
+      return;
+    }
+    const button = event.currentTarget.querySelector("button");
+    try {
+      const preview = model.parseMemoryPreview(
+        await withBusy(button, "Adding note…", () => api.fetchMemory(memoryId))
+      );
+      if (!preview.found) {
+        throw new Error("That memory was not found in your Remnic scope.");
+      }
+      if (preview.memory.id !== memoryId) throw new Error("The selected note response is invalid.");
+      state.selectedNotes = [
+        ...state.selectedNotes,
+        {
+          memoryId,
+          content: model.stripAttributesSuffix(preview.memory.content),
+          revision: preview.memory.revision,
+        },
+      ];
+      byId("memoryIdInput").value = "";
+      byId("consentInput").checked = false;
+      renderSelectedNotes();
+      announce("Selected note added. Review it before consent.");
+    } catch (error) {
+      setError("memoryError", errorMessage(error, "The selected note did not load."));
+    }
+  }
+
+  async function generateDrafts() {
+    setError("generateError");
+    if (state.selectedNotes.length === 0) {
+      setError("generateError", "Select at least one note first.");
+      return;
+    }
+    if (!byId("consentInput").checked) {
+      setError("generateError", "Select the consent box before any model call.");
+      byId("consentInput").focus();
+      return;
+    }
+    try {
+      await withBusy(byId("generateButton"), "Drafting cards…", () =>
+        api.generateDrafts({
+          sourceMemoryIds: state.selectedNotes.map((note) => note.memoryId),
+          sourceMemoryRevisions: state.selectedNotes.map((note) => ({
+            memoryId: note.memoryId,
+            revision: note.revision,
+          })),
+          consent: true,
+        })
+      );
+    } catch (error) {
+      if (error?.code !== "request_timeout") {
+        setError("generateError", errorMessage(error, "The configured model did not return valid drafts."));
+        return;
+      }
+      byId("consentInput").checked = false;
+      let refreshed = false;
+      try {
+        await loadOwnerState();
+        refreshed = true;
+      } catch {}
+      setError(
+        "generateError",
+        refreshed
+          ? "Drafting timed out. Review the current guide before deciding whether to draft again."
+          : "Drafting timed out. Refresh the guide before deciding whether to draft again."
+      );
+      return;
+    }
+    byId("consentInput").checked = false;
+    const message = "Drafts ready. Review each card before approval.";
+    toast(message);
+    announce(message);
+    try {
+      await loadOwnerState();
+      byId("reviewCards").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "start" });
+    } catch {
+      const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
+      setError("generateError", warning);
+      announce(warning);
+    }
+  }
+
+  async function createShare(event) {
+    event.preventDefault();
+    setError("shareError");
+    byId("newLinkPanel").hidden = true;
+    byId("shareLinkInput").value = "";
+    byId("openLinkButton").removeAttribute("href");
+    const selectedInputs = [...document.querySelectorAll('input[name="shareCard"]:checked')];
+    const cardIds = selectedInputs.map((input) => input.value);
+    if (cardIds.length === 0) {
+      setError("shareError", "Select at least one approved support card.");
+      return;
+    }
+    if (cardIds.length > MAX_SHARED_CARDS) {
+      setError("shareError", "Select no more than eight approved support cards.");
+      return;
+    }
+    const cardRevisions = selectedInputs.map((input) => ({
+      cardId: input.value,
+      revision: input.dataset.revision ?? "",
+    }));
+    if (cardRevisions.some((card) => !card.revision)) {
+      setError("shareError", "A selected support card changed. Refresh the guide and select it again.");
+      return;
+    }
+    const choice = document.querySelector('input[name="duration"]:checked')?.value ?? "2h";
+    let expiresAt;
+    try {
+      expiresAt = model.expiryForChoice(choice, byId("customTimeInput").value);
+    } catch (error) {
+      setError("shareError", errorMessage(error, "Choose a valid share time."));
+      return;
+    }
+    const button = event.currentTarget.querySelector('button[type="submit"]');
+    let created;
+    try {
+      created = model.parseCreatedGrant(
+        await withBusy(button, "Creating link…", () => api.createGrant({ cardIds, cardRevisions, expiresAt }))
+      );
+    } catch (error) {
+      if (error?.code !== "request_timeout") {
+        setError("shareError", errorMessage(error, "The share link was not created."));
+        return;
+      }
+      let refreshed = false;
+      try {
+        await loadOwnerState();
+        refreshed = true;
+      } catch {}
+      setError(
+        "shareError",
+        refreshed
+          ? "The server did not confirm whether it created a link. Review the live share list and stop any link you do not recognize before creating another."
+          : "The server did not confirm whether it created a link. Refresh the guide and review live shares before creating another."
+      );
+      return;
+    }
+    const url = model.buildShareUrl(window.location.href, created.grantId, created.secret, replayMode);
+    byId("shareLinkInput").value = url;
+    byId("openLinkButton").href = url;
+    byId("newLinkPanel").hidden = false;
+    const message = `Share link created. It ends ${model.formatDate(created.expiresAt)}.`;
+    toast(message);
+    announce(message);
+    byId("newLinkPanel").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "nearest" });
+    try {
+      await loadOwnerState();
+    } catch {
+      setError("shareError", "The share link was created, but the share list did not refresh. Use the link above.");
+    }
+  }
+
+  async function copyShareLink() {
+    const value = byId("shareLinkInput").value;
+    try {
+      await navigator.clipboard.writeText(value);
+      toast("Share link copied.");
+      announce("Share link copied.");
+    } catch {
+      byId("shareLinkInput").focus();
+      byId("shareLinkInput").select();
+      setError("shareError", "Copy the selected share link manually.");
+    }
+  }
+
+  async function connectOwner(event) {
+    event.preventDefault();
+    setError("connectError");
+    state.token = byId("tokenInput").value.trim();
+    if (!state.token) return;
+    const button = event.currentTarget.querySelector("button");
+    try {
+      await withBusy(button, "Opening guide…", loadOwnerState);
+      showOwner();
+      announce("Owner guide loaded.");
+    } catch (error) {
+      state.token = "";
+      setError("connectError", errorMessage(error, "The owner guide did not load."));
+    }
+  }
+
+  function showLocked(error) {
+    window.clearTimeout(state.helperExpiryTimer);
+    state.helperExpiryTimer = null;
+    window.clearTimeout(state.helperRevalidationTimer);
+    state.helperRevalidationTimer = null;
+    state.helperLoadController?.abort();
+    state.helperLoadController = null;
+    state.helperQuestionController?.abort();
+    state.helperQuestionController = null;
+    state.helperRevalidationController?.abort();
+    state.helperRevalidationController = null;
+    const lastGuide = state.guide;
+    state.guide = null;
+    byId("connectPanel")?.remove();
+    byId("ownerView")?.remove();
+    byId("helperView").hidden = true;
+    byId("helperLoading").hidden = false;
+    clear(byId("guideGroups"));
+    byId("answerPanel").hidden = true;
+    clear(byId("citationList"));
+    const lock = model.lockState(error, lastGuide);
+    const retryable =
+      !lastGuide &&
+      Boolean(state.helperGrantId && state.helperSecret) &&
+      !TERMINAL_HELPER_ERROR_CODES.has(error?.code);
+    byId("lockedEyebrow").textContent = lock.eyebrow;
+    byId("lockedTitle").textContent = lock.title;
+    byId("lockedDetail").textContent = lock.detail;
+    byId("retryHelperButton").hidden = !retryable;
+    byId("lockedView").hidden = false;
+    byId("viewMarkerText").textContent = "Locked helper view";
+    document.title = "Share link locked · What Helps Me";
+    byId("lockedTitle").focus?.();
+    announce(lock.title);
+  }
+
+  async function readHelperGuide(signal) {
+    const result = await api.readGrant(state.helperGrantId, state.helperSecret, signal);
+    if (replayMode) return model.parsePublicGuide(result);
+    if (Number.isFinite(result.serverOffsetMs)) state.helperServerOffsetMs = result.serverOffsetMs;
+    return model.parsePublicGuide(result.payload);
+  }
+
+  function scheduleHelperExpiry() {
+    window.clearTimeout(state.helperExpiryTimer);
+    state.helperExpiryTimer = null;
+    if (!state.guide || state.helperLifecyclePaused) return;
+    const serverNow = Date.now() + (state.helperServerOffsetMs ?? 0);
+    const remainingMs = Date.parse(state.guide.expiresAt) - serverNow;
+    if (remainingMs <= 0 && !replayMode && state.helperServerOffsetMs === null) return;
+    if (remainingMs <= 0) {
+      const error = new Error("The share link has expired.");
+      error.code = "grant_expired";
+      showLocked(error);
+      return;
+    }
+    state.helperExpiryTimer = window.setTimeout(() => {
+      const error = new Error("The share link has expired.");
+      error.code = "grant_expired";
+      showLocked(error);
+    }, remainingMs);
+  }
+
+  function renderGuide(guide) {
+    byId("helperLoading").hidden = true;
+    byId("helperExpiry").textContent = model.formatDate(guide.expiresAt);
+    byId("helperCardCount").textContent = `${guide.cards.length} card${guide.cards.length === 1 ? "" : "s"}`;
+    const groupsNode = byId("guideGroups");
+    clear(groupsNode);
+    for (const group of model.groupCards(guide.cards)) {
+      const section = element("section", "guide-group");
+      section.append(element("h3", "", group.label));
+      for (const card of group.cards) {
+        const article = element("article", "public-card");
+        article.dataset.category = card.category;
+        article.dataset.cardId = card.cardId;
+        article.append(element("h3", "", card.title), element("p", "", card.statement));
+        section.append(article);
+      }
+      groupsNode.append(section);
+    }
+    scheduleHelperExpiry();
+  }
+
+  function scheduleHelperRevalidation() {
+    window.clearTimeout(state.helperRevalidationTimer);
+    state.helperRevalidationTimer = null;
+    if (replayMode || !state.guide || state.helperLifecyclePaused) return;
+    state.helperRevalidationTimer = window.setTimeout(revalidateHelper, state.helperRevalidationDelayMs);
+  }
+
+  async function revalidateHelper() {
+    state.helperRevalidationTimer = null;
+    if (!state.guide || state.helperLifecyclePaused) return;
+    const controller = new AbortController();
+    state.helperRevalidationController?.abort();
+    state.helperRevalidationController = controller;
+    const timeout = window.setTimeout(() => controller.abort(), HELPER_READ_TIMEOUT_MS);
+    try {
+      state.guide = await readHelperGuide(controller.signal);
+      state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;
+      scheduleHelperExpiry();
+    } catch (error) {
+      if (controller.signal.aborted || !state.guide) return;
+      if (["grant_expired", "grant_gone", "grant_not_found", "grant_stale"].includes(error?.code)) {
+        showLocked(error);
+        return;
+      }
+      if (error?.code === "rate_limited") {
+        state.helperRevalidationDelayMs = Math.min(
+          state.helperRevalidationDelayMs * 2,
+          HELPER_REVALIDATION_MAX_MS
+        );
+      }
+    } finally {
+      window.clearTimeout(timeout);
+      if (state.helperRevalidationController === controller) {
+        state.helperRevalidationController = null;
+        scheduleHelperRevalidation();
+      }
+    }
+  }
+
+  async function loadHelper() {
+    byId("connectPanel")?.remove();
+    byId("ownerView")?.remove();
+    byId("lockedView").hidden = true;
+    byId("retryHelperButton").hidden = true;
+    byId("helperView").hidden = false;
+    byId("viewMarkerText").textContent = replayMode ? "Helper replay" : "Helper view";
+    document.title = "Shared support passport · What Helps Me";
+    if (!state.helperGrantId || !state.helperSecret) {
+      const error = new Error("The share link is incomplete.");
+      error.code = "missing_link";
+      showLocked(error);
+      return;
+    }
+    if (replayMode) replayStore.seedSharedGuide(state.helperGrantId, state.helperSecret);
+    const controller = new AbortController();
+    state.helperLoadController?.abort();
+    state.helperLoadController = controller;
+    const timeout = window.setTimeout(() => controller.abort(), HELPER_READ_TIMEOUT_MS);
+    try {
+      state.guide = await readHelperGuide(controller.signal);
+      renderGuide(state.guide);
+      if (!state.guide) return;
+      scheduleHelperRevalidation();
+      announce(`Support passport loaded with ${state.guide.cards.length} cards.`);
+    } catch (error) {
+      if (controller.signal.reason === PAGE_HIDDEN_ABORT) return;
+      showLocked(error);
+    } finally {
+      window.clearTimeout(timeout);
+      if (state.helperLoadController === controller) state.helperLoadController = null;
+    }
+  }
+
+  async function askQuestion(event) {
+    event.preventDefault();
+    setError("questionError");
+    const question = byId("questionInput").value.trim();
+    if (!question || !state.guide) return;
+    byId("answerPanel").hidden = true;
+    byId("answerCopy").textContent = "";
+    clear(byId("citationList"));
+    const button = event.currentTarget.querySelector("button");
+    const controller = new AbortController();
+    state.helperQuestionController?.abort();
+    state.helperQuestionController = controller;
+    let timedOut = false;
+    const timeout = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, HELPER_QUESTION_TIMEOUT_MS);
+    try {
+      const payload = await withBusy(button, "Checking shared cards…", () =>
+        api.askGrant(state.helperGrantId, state.helperSecret, question, controller.signal)
+      );
+      const answer = model.parseAnswer(payload, state.guide);
+      byId("answerCopy").textContent = answer.answer;
+      const citations = byId("citationList");
+      clear(citations);
+      for (const cardId of answer.citedCardIds) {
+        const card = state.guide.cards.find((candidate) => candidate.cardId === cardId);
+        citations.append(element("div", "citation", `Support card · ${card?.title ?? cardId}`));
+      }
+      if (answer.citedCardIds.length === 0)
+        citations.append(element("div", "citation", "No support card covers this question."));
+      byId("answerPanel").hidden = false;
+      byId("answerPanel").focus();
+      announce("Answer ready with support card citations.");
+    } catch (error) {
+      if (!state.guide) return;
+      if (controller.signal.reason === PAGE_HIDDEN_ABORT) return;
+      if (timedOut) {
+        setError("questionError", "The question took too long. Try again.");
+        return;
+      }
+      if (["grant_expired", "grant_gone", "grant_not_found", "grant_stale"].includes(error?.code)) {
+        showLocked(error);
+        return;
+      }
+      setError("questionError", errorMessage(error, "The question did not complete."));
+    } finally {
+      window.clearTimeout(timeout);
+      if (state.helperQuestionController === controller) state.helperQuestionController = null;
+    }
+  }
+
+  function bindOwnerEvents() {
+    byId("memoryForm").addEventListener("submit", addMemory);
+    byId("generateButton").addEventListener("click", generateDrafts);
+    byId("newCardButton").addEventListener("click", () => openCardDialog());
+    byId("cardForm").addEventListener("submit", saveCard);
+    byId("cardDialogClose").addEventListener("click", closeCardDialog);
+    byId("cardCancelButton").addEventListener("click", closeCardDialog);
+    byId("shareForm").addEventListener("submit", createShare);
+    byId("copyLinkButton").addEventListener("click", copyShareLink);
+    byId("refreshButton").addEventListener("click", async (event) => {
+      try {
+        await withBusy(event.currentTarget, "…", loadOwnerState);
+        announce("Cards and share links refreshed.");
+      } catch (error) {
+        setError("shareError", errorMessage(error, "The guide did not refresh."));
+      }
+    });
+    for (const input of document.querySelectorAll('input[name="duration"]')) {
+      input.addEventListener("change", () => {
+        byId("customTimeField").hidden = input.value !== "custom" || !input.checked;
+      });
+    }
+  }
+
+  function bindHelperEvents() {
+    byId("retryHelperButton").addEventListener("click", async (event) => {
+      await withBusy(event.currentTarget, "Trying again…", loadHelper);
+    });
+    byId("questionForm").addEventListener("submit", askQuestion);
+    byId("questionInput").addEventListener("input", () => {
+      byId("questionCount").textContent = String(byId("questionInput").value.length);
+    });
+    replayChannel?.addEventListener("message", (event) => {
+      if (event.data?.type === "grant-revoked" && event.data.grantId === state.helperGrantId) {
+        const error = new Error("The share link is no longer active.");
+        error.code = "grant_gone";
+        showLocked(error);
+      }
+    });
+    window.addEventListener("pagehide", (event) => {
+      state.helperLifecyclePaused = true;
+      window.clearTimeout(state.helperExpiryTimer);
+      window.clearTimeout(state.helperRevalidationTimer);
+      state.helperLoadController?.abort(PAGE_HIDDEN_ABORT);
+      state.helperQuestionController?.abort(PAGE_HIDDEN_ABORT);
+      state.helperRevalidationController?.abort(PAGE_HIDDEN_ABORT);
+      if (!event.persisted) replayChannel?.close();
+    });
+    window.addEventListener("pageshow", (event) => {
+      if (!event.persisted) return;
+      state.helperLifecyclePaused = false;
+      if (!state.guide) {
+        if (byId("helperView")) void loadHelper();
+        return;
+      }
+      scheduleHelperExpiry();
+      if (state.guide && !replayMode) void revalidateHelper();
+    });
+  }
+
+  async function init() {
+    if (replayMode) byId("replayBanner").hidden = false;
+    if (grantId || hasSecretFragment) {
+      bindHelperEvents();
+      await loadHelper();
+      return;
+    }
+
+    bindOwnerEvents();
+    const prefill =
+      typeof window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ === "string"
+        ? window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__.trim()
+        : "";
+    if (replayMode) {
+      state.token = "synthetic-replay";
+      state.selectedNotes = replayStore.notes.map((note) => ({ ...note }));
+      renderSelectedNotes();
+      await loadOwnerState();
+      showOwner();
+      return;
+    }
+    if (prefill) byId("tokenInput").value = prefill;
+    byId("connectForm").addEventListener("submit", connectOwner);
+  }
+
+  void init().catch((error) => {
+    if (grantId || hasSecretFragment) showLocked(error);
+    else setError("connectError", errorMessage(error, "The support passport did not start."));
+  });
+})();

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -54,6 +54,7 @@
     pendingCardMutationIds: new Set(),
     pendingGrantRevocationIds: new Set(),
     cardSavePending: false,
+    draftGenerationPending: false,
     shareCreationPending: false,
     shareCreationCardIds: null,
     ownerLifecyclePaused: false,
@@ -262,6 +263,7 @@
       copy.append(element("code", "", note.memoryId), element("p", "", note.content));
       const remove = element("button", "button button-quiet", "Remove");
       remove.type = "button";
+      remove.disabled = state.draftGenerationPending;
       remove.setAttribute("aria-label", `Remove selected note ${note.memoryId}`);
       remove.addEventListener("click", () => {
         state.selectedNotes = state.selectedNotes.filter((candidate) => candidate.memoryId !== note.memoryId);
@@ -673,6 +675,7 @@
 
   async function addMemory(event) {
     event.preventDefault();
+    if (state.draftGenerationPending) return;
     setError("memoryError");
     const memoryInput = byId("memoryIdInput");
     const submittedValue = memoryInput.value;
@@ -710,6 +713,7 @@
   }
 
   async function generateDrafts() {
+    if (state.draftGenerationPending) return;
     setError("generateError");
     if (state.selectedNotes.length === 0) {
       setError("generateError", "Select at least one note first.");
@@ -720,15 +724,16 @@
       byId("consentInput").focus();
       return;
     }
+    const submittedNotes = state.selectedNotes.map((note) => ({ ...note }));
     const button = byId("generateButton");
     const priorLabel = button.textContent;
-    button.disabled = true;
+    setDraftGenerationPending(true);
     button.textContent = "Drafting cards…";
     try {
       try {
         await api.generateDrafts({
-          sourceMemoryIds: state.selectedNotes.map((note) => note.memoryId),
-          sourceMemoryRevisions: state.selectedNotes.map((note) => ({
+          sourceMemoryIds: submittedNotes.map((note) => note.memoryId),
+          sourceMemoryRevisions: submittedNotes.map((note) => ({
             memoryId: note.memoryId,
             revision: note.revision,
           })),
@@ -766,9 +771,17 @@
         announce(warning);
       }
     } finally {
-      button.disabled = false;
       button.textContent = priorLabel;
+      setDraftGenerationPending(false);
     }
+  }
+
+  function setDraftGenerationPending(pending) {
+    state.draftGenerationPending = pending;
+    for (const control of byId("memoryForm").querySelectorAll("input, button")) control.disabled = pending;
+    byId("consentInput").disabled = pending;
+    byId("generateButton").disabled = pending;
+    renderSelectedNotes();
   }
 
   async function createShare(event) {
@@ -1152,6 +1165,7 @@
     state.pendingCardMutationIds.clear();
     state.pendingGrantRevocationIds.clear();
     state.cardSavePending = false;
+    state.draftGenerationPending = false;
     state.shareCreationPending = false;
     state.shareCreationCardIds = null;
     clearPrefillToken();
@@ -1170,6 +1184,7 @@
     byId("announcer").textContent = "";
     for (const id of ["connectError", "memoryError", "generateError", "cardError", "shareError"]) setError(id);
     setCardSavePending(false);
+    setDraftGenerationPending(false);
     setShareCreationPending(false);
     renderSelectedNotes();
     renderCards();

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -25,7 +25,7 @@
   const OWNER_RECONCILIATION_DELAY_MS = 250;
   const MAX_VISIBLE_GRANTS = 100;
   const MAX_SHARED_CARDS = 8;
-  const PAGE_HIDDEN_ABORT = new Error("The helper page was hidden.");
+  const PAGE_HIDDEN_ABORT = new Error("The page was hidden.");
   const SCROLL_BEHAVIOR = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
   const TERMINAL_HELPER_ERROR_CODES = new Set([
     "grant_expired",
@@ -56,6 +56,8 @@
     cardSavePending: false,
     shareCreationPending: false,
     shareCreationCardIds: null,
+    ownerLifecyclePaused: false,
+    ownerRequestControllers: new Set(),
     toastTimer: null,
   };
 
@@ -107,6 +109,7 @@
   }
 
   async function fetchJson(path, options = {}) {
+    if (options.owner && state.ownerLifecyclePaused) throw PAGE_HIDDEN_ABORT;
     const method = options.method ?? "GET";
     const timeoutMs =
       options.timeoutMs ??
@@ -127,6 +130,7 @@
         controller.abort(new Error("The request took too long."));
       }, timeoutMs);
     }
+    if (options.owner && controller) state.ownerRequestControllers.add(controller);
     const headers = new Headers(options.headers ?? {});
     headers.set("accept", "application/json");
     if (options.owner) headers.set("authorization", `Bearer ${state.token}`);
@@ -158,6 +162,7 @@
         error.status = response.status;
         throw error;
       }
+      if (options.owner && state.ownerLifecyclePaused) throw PAGE_HIDDEN_ABORT;
       if (!options.captureServerTime) return payload;
       const serverNowMs = Date.parse(response.headers.get("date") ?? "");
       return {
@@ -171,6 +176,7 @@
       throw timeoutError;
     } finally {
       if (timeout) window.clearTimeout(timeout);
+      if (options.owner && controller) state.ownerRequestControllers.delete(controller);
       removeCallerAbort();
     }
   }
@@ -443,8 +449,10 @@
   }
 
   async function reconcileOwnerState(match) {
+    if (state.ownerLifecyclePaused) return { matched: false, refreshed: false };
     let refreshed = false;
     for (let attempt = 0; attempt < OWNER_RECONCILIATION_ATTEMPTS; attempt += 1) {
+      if (state.ownerLifecyclePaused) return { matched: false, refreshed };
       try {
         await loadOwnerState();
         refreshed = true;
@@ -855,6 +863,7 @@
   async function connectOwner(event) {
     event.preventDefault();
     setError("connectError");
+    state.ownerLifecyclePaused = false;
     state.token = byId("tokenInput").value.trim();
     if (!state.token) return;
     const button = event.currentTarget.querySelector("button");
@@ -1097,6 +1106,54 @@
         byId("customTimeField").hidden = input.value !== "custom" || !input.checked;
       });
     }
+    window.addEventListener("pagehide", () => {
+      clearOwnerSession();
+    });
+    window.addEventListener("pageshow", (event) => {
+      if (!event.persisted) return;
+      if (replayMode) {
+        window.location.reload();
+        return;
+      }
+      clearOwnerSession();
+    });
+  }
+
+  function clearOwnerSession() {
+    state.ownerLifecyclePaused = true;
+    for (const controller of state.ownerRequestControllers) controller.abort(PAGE_HIDDEN_ABORT);
+    state.ownerRequestControllers.clear();
+    state.token = "";
+    state.cards = [];
+    state.grants = [];
+    state.selectedNotes = [];
+    state.pendingCardMutationIds.clear();
+    state.pendingGrantRevocationIds.clear();
+    state.cardSavePending = false;
+    state.shareCreationPending = false;
+    state.shareCreationCardIds = null;
+    window.clearTimeout(state.toastTimer);
+    byId("connectForm").reset();
+    byId("memoryForm").reset();
+    byId("cardForm").reset();
+    byId("shareForm").reset();
+    if (byId("cardDialog").open) byId("cardDialog").close();
+    byId("newLinkPanel").hidden = true;
+    byId("shareLinkInput").value = "";
+    byId("openLinkButton").removeAttribute("href");
+    byId("toast").textContent = "";
+    byId("toast").classList.remove("visible");
+    byId("announcer").textContent = "";
+    for (const id of ["connectError", "memoryError", "generateError", "cardError", "shareError"]) setError(id);
+    setCardSavePending(false);
+    setShareCreationPending(false);
+    renderSelectedNotes();
+    renderCards();
+    renderShareCards();
+    renderGrants();
+    byId("ownerView").hidden = true;
+    byId("connectPanel").hidden = false;
+    byId("viewMarkerText").textContent = "Owner view";
   }
 
   function bindHelperEvents() {
@@ -1148,6 +1205,7 @@
       typeof window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ === "string"
         ? window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__.trim()
         : "";
+    window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ = "";
     if (replayMode) {
       state.token = "synthetic-replay";
       state.selectedNotes = replayStore.notes.map((note) => ({ ...note }));

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -144,11 +144,11 @@
         cache: "no-store",
         signal: controller?.signal ?? options.signal,
       });
-      let payload = {};
+      let payload;
       try {
         payload = await response.json();
       } catch {
-        if (!response.ok) throw new Error(`The server returned HTTP ${response.status}.`);
+        throw new Error(`The server returned invalid JSON with HTTP ${response.status}.`);
       }
       if (!response.ok) {
         const error = new Error(
@@ -619,16 +619,22 @@
           setError("cardError", errorMessage(error, "The draft did not save."));
           return;
         }
-        const reconciled = await reconcileOwnerState(() =>
-          state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input))
-        );
+        const reconciled = await reconcileOwnerState(() => {
+          if (cardId) return null;
+          return state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input));
+        });
         if (!reconciled.matched) {
-          setError(
-            "cardError",
-            reconciled.refreshed
+          let message;
+          if (cardId) {
+            message = reconciled.refreshed
+              ? "The edit timed out. Review the current guide before trying again."
+              : "The server did not confirm the edit. Refresh the guide before trying again.";
+          } else {
+            message = reconciled.refreshed
               ? "The request stopped before the draft saved. Review the current guide before trying again."
-              : "The server did not confirm whether the draft saved. Refresh the guide before saving it again."
-          );
+              : "The server did not confirm whether the draft saved. Refresh the guide before saving it again.";
+          }
+          setError("cardError", message);
           return;
         }
         ownerStateFresh = true;

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -51,6 +51,8 @@
     helperRevalidationTimer: null,
     helperRevalidationDelayMs: HELPER_REVALIDATION_MS,
     helperLifecyclePaused: false,
+    pendingCardMutationIds: new Set(),
+    pendingGrantRevocationIds: new Set(),
     shareCreationPending: false,
     shareCreationCardIds: null,
     toastTimer: null,
@@ -277,10 +279,14 @@
   async function mutateCard(card, action, button) {
     setError("generateError");
     const verbs = { approve: "Approving…", reject: "Rejecting…", withdraw: "Stopping…" };
-    let ownerStateFresh = false;
+    const priorLabel = button.textContent;
+    state.pendingCardMutationIds.add(card.cardId);
+    button.disabled = true;
+    button.textContent = verbs[action];
     try {
-      await withBusy(button, verbs[action], () =>
-        api.mutateCard(
+      let ownerStateFresh = false;
+      try {
+        await api.mutateCard(
           card.cardId,
           {
             expectedRevision: card.revision,
@@ -292,45 +298,50 @@
                   : "owner-withdrew-ui",
           },
           action
-        )
-      );
-    } catch (error) {
-      if (error?.code !== "request_timeout") {
-        setError("generateError", errorMessage(error, "The support card did not change."));
-        return;
-      }
-      const reconciled = await reconcileOwnerState(() => {
-        const current = state.cards.find((candidate) => candidate.cardId === card.cardId);
-        if (action === "approve") {
-          return current?.status === "active" && current.revision !== card.revision ? current : null;
-        }
-        return current ? null : card;
-      });
-      if (!reconciled.matched) {
-        setError(
-          "generateError",
-          reconciled.refreshed
-            ? "The request stopped without a confirmed change. Review the current guide before trying again."
-            : "The request stopped without a confirmed change. Refresh the guide before trying again."
         );
-        return;
+      } catch (error) {
+        if (error?.code !== "request_timeout") {
+          setError("generateError", errorMessage(error, "The support card did not change."));
+          return;
+        }
+        const reconciled = await reconcileOwnerState(() => {
+          const current = state.cards.find((candidate) => candidate.cardId === card.cardId);
+          if (action === "approve") {
+            return current?.status === "active" && current.revision !== card.revision ? current : null;
+          }
+          return current ? null : card;
+        });
+        if (!reconciled.matched) {
+          setError(
+            "generateError",
+            reconciled.refreshed
+              ? "The request stopped without a confirmed change. Review the current guide before trying again."
+              : "The request stopped without a confirmed change. Refresh the guide before trying again."
+          );
+          return;
+        }
+        ownerStateFresh = true;
       }
-      ownerStateFresh = true;
-    }
-    const message =
-      action === "approve"
-        ? `Approved ${card.title}. It can now be shared.`
-        : action === "reject"
-          ? `Rejected ${card.title}. It stays private.`
-          : `Withdrew ${card.title}. Existing links will lock.`;
-    toast(message);
-    announce(message);
-    try {
-      if (!ownerStateFresh) await loadOwnerState();
-    } catch {
-      const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
-      setError("generateError", warning);
-      announce(warning);
+      const message =
+        action === "approve"
+          ? `Approved ${card.title}. It can now be shared.`
+          : action === "reject"
+            ? `Rejected ${card.title}. It stays private.`
+            : `Withdrew ${card.title}. Existing links will lock.`;
+      toast(message);
+      announce(message);
+      try {
+        if (!ownerStateFresh) await loadOwnerState();
+      } catch {
+        const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
+        setError("generateError", warning);
+        announce(warning);
+      }
+    } finally {
+      state.pendingCardMutationIds.delete(card.cardId);
+      button.disabled = false;
+      button.textContent = priorLabel;
+      renderCards();
     }
   }
 
@@ -345,6 +356,7 @@
 
     for (const card of state.cards) {
       const article = element("article", "support-card");
+      article.dataset.cardId = card.cardId;
       article.dataset.category = card.category;
       const top = element("div", "card-topline");
       const status = element(
@@ -375,6 +387,9 @@
         actions.append(
           cardButton("Withdraw", "button-danger", (event) => mutateCard(card, "withdraw", event.currentTarget))
         );
+      }
+      if (state.pendingCardMutationIds.has(card.cardId)) {
+        for (const button of actions.querySelectorAll("button")) button.disabled = true;
       }
       article.append(top, title, statement, dates, actions);
       list.append(article);
@@ -458,6 +473,7 @@
     byId("grantsEmpty").hidden = state.grants.length > 0;
     for (const grant of state.grants) {
       const article = element("article", "grant-card");
+      article.dataset.grantId = grant.grantId;
       const stateText =
         grant.status === "active" ? "Live share" : grant.status === "revoked" ? "Sharing stopped" : "Share time ended";
       article.append(
@@ -470,41 +486,52 @@
       );
       if (grant.status === "active") {
         const stop = cardButton("Stop sharing", "button-danger", async (event) => {
+          const button = event.currentTarget;
+          const priorLabel = button.textContent;
           let ownerStateFresh = false;
+          state.pendingGrantRevocationIds.add(grant.grantId);
+          button.disabled = true;
+          button.textContent = "Stopping sharing…";
           try {
-            await withBusy(event.currentTarget, "Stopping sharing…", () =>
-              api.revokeGrant(grant.grantId, { expectedVersion: grant.stateVersion })
-            );
-          } catch (error) {
-            if (error?.code !== "request_timeout") {
-              setError("shareError", errorMessage(error, "The share link did not stop."));
-              return;
+            try {
+              await api.revokeGrant(grant.grantId, { expectedVersion: grant.stateVersion });
+            } catch (error) {
+              if (error?.code !== "request_timeout") {
+                setError("shareError", errorMessage(error, "The share link did not stop."));
+                return;
+              }
+              const reconciled = await reconcileOwnerState(() => {
+                const current = state.grants.find((candidate) => candidate.grantId === grant.grantId);
+                return !current || current.status !== "active" ? grant : null;
+              });
+              if (!reconciled.matched) {
+                setError(
+                  "shareError",
+                  "The server did not confirm that sharing stopped. Refresh the guide and check this link."
+                );
+                return;
+              }
+              ownerStateFresh = true;
             }
-            const reconciled = await reconcileOwnerState(() => {
-              const current = state.grants.find((candidate) => candidate.grantId === grant.grantId);
-              return !current || current.status !== "active" ? grant : null;
-            });
-            if (!reconciled.matched) {
-              setError(
-                "shareError",
-                "The server did not confirm that sharing stopped. Refresh the guide and check this link."
-              );
-              return;
+            replayChannel?.postMessage({ type: "grant-revoked", grantId: grant.grantId });
+            const message = "Sharing stopped. The helper link is now locked.";
+            toast(message);
+            announce(message);
+            try {
+              if (!ownerStateFresh) await loadOwnerState();
+            } catch {
+              const warning = `${message} The share list did not refresh. Refresh the guide before another change.`;
+              setError("shareError", warning);
+              announce(warning);
             }
-            ownerStateFresh = true;
-          }
-          replayChannel?.postMessage({ type: "grant-revoked", grantId: grant.grantId });
-          const message = "Sharing stopped. The helper link is now locked.";
-          toast(message);
-          announce(message);
-          try {
-            if (!ownerStateFresh) await loadOwnerState();
-          } catch {
-            const warning = `${message} The share list did not refresh. Refresh the guide before another change.`;
-            setError("shareError", warning);
-            announce(warning);
+          } finally {
+            state.pendingGrantRevocationIds.delete(grant.grantId);
+            button.disabled = false;
+            button.textContent = priorLabel;
+            renderGrants();
           }
         });
+        stop.disabled = state.pendingGrantRevocationIds.has(grant.grantId);
         article.append(stop);
       }
       list.append(article);

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -56,6 +56,7 @@
     helperRevalidationController: null,
     helperRevalidationTimer: null,
     helperRevalidationDelayMs: HELPER_REVALIDATION_MS,
+    helperViewGeneration: 0,
     helperLifecyclePaused: false,
     ownerServerOffsetMs: null,
     pendingCardMutationIds: new Set(),
@@ -67,6 +68,7 @@
     shareCreationCardIds: null,
     displayedGrant: null,
     displayedGrantTimer: null,
+    ownerGrantExpiryTimer: null,
     ownerLifecyclePaused: false,
     ownerRequestControllers: new Set(),
     ownerLoadGeneration: 0,
@@ -572,14 +574,18 @@
   }
 
   function renderGrants() {
+    window.clearTimeout(state.ownerGrantExpiryTimer);
+    state.ownerGrantExpiryTimer = null;
     const list = byId("grantList");
     clear(list);
     byId("grantsEmpty").hidden = state.grants.length > 0;
     for (const grant of state.grants) {
+      const grantStatus =
+        grant.status === "active" && Date.parse(grant.expiresAt) <= ownerNowMs() ? "expired" : grant.status;
       const article = element("article", "grant-card");
       article.dataset.grantId = grant.grantId;
       const stateText =
-        grant.status === "active" ? "Live share" : grant.status === "revoked" ? "Sharing stopped" : "Share time ended";
+        grantStatus === "active" ? "Live share" : grantStatus === "revoked" ? "Sharing stopped" : "Share time ended";
       article.append(
         element("p", "", stateText),
         element(
@@ -588,7 +594,7 @@
           `${grant.cards.length} card${grant.cards.length === 1 ? "" : "s"} · Ends ${model.formatDate(grant.expiresAt)}`
         )
       );
-      if (grant.status === "active") {
+      if (grantStatus === "active") {
         const stop = cardButton("Stop sharing", "button-danger", async (event) => {
           const ownerSessionGeneration = state.ownerSessionGeneration;
           const button = event.currentTarget;
@@ -645,6 +651,17 @@
         article.append(stop);
       }
       list.append(article);
+    }
+    const nextExpiry = state.grants
+      .filter((grant) => grant.status === "active")
+      .map((grant) => Date.parse(grant.expiresAt) - ownerNowMs())
+      .filter((remainingMs) => remainingMs > 0)
+      .sort((left, right) => left - right)[0];
+    if (Number.isFinite(nextExpiry)) {
+      state.ownerGrantExpiryTimer = window.setTimeout(() => {
+        reconcileDisplayedShareLink();
+        renderGrants();
+      }, nextExpiry);
     }
   }
 
@@ -939,7 +956,7 @@
     const choice = document.querySelector('input[name="duration"]:checked')?.value ?? "2h";
     let expiry;
     try {
-      expiry = model.expiryForChoice(choice, byId("customTimeInput").value);
+      expiry = model.expiryForChoice(choice, byId("customTimeInput").value, ownerNowMs());
     } catch (error) {
       setError("shareError", errorMessage(error, "Choose a valid share time."));
       return;
@@ -1064,6 +1081,7 @@
     state.helperQuestionController = null;
     state.helperRevalidationController?.abort();
     state.helperRevalidationController = null;
+    state.helperViewGeneration += 1;
     const lastGuide = state.guide;
     state.guide = null;
     byId("connectPanel")?.remove();
@@ -1146,18 +1164,25 @@
   async function revalidateHelper() {
     state.helperRevalidationTimer = null;
     if (!state.guide || state.helperLifecyclePaused) return;
+    const helperViewGeneration = state.helperViewGeneration;
     const controller = new AbortController();
     state.helperRevalidationController?.abort();
     state.helperRevalidationController = controller;
     const timeout = window.setTimeout(() => controller.abort(HELPER_READ_TIMEOUT_ABORT), HELPER_READ_TIMEOUT_MS);
     try {
       const guide = await readHelperGuide(controller.signal);
-      if (state.helperLifecyclePaused) return;
+      if (state.helperLifecyclePaused || helperViewGeneration !== state.helperViewGeneration) return;
       state.guide = guide;
       state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;
       scheduleHelperExpiry();
     } catch (error) {
-      if (state.helperLifecyclePaused || controller.signal.reason === PAGE_HIDDEN_ABORT || !state.guide) return;
+      if (
+        state.helperLifecyclePaused ||
+        helperViewGeneration !== state.helperViewGeneration ||
+        controller.signal.reason === PAGE_HIDDEN_ABORT ||
+        !state.guide
+      )
+        return;
       if (controller.signal.aborted) {
         if (controller.signal.reason !== HELPER_READ_TIMEOUT_ABORT) return;
         showLocked(HELPER_READ_TIMEOUT_ABORT);
@@ -1172,7 +1197,10 @@
       }
     } finally {
       window.clearTimeout(timeout);
-      if (state.helperRevalidationController === controller) {
+      if (
+        state.helperRevalidationController === controller &&
+        helperViewGeneration === state.helperViewGeneration
+      ) {
         state.helperRevalidationController = null;
         scheduleHelperRevalidation();
       }
@@ -1180,6 +1208,7 @@
   }
 
   async function loadHelper() {
+    const helperViewGeneration = ++state.helperViewGeneration;
     byId("connectPanel")?.remove();
     byId("ownerView")?.remove();
     byId("lockedView").hidden = true;
@@ -1200,14 +1229,19 @@
     const timeout = window.setTimeout(() => controller.abort(HELPER_READ_TIMEOUT_ABORT), HELPER_READ_TIMEOUT_MS);
     try {
       const guide = await readHelperGuide(controller.signal);
-      if (state.helperLifecyclePaused) return;
+      if (state.helperLifecyclePaused || helperViewGeneration !== state.helperViewGeneration) return;
       state.guide = guide;
       renderGuide(state.guide);
       if (!state.guide) return;
       scheduleHelperRevalidation();
       announce(`Support passport loaded with ${state.guide.cards.length} cards.`);
     } catch (error) {
-      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT)
+      if (
+        state.helperLifecyclePaused ||
+        helperViewGeneration !== state.helperViewGeneration ||
+        error === PAGE_HIDDEN_ABORT ||
+        controller.signal.reason === PAGE_HIDDEN_ABORT
+      )
         return;
       showLocked(controller.signal.reason === HELPER_READ_TIMEOUT_ABORT ? HELPER_READ_TIMEOUT_ABORT : error);
     } finally {
@@ -1350,6 +1384,8 @@
     state.shareCreationPending = false;
     state.shareCreationCardIds = null;
     clearDisplayedShareLink();
+    window.clearTimeout(state.ownerGrantExpiryTimer);
+    state.ownerGrantExpiryTimer = null;
     clearPrefillToken();
     window.clearTimeout(state.announcementTimer);
     state.announcementTimer = null;
@@ -1357,8 +1393,10 @@
     byId("connectForm").reset();
     byId("memoryForm").reset();
     byId("memoryForm").querySelector('button[type="submit"]').textContent = "Add selected note";
+    byId("generateButton").textContent = "Draft my support cards";
     byId("cardForm").reset();
     byId("shareForm").reset();
+    byId("shareForm").querySelector('button[type="submit"]').textContent = "Create share link";
     byId("customTimeField").hidden = true;
     if (byId("cardDialog").open) byId("cardDialog").close();
     byId("toast").textContent = "";

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -17,7 +17,7 @@
   const HELPER_REVALIDATION_MS = 30_000;
   const HELPER_REVALIDATION_MAX_MS = 5 * 60_000;
   const HELPER_READ_TIMEOUT_MS = 10_000;
-  const HELPER_QUESTION_TIMEOUT_MS = 60_000;
+  const HELPER_QUESTION_TIMEOUT_MS = 15 * 60_000;
   const OWNER_READ_TIMEOUT_MS = 30_000;
   const OWNER_WRITE_TIMEOUT_MS = 60_000;
   const OWNER_MODEL_WRITE_TIMEOUT_MS = 15 * 60_000;
@@ -58,6 +58,7 @@
     shareCreationCardIds: null,
     ownerLifecyclePaused: false,
     ownerRequestControllers: new Set(),
+    ownerLoadGeneration: 0,
     toastTimer: null,
   };
   initialHelperSecret = "";
@@ -549,12 +550,17 @@
   }
 
   async function loadOwnerState() {
+    const generation = ++state.ownerLoadGeneration;
     const [cardPayload, grantPayload] = await Promise.all([api.listCards(), api.listGrants()]);
-    state.cards = model.parseCardList(cardPayload);
-    state.grants = model.parseGrantList(grantPayload).slice(0, MAX_VISIBLE_GRANTS);
+    const cards = model.parseCardList(cardPayload);
+    const grants = model.parseGrantList(grantPayload).slice(0, MAX_VISIBLE_GRANTS);
+    if (generation !== state.ownerLoadGeneration || state.ownerLifecyclePaused) return false;
+    state.cards = cards;
+    state.grants = grants;
     renderCards();
     renderShareCards();
     renderGrants();
+    return true;
   }
 
   function toLocalInputValue(date) {
@@ -1134,6 +1140,7 @@
 
   function clearOwnerSession() {
     state.ownerLifecyclePaused = true;
+    state.ownerLoadGeneration += 1;
     for (const controller of state.ownerRequestControllers) controller.abort(PAGE_HIDDEN_ABORT);
     state.ownerRequestControllers.clear();
     state.token = "";

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -28,6 +28,9 @@
   const MAX_VISIBLE_GRANTS = 100;
   const MAX_SHARED_CARDS = 8;
   const PAGE_HIDDEN_ABORT = new Error("The page was hidden.");
+  const HELPER_READ_TIMEOUT_ABORT = Object.assign(new Error("The support passport check took too long."), {
+    code: "request_timeout",
+  });
   const SCROLL_BEHAVIOR = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
   const TERMINAL_HELPER_ERROR_CODES = new Set([
     "grant_expired",
@@ -1072,7 +1075,7 @@
     const helperNow = Date.now() + (state.helperServerOffsetMs ?? 0);
     const lock = model.lockState(error, lastGuide, helperNow);
     const retryable =
-      !lastGuide && Boolean(state.helperGrantId && state.helperSecret) && !TERMINAL_HELPER_ERROR_CODES.has(error?.code);
+      Boolean(state.helperGrantId && state.helperSecret) && !TERMINAL_HELPER_ERROR_CODES.has(error?.code);
     byId("lockedEyebrow").textContent = lock.eyebrow;
     byId("lockedTitle").textContent = lock.title;
     byId("lockedDetail").textContent = lock.detail;
@@ -1146,7 +1149,7 @@
     const controller = new AbortController();
     state.helperRevalidationController?.abort();
     state.helperRevalidationController = controller;
-    const timeout = window.setTimeout(() => controller.abort(), HELPER_READ_TIMEOUT_MS);
+    const timeout = window.setTimeout(() => controller.abort(HELPER_READ_TIMEOUT_ABORT), HELPER_READ_TIMEOUT_MS);
     try {
       const guide = await readHelperGuide(controller.signal);
       if (state.helperLifecyclePaused) return;
@@ -1154,7 +1157,12 @@
       state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;
       scheduleHelperExpiry();
     } catch (error) {
-      if (controller.signal.aborted || !state.guide) return;
+      if (state.helperLifecyclePaused || controller.signal.reason === PAGE_HIDDEN_ABORT || !state.guide) return;
+      if (controller.signal.aborted) {
+        if (controller.signal.reason !== HELPER_READ_TIMEOUT_ABORT) return;
+        showLocked(HELPER_READ_TIMEOUT_ABORT);
+        return;
+      }
       if (["grant_expired", "grant_gone", "grant_not_found", "grant_stale"].includes(error?.code)) {
         showLocked(error);
         return;
@@ -1189,7 +1197,7 @@
     const controller = new AbortController();
     state.helperLoadController?.abort();
     state.helperLoadController = controller;
-    const timeout = window.setTimeout(() => controller.abort(), HELPER_READ_TIMEOUT_MS);
+    const timeout = window.setTimeout(() => controller.abort(HELPER_READ_TIMEOUT_ABORT), HELPER_READ_TIMEOUT_MS);
     try {
       const guide = await readHelperGuide(controller.signal);
       if (state.helperLifecyclePaused) return;
@@ -1201,7 +1209,7 @@
     } catch (error) {
       if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT)
         return;
-      showLocked(error);
+      showLocked(controller.signal.reason === HELPER_READ_TIMEOUT_ABORT ? HELPER_READ_TIMEOUT_ABORT : error);
     } finally {
       window.clearTimeout(timeout);
       if (state.helperLoadController === controller) state.helperLoadController = null;

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -674,7 +674,9 @@
   async function addMemory(event) {
     event.preventDefault();
     setError("memoryError");
-    const memoryId = byId("memoryIdInput").value.trim();
+    const memoryInput = byId("memoryIdInput");
+    const submittedValue = memoryInput.value;
+    const memoryId = submittedValue.trim();
     if (state.selectedNotes.some((note) => note.memoryId === memoryId)) {
       setError("memoryError", "That note is already selected.");
       return;
@@ -698,7 +700,7 @@
           revision: preview.memory.revision,
         },
       ];
-      byId("memoryIdInput").value = "";
+      if (memoryInput.value === submittedValue) memoryInput.value = "";
       byId("consentInput").checked = false;
       renderSelectedNotes();
       announce("Selected note added. Review it before consent.");
@@ -1158,6 +1160,7 @@
     byId("memoryForm").reset();
     byId("cardForm").reset();
     byId("shareForm").reset();
+    byId("customTimeField").hidden = true;
     if (byId("cardDialog").open) byId("cardDialog").close();
     byId("newLinkPanel").hidden = true;
     byId("shareLinkInput").value = "";

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -833,6 +833,7 @@
 
   async function createShare(event) {
     event.preventDefault();
+    if (state.shareCreationPending) return;
     setError("shareError");
     clearDisplayedShareLink();
     const selectedInputs = [...document.querySelectorAll('input[name="shareCard"]:checked')];

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -466,7 +466,7 @@
             }
             const reconciled = await reconcileOwnerState(() => {
               const current = state.grants.find((candidate) => candidate.grantId === grant.grantId);
-              return !current || current.status === "revoked" ? grant : null;
+              return !current || current.status !== "active" ? grant : null;
             });
             if (!reconciled.matched) {
               setError(

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -1038,6 +1038,16 @@
     }
   }
 
+  function clearHelperSensitiveView() {
+    byId("questionForm").reset();
+    byId("questionInput").disabled = false;
+    byId("questionCount").textContent = "0";
+    byId("answerCopy").textContent = "";
+    byId("answerPanel").hidden = true;
+    clear(byId("citationList"));
+    setError("questionError");
+  }
+
   function showLocked(error) {
     if (state.helperLifecyclePaused && error?.code !== "session_ended") return;
     window.clearTimeout(state.helperExpiryTimer);
@@ -1057,8 +1067,7 @@
     byId("helperView").hidden = true;
     byId("helperLoading").hidden = false;
     clear(byId("guideGroups"));
-    byId("answerPanel").hidden = true;
-    clear(byId("citationList"));
+    clearHelperSensitiveView();
     const helperNow = Date.now() + (state.helperServerOffsetMs ?? 0);
     const lock = model.lockState(error, lastGuide, helperNow);
     const retryable =
@@ -1397,13 +1406,8 @@
     const error = new Error("The helper session ended when this page was hidden.");
     error.code = "session_ended";
     showLocked(error);
-    byId("questionForm").reset();
-    byId("questionInput").disabled = false;
-    byId("questionCount").textContent = "0";
-    byId("answerCopy").textContent = "";
     byId("helperExpiry").textContent = "";
     byId("helperCardCount").textContent = "";
-    setError("questionError");
   }
 
   async function init() {

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -7,7 +7,7 @@
   const replayMode = params.get("mode") === "replay";
   const grantId = params.get("grant") ?? "";
   const hasSecretFragment = new URLSearchParams(window.location.hash.slice(1)).has("secret");
-  const secret = model.parseSecret(window.location.hash);
+  let initialHelperSecret = model.parseSecret(window.location.hash);
   if (hasSecretFragment) {
     window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
   }
@@ -41,7 +41,7 @@
     grants: [],
     selectedNotes: [],
     guide: null,
-    helperSecret: secret,
+    helperSecret: initialHelperSecret,
     helperGrantId: grantId,
     helperServerOffsetMs: null,
     helperExpiryTimer: null,
@@ -60,6 +60,7 @@
     ownerRequestControllers: new Set(),
     toastTimer: null,
   };
+  initialHelperSecret = "";
 
   function element(tag, className, text) {
     const node = document.createElement(tag);
@@ -1032,7 +1033,8 @@
   async function askQuestion(event) {
     event.preventDefault();
     setError("questionError");
-    const question = byId("questionInput").value.trim();
+    const questionInput = byId("questionInput");
+    const question = questionInput.value.trim();
     if (!question || !state.guide) return;
     byId("answerPanel").hidden = true;
     byId("answerCopy").textContent = "";
@@ -1046,6 +1048,7 @@
       timedOut = true;
       controller.abort();
     }, HELPER_QUESTION_TIMEOUT_MS);
+    questionInput.disabled = true;
     try {
       const payload = await withBusy(button, "Checking shared cards…", () =>
         api.askGrant(state.helperGrantId, state.helperSecret, question, controller.signal)
@@ -1078,6 +1081,16 @@
     } finally {
       window.clearTimeout(timeout);
       if (state.helperQuestionController === controller) state.helperQuestionController = null;
+      questionInput.disabled = false;
+    }
+  }
+
+  function clearPrefillToken() {
+    window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ = "";
+    for (const script of document.scripts) {
+      if (script.src || !script.textContent?.includes("__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__")) continue;
+      script.textContent = "";
+      script.remove();
     }
   }
 
@@ -1132,6 +1145,7 @@
     state.cardSavePending = false;
     state.shareCreationPending = false;
     state.shareCreationCardIds = null;
+    clearPrefillToken();
     window.clearTimeout(state.toastTimer);
     byId("connectForm").reset();
     byId("memoryForm").reset();
@@ -1172,24 +1186,30 @@
       }
     });
     window.addEventListener("pagehide", (event) => {
-      state.helperLifecyclePaused = true;
-      window.clearTimeout(state.helperExpiryTimer);
-      window.clearTimeout(state.helperRevalidationTimer);
-      state.helperLoadController?.abort(PAGE_HIDDEN_ABORT);
-      state.helperQuestionController?.abort(PAGE_HIDDEN_ABORT);
-      state.helperRevalidationController?.abort(PAGE_HIDDEN_ABORT);
+      clearHelperSession();
       if (!event.persisted) replayChannel?.close();
     });
     window.addEventListener("pageshow", (event) => {
       if (!event.persisted) return;
-      state.helperLifecyclePaused = false;
-      if (!state.guide) {
-        if (byId("helperView")) void loadHelper();
-        return;
-      }
-      scheduleHelperExpiry();
-      if (state.guide && !replayMode) void revalidateHelper();
+      clearHelperSession();
     });
+  }
+
+  function clearHelperSession() {
+    state.helperLifecyclePaused = true;
+    state.helperSecret = "";
+    state.helperServerOffsetMs = null;
+    state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;
+    const error = new Error("The helper session ended when this page was hidden.");
+    error.code = "grant_gone";
+    showLocked(error);
+    byId("questionForm").reset();
+    byId("questionInput").disabled = false;
+    byId("questionCount").textContent = "0";
+    byId("answerCopy").textContent = "";
+    byId("helperExpiry").textContent = "";
+    byId("helperCardCount").textContent = "";
+    setError("questionError");
   }
 
   async function init() {
@@ -1205,7 +1225,7 @@
       typeof window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ === "string"
         ? window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__.trim()
         : "";
-    window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ = "";
+    clearPrefillToken();
     if (replayMode) {
       state.token = "synthetic-replay";
       state.selectedNotes = replayStore.notes.map((note) => ({ ...note }));

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -537,12 +537,8 @@
     const reviewValue = byId("cardReviewInput").value;
     const reviewDate = new Date(reviewValue);
     const existingCard = state.cards.find((card) => card.cardId === cardId);
-    const keepsExistingReminder =
-      existingCard && reviewValue === toLocalInputValue(new Date(existingCard.reviewBy));
-    if (
-      !Number.isFinite(reviewDate.getTime()) ||
-      (reviewDate.getTime() <= Date.now() && !keepsExistingReminder)
-    ) {
+    const keepsExistingReminder = existingCard && reviewValue === toLocalInputValue(new Date(existingCard.reviewBy));
+    if (!Number.isFinite(reviewDate.getTime()) || (reviewDate.getTime() <= Date.now() && !keepsExistingReminder)) {
       setError("cardError", "Choose a future review reminder.");
       return;
     }
@@ -554,40 +550,47 @@
       ...(cardId ? { expectedRevision } : {}),
     };
     const priorCardIds = new Set(state.cards.map((card) => card.cardId));
+    const button = byId("cardSaveButton");
+    const priorLabel = button.textContent;
+    button.disabled = true;
+    button.textContent = "Saving draft…";
     let ownerStateFresh = false;
     try {
-      await withBusy(byId("cardSaveButton"), "Saving draft…", () =>
-        cardId ? api.replaceCard(cardId, input) : api.createManualDraft(input)
-      );
-    } catch (error) {
-      if (error?.code !== "request_timeout") {
-        setError("cardError", errorMessage(error, "The draft did not save."));
-        return;
-      }
-      const reconciled = await reconcileOwnerState(() =>
-        state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input))
-      );
-      if (!reconciled.matched) {
-        setError(
-          "cardError",
-          reconciled.refreshed
-            ? "The request stopped before the draft saved. Review the current guide before trying again."
-            : "The server did not confirm whether the draft saved. Refresh the guide before saving it again."
+      try {
+        await (cardId ? api.replaceCard(cardId, input) : api.createManualDraft(input));
+      } catch (error) {
+        if (error?.code !== "request_timeout") {
+          setError("cardError", errorMessage(error, "The draft did not save."));
+          return;
+        }
+        const reconciled = await reconcileOwnerState(() =>
+          state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input))
         );
-        return;
+        if (!reconciled.matched) {
+          setError(
+            "cardError",
+            reconciled.refreshed
+              ? "The request stopped before the draft saved. Review the current guide before trying again."
+              : "The server did not confirm whether the draft saved. Refresh the guide before saving it again."
+          );
+          return;
+        }
+        ownerStateFresh = true;
       }
-      ownerStateFresh = true;
-    }
-    closeCardDialog();
-    const message = "Draft saved. Review and approve it before sharing.";
-    toast(message);
-    announce(message);
-    try {
-      if (!ownerStateFresh) await loadOwnerState();
-    } catch {
-      const warning = "The draft was saved, but the card list did not refresh. Refresh the guide before editing it.";
-      setError("generateError", warning);
-      announce(warning);
+      closeCardDialog();
+      const message = "Draft saved. Review and approve it before sharing.";
+      toast(message);
+      announce(message);
+      try {
+        if (!ownerStateFresh) await loadOwnerState();
+      } catch {
+        const warning = "The draft was saved, but the card list did not refresh. Refresh the guide before editing it.";
+        setError("generateError", warning);
+        announce(warning);
+      }
+    } finally {
+      button.disabled = false;
+      button.textContent = priorLabel;
     }
   }
 
@@ -605,9 +608,7 @@
     }
     const button = event.currentTarget.querySelector("button");
     try {
-      const preview = model.parseMemoryPreview(
-        await withBusy(button, "Adding note…", () => api.fetchMemory(memoryId))
-      );
+      const preview = model.parseMemoryPreview(await withBusy(button, "Adding note…", () => api.fetchMemory(memoryId)));
       if (!preview.found) {
         throw new Error("That memory was not found in your Remnic scope.");
       }
@@ -812,9 +813,7 @@
     clear(byId("citationList"));
     const lock = model.lockState(error, lastGuide);
     const retryable =
-      !lastGuide &&
-      Boolean(state.helperGrantId && state.helperSecret) &&
-      !TERMINAL_HELPER_ERROR_CODES.has(error?.code);
+      !lastGuide && Boolean(state.helperGrantId && state.helperSecret) && !TERMINAL_HELPER_ERROR_CODES.has(error?.code);
     byId("lockedEyebrow").textContent = lock.eyebrow;
     byId("lockedTitle").textContent = lock.title;
     byId("lockedDetail").textContent = lock.detail;
@@ -899,10 +898,7 @@
         return;
       }
       if (error?.code === "rate_limited") {
-        state.helperRevalidationDelayMs = Math.min(
-          state.helperRevalidationDelayMs * 2,
-          HELPER_REVALIDATION_MAX_MS
-        );
+        state.helperRevalidationDelayMs = Math.min(state.helperRevalidationDelayMs * 2, HELPER_REVALIDATION_MAX_MS);
       }
     } finally {
       window.clearTimeout(timeout);

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -1159,7 +1159,11 @@
   }
 
   function clearPrefillToken() {
-    window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ = "";
+    try {
+      delete window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__;
+    } catch {
+      window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ = "";
+    }
     for (const script of document.scripts) {
       if (script.src || !script.textContent?.includes("__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__")) continue;
       script.textContent = "";
@@ -1290,6 +1294,7 @@
   async function init() {
     if (replayMode) byId("replayBanner").hidden = false;
     if (grantId || hasSecretFragment) {
+      clearPrefillToken();
       bindHelperEvents();
       await loadHelper();
       return;

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -1,5 +1,6 @@
 (function startWhatHelpsMe() {
-  const initialHash = window.location.hash;
+  const bootstrapHash = window.__REMNIC_WHAT_HELPS_ME_FRAGMENT__;
+  const initialHash = typeof bootstrapHash === "string" ? bootstrapHash : window.location.hash;
   const hasSecretFragment = new URLSearchParams(initialHash.slice(1)).has("secret");
   if (hasSecretFragment) {
     window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -33,6 +33,7 @@
     "grant_not_found",
     "grant_stale",
     "missing_link",
+    "session_ended",
   ]);
 
   const state = {
@@ -1274,7 +1275,7 @@
     state.helperServerOffsetMs = null;
     state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;
     const error = new Error("The helper session ended when this page was hidden.");
-    error.code = "grant_gone";
+    error.code = "session_ended";
     showLocked(error);
     byId("questionForm").reset();
     byId("questionInput").disabled = false;
@@ -1294,10 +1295,8 @@
     }
 
     bindOwnerEvents();
-    const prefill =
-      typeof window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__ === "string"
-        ? window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__.trim()
-        : "";
+    const prefillValue = window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__;
+    const prefill = typeof prefillValue === "string" ? prefillValue.trim() : "";
     clearPrefillToken();
     if (replayMode) {
       state.token = "synthetic-replay";

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -52,6 +52,7 @@
     helperRevalidationTimer: null,
     helperRevalidationDelayMs: HELPER_REVALIDATION_MS,
     helperLifecyclePaused: false,
+    ownerServerOffsetMs: null,
     pendingCardMutationIds: new Set(),
     pendingGrantRevocationIds: new Set(),
     cardSavePending: false,
@@ -63,6 +64,7 @@
     ownerLifecyclePaused: false,
     ownerRequestControllers: new Set(),
     ownerLoadGeneration: 0,
+    ownerSessionGeneration: 0,
     toastTimer: null,
   };
   initialHelperSecret = "";
@@ -79,7 +81,17 @@
   }
 
   function setError(id, message = "") {
+    if (message === null) return;
+    if (message && (state.ownerLifecyclePaused || state.helperLifecyclePaused)) return;
     byId(id).textContent = message;
+  }
+
+  function ownerNowMs() {
+    return Date.now() + (state.ownerServerOffsetMs ?? 0);
+  }
+
+  function ownerSessionIsCurrent(generation) {
+    return !state.ownerLifecyclePaused && generation === state.ownerSessionGeneration;
   }
 
   function clearDisplayedShareLink() {
@@ -95,7 +107,7 @@
     window.clearTimeout(state.displayedGrantTimer);
     state.displayedGrantTimer = null;
     if (!state.displayedGrant) return;
-    const remainingMs = Date.parse(state.displayedGrant.expiresAt) - Date.now();
+    const remainingMs = Date.parse(state.displayedGrant.expiresAt) - ownerNowMs();
     if (remainingMs <= 0) {
       clearDisplayedShareLink();
       return;
@@ -112,7 +124,7 @@
         (card) => card.cardId === selected.cardId && card.revision === selected.revision && card.status === "active"
       )
     );
-    if (!grant || grant.status !== "active" || Date.parse(grant.expiresAt) <= Date.now() || !cardsStillCurrent) {
+    if (!grant || grant.status !== "active" || Date.parse(grant.expiresAt) <= ownerNowMs() || !cardsStillCurrent) {
       clearDisplayedShareLink();
       return;
     }
@@ -139,6 +151,7 @@
   }
 
   function errorMessage(error, fallback) {
+    if (error === PAGE_HIDDEN_ABORT) return null;
     if (error instanceof Error && error.message.trim()) return error.message;
     return fallback;
   }
@@ -195,6 +208,7 @@
         cache: "no-store",
         signal: controller?.signal ?? options.signal,
       });
+      if ((controller?.signal ?? options.signal)?.reason === PAGE_HIDDEN_ABORT) throw PAGE_HIDDEN_ABORT;
       let payload;
       try {
         payload = await response.json();
@@ -210,13 +224,23 @@
         throw error;
       }
       if (options.owner && state.ownerLifecyclePaused) throw PAGE_HIDDEN_ABORT;
-      if (!options.captureServerTime) return payload;
       const serverNowMs = Date.parse(response.headers.get("date") ?? "");
+      if (options.owner && Number.isFinite(serverNowMs)) {
+        state.ownerServerOffsetMs = serverNowMs - Date.now();
+      }
+      if (!options.captureServerTime) return payload;
       return {
         payload,
         serverOffsetMs: Number.isFinite(serverNowMs) ? serverNowMs - Date.now() : null,
       };
     } catch (error) {
+      if (
+        (controller?.signal ?? options.signal)?.reason === PAGE_HIDDEN_ABORT ||
+        (options.owner && state.ownerLifecyclePaused) ||
+        (options.secret && state.helperLifecyclePaused)
+      ) {
+        throw PAGE_HIDDEN_ABORT;
+      }
       if (!timedOut) throw error;
       const timeoutError = new Error(options.timeoutMessage ?? "The owner request took too long. Try again.");
       timeoutError.code = "request_timeout";
@@ -290,8 +314,8 @@
 
   function showOwner() {
     byId("connectPanel").hidden = true;
-    byId("helperView").remove();
-    byId("lockedView").remove();
+    byId("helperView")?.remove();
+    byId("lockedView")?.remove();
     byId("ownerView").hidden = false;
     byId("viewMarkerText").textContent = replayMode ? "Owner replay" : "Owner view";
   }
@@ -332,6 +356,7 @@
   }
 
   async function mutateCard(card, action, button) {
+    const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("generateError");
     const verbs = { approve: "Approving…", reject: "Rejecting…", withdraw: "Stopping…" };
     const priorLabel = button.textContent;
@@ -366,6 +391,7 @@
           }
           return current ? null : card;
         });
+        if (reconciled.cancelled) return;
         if (!reconciled.matched) {
           setError(
             "generateError",
@@ -388,16 +414,19 @@
       announce(message);
       try {
         if (!ownerStateFresh) await loadOwnerState();
-      } catch {
+      } catch (error) {
+        if (error === PAGE_HIDDEN_ABORT) return;
         const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
         setError("generateError", warning);
         announce(warning);
       }
     } finally {
-      state.pendingCardMutationIds.delete(card.cardId);
-      button.disabled = false;
-      button.textContent = priorLabel;
-      renderCards();
+      if (ownerSessionIsCurrent(ownerSessionGeneration)) {
+        state.pendingCardMutationIds.delete(card.cardId);
+        button.disabled = false;
+        button.textContent = priorLabel;
+        renderCards();
+      }
     }
   }
 
@@ -498,16 +527,20 @@
   }
 
   async function reconcileOwnerState(match) {
-    if (state.ownerLifecyclePaused) return { matched: false, refreshed: false };
+    const ownerSessionGeneration = state.ownerSessionGeneration;
+    if (!ownerSessionIsCurrent(ownerSessionGeneration)) return { matched: false, refreshed: false, cancelled: true };
     let refreshed = false;
     for (let attempt = 0; attempt < OWNER_RECONCILIATION_ATTEMPTS; attempt += 1) {
-      if (state.ownerLifecyclePaused) return { matched: false, refreshed };
+      if (!ownerSessionIsCurrent(ownerSessionGeneration)) return { matched: false, refreshed, cancelled: true };
       try {
         await loadOwnerState();
+        if (!ownerSessionIsCurrent(ownerSessionGeneration)) return { matched: false, refreshed, cancelled: true };
         refreshed = true;
         const value = match();
         if (value) return { matched: true, value };
-      } catch {}
+      } catch (error) {
+        if (error === PAGE_HIDDEN_ABORT) return { matched: false, refreshed, cancelled: true };
+      }
       if (attempt + 1 < OWNER_RECONCILIATION_ATTEMPTS) {
         await delay(OWNER_RECONCILIATION_DELAY_MS);
       }
@@ -544,6 +577,7 @@
       );
       if (grant.status === "active") {
         const stop = cardButton("Stop sharing", "button-danger", async (event) => {
+          const ownerSessionGeneration = state.ownerSessionGeneration;
           const button = event.currentTarget;
           const priorLabel = button.textContent;
           let ownerStateFresh = false;
@@ -562,6 +596,7 @@
                 const current = state.grants.find((candidate) => candidate.grantId === grant.grantId);
                 return !current || current.status !== "active" ? grant : null;
               });
+              if (reconciled.cancelled) return;
               if (!reconciled.matched) {
                 setError(
                   "shareError",
@@ -578,16 +613,19 @@
             announce(message);
             try {
               if (!ownerStateFresh) await loadOwnerState();
-            } catch {
+            } catch (error) {
+              if (error === PAGE_HIDDEN_ABORT) return;
               const warning = `${message} The share list did not refresh. Refresh the guide before another change.`;
               setError("shareError", warning);
               announce(warning);
             }
           } finally {
-            state.pendingGrantRevocationIds.delete(grant.grantId);
-            button.disabled = false;
-            button.textContent = priorLabel;
-            renderGrants();
+            if (ownerSessionIsCurrent(ownerSessionGeneration)) {
+              state.pendingGrantRevocationIds.delete(grant.grantId);
+              button.disabled = false;
+              button.textContent = priorLabel;
+              renderGrants();
+            }
           }
         });
         stop.disabled = state.pendingGrantRevocationIds.has(grant.grantId);
@@ -651,6 +689,7 @@
   async function saveCard(event) {
     event.preventDefault();
     if (state.cardSavePending) return;
+    const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("cardError");
     const cardId = byId("cardIdInput").value;
     const expectedRevision = byId("cardRevisionInput").value;
@@ -687,6 +726,7 @@
           if (cardId) return null;
           return state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input));
         });
+        if (reconciled.cancelled) return;
         if (!reconciled.matched) {
           let message;
           if (cardId) {
@@ -709,14 +749,17 @@
       announce(message);
       try {
         if (!ownerStateFresh) await loadOwnerState();
-      } catch {
+      } catch (error) {
+        if (error === PAGE_HIDDEN_ABORT) return;
         const warning = "The draft was saved, but the card list did not refresh. Refresh the guide before editing it.";
         setError("generateError", warning);
         announce(warning);
       }
     } finally {
-      button.textContent = priorLabel;
-      setCardSavePending(false);
+      if (ownerSessionIsCurrent(ownerSessionGeneration)) {
+        button.textContent = priorLabel;
+        setCardSavePending(false);
+      }
     }
   }
 
@@ -761,6 +804,7 @@
 
   async function generateDrafts() {
     if (state.draftGenerationPending) return;
+    const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("generateError");
     if (state.selectedNotes.length === 0) {
       setError("generateError", "Select at least one note first.");
@@ -796,7 +840,9 @@
         try {
           await loadOwnerState();
           refreshed = true;
-        } catch {}
+        } catch (error) {
+          if (error === PAGE_HIDDEN_ABORT) return;
+        }
         setError(
           "generateError",
           refreshed
@@ -812,14 +858,17 @@
       try {
         await loadOwnerState();
         byId("reviewCards").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "start" });
-      } catch {
+      } catch (error) {
+        if (error === PAGE_HIDDEN_ABORT) return;
         const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
         setError("generateError", warning);
         announce(warning);
       }
     } finally {
-      button.textContent = priorLabel;
-      setDraftGenerationPending(false);
+      if (ownerSessionIsCurrent(ownerSessionGeneration)) {
+        button.textContent = priorLabel;
+        setDraftGenerationPending(false);
+      }
     }
   }
 
@@ -834,6 +883,7 @@
   async function createShare(event) {
     event.preventDefault();
     if (state.shareCreationPending) return;
+    const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("shareError");
     clearDisplayedShareLink();
     const selectedInputs = [...document.querySelectorAll('input[name="shareCard"]:checked')];
@@ -881,7 +931,9 @@
         try {
           await loadOwnerState();
           refreshed = true;
-        } catch {}
+        } catch (error) {
+          if (error === PAGE_HIDDEN_ABORT) return;
+        }
         setError(
           "shareError",
           refreshed
@@ -907,17 +959,20 @@
       byId("newLinkPanel").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "nearest" });
       try {
         await loadOwnerState();
-      } catch {
+      } catch (error) {
+        if (error === PAGE_HIDDEN_ABORT) return;
         setError("shareError", "The share link was created, but the share list did not refresh. Use the link above.");
       }
     } finally {
-      setShareCreationPending(false);
-      if (clearSelection) {
-        for (const input of document.querySelectorAll('input[name="shareCard"]')) input.checked = false;
-        updateShareCardChoices();
+      if (ownerSessionIsCurrent(ownerSessionGeneration)) {
+        setShareCreationPending(false);
+        if (clearSelection) {
+          for (const input of document.querySelectorAll('input[name="shareCard"]')) input.checked = false;
+          updateShareCardChoices();
+        }
+        button.disabled = false;
+        button.textContent = priorLabel;
       }
-      button.disabled = false;
-      button.textContent = priorLabel;
     }
   }
 
@@ -938,20 +993,24 @@
     event.preventDefault();
     setError("connectError");
     state.ownerLifecyclePaused = false;
+    const ownerSessionGeneration = state.ownerSessionGeneration;
     state.token = byId("tokenInput").value.trim();
     if (!state.token) return;
     const button = event.currentTarget.querySelector("button");
     try {
       await withBusy(button, "Opening guide…", loadOwnerState);
+      if (!ownerSessionIsCurrent(ownerSessionGeneration)) return;
       showOwner();
       announce("Owner guide loaded.");
     } catch (error) {
+      if (!ownerSessionIsCurrent(ownerSessionGeneration)) return;
       state.token = "";
       setError("connectError", errorMessage(error, "The owner guide did not load."));
     }
   }
 
   function showLocked(error) {
+    if (state.helperLifecyclePaused && error?.code !== "session_ended") return;
     window.clearTimeout(state.helperExpiryTimer);
     state.helperExpiryTimer = null;
     window.clearTimeout(state.helperRevalidationTimer);
@@ -987,6 +1046,7 @@
 
   async function readHelperGuide(signal) {
     const result = await api.readGrant(state.helperGrantId, state.helperSecret, signal);
+    if (state.helperLifecyclePaused) throw PAGE_HIDDEN_ABORT;
     if (replayMode) return model.parsePublicGuide(result);
     if (Number.isFinite(result.serverOffsetMs)) state.helperServerOffsetMs = result.serverOffsetMs;
     return model.parsePublicGuide(result.payload);
@@ -1048,7 +1108,9 @@
     state.helperRevalidationController = controller;
     const timeout = window.setTimeout(() => controller.abort(), HELPER_READ_TIMEOUT_MS);
     try {
-      state.guide = await readHelperGuide(controller.signal);
+      const guide = await readHelperGuide(controller.signal);
+      if (state.helperLifecyclePaused) return;
+      state.guide = guide;
       state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;
       scheduleHelperExpiry();
     } catch (error) {
@@ -1089,13 +1151,15 @@
     state.helperLoadController = controller;
     const timeout = window.setTimeout(() => controller.abort(), HELPER_READ_TIMEOUT_MS);
     try {
-      state.guide = await readHelperGuide(controller.signal);
+      const guide = await readHelperGuide(controller.signal);
+      if (state.helperLifecyclePaused) return;
+      state.guide = guide;
       renderGuide(state.guide);
       if (!state.guide) return;
       scheduleHelperRevalidation();
       announce(`Support passport loaded with ${state.guide.cards.length} cards.`);
     } catch (error) {
-      if (controller.signal.reason === PAGE_HIDDEN_ABORT) return;
+      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT) return;
       showLocked(error);
     } finally {
       window.clearTimeout(timeout);
@@ -1126,6 +1190,7 @@
       const payload = await withBusy(button, "Checking shared cards…", () =>
         api.askGrant(state.helperGrantId, state.helperSecret, question, controller.signal)
       );
+      if (state.helperLifecyclePaused) return;
       const answer = model.parseAnswer(payload, state.guide);
       byId("answerCopy").textContent = answer.answer;
       const citations = byId("citationList");
@@ -1141,7 +1206,7 @@
       announce("Answer ready with support card citations.");
     } catch (error) {
       if (!state.guide) return;
-      if (controller.signal.reason === PAGE_HIDDEN_ABORT) return;
+      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT) return;
       if (timedOut) {
         setError("questionError", "The question took too long. Try again.");
         return;
@@ -1188,6 +1253,7 @@
         await withBusy(event.currentTarget, "…", loadOwnerState);
         announce("Cards and share links refreshed.");
       } catch (error) {
+        if (error === PAGE_HIDDEN_ABORT) return;
         setError("shareError", errorMessage(error, "The guide did not refresh."));
       }
     });
@@ -1211,9 +1277,11 @@
 
   function clearOwnerSession() {
     state.ownerLifecyclePaused = true;
+    state.ownerSessionGeneration += 1;
     state.ownerLoadGeneration += 1;
     for (const controller of state.ownerRequestControllers) controller.abort(PAGE_HIDDEN_ABORT);
     state.ownerRequestControllers.clear();
+    state.ownerServerOffsetMs = null;
     state.token = "";
     state.cards = [];
     state.grants = [];
@@ -1276,6 +1344,9 @@
 
   function clearHelperSession() {
     state.helperLifecyclePaused = true;
+    state.helperLoadController?.abort(PAGE_HIDDEN_ABORT);
+    state.helperQuestionController?.abort(PAGE_HIDDEN_ABORT);
+    state.helperRevalidationController?.abort(PAGE_HIDDEN_ABORT);
     state.helperSecret = "";
     state.helperServerOffsetMs = null;
     state.helperRevalidationDelayMs = HELPER_REVALIDATION_MS;

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -57,6 +57,8 @@
     draftGenerationPending: false,
     shareCreationPending: false,
     shareCreationCardIds: null,
+    displayedGrant: null,
+    displayedGrantTimer: null,
     ownerLifecyclePaused: false,
     ownerRequestControllers: new Set(),
     ownerLoadGeneration: 0,
@@ -77,6 +79,47 @@
 
   function setError(id, message = "") {
     byId(id).textContent = message;
+  }
+
+  function clearDisplayedShareLink() {
+    window.clearTimeout(state.displayedGrantTimer);
+    state.displayedGrantTimer = null;
+    state.displayedGrant = null;
+    byId("newLinkPanel").hidden = true;
+    byId("shareLinkInput").value = "";
+    byId("openLinkButton").removeAttribute("href");
+  }
+
+  function scheduleDisplayedShareLinkExpiry() {
+    window.clearTimeout(state.displayedGrantTimer);
+    state.displayedGrantTimer = null;
+    if (!state.displayedGrant) return;
+    const remainingMs = Date.parse(state.displayedGrant.expiresAt) - Date.now();
+    if (remainingMs <= 0) {
+      clearDisplayedShareLink();
+      return;
+    }
+    state.displayedGrantTimer = window.setTimeout(clearDisplayedShareLink, remainingMs);
+  }
+
+  function reconcileDisplayedShareLink() {
+    const displayed = state.displayedGrant;
+    if (!displayed) return;
+    const grant = state.grants.find((candidate) => candidate.grantId === displayed.grantId);
+    const cardsStillCurrent = displayed.cards.every((selected) =>
+      state.cards.some(
+        (card) => card.cardId === selected.cardId && card.revision === selected.revision && card.status === "active"
+      )
+    );
+    if (!grant || grant.status !== "active" || Date.parse(grant.expiresAt) <= Date.now() || !cardsStillCurrent) {
+      clearDisplayedShareLink();
+      return;
+    }
+    scheduleDisplayedShareLinkExpiry();
+  }
+
+  function clearDisplayedShareLinkForCard(cardId) {
+    if (state.displayedGrant?.cards.some((card) => card.cardId === cardId)) clearDisplayedShareLink();
   }
 
   function announce(message) {
@@ -339,6 +382,7 @@
           : action === "reject"
             ? `Rejected ${card.title}. It stays private.`
             : `Withdrew ${card.title}. Existing links will lock.`;
+      if (action === "withdraw") clearDisplayedShareLinkForCard(card.cardId);
       toast(message);
       announce(message);
       try {
@@ -526,6 +570,7 @@
               }
               ownerStateFresh = true;
             }
+            if (state.displayedGrant?.grantId === grant.grantId) clearDisplayedShareLink();
             replayChannel?.postMessage({ type: "grant-revoked", grantId: grant.grantId });
             const message = "Sharing stopped. The helper link is now locked.";
             toast(message);
@@ -559,6 +604,7 @@
     if (generation !== state.ownerLoadGeneration || state.ownerLifecyclePaused) return false;
     state.cards = cards;
     state.grants = grants;
+    reconcileDisplayedShareLink();
     renderCards();
     renderShareCards();
     renderGrants();
@@ -787,9 +833,7 @@
   async function createShare(event) {
     event.preventDefault();
     setError("shareError");
-    byId("newLinkPanel").hidden = true;
-    byId("shareLinkInput").value = "";
-    byId("openLinkButton").removeAttribute("href");
+    clearDisplayedShareLink();
     const selectedInputs = [...document.querySelectorAll('input[name="shareCard"]:checked')];
     const cardIds = selectedInputs.map((input) => input.value);
     if (cardIds.length === 0) {
@@ -846,9 +890,15 @@
       }
       const url = model.buildShareUrl(window.location.href, created.grantId, created.secret, replayMode);
       clearSelection = true;
+      state.displayedGrant = {
+        grantId: created.grantId,
+        expiresAt: created.expiresAt,
+        cards: cardRevisions.map((card) => ({ ...card })),
+      };
       byId("shareLinkInput").value = url;
       byId("openLinkButton").href = url;
       byId("newLinkPanel").hidden = false;
+      scheduleDisplayedShareLinkExpiry();
       const message = `Share link created. It ends ${model.formatDate(created.expiresAt)}.`;
       toast(message);
       announce(message);
@@ -1168,6 +1218,7 @@
     state.draftGenerationPending = false;
     state.shareCreationPending = false;
     state.shareCreationCardIds = null;
+    clearDisplayedShareLink();
     clearPrefillToken();
     window.clearTimeout(state.toastTimer);
     byId("connectForm").reset();
@@ -1176,9 +1227,6 @@
     byId("shareForm").reset();
     byId("customTimeField").hidden = true;
     if (byId("cardDialog").open) byId("cardDialog").close();
-    byId("newLinkPanel").hidden = true;
-    byId("shareLinkInput").value = "";
-    byId("openLinkButton").removeAttribute("href");
     byId("toast").textContent = "";
     byId("toast").classList.remove("visible");
     byId("announcer").textContent = "";

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -53,6 +53,7 @@
     helperLifecyclePaused: false,
     pendingCardMutationIds: new Set(),
     pendingGrantRevocationIds: new Set(),
+    cardSavePending: false,
     shareCreationPending: false,
     shareCreationCardIds: null,
     toastTimer: null,
@@ -553,6 +554,7 @@
   }
 
   function openCardDialog(card = null) {
+    if (state.cardSavePending) return;
     byId("cardDialogTitle").textContent = card ? "Edit this support card" : "Write a support card";
     byId("cardSaveButton").textContent = "Save draft";
     byId("cardIdInput").value = card?.cardId ?? "";
@@ -569,11 +571,22 @@
   }
 
   function closeCardDialog() {
+    if (state.cardSavePending) return;
     byId("cardDialog").close();
+  }
+
+  function setCardSavePending(pending) {
+    state.cardSavePending = pending;
+    byId("cardForm").setAttribute("aria-busy", String(pending));
+    for (const control of byId("cardForm").querySelectorAll("input, textarea, select, button")) {
+      control.disabled = pending;
+    }
+    byId("newCardButton").disabled = pending;
   }
 
   async function saveCard(event) {
     event.preventDefault();
+    if (state.cardSavePending) return;
     setError("cardError");
     const cardId = byId("cardIdInput").value;
     const expectedRevision = byId("cardRevisionInput").value;
@@ -595,7 +608,7 @@
     const priorCardIds = new Set(state.cards.map((card) => card.cardId));
     const button = byId("cardSaveButton");
     const priorLabel = button.textContent;
-    button.disabled = true;
+    setCardSavePending(true);
     button.textContent = "Saving draft…";
     let ownerStateFresh = false;
     try {
@@ -620,7 +633,7 @@
         }
         ownerStateFresh = true;
       }
-      closeCardDialog();
+      byId("cardDialog").close();
       const message = "Draft saved. Review and approve it before sharing.";
       toast(message);
       announce(message);
@@ -632,8 +645,8 @@
         announce(warning);
       }
     } finally {
-      button.disabled = false;
       button.textContent = priorLabel;
+      setCardSavePending(false);
     }
   }
 
@@ -1060,6 +1073,9 @@
     byId("cardForm").addEventListener("submit", saveCard);
     byId("cardDialogClose").addEventListener("click", closeCardDialog);
     byId("cardCancelButton").addEventListener("click", closeCardDialog);
+    byId("cardDialog").addEventListener("cancel", (event) => {
+      if (state.cardSavePending) event.preventDefault();
+    });
     byId("shareForm").addEventListener("submit", createShare);
     byId("copyLinkButton").addEventListener("click", copyShareLink);
     byId("refreshButton").addEventListener("click", async (event) => {

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -51,6 +51,8 @@
     helperRevalidationTimer: null,
     helperRevalidationDelayMs: HELPER_REVALIDATION_MS,
     helperLifecyclePaused: false,
+    shareCreationPending: false,
+    shareCreationCardIds: null,
     toastTimer: null,
   };
 
@@ -391,6 +393,7 @@
       input.name = "shareCard";
       input.value = card.cardId;
       input.dataset.revision = card.revision;
+      input.checked = state.shareCreationCardIds?.has(card.cardId) ?? false;
       input.addEventListener("change", updateShareCardChoices);
       const copy = element("span");
       copy.append(element("strong", "", card.title), element("small", "", card.statement));
@@ -402,8 +405,21 @@
 
   function updateShareCardChoices() {
     const choices = [...document.querySelectorAll('input[name="shareCard"]')];
+    if (state.shareCreationPending) {
+      for (const input of choices) input.disabled = true;
+      return;
+    }
     const selectedCount = choices.filter((input) => input.checked).length;
     for (const input of choices) input.disabled = !input.checked && selectedCount >= MAX_SHARED_CARDS;
+  }
+
+  function setShareCreationPending(pending, selectedInputs = []) {
+    state.shareCreationPending = pending;
+    state.shareCreationCardIds = pending ? new Set(selectedInputs.map((input) => input.value)) : null;
+    for (const input of document.querySelectorAll('input[name="duration"], #customTimeInput')) {
+      input.disabled = pending;
+    }
+    updateShareCardChoices();
   }
 
   function delay(milliseconds) {
@@ -641,47 +657,54 @@
       byId("consentInput").focus();
       return;
     }
+    const button = byId("generateButton");
+    const priorLabel = button.textContent;
+    button.disabled = true;
+    button.textContent = "Drafting cards…";
     try {
-      await withBusy(byId("generateButton"), "Drafting cards…", () =>
-        api.generateDrafts({
+      try {
+        await api.generateDrafts({
           sourceMemoryIds: state.selectedNotes.map((note) => note.memoryId),
           sourceMemoryRevisions: state.selectedNotes.map((note) => ({
             memoryId: note.memoryId,
             revision: note.revision,
           })),
           consent: true,
-        })
-      );
-    } catch (error) {
-      if (error?.code !== "request_timeout") {
-        setError("generateError", errorMessage(error, "The configured model did not return valid drafts."));
+        });
+      } catch (error) {
+        if (error?.code !== "request_timeout") {
+          setError("generateError", errorMessage(error, "The configured model did not return valid drafts."));
+          return;
+        }
+        byId("consentInput").checked = false;
+        let refreshed = false;
+        try {
+          await loadOwnerState();
+          refreshed = true;
+        } catch {}
+        setError(
+          "generateError",
+          refreshed
+            ? "Drafting timed out. Review the current guide before deciding whether to draft again."
+            : "Drafting timed out. Refresh the guide before deciding whether to draft again."
+        );
         return;
       }
       byId("consentInput").checked = false;
-      let refreshed = false;
+      const message = "Drafts ready. Review each card before approval.";
+      toast(message);
+      announce(message);
       try {
         await loadOwnerState();
-        refreshed = true;
-      } catch {}
-      setError(
-        "generateError",
-        refreshed
-          ? "Drafting timed out. Review the current guide before deciding whether to draft again."
-          : "Drafting timed out. Refresh the guide before deciding whether to draft again."
-      );
-      return;
-    }
-    byId("consentInput").checked = false;
-    const message = "Drafts ready. Review each card before approval.";
-    toast(message);
-    announce(message);
-    try {
-      await loadOwnerState();
-      byId("reviewCards").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "start" });
-    } catch {
-      const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
-      setError("generateError", warning);
-      announce(warning);
+        byId("reviewCards").scrollIntoView({ behavior: SCROLL_BEHAVIOR, block: "start" });
+      } catch {
+        const warning = `${message} The card list did not refresh. Refresh the guide before another change.`;
+        setError("generateError", warning);
+        announce(warning);
+      }
+    } finally {
+      button.disabled = false;
+      button.textContent = priorLabel;
     }
   }
 
@@ -719,6 +742,8 @@
     }
     const button = event.currentTarget.querySelector('button[type="submit"]');
     const priorLabel = button.textContent;
+    let clearSelection = false;
+    setShareCreationPending(true, selectedInputs);
     button.disabled = true;
     button.textContent = "Creating link…";
     try {
@@ -744,6 +769,7 @@
         return;
       }
       const url = model.buildShareUrl(window.location.href, created.grantId, created.secret, replayMode);
+      clearSelection = true;
       byId("shareLinkInput").value = url;
       byId("openLinkButton").href = url;
       byId("newLinkPanel").hidden = false;
@@ -757,6 +783,11 @@
         setError("shareError", "The share link was created, but the share list did not refresh. Use the link above.");
       }
     } finally {
+      setShareCreationPending(false);
+      if (clearSelection) {
+        for (const input of document.querySelectorAll('input[name="shareCard"]')) input.checked = false;
+        updateShareCardChoices();
+      }
       button.disabled = false;
       button.textContent = priorLabel;
     }

--- a/admin-console/public/what-helps-me/app.js
+++ b/admin-console/public/what-helps-me/app.js
@@ -1,4 +1,9 @@
 (function startWhatHelpsMe() {
+  const initialHash = window.location.hash;
+  const hasSecretFragment = new URLSearchParams(initialHash.slice(1)).has("secret");
+  if (hasSecretFragment) {
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  }
   const model = window.WhatHelpsMeModel;
   if (!model) throw new Error("What Helps Me model did not load.");
 
@@ -6,11 +11,7 @@
   const params = new URLSearchParams(window.location.search);
   const replayMode = params.get("mode") === "replay";
   const grantId = params.get("grant") ?? "";
-  const hasSecretFragment = new URLSearchParams(window.location.hash.slice(1)).has("secret");
-  let initialHelperSecret = model.parseSecret(window.location.hash);
-  if (hasSecretFragment) {
-    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
-  }
+  let initialHelperSecret = model.parseSecret(initialHash);
   const replayStore = replayMode ? model.createReplayStore() : null;
   const replayChannel =
     replayMode && "BroadcastChannel" in window ? new BroadcastChannel("remnic-what-helps-me-replay") : null;
@@ -56,6 +57,7 @@
     pendingCardMutationIds: new Set(),
     pendingGrantRevocationIds: new Set(),
     cardSavePending: false,
+    notePreviewPending: false,
     draftGenerationPending: false,
     shareCreationPending: false,
     shareCreationCardIds: null,
@@ -65,6 +67,7 @@
     ownerRequestControllers: new Set(),
     ownerLoadGeneration: 0,
     ownerSessionGeneration: 0,
+    announcementTimer: null,
     toastTimer: null,
   };
   initialHelperSecret = "";
@@ -136,8 +139,10 @@
   }
 
   function announce(message) {
+    window.clearTimeout(state.announcementTimer);
     byId("announcer").textContent = "";
-    window.setTimeout(() => {
+    state.announcementTimer = window.setTimeout(() => {
+      state.announcementTimer = null;
       byId("announcer").textContent = message;
     }, 10);
   }
@@ -356,13 +361,17 @@
   }
 
   async function mutateCard(card, action, button) {
+    if (state.shareCreationPending && state.shareCreationCardIds?.has(card.cardId)) return;
     const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("generateError");
     const verbs = { approve: "Approving…", reject: "Rejecting…", withdraw: "Stopping…" };
     const priorLabel = button.textContent;
     state.pendingCardMutationIds.add(card.cardId);
-    button.disabled = true;
+    for (const actionButton of button.closest(".card-actions")?.querySelectorAll("button") ?? []) {
+      actionButton.disabled = true;
+    }
     button.textContent = verbs[action];
+    updateShareCardChoices();
     try {
       let ownerStateFresh = false;
       try {
@@ -426,6 +435,7 @@
         button.disabled = false;
         button.textContent = priorLabel;
         renderCards();
+        updateShareCardChoices();
       }
     }
   }
@@ -473,7 +483,10 @@
           cardButton("Withdraw", "button-danger", (event) => mutateCard(card, "withdraw", event.currentTarget))
         );
       }
-      if (state.pendingCardMutationIds.has(card.cardId)) {
+      if (
+        state.pendingCardMutationIds.has(card.cardId) ||
+        (state.shareCreationPending && state.shareCreationCardIds?.has(card.cardId))
+      ) {
         for (const button of actions.querySelectorAll("button")) button.disabled = true;
       }
       article.append(top, title, statement, dates, actions);
@@ -505,6 +518,11 @@
 
   function updateShareCardChoices() {
     const choices = [...document.querySelectorAll('input[name="shareCard"]')];
+    const selectedMutationPending = choices.some(
+      (input) => input.checked && state.pendingCardMutationIds.has(input.value)
+    );
+    const submit = byId("shareForm").querySelector('button[type="submit"]');
+    submit.disabled = state.shareCreationPending || selectedMutationPending;
     if (state.shareCreationPending) {
       for (const input of choices) input.disabled = true;
       return;
@@ -519,6 +537,7 @@
     for (const input of document.querySelectorAll('input[name="duration"], #customTimeInput')) {
       input.disabled = pending;
     }
+    renderCards();
     updateShareCardChoices();
   }
 
@@ -546,16 +565,6 @@
       }
     }
     return { matched: false, refreshed };
-  }
-
-  function sameCardDraft(card, input) {
-    return (
-      card.status === "pending_review" &&
-      card.title === input.title &&
-      card.statement === input.statement &&
-      card.category === input.category &&
-      card.reviewBy === input.reviewBy
-    );
   }
 
   function renderGrants() {
@@ -708,12 +717,10 @@
       reviewBy: keepsExistingReminder ? existingCard.reviewBy : reviewDate.toISOString(),
       ...(cardId ? { expectedRevision } : {}),
     };
-    const priorCardIds = new Set(state.cards.map((card) => card.cardId));
     const button = byId("cardSaveButton");
     const priorLabel = button.textContent;
     setCardSavePending(true);
     button.textContent = "Saving draft…";
-    let ownerStateFresh = false;
     try {
       try {
         await (cardId ? api.replaceCard(cardId, input) : api.createManualDraft(input));
@@ -722,33 +729,27 @@
           setError("cardError", errorMessage(error, "The draft did not save."));
           return;
         }
-        const reconciled = await reconcileOwnerState(() => {
-          if (cardId) return null;
-          return state.cards.find((card) => !priorCardIds.has(card.cardId) && sameCardDraft(card, input));
-        });
+        const reconciled = await reconcileOwnerState(() => null);
         if (reconciled.cancelled) return;
-        if (!reconciled.matched) {
-          let message;
-          if (cardId) {
-            message = reconciled.refreshed
-              ? "The edit timed out. Review the current guide before trying again."
-              : "The server did not confirm the edit. Refresh the guide before trying again.";
-          } else {
-            message = reconciled.refreshed
-              ? "The request stopped before the draft saved. Review the current guide before trying again."
-              : "The server did not confirm whether the draft saved. Refresh the guide before saving it again.";
-          }
-          setError("cardError", message);
-          return;
+        let message;
+        if (cardId) {
+          message = reconciled.refreshed
+            ? "The edit timed out. Review the current guide before trying again."
+            : "The server did not confirm the edit. Refresh the guide before trying again.";
+        } else {
+          message = reconciled.refreshed
+            ? "The request timed out. Review the current guide to see whether the draft saved before trying again."
+            : "The server did not confirm whether the draft saved. Refresh the guide before saving it again.";
         }
-        ownerStateFresh = true;
+        setError("cardError", message);
+        return;
       }
       byId("cardDialog").close();
       const message = "Draft saved. Review and approve it before sharing.";
       toast(message);
       announce(message);
       try {
-        if (!ownerStateFresh) await loadOwnerState();
+        await loadOwnerState();
       } catch (error) {
         if (error === PAGE_HIDDEN_ABORT) return;
         const warning = "The draft was saved, but the card list did not refresh. Refresh the guide before editing it.";
@@ -765,7 +766,8 @@
 
   async function addMemory(event) {
     event.preventDefault();
-    if (state.draftGenerationPending) return;
+    if (state.draftGenerationPending || state.notePreviewPending) return;
+    const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("memoryError");
     const memoryInput = byId("memoryIdInput");
     const submittedValue = memoryInput.value;
@@ -779,8 +781,11 @@
       return;
     }
     const button = event.currentTarget.querySelector("button");
+    const priorLabel = button.textContent;
+    setNotePreviewPending(true);
+    button.textContent = "Adding note…";
     try {
-      const preview = model.parseMemoryPreview(await withBusy(button, "Adding note…", () => api.fetchMemory(memoryId)));
+      const preview = model.parseMemoryPreview(await api.fetchMemory(memoryId));
       if (!preview.found) {
         throw new Error("That memory was not found in your Remnic scope.");
       }
@@ -799,6 +804,11 @@
       announce("Selected note added. Review it before consent.");
     } catch (error) {
       setError("memoryError", errorMessage(error, "The selected note did not load."));
+    } finally {
+      if (ownerSessionIsCurrent(ownerSessionGeneration)) {
+        button.textContent = priorLabel;
+        setNotePreviewPending(false);
+      }
     }
   }
 
@@ -808,6 +818,10 @@
     setError("generateError");
     if (state.selectedNotes.length === 0) {
       setError("generateError", "Select at least one note first.");
+      return;
+    }
+    if (state.notePreviewPending) {
+      setError("generateError", "Wait for the selected note to finish loading before drafting.");
       return;
     }
     if (!byId("consentInput").checked) {
@@ -874,9 +888,20 @@
 
   function setDraftGenerationPending(pending) {
     state.draftGenerationPending = pending;
-    for (const control of byId("memoryForm").querySelectorAll("input, button")) control.disabled = pending;
-    byId("consentInput").disabled = pending;
-    byId("generateButton").disabled = pending;
+    syncDraftControls();
+  }
+
+  function setNotePreviewPending(pending) {
+    state.notePreviewPending = pending;
+    syncDraftControls();
+  }
+
+  function syncDraftControls() {
+    byId("memoryIdInput").disabled = state.draftGenerationPending;
+    byId("memoryForm").querySelector('button[type="submit"]').disabled =
+      state.draftGenerationPending || state.notePreviewPending;
+    byId("consentInput").disabled = state.draftGenerationPending || state.notePreviewPending;
+    byId("generateButton").disabled = state.draftGenerationPending || state.notePreviewPending;
     renderSelectedNotes();
   }
 
@@ -885,11 +910,14 @@
     if (state.shareCreationPending) return;
     const ownerSessionGeneration = state.ownerSessionGeneration;
     setError("shareError");
-    clearDisplayedShareLink();
     const selectedInputs = [...document.querySelectorAll('input[name="shareCard"]:checked')];
     const cardIds = selectedInputs.map((input) => input.value);
     if (cardIds.length === 0) {
       setError("shareError", "Select at least one approved support card.");
+      return;
+    }
+    if (cardIds.some((cardId) => state.pendingCardMutationIds.has(cardId))) {
+      setError("shareError", "Wait for the selected support card to finish changing before sharing it.");
       return;
     }
     if (cardIds.length > MAX_SHARED_CARDS) {
@@ -912,6 +940,7 @@
       setError("shareError", errorMessage(error, "Choose a valid share time."));
       return;
     }
+    clearDisplayedShareLink();
     const button = event.currentTarget.querySelector('button[type="submit"]');
     const priorLabel = button.textContent;
     let clearSelection = false;
@@ -1030,7 +1059,8 @@
     clear(byId("guideGroups"));
     byId("answerPanel").hidden = true;
     clear(byId("citationList"));
-    const lock = model.lockState(error, lastGuide);
+    const helperNow = Date.now() + (state.helperServerOffsetMs ?? 0);
+    const lock = model.lockState(error, lastGuide, helperNow);
     const retryable =
       !lastGuide && Boolean(state.helperGrantId && state.helperSecret) && !TERMINAL_HELPER_ERROR_CODES.has(error?.code);
     byId("lockedEyebrow").textContent = lock.eyebrow;
@@ -1159,7 +1189,8 @@
       scheduleHelperRevalidation();
       announce(`Support passport loaded with ${state.guide.cards.length} cards.`);
     } catch (error) {
-      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT) return;
+      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT)
+        return;
       showLocked(error);
     } finally {
       window.clearTimeout(timeout);
@@ -1177,6 +1208,7 @@
     byId("answerCopy").textContent = "";
     clear(byId("citationList"));
     const button = event.currentTarget.querySelector("button");
+    const priorLabel = "Ask from this guide";
     const controller = new AbortController();
     state.helperQuestionController?.abort();
     state.helperQuestionController = controller;
@@ -1186,11 +1218,11 @@
       controller.abort();
     }, HELPER_QUESTION_TIMEOUT_MS);
     questionInput.disabled = true;
+    button.disabled = true;
+    button.textContent = "Checking shared cards…";
     try {
-      const payload = await withBusy(button, "Checking shared cards…", () =>
-        api.askGrant(state.helperGrantId, state.helperSecret, question, controller.signal)
-      );
-      if (state.helperLifecyclePaused) return;
+      const payload = await api.askGrant(state.helperGrantId, state.helperSecret, question, controller.signal);
+      if (state.helperLifecyclePaused || state.helperQuestionController !== controller) return;
       const answer = model.parseAnswer(payload, state.guide);
       byId("answerCopy").textContent = answer.answer;
       const citations = byId("citationList");
@@ -1206,7 +1238,9 @@
       announce("Answer ready with support card citations.");
     } catch (error) {
       if (!state.guide) return;
-      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT) return;
+      if (state.helperQuestionController !== controller) return;
+      if (state.helperLifecyclePaused || error === PAGE_HIDDEN_ABORT || controller.signal.reason === PAGE_HIDDEN_ABORT)
+        return;
       if (timedOut) {
         setError("questionError", "The question took too long. Try again.");
         return;
@@ -1218,8 +1252,12 @@
       setError("questionError", errorMessage(error, "The question did not complete."));
     } finally {
       window.clearTimeout(timeout);
-      if (state.helperQuestionController === controller) state.helperQuestionController = null;
-      questionInput.disabled = false;
+      if (state.helperQuestionController === controller) {
+        state.helperQuestionController = null;
+        questionInput.disabled = false;
+        button.disabled = false;
+        button.textContent = priorLabel;
+      }
     }
   }
 
@@ -1289,14 +1327,18 @@
     state.pendingCardMutationIds.clear();
     state.pendingGrantRevocationIds.clear();
     state.cardSavePending = false;
+    state.notePreviewPending = false;
     state.draftGenerationPending = false;
     state.shareCreationPending = false;
     state.shareCreationCardIds = null;
     clearDisplayedShareLink();
     clearPrefillToken();
+    window.clearTimeout(state.announcementTimer);
+    state.announcementTimer = null;
     window.clearTimeout(state.toastTimer);
     byId("connectForm").reset();
     byId("memoryForm").reset();
+    byId("memoryForm").querySelector('button[type="submit"]').textContent = "Add selected note";
     byId("cardForm").reset();
     byId("shareForm").reset();
     byId("customTimeField").hidden = true;
@@ -1344,6 +1386,8 @@
 
   function clearHelperSession() {
     state.helperLifecyclePaused = true;
+    window.clearTimeout(state.announcementTimer);
+    state.announcementTimer = null;
     state.helperLoadController?.abort(PAGE_HIDDEN_ABORT);
     state.helperQuestionController?.abort(PAGE_HIDDEN_ABORT);
     state.helperRevalidationController?.abort(PAGE_HIDDEN_ABORT);

--- a/admin-console/public/what-helps-me/index.html
+++ b/admin-console/public/what-helps-me/index.html
@@ -1,0 +1,278 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <meta name="description" content="What Helps Me is an owner-controlled support passport built with Remnic.">
+  <link rel="icon" href="data:,">
+  <title>What Helps Me · Remnic</title>
+  <link rel="stylesheet" href="./what-helps-me.css">
+</head>
+<body>
+  <a class="skip-link" href="#mainContent">Skip to the support passport</a>
+
+  <div class="replay-banner" id="replayBanner" role="status" hidden>
+    <strong>Synthetic replay</strong>
+    <span>This mode uses invented notes. It is not live proof.</span>
+  </div>
+
+  <header class="site-header">
+    <a class="wordmark" href="../" aria-label="Return to the Remnic admin console">
+      <span class="wordmark-mark" aria-hidden="true">W</span>
+      <span><strong>WHAT HELPS ME</strong><small>A Remnic support passport</small></span>
+    </a>
+    <div class="view-marker" id="viewMarker" aria-label="Current view">
+      <span class="view-marker-dot" aria-hidden="true"></span>
+      <span id="viewMarkerText">Owner view</span>
+    </div>
+  </header>
+
+  <main id="mainContent" tabindex="-1">
+    <section class="connect-panel" id="connectPanel" aria-labelledby="connectTitle">
+      <div>
+        <p class="eyebrow">Private owner access</p>
+        <h1 id="connectTitle">Open my support passport</h1>
+        <p>Use the same bearer token as the Remnic admin console.</p>
+      </div>
+      <form class="connect-form" id="connectForm">
+        <label for="tokenInput">Bearer token</label>
+        <div class="input-action">
+          <input id="tokenInput" name="token" type="password" autocomplete="off" required placeholder="Kept only in this page's memory">
+          <button class="button button-primary" type="submit">Open my guide</button>
+        </div>
+        <p class="field-note">The page does not save the token in cookies or browser storage.</p>
+        <p class="form-error" id="connectError" role="alert"></p>
+      </form>
+    </section>
+
+    <div id="ownerView" hidden>
+      <section class="owner-hero" aria-labelledby="ownerTitle">
+        <div class="owner-hero-copy">
+          <p class="eyebrow">My support passport</p>
+          <h1 id="ownerTitle">The person is the author.</h1>
+          <p class="hero-lede">Turn selected notes into clear support cards. Approve every word before sharing anything.</p>
+          <nav class="journey" aria-label="Guide steps">
+            <a href="#selectNotes"><span>1</span>Select notes</a>
+            <a href="#reviewCards"><span>2</span>Review cards</a>
+            <a href="#shareGuide"><span>3</span>Share my guide</a>
+          </nav>
+        </div>
+        <div class="passport-seal" aria-label="Owner controlled">
+          <span class="seal-orbit" aria-hidden="true"></span>
+          <strong>MY WORDS</strong>
+          <small>MY CHOICE</small>
+        </div>
+      </section>
+
+      <div class="owner-layout">
+        <div class="owner-build">
+          <section class="folio-section" id="selectNotes" aria-labelledby="notesTitle">
+            <div class="section-heading">
+              <div>
+                <p class="step-label">Step 1 · Select notes</p>
+                <h2 id="notesTitle">Choose only the notes you want to send</h2>
+              </div>
+              <span class="count-badge" id="noteCount">0 selected</span>
+            </div>
+            <p class="section-lede">Add exact Remnic memory IDs. The page shows each full note before you consent.</p>
+
+            <form class="memory-picker" id="memoryForm">
+              <label for="memoryIdInput">Memory ID</label>
+              <div class="input-action">
+                <input id="memoryIdInput" name="memoryId" required maxlength="128" pattern="[A-Za-z0-9._:-]+" placeholder="memory-id">
+                <button class="button button-secondary" type="submit">Add selected note</button>
+              </div>
+              <p class="form-error" id="memoryError" role="alert"></p>
+            </form>
+
+            <div class="empty-state" id="notesEmpty">
+              <span aria-hidden="true">+</span>
+              <p><strong>No notes selected.</strong> Add one exact memory ID to start.</p>
+            </div>
+            <ul class="note-list" id="noteList" aria-label="Selected notes"></ul>
+
+            <div class="consent-panel">
+              <label class="check-row" for="consentInput">
+                <input id="consentInput" type="checkbox">
+                <span>Send these selected notes to my configured model to draft my cards.</span>
+              </label>
+              <p>The model gets only these selected notes. You must review every draft.</p>
+              <button class="button button-primary" id="generateButton" type="button">Draft my support cards</button>
+              <p class="form-error" id="generateError" role="alert"></p>
+            </div>
+          </section>
+
+          <section class="folio-section" id="reviewCards" aria-labelledby="cardsTitle">
+            <div class="section-heading">
+              <div>
+                <p class="step-label">Step 2 · Review cards</p>
+                <h2 id="cardsTitle">Approve each card yourself</h2>
+              </div>
+              <button class="button button-secondary" id="newCardButton" type="button">Write a card</button>
+            </div>
+            <p class="section-lede">A draft stays private. An approved card can be selected for a share link.</p>
+            <div class="summary-strip" aria-label="Support card totals">
+              <span><strong id="draftCount">0</strong> Draft</span>
+              <span><strong id="approvedCount">0</strong> Approved</span>
+            </div>
+            <div class="empty-state" id="cardsEmpty">
+              <span aria-hidden="true">✦</span>
+              <p><strong>No support cards yet.</strong> Draft from selected notes or write one yourself.</p>
+            </div>
+            <div class="card-list" id="cardList" aria-live="polite"></div>
+          </section>
+        </div>
+
+        <aside class="share-column" id="shareGuide" aria-labelledby="shareTitle">
+          <section class="share-panel">
+            <p class="step-label">Step 3 · Share my guide</p>
+            <h2 id="shareTitle">Choose what a helper can see</h2>
+            <p>Each link holds exact approved card versions. It ends on time or when you stop sharing.</p>
+
+            <form id="shareForm">
+              <fieldset class="card-picker">
+                <legend>Approved support cards</legend>
+                <div id="shareCardList"></div>
+                <p class="field-note" id="shareCardsEmpty">Approve a card before you create a share link.</p>
+              </fieldset>
+
+              <fieldset class="duration-picker">
+                <legend>Share for</legend>
+                <div class="segmented-control">
+                  <label><input type="radio" name="duration" value="30m"><span>30 min</span></label>
+                  <label><input type="radio" name="duration" value="2h" checked><span>2 hours</span></label>
+                  <label><input type="radio" name="duration" value="1d"><span>1 day</span></label>
+                  <label><input type="radio" name="duration" value="custom"><span>Custom</span></label>
+                </div>
+                <label class="custom-time" id="customTimeField" for="customTimeInput" hidden>
+                  End sharing at
+                  <input id="customTimeInput" type="datetime-local">
+                </label>
+              </fieldset>
+
+              <button class="button button-primary button-full" type="submit">Create share link</button>
+              <p class="form-error" id="shareError" role="alert"></p>
+            </form>
+
+            <div class="new-link" id="newLinkPanel" hidden>
+              <p class="eyebrow">Share link ready</p>
+              <label for="shareLinkInput">Copy this link once</label>
+              <textarea id="shareLinkInput" rows="4" readonly></textarea>
+              <div class="button-row">
+                <button class="button button-secondary" id="copyLinkButton" type="button">Copy link</button>
+                <a class="button button-quiet" id="openLinkButton" href="#" target="_blank" rel="noopener">Open helper view</a>
+              </div>
+              <p>The secret is not saved by Remnic. Make a new link if you lose it.</p>
+            </div>
+          </section>
+
+          <section class="live-links" aria-labelledby="liveLinksTitle">
+            <div class="section-heading compact">
+              <div><p class="step-label">Owner control</p><h2 id="liveLinksTitle">Live shares</h2></div>
+              <button class="icon-button" id="refreshButton" type="button" aria-label="Refresh cards and share links">↻</button>
+            </div>
+            <div class="empty-state compact" id="grantsEmpty"><p>No live share links.</p></div>
+            <div id="grantList" aria-live="polite"></div>
+          </section>
+        </aside>
+      </div>
+    </div>
+
+    <div id="helperView" hidden>
+      <section class="helper-hero" aria-labelledby="helperTitle">
+        <div>
+          <p class="eyebrow">Support passport</p>
+          <h1 id="helperTitle">What helps me</h1>
+          <p class="hero-lede">These are the exact support cards this person chose to share.</p>
+        </div>
+        <div class="helper-time">
+          <span>Shared until</span>
+          <strong id="helperExpiry">Loading…</strong>
+        </div>
+      </section>
+      <div class="helper-layout">
+        <section class="guide-panel" aria-labelledby="guideTitle">
+          <div class="section-heading">
+            <div><p class="step-label">Approved guide</p><h2 id="guideTitle">How to help</h2></div>
+            <span class="count-badge" id="helperCardCount">0 cards</span>
+          </div>
+          <div class="helper-loading" id="helperLoading" role="status">
+            <span class="loading-pulse" aria-hidden="true"></span>
+            <p>Opening the shared guide…</p>
+          </div>
+          <div id="guideGroups"></div>
+        </section>
+        <aside class="question-panel" aria-labelledby="questionTitle">
+          <p class="step-label">Ask from this guide</p>
+          <h2 id="questionTitle">Ask one clear question</h2>
+          <p>The answer uses these shared cards only. It cites each card it uses.</p>
+          <form id="questionForm">
+            <label for="questionInput">Your question</label>
+            <textarea id="questionInput" maxlength="500" rows="4" required placeholder="What should I do when this person is overwhelmed?"></textarea>
+            <div class="character-count"><span id="questionCount">0</span> / 500</div>
+            <button class="button button-primary button-full" type="submit">Ask from this guide</button>
+            <p class="form-error" id="questionError" role="alert"></p>
+          </form>
+          <div class="answer-panel" id="answerPanel" tabindex="-1" hidden>
+            <p class="eyebrow">Answer from shared cards</p>
+            <p class="answer-copy" id="answerCopy"></p>
+            <div class="citation-list" id="citationList" aria-label="Support card citations"></div>
+          </div>
+        </aside>
+      </div>
+    </div>
+
+    <section class="locked-view" id="lockedView" aria-labelledby="lockedTitle" hidden>
+      <div class="lock-seal" aria-hidden="true"><span></span></div>
+      <p class="eyebrow" id="lockedEyebrow">Share link not found</p>
+      <h1 id="lockedTitle" tabindex="-1">This link does not open a support passport.</h1>
+      <p id="lockedDetail">Ask the person who shared it for a new link.</p>
+      <button class="button button-primary" id="retryHelperButton" type="button" hidden>Try again</button>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <span>What Helps Me · Built with Remnic</span>
+    <a href="https://www.england.nhs.uk/long-read/health-and-care-passports-implementation-guidance/" target="_blank" rel="noopener noreferrer">NHS health and care passport guidance ↗</a>
+  </footer>
+
+  <dialog class="card-dialog" id="cardDialog" aria-labelledby="cardDialogTitle">
+    <form id="cardForm">
+      <button class="dialog-close" id="cardDialogClose" type="button" aria-label="Close support card editor">×</button>
+      <p class="eyebrow">Owner review</p>
+      <h2 id="cardDialogTitle">Write a support card</h2>
+      <input id="cardIdInput" type="hidden">
+      <input id="cardRevisionInput" type="hidden">
+      <label for="cardTitleInput">Card title</label>
+      <input id="cardTitleInput" maxlength="80" required>
+      <label for="cardStatementInput">What helps me</label>
+      <textarea id="cardStatementInput" maxlength="500" rows="5" required></textarea>
+      <label for="cardCategoryInput">Category</label>
+      <select id="cardCategoryInput" required>
+        <option value="communication">Communication</option>
+        <option value="environment">Environment</option>
+        <option value="transitions">Changes and transitions</option>
+        <option value="sensory">Sensory comfort</option>
+        <option value="regulation">Feeling settled</option>
+        <option value="interests">Interests and connection</option>
+        <option value="other">Other support</option>
+      </select>
+      <label for="cardReviewInput">Review reminder</label>
+      <input id="cardReviewInput" type="datetime-local" required>
+      <p class="field-note">This date is a reminder. It never hides the card automatically.</p>
+      <p class="form-error" id="cardError" role="alert"></p>
+      <div class="button-row dialog-actions">
+        <button class="button button-quiet" id="cardCancelButton" type="button">Keep reviewing</button>
+        <button class="button button-primary" id="cardSaveButton" type="submit">Save draft</button>
+      </div>
+    </form>
+  </dialog>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+  <div class="sr-only" id="announcer" role="status" aria-live="assertive"></div>
+
+  <script src="./model.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/admin-console/public/what-helps-me/index.html
+++ b/admin-console/public/what-helps-me/index.html
@@ -38,7 +38,7 @@
       <form class="connect-form" id="connectForm">
         <label for="tokenInput">Bearer token</label>
         <div class="input-action">
-          <input id="tokenInput" name="token" type="password" autocomplete="off" required placeholder="Kept only in this page's memory">
+          <input id="tokenInput" type="password" autocomplete="off" required placeholder="Kept only in this page's memory">
           <button class="button button-primary" type="submit">Open my guide</button>
         </div>
         <p class="field-note">The page does not save the token in cookies or browser storage.</p>

--- a/admin-console/public/what-helps-me/index.html
+++ b/admin-console/public/what-helps-me/index.html
@@ -272,6 +272,18 @@
   <div class="toast" id="toast" role="status" aria-live="polite"></div>
   <div class="sr-only" id="announcer" role="status" aria-live="assertive"></div>
 
+  <script>
+    (() => {
+      const clearOwnerToken = () => {
+        const input = document.getElementById("tokenInput");
+        if (input instanceof HTMLInputElement) input.value = "";
+      };
+      window.addEventListener("pagehide", clearOwnerToken);
+      window.addEventListener("pageshow", (event) => {
+        if (event.persisted) clearOwnerToken();
+      });
+    })();
+  </script>
   <script src="./model.js"></script>
   <script src="./app.js"></script>
 </body>

--- a/admin-console/public/what-helps-me/index.html
+++ b/admin-console/public/what-helps-me/index.html
@@ -18,10 +18,10 @@
   </div>
 
   <header class="site-header">
-    <a class="wordmark" href="../" aria-label="Return to the Remnic admin console">
+    <div class="wordmark">
       <span class="wordmark-mark" aria-hidden="true">W</span>
       <span><strong>WHAT HELPS ME</strong><small>A Remnic support passport</small></span>
-    </a>
+    </div>
     <div class="view-marker" id="viewMarker" aria-label="Current view">
       <span class="view-marker-dot" aria-hidden="true"></span>
       <span id="viewMarkerText">Owner view</span>

--- a/admin-console/public/what-helps-me/index.html
+++ b/admin-console/public/what-helps-me/index.html
@@ -5,6 +5,55 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light">
   <meta name="description" content="What Helps Me is an owner-controlled support passport built with Remnic.">
+  <script>
+    (() => {
+      const fragmentKey = "__REMNIC_WHAT_HELPS_ME_FRAGMENT__";
+      const ownerTokenKey = ["__REMNIC", "ADMIN_CONSOLE", "PREFILL_TOKEN__"].join("_");
+      let fragment = window.location.hash;
+      if (!new URLSearchParams(fragment.slice(1)).has("secret")) return;
+      window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+      const clearFragment = () => {
+        fragment = "";
+        try {
+          delete window[fragmentKey];
+        } catch {
+          window[fragmentKey] = "";
+        }
+      };
+      Object.defineProperty(window, fragmentKey, {
+        configurable: true,
+        get() {
+          const value = fragment;
+          clearFragment();
+          return value;
+        },
+      });
+      const clearOwnerPrefill = () => {
+        try {
+          delete window[ownerTokenKey];
+        } catch {
+          window[ownerTokenKey] = "";
+        }
+        for (const script of document.scripts) {
+          if (script.src || !script.textContent?.includes(ownerTokenKey)) continue;
+          script.textContent = "";
+          script.remove();
+        }
+      };
+      const observer = new MutationObserver(clearOwnerPrefill);
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => {
+          clearOwnerPrefill();
+          observer.disconnect();
+        },
+        { once: true }
+      );
+      window.addEventListener("pagehide", clearFragment, { once: true });
+      window.addEventListener("beforeunload", clearFragment, { once: true });
+    })();
+  </script>
   <link rel="icon" href="data:,">
   <title>What Helps Me · Remnic</title>
   <link rel="stylesheet" href="./what-helps-me.css">
@@ -80,7 +129,7 @@
             <form class="memory-picker" id="memoryForm">
               <label for="memoryIdInput">Memory ID</label>
               <div class="input-action">
-                <input id="memoryIdInput" name="memoryId" required maxlength="128" pattern="[A-Za-z0-9._:-]+" placeholder="memory-id">
+                <input id="memoryIdInput" name="memoryId" required maxlength="512" placeholder="memory-id">
                 <button class="button button-secondary" type="submit">Add selected note</button>
               </div>
               <p class="form-error" id="memoryError" role="alert"></p>

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -113,17 +113,6 @@
     return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
   }
 
-  function stripAttributesSuffix(content) {
-    const trimmed = content.trimEnd();
-    if (!trimmed.endsWith("]")) return content.trim();
-    const marker = "\n[Attributes: ";
-    const markerIndex = trimmed.lastIndexOf(marker);
-    if (markerIndex === -1) return content.trim();
-    const inner = trimmed.slice(markerIndex + marker.length, -1);
-    if (inner.includes("]") || inner.includes("\n")) return content.trim();
-    return trimmed.slice(0, markerIndex).trim();
-  }
-
   function assertCard(value) {
     const keys = ["cardId", "title", "statement", "category", "status", "updatedAt", "reviewBy", "revision"];
     if (!hasExactKeys(value, keys)) throw new Error("The support card response has an unexpected shape.");
@@ -586,6 +575,5 @@
     parseMemoryPreview,
     parsePublicGuide,
     parseSecret,
-    stripAttributesSuffix,
   });
 })(window);

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -1,0 +1,579 @@
+(function attachWhatHelpsMeModel(globalScope) {
+  const CARD_CATEGORIES = Object.freeze([
+    "communication",
+    "environment",
+    "transitions",
+    "sensory",
+    "regulation",
+    "interests",
+    "other",
+  ]);
+  const CARD_STATUSES = Object.freeze(["pending_review", "active", "rejected", "superseded", "archived"]);
+  const SHARE_REQUEST_MARGIN_MS = 60_000;
+  const CATEGORY_LABELS = Object.freeze({
+    communication: "Communication",
+    environment: "Environment",
+    transitions: "Changes and transitions",
+    sensory: "Sensory comfort",
+    regulation: "Feeling settled",
+    interests: "Interests and connection",
+    other: "Other support",
+  });
+  const LOCK_STATES = Object.freeze({
+    bad_link: {
+      key: "bad-link",
+      eyebrow: "Share link not found",
+      title: "This link does not open a support passport.",
+      detail: "Ask the person who shared it for a new link.",
+    },
+    expired: {
+      key: "expired",
+      eyebrow: "Share time ended",
+      title: "This share link has expired.",
+      detail: "Ask the person for a new link if they still want to share.",
+    },
+    stopped: {
+      key: "stopped",
+      eyebrow: "Sharing stopped",
+      title: "This support passport is locked.",
+      detail: "The person controls this guide and has ended this share link.",
+    },
+    stale: {
+      key: "stale",
+      eyebrow: "Guide changed",
+      title: "This share link is no longer current.",
+      detail: "Ask the person for a new link with the support cards they choose.",
+    },
+    error: {
+      key: "error",
+      eyebrow: "Guide unavailable",
+      title: "The support passport did not load.",
+      detail: "Check the connection and try this link again.",
+    },
+  });
+  const REPLAY_NOTES = Object.freeze([
+    Object.freeze({
+      memoryId: "synthetic-note-light",
+      content: "Bright lights make it hard for me to think.",
+    }),
+    Object.freeze({
+      memoryId: "synthetic-note-change",
+      content: "Tell me before plans change.",
+    }),
+    Object.freeze({
+      memoryId: "synthetic-note-quiet",
+      content: "If I stop speaking, offer a quiet place and time.",
+    }),
+  ]);
+  const REPLAY_DRAFTS = Object.freeze([
+    Object.freeze({
+      title: "Lighting",
+      statement: "Bright lights make it hard for me to think.",
+      category: "sensory",
+    }),
+    Object.freeze({
+      title: "Plan changes",
+      statement: "Tell me before plans change.",
+      category: "transitions",
+    }),
+    Object.freeze({
+      title: "When I stop speaking",
+      statement: "If I stop speaking, offer a quiet place and time.",
+      category: "communication",
+    }),
+  ]);
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function hasExactKeys(value, keys) {
+    if (!isObject(value)) return false;
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+  }
+
+  function isIsoTimestamp(value) {
+    return typeof value === "string" && Number.isFinite(Date.parse(value));
+  }
+
+  function isMemoryId(value) {
+    return typeof value === "string" && /^[A-Za-z0-9._:-]{1,128}$/.test(value);
+  }
+
+  function isGrantId(value) {
+    return (
+      typeof value === "string" &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+    );
+  }
+
+  function isRevision(value) {
+    return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+  }
+
+  function stripAttributesSuffix(content) {
+    const trimmed = content.trimEnd();
+    if (!trimmed.endsWith("]")) return content.trim();
+    const marker = "\n[Attributes: ";
+    const markerIndex = trimmed.lastIndexOf(marker);
+    if (markerIndex === -1) return content.trim();
+    const inner = trimmed.slice(markerIndex + marker.length, -1);
+    if (inner.includes("]") || inner.includes("\n")) return content.trim();
+    return trimmed.slice(0, markerIndex).trim();
+  }
+
+  function assertCard(value) {
+    const keys = ["cardId", "title", "statement", "category", "status", "updatedAt", "reviewBy", "revision"];
+    if (!hasExactKeys(value, keys)) throw new Error("The support card response has an unexpected shape.");
+    if (
+      !isMemoryId(value.cardId) ||
+      typeof value.title !== "string" ||
+      value.title.length < 1 ||
+      value.title.length > 80
+    ) {
+      throw new Error("The support card response is invalid.");
+    }
+    if (typeof value.statement !== "string" || value.statement.length < 1 || value.statement.length > 500) {
+      throw new Error("The support card response is invalid.");
+    }
+    if (!CARD_CATEGORIES.includes(value.category) || !CARD_STATUSES.includes(value.status)) {
+      throw new Error("The support card response is invalid.");
+    }
+    if (!isIsoTimestamp(value.updatedAt) || !isIsoTimestamp(value.reviewBy) || !isRevision(value.revision)) {
+      throw new Error("The support card response is invalid.");
+    }
+    return value;
+  }
+
+  function parseCardList(payload) {
+    if (!hasExactKeys(payload, ["cards"]) || !Array.isArray(payload.cards) || payload.cards.length > 100) {
+      throw new Error("The support card list has an unexpected shape.");
+    }
+    const cards = payload.cards.map(assertCard);
+    if (new Set(cards.map((card) => card.cardId)).size !== cards.length) {
+      throw new Error("The support card list contains duplicate cards.");
+    }
+    return cards;
+  }
+
+  function parseMemoryPreview(payload) {
+    if (hasExactKeys(payload, ["found"]) && payload.found === false) return payload;
+    if (!hasExactKeys(payload, ["found", "memory"]) || payload.found !== true) {
+      throw new Error("The selected note response has an unexpected shape.");
+    }
+    if (
+      !hasExactKeys(payload.memory, ["id", "content", "revision"]) ||
+      !isMemoryId(payload.memory.id) ||
+      typeof payload.memory.content !== "string" ||
+      payload.memory.content.length < 1 ||
+      payload.memory.content.length > 20_000 ||
+      !isRevision(payload.memory.revision)
+    ) {
+      throw new Error("The selected note response is invalid.");
+    }
+    return payload;
+  }
+
+  function assertGrant(value) {
+    const required = ["grantId", "stateVersion", "cards", "createdAt", "expiresAt", "status"];
+    const optional = value?.revokedAt === undefined ? [] : ["revokedAt"];
+    if (!hasExactKeys(value, [...required, ...optional]))
+      throw new Error("The share link response has an unexpected shape.");
+    if (
+      typeof value.grantId !== "string" ||
+      !Array.isArray(value.cards) ||
+      value.cards.length < 1 ||
+      value.cards.length > 8
+    ) {
+      throw new Error("The share link response is invalid.");
+    }
+    if (
+      !Number.isInteger(value.stateVersion) ||
+      value.stateVersion < 1 ||
+      !["active", "expired", "revoked"].includes(value.status)
+    ) {
+      throw new Error("The share link response is invalid.");
+    }
+    if (
+      !isIsoTimestamp(value.createdAt) ||
+      !isIsoTimestamp(value.expiresAt) ||
+      (value.revokedAt !== undefined && !isIsoTimestamp(value.revokedAt))
+    ) {
+      throw new Error("The share link response is invalid.");
+    }
+    for (const card of value.cards) {
+      if (!hasExactKeys(card, ["cardId", "revision"]) || !isMemoryId(card.cardId) || !isRevision(card.revision)) {
+        throw new Error("The share link response is invalid.");
+      }
+    }
+    return value;
+  }
+
+  function parseGrantList(payload) {
+    if (!hasExactKeys(payload, ["grants"]) || !Array.isArray(payload.grants)) {
+      throw new Error("The share link list has an unexpected shape.");
+    }
+    return payload.grants.map(assertGrant);
+  }
+
+  function parseCreatedGrant(payload) {
+    if (!hasExactKeys(payload, ["grantId", "secret", "expiresAt", "version"])) {
+      throw new Error("The new share link response has an unexpected shape.");
+    }
+    if (
+      !isGrantId(payload.grantId) ||
+      typeof payload.secret !== "string" ||
+      !/^[A-Za-z0-9_-]{43}$/.test(payload.secret) ||
+      !isIsoTimestamp(payload.expiresAt) ||
+      !Number.isInteger(payload.version) ||
+      payload.version < 1
+    ) {
+      throw new Error("The new share link response is invalid.");
+    }
+    return payload;
+  }
+
+  function assertPublicCard(value) {
+    const keys = ["cardId", "title", "statement", "category", "updatedAt"];
+    if (!hasExactKeys(value, keys) || !isMemoryId(value.cardId)) throw new Error("The public support card is invalid.");
+    if (typeof value.title !== "string" || value.title.length < 1 || value.title.length > 80) {
+      throw new Error("The public support card is invalid.");
+    }
+    if (typeof value.statement !== "string" || value.statement.length < 1 || value.statement.length > 500) {
+      throw new Error("The public support card is invalid.");
+    }
+    if (!CARD_CATEGORIES.includes(value.category) || !isIsoTimestamp(value.updatedAt)) {
+      throw new Error("The public support card is invalid.");
+    }
+    return value;
+  }
+
+  function parsePublicGuide(payload) {
+    if (!hasExactKeys(payload, ["schemaVersion", "grantId", "expiresAt", "updatedAt", "cards"])) {
+      throw new Error("The support passport response has an unexpected shape.");
+    }
+    if (payload.schemaVersion !== 1 || typeof payload.grantId !== "string") {
+      throw new Error("The support passport response is invalid.");
+    }
+    if (!isIsoTimestamp(payload.expiresAt) || !isIsoTimestamp(payload.updatedAt) || !Array.isArray(payload.cards)) {
+      throw new Error("The support passport response is invalid.");
+    }
+    const cards = payload.cards.map(assertPublicCard);
+    if (cards.length < 1 || cards.length > 8 || new Set(cards.map((card) => card.cardId)).size !== cards.length) {
+      throw new Error("The support passport response is invalid.");
+    }
+    return { ...payload, cards };
+  }
+
+  function parseAnswer(payload, guide) {
+    if (!hasExactKeys(payload, ["answer", "citedCardIds", "coverage"])) {
+      throw new Error("The helper answer has an unexpected shape.");
+    }
+    if (typeof payload.answer !== "string" || payload.answer.length < 1 || payload.answer.length > 800) {
+      throw new Error("The helper answer is invalid.");
+    }
+    if (!Array.isArray(payload.citedCardIds) || !["grounded", "not_in_guide"].includes(payload.coverage)) {
+      throw new Error("The helper answer is invalid.");
+    }
+    const allowed = new Set(guide.cards.map((card) => card.cardId));
+    if (payload.citedCardIds.length > 8 || payload.citedCardIds.some((cardId) => !allowed.has(cardId))) {
+      throw new Error("The helper answer cites a card outside this guide.");
+    }
+    if (new Set(payload.citedCardIds).size !== payload.citedCardIds.length) {
+      throw new Error("The helper answer contains duplicate citations.");
+    }
+    if (payload.coverage === "grounded" && payload.citedCardIds.length === 0) {
+      throw new Error("The helper answer needs a support card citation.");
+    }
+    if (payload.coverage === "not_in_guide" && payload.citedCardIds.length !== 0) {
+      throw new Error("An uncovered answer cannot cite a support card.");
+    }
+    return payload;
+  }
+
+  function parseSecret(hash) {
+    if (typeof hash !== "string" || !hash.startsWith("#")) return "";
+    const params = new URLSearchParams(hash.slice(1));
+    if ([...params.keys()].some((key) => key !== "secret")) return "";
+    const secret = params.get("secret") ?? "";
+    return /^[A-Za-z0-9_-]{32,256}$/.test(secret) ? secret : "";
+  }
+
+  function buildShareUrl(currentUrl, grantId, secret, replay) {
+    const url = new URL(currentUrl);
+    url.pathname = "/remnic/ui/what-helps-me/";
+    url.search = "";
+    url.hash = "";
+    url.searchParams.set("grant", grantId);
+    if (replay) url.searchParams.set("mode", "replay");
+    url.hash = `secret=${encodeURIComponent(secret)}`;
+    return url.toString();
+  }
+
+  function lockState(error, lastGuide, now = Date.now()) {
+    const code = typeof error?.code === "string" ? error.code : "";
+    if (code === "grant_stale") return LOCK_STATES.stale;
+    if (code === "grant_not_found" || code === "missing_link") return LOCK_STATES.bad_link;
+    if (code === "grant_expired") return LOCK_STATES.expired;
+    if (code === "grant_gone") {
+      return lastGuide && Date.parse(lastGuide.expiresAt) <= now ? LOCK_STATES.expired : LOCK_STATES.stopped;
+    }
+    return LOCK_STATES.error;
+  }
+
+  function groupCards(cards) {
+    const groups = [];
+    for (const category of CARD_CATEGORIES) {
+      const matches = cards.filter((card) => card.category === category);
+      if (matches.length > 0) groups.push({ category, label: CATEGORY_LABELS[category], cards: matches });
+    }
+    return groups;
+  }
+
+  function expiryForChoice(choice, customValue, now = Date.now()) {
+    const durations = { "30m": 30 * 60_000, "2h": 2 * 60 * 60_000, "1d": 24 * 60 * 60_000 };
+    const timestamp = Object.hasOwn(durations, choice) ? now + durations[choice] : Date.parse(customValue);
+    if (
+      !Number.isFinite(timestamp) ||
+      timestamp < now + 300_000 + SHARE_REQUEST_MARGIN_MS ||
+      timestamp > now + 7 * 24 * 60 * 60_000
+    ) {
+      throw new Error("Choose a share time at least six minutes from now and no more than seven days away.");
+    }
+    return new Date(timestamp).toISOString();
+  }
+
+  function formatDate(value) {
+    if (!isIsoTimestamp(value)) return "Date unavailable";
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  }
+
+  function replayRevision(seed) {
+    let output = "";
+    let value = 2166136261;
+    for (let index = 0; index < seed.length; index += 1) {
+      value ^= seed.charCodeAt(index);
+      value = Math.imul(value, 16777619);
+    }
+    for (let index = 0; index < 8; index += 1) {
+      value = Math.imul(value ^ index, 2246822519);
+      output += (value >>> 0).toString(16).padStart(8, "0");
+    }
+    return output;
+  }
+
+  function replayId(prefix) {
+    const bytes = new Uint8Array(8);
+    globalScope.crypto.getRandomValues(bytes);
+    return `${prefix}-${[...bytes].map((value) => value.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  function createReplayStore(now = () => new Date()) {
+    let cards = [];
+    let grants = [];
+    const secrets = new Map();
+    const replacements = new Map();
+
+    function makeCard(input, status = "pending_review") {
+      const updatedAt = now().toISOString();
+      const cardId = replayId("replay-card");
+      const reviewBy = input.reviewBy || new Date(now().getTime() + 180 * 24 * 60 * 60_000).toISOString();
+      return {
+        cardId,
+        title: input.title,
+        statement: input.statement,
+        category: input.category,
+        status,
+        updatedAt,
+        reviewBy,
+        revision: replayRevision(`${cardId}:${status}:${updatedAt}:${input.statement}`),
+      };
+    }
+
+    function publicGuide(grant) {
+      const selected = grant.cards.map((reference) => cards.find((card) => card.cardId === reference.cardId));
+      if (selected.some((card) => !card || card.status !== "active")) {
+        const error = new Error("The shared support guide has changed.");
+        error.code = "grant_stale";
+        throw error;
+      }
+      return {
+        schemaVersion: 1,
+        grantId: grant.grantId,
+        expiresAt: grant.expiresAt,
+        updatedAt: selected.reduce(
+          (latest, card) => (card.updatedAt > latest ? card.updatedAt : latest),
+          selected[0].updatedAt
+        ),
+        cards: selected.map(({ cardId, title, statement, category, updatedAt }) => ({
+          cardId,
+          title,
+          statement,
+          category,
+          updatedAt,
+        })),
+      };
+    }
+
+    return {
+      notes: REPLAY_NOTES.map((note) => ({
+        ...note,
+        revision: replayRevision(`${note.memoryId}:${note.content}`),
+      })),
+      async listCards() {
+        return {
+          cards: cards
+            .filter((card) => card.status === "pending_review" || card.status === "active")
+            .map((card) => ({ ...card })),
+        };
+      },
+      async createManualDraft(input) {
+        const card = makeCard(input);
+        cards = [...cards, card];
+        return { card: { ...card } };
+      },
+      async generateDrafts(input) {
+        if (input.consent !== true) throw new Error("Consent is required.");
+        const created = REPLAY_DRAFTS.map((draft) => makeCard(draft));
+        cards = [...cards, ...created];
+        return { cards: created.map((card) => ({ ...card })) };
+      },
+      async replaceCard(cardId, input) {
+        const prior = cards.find((card) => card.cardId === cardId && card.revision === input.expectedRevision);
+        if (!prior) throw new Error("The support card changed after it was loaded.");
+        const card = makeCard(input);
+        if (prior.status === "active") replacements.set(card.cardId, prior.cardId);
+        else prior.status = "rejected";
+        cards = [...cards, card];
+        return { card: { ...card } };
+      },
+      async mutateCard(cardId, input, action) {
+        const card = cards.find(
+          (candidate) => candidate.cardId === cardId && candidate.revision === input.expectedRevision
+        );
+        if (!card) throw new Error("The support card changed after it was loaded.");
+        const expected = action === "withdraw" ? "active" : "pending_review";
+        if (card.status !== expected) throw new Error(`The support card must have status ${expected}.`);
+        card.status = action === "approve" ? "active" : action === "reject" ? "rejected" : "archived";
+        card.updatedAt = now().toISOString();
+        card.revision = replayRevision(`${card.cardId}:${card.status}:${card.updatedAt}:${card.statement}`);
+        if (action === "approve" && replacements.has(card.cardId)) {
+          const prior = cards.find((candidate) => candidate.cardId === replacements.get(card.cardId));
+          if (prior) prior.status = "superseded";
+          replacements.delete(card.cardId);
+        }
+        return { card: { ...card } };
+      },
+      seedSharedGuide(grantId, secret) {
+        cards = REPLAY_DRAFTS.map((draft) => makeCard(draft, "active"));
+        grants = [
+          {
+            grantId,
+            stateVersion: 1,
+            cards: cards.map((card) => ({ cardId: card.cardId, revision: card.revision })),
+            createdAt: now().toISOString(),
+            expiresAt: new Date(now().getTime() + 2 * 60 * 60_000).toISOString(),
+            status: "active",
+          },
+        ];
+        secrets.set(grantId, secret);
+      },
+      async createGrant(input) {
+        const selected = input.cardIds.map((cardId) => cards.find((card) => card.cardId === cardId));
+        const revisions = new Map(input.cardRevisions.map((card) => [card.cardId, card.revision]));
+        if (
+          revisions.size !== input.cardIds.length ||
+          selected.some((card) => !card || card.status !== "active" || revisions.get(card.cardId) !== card.revision)
+        )
+          throw new Error("Only approved support cards can be shared.");
+        const grantId = globalScope.crypto.randomUUID();
+        const secret = replayId("replay-secret").padEnd(43, "x");
+        const grant = {
+          grantId,
+          stateVersion: 1,
+          cards: input.cardRevisions.map((card) => ({ ...card })),
+          createdAt: now().toISOString(),
+          expiresAt: input.expiresAt,
+          status: "active",
+        };
+        grants = [grant, ...grants];
+        secrets.set(grantId, secret);
+        return { grantId, secret, expiresAt: grant.expiresAt, version: grant.stateVersion };
+      },
+      async listGrants() {
+        return { grants: grants.map((grant) => ({ ...grant, cards: grant.cards.map((card) => ({ ...card })) })) };
+      },
+      async revokeGrant(grantId, input) {
+        const grant = grants.find(
+          (candidate) => candidate.grantId === grantId && candidate.stateVersion === input.expectedVersion
+        );
+        if (!grant) throw new Error("The share link changed after it was loaded.");
+        grant.status = "revoked";
+        grant.revokedAt = now().toISOString();
+        grant.stateVersion += 1;
+        return { grantId, revokedAt: grant.revokedAt, version: grant.stateVersion };
+      },
+      async readGrant(grantId, secret) {
+        const grant = grants.find((candidate) => candidate.grantId === grantId);
+        if (!grant || secrets.get(grantId) !== secret) {
+          const error = new Error("The share link was not found.");
+          error.code = "grant_not_found";
+          throw error;
+        }
+        if (grant.status !== "active") {
+          const error = new Error("The share link is no longer active.");
+          error.code = "grant_gone";
+          throw error;
+        }
+        if (Date.parse(grant.expiresAt) <= now().getTime()) {
+          const error = new Error("The share link has expired.");
+          error.code = "grant_expired";
+          throw error;
+        }
+        return publicGuide(grant);
+      },
+      async askGrant(grantId, secret, question) {
+        const guide = await this.readGrant(grantId, secret);
+        const quietCard = guide.cards.find((card) => card.category === "communication") || guide.cards[0];
+        if (!quietCard || !/overwhelm|speaking|quiet/i.test(question)) {
+          return {
+            answer: "That is not covered in this person's support guide.",
+            citedCardIds: [],
+            coverage: "not_in_guide",
+          };
+        }
+        return {
+          answer: "Offer a quiet place and time. Give the person space to respond.",
+          citedCardIds: [quietCard.cardId],
+          coverage: "grounded",
+        };
+      },
+    };
+  }
+
+  globalScope.WhatHelpsMeModel = Object.freeze({
+    CARD_CATEGORIES,
+    CATEGORY_LABELS,
+    LOCK_STATES,
+    REPLAY_NOTES,
+    buildShareUrl,
+    createReplayStore,
+    expiryForChoice,
+    formatDate,
+    groupCards,
+    lockState,
+    parseAnswer,
+    parseCardList,
+    parseCreatedGrant,
+    parseGrantList,
+    parseMemoryPreview,
+    parsePublicGuide,
+    parseSecret,
+    stripAttributesSuffix,
+  });
+})(window);

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -368,6 +368,9 @@
   }
 
   function replayId(prefix) {
+    if (!globalScope.crypto?.getRandomValues) {
+      throw new Error("Synthetic replay needs a secure browser context.");
+    }
     const bytes = new Uint8Array(8);
     globalScope.crypto.getRandomValues(bytes);
     return `${prefix}-${[...bytes].map((value) => value.toString(16).padStart(2, "0")).join("")}`;
@@ -397,7 +400,7 @@
 
     function publicGuide(grant) {
       const selected = grant.cards.map((reference) => cards.find((card) => card.cardId === reference.cardId));
-      if (selected.some((card) => !card || card.status !== "active")) {
+      if (selected.length === 0 || selected.some((card) => !card || card.status !== "active")) {
         const error = new Error("The shared support guide has changed.");
         error.code = "grant_stale";
         throw error;
@@ -453,13 +456,19 @@
         return { card: { ...card } };
       },
       async mutateCard(cardId, input, action) {
+        const nextStatus = {
+          approve: "active",
+          reject: "rejected",
+          withdraw: "archived",
+        }[action];
+        if (!nextStatus) throw new Error("The support card action is invalid.");
         const card = cards.find(
           (candidate) => candidate.cardId === cardId && candidate.revision === input.expectedRevision
         );
         if (!card) throw new Error("The support card changed after it was loaded.");
         const expected = action === "withdraw" ? "active" : "pending_review";
         if (card.status !== expected) throw new Error(`The support card must have status ${expected}.`);
-        card.status = action === "approve" ? "active" : action === "reject" ? "rejected" : "archived";
+        card.status = nextStatus;
         card.updatedAt = now().toISOString();
         card.revision = replayRevision(`${card.cardId}:${card.status}:${card.updatedAt}:${card.statement}`);
         if (action === "approve" && replacements.has(card.cardId)) {
@@ -491,6 +500,9 @@
           selected.some((card) => !card || card.status !== "active" || revisions.get(card.cardId) !== card.revision)
         )
           throw new Error("Only approved support cards can be shared.");
+        if (!globalScope.crypto?.randomUUID) {
+          throw new Error("Synthetic replay needs a secure browser context.");
+        }
         const grantId = globalScope.crypto.randomUUID();
         const secret = replayId("replay-secret").padEnd(43, "x");
         const grant = {

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -38,6 +38,12 @@
       title: "This support passport is locked.",
       detail: "The person controls this guide and has ended this share link.",
     },
+    session_ended: {
+      key: "session-ended",
+      eyebrow: "Session ended",
+      title: "This helper session ended.",
+      detail: "Open the original share link again to view this support passport.",
+    },
     stale: {
       key: "stale",
       eyebrow: "Guide changed",
@@ -306,6 +312,7 @@
     if (code === "grant_stale") return LOCK_STATES.stale;
     if (code === "grant_not_found" || code === "missing_link") return LOCK_STATES.bad_link;
     if (code === "grant_expired") return LOCK_STATES.expired;
+    if (code === "session_ended") return LOCK_STATES.session_ended;
     if (code === "grant_gone") {
       return lastGuide && Date.parse(lastGuide.expiresAt) <= now ? LOCK_STATES.expired : LOCK_STATES.stopped;
     }

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -9,7 +9,6 @@
     "other",
   ]);
   const CARD_STATUSES = Object.freeze(["pending_review", "active", "rejected", "superseded", "archived"]);
-  const SHARE_REQUEST_MARGIN_MS = 60_000;
   const CATEGORY_LABELS = Object.freeze({
     communication: "Communication",
     environment: "Environment",
@@ -330,15 +329,16 @@
 
   function expiryForChoice(choice, customValue, now = Date.now()) {
     const durations = { "30m": 30 * 60_000, "2h": 2 * 60 * 60_000, "1d": 24 * 60 * 60_000 };
-    const timestamp = Object.hasOwn(durations, choice) ? now + durations[choice] : Date.parse(customValue);
+    if (Object.hasOwn(durations, choice)) return { durationMs: durations[choice] };
+    const timestamp = Date.parse(customValue);
     if (
       !Number.isFinite(timestamp) ||
-      timestamp < now + 300_000 + SHARE_REQUEST_MARGIN_MS ||
+      timestamp < now + 300_000 ||
       timestamp > now + 7 * 24 * 60 * 60_000
     ) {
-      throw new Error("Choose a share time at least six minutes from now and no more than seven days away.");
+      throw new Error("Choose a share time at least five minutes from now and no more than seven days away.");
     }
-    return new Date(timestamp).toISOString();
+    return { expiresAt: new Date(timestamp).toISOString() };
   }
 
   function formatDate(value) {

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -502,12 +502,13 @@
         }
         const grantId = globalScope.crypto.randomUUID();
         const secret = replayId("replay-secret").padEnd(43, "x");
+        const expiresAt = input.expiresAt ?? new Date(now().getTime() + input.durationMs).toISOString();
         const grant = {
           grantId,
           stateVersion: 1,
           cards: input.cardRevisions.map((card) => ({ ...card })),
           createdAt: now().toISOString(),
-          expiresAt: input.expiresAt,
+          expiresAt,
           status: "active",
         };
         grants = [grant, ...grants];

--- a/admin-console/public/what-helps-me/model.js
+++ b/admin-console/public/what-helps-me/model.js
@@ -9,6 +9,7 @@
     "other",
   ]);
   const CARD_STATUSES = Object.freeze(["pending_review", "active", "rejected", "superseded", "archived"]);
+  const SHARE_REQUEST_MARGIN_MS = 60_000;
   const CATEGORY_LABELS = Object.freeze({
     communication: "Communication",
     environment: "Environment",
@@ -333,10 +334,10 @@
     const timestamp = Date.parse(customValue);
     if (
       !Number.isFinite(timestamp) ||
-      timestamp < now + 300_000 ||
+      timestamp < now + 300_000 + SHARE_REQUEST_MARGIN_MS ||
       timestamp > now + 7 * 24 * 60 * 60_000
     ) {
-      throw new Error("Choose a share time at least five minutes from now and no more than seven days away.");
+      throw new Error("Choose a share time at least six minutes from now and no more than seven days away.");
     }
     return { expiresAt: new Date(timestamp).toISOString() };
   }

--- a/admin-console/public/what-helps-me/what-helps-me.css
+++ b/admin-console/public/what-helps-me/what-helps-me.css
@@ -1,0 +1,1296 @@
+:root {
+  --ink: #17324d;
+  --ink-soft: #40566c;
+  --paper: #ffffff;
+  --mist: #eaf2f4;
+  --sky: #d5e9ee;
+  --teal: #0b6e69;
+  --teal-dark: #07534f;
+  --saffron: #f0b44d;
+  --coral: #b74632;
+  --line: #bdced4;
+  --focus: #9f3a16;
+  --shadow: 0 18px 50px rgba(23, 50, 77, 0.1);
+  --radius: 18px;
+  --display: Charter, "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  --body: "Avenir Next", Avenir, "Segoe UI", Arial, sans-serif;
+  --utility: "Arial Narrow", "Avenir Next Condensed", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background: linear-gradient(90deg, transparent 0 48px, rgba(23, 50, 77, 0.045) 48px 49px, transparent 49px),
+    var(--mist);
+  font-family: var(--body);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+button,
+input,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+}
+
+button,
+.button,
+input,
+select {
+  min-height: 44px;
+}
+
+button,
+.button {
+  touch-action: manipulation;
+}
+
+a {
+  color: var(--teal-dark);
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  top: -120px;
+  left: 10px;
+  z-index: 100;
+  padding: 12px 16px;
+  color: white;
+  background: var(--ink);
+  border-radius: 8px;
+}
+
+.skip-link:focus {
+  top: 10px;
+}
+
+.replay-banner {
+  padding: 9px 24px;
+  color: var(--ink);
+  background: var(--saffron);
+  border-bottom: 2px solid var(--ink);
+  text-align: center;
+}
+
+.replay-banner strong {
+  margin-right: 10px;
+  font-family: var(--utility);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 76px;
+  padding: 14px clamp(20px, 5vw, 72px);
+  background: rgba(255, 255, 255, 0.94);
+  border-bottom: 1px solid var(--line);
+}
+
+.wordmark {
+  display: inline-flex;
+  gap: 12px;
+  align-items: center;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.wordmark-mark {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  color: white;
+  background: var(--ink);
+  border-radius: 50% 50% 50% 12px;
+  font-family: var(--display);
+  font-size: 25px;
+  font-weight: 700;
+}
+
+.wordmark strong,
+.wordmark small {
+  display: block;
+}
+
+.wordmark strong {
+  font-family: var(--utility);
+  font-size: 14px;
+  letter-spacing: 0.14em;
+}
+
+.wordmark small {
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.view-marker {
+  display: flex;
+  gap: 9px;
+  align-items: center;
+  min-height: 44px;
+  padding: 8px 14px;
+  color: var(--ink-soft);
+  background: var(--mist);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-weight: 650;
+}
+
+.view-marker-dot {
+  width: 10px;
+  height: 10px;
+  background: var(--teal);
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(11, 110, 105, 0.14);
+}
+
+main {
+  width: min(1280px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: clamp(28px, 5vw, 72px) 0 88px;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2,
+h3 {
+  text-wrap: balance;
+}
+
+h1,
+h2 {
+  font-family: var(--display);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(2.65rem, 7vw, 5.8rem);
+  line-height: 0.94;
+}
+
+h2 {
+  margin-bottom: 10px;
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  line-height: 1.06;
+}
+
+h3 {
+  margin-bottom: 8px;
+  font-size: 1.14rem;
+}
+
+.eyebrow,
+.step-label {
+  margin-bottom: 9px;
+  color: var(--teal-dark);
+  font-family: var(--utility);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero-lede,
+.section-lede {
+  color: var(--ink-soft);
+  font-size: 1.08rem;
+}
+
+.owner-hero,
+.helper-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: clamp(28px, 6vw, 80px);
+  align-items: center;
+  min-height: 390px;
+  padding: clamp(30px, 6vw, 72px);
+  overflow: hidden;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 32px 32px 32px 8px;
+  box-shadow: var(--shadow);
+}
+
+.owner-hero::after,
+.helper-hero::after {
+  position: absolute;
+  right: -90px;
+  bottom: -140px;
+  width: 360px;
+  height: 360px;
+  content: "";
+  background: var(--sky);
+  border: 1px solid var(--line);
+  border-radius: 50%;
+}
+
+.owner-hero-copy,
+.helper-hero > div {
+  position: relative;
+  z-index: 1;
+}
+
+.owner-hero-copy {
+  max-width: 800px;
+}
+
+.journey {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.journey a {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 44px;
+  padding: 8px 13px;
+  color: var(--ink);
+  background: var(--mist);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.journey span {
+  display: grid;
+  width: 25px;
+  height: 25px;
+  place-items: center;
+  color: white;
+  background: var(--teal);
+  border-radius: 50%;
+  font-size: 0.82rem;
+}
+
+.passport-seal {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: clamp(180px, 20vw, 250px);
+  aspect-ratio: 1;
+  place-content: center;
+  color: var(--ink);
+  background: var(--saffron);
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 10px var(--saffron), inset 0 0 0 12px var(--ink);
+  text-align: center;
+  transform: rotate(-4deg);
+}
+
+.passport-seal strong,
+.passport-seal small {
+  display: block;
+  font-family: var(--utility);
+  letter-spacing: 0.12em;
+}
+
+.passport-seal strong {
+  font-size: clamp(1.1rem, 2vw, 1.55rem);
+}
+
+.passport-seal small {
+  margin-top: 4px;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.seal-orbit {
+  position: absolute;
+  inset: 22px;
+  border: 1px dashed rgba(23, 50, 77, 0.65);
+  border-radius: 50%;
+}
+
+.owner-layout,
+.helper-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(330px, 0.8fr);
+  gap: 24px;
+  align-items: start;
+  margin-top: 24px;
+}
+
+.owner-build {
+  display: grid;
+  gap: 24px;
+}
+
+.folio-section,
+.share-panel,
+.live-links,
+.guide-panel,
+.question-panel,
+.connect-panel {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.folio-section,
+.guide-panel {
+  padding: clamp(24px, 4vw, 44px);
+}
+
+.share-column {
+  position: sticky;
+  top: 18px;
+  display: grid;
+  gap: 18px;
+}
+
+.share-panel,
+.question-panel {
+  padding: 28px;
+  border-top: 8px solid var(--saffron);
+}
+
+.live-links {
+  padding: 24px;
+}
+
+.section-heading {
+  display: flex;
+  gap: 20px;
+  align-items: start;
+  justify-content: space-between;
+}
+
+.section-heading.compact h2 {
+  font-size: 1.55rem;
+}
+
+.count-badge {
+  flex: none;
+  min-height: 34px;
+  padding: 6px 11px;
+  color: var(--ink);
+  background: var(--sky);
+  border-radius: 999px;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+label,
+legend {
+  font-weight: 750;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 11px 13px;
+  background: white;
+  border: 1.5px solid #8ba3ad;
+  border-radius: 10px;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+  border-color: var(--ink-soft);
+}
+
+.input-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.memory-picker,
+.connect-form {
+  margin-top: 22px;
+}
+
+.field-note,
+.character-count {
+  margin: 7px 0 0;
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+}
+
+.form-error {
+  min-height: 1.5em;
+  margin: 8px 0 0;
+  color: #8b2d1f;
+  font-weight: 700;
+}
+
+.button,
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.5px solid transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 800;
+  line-height: 1.2;
+  text-align: center;
+  text-decoration: none;
+}
+
+.button {
+  min-height: 48px;
+  padding: 11px 17px;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.button-primary {
+  color: white;
+  background: var(--teal);
+  border-color: var(--teal);
+}
+
+.button-primary:hover:not(:disabled) {
+  background: var(--teal-dark);
+}
+
+.button-secondary {
+  color: var(--ink);
+  background: var(--saffron);
+  border-color: var(--ink);
+}
+
+.button-quiet {
+  color: var(--ink);
+  background: white;
+  border-color: var(--line);
+}
+
+.button-danger {
+  color: white;
+  background: var(--coral);
+  border-color: var(--coral);
+}
+
+.button-full {
+  width: 100%;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.icon-button {
+  width: 44px;
+  height: 44px;
+  color: var(--ink);
+  background: var(--mist);
+  border-color: var(--line);
+  font-size: 1.3rem;
+}
+
+.empty-state {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  min-height: 96px;
+  margin-top: 20px;
+  padding: 20px;
+  color: var(--ink-soft);
+  background: #f7fafb;
+  border: 1px dashed #8ba3ad;
+  border-radius: 12px;
+}
+
+.empty-state p {
+  margin: 0;
+}
+
+.empty-state > span {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  flex: none;
+  place-items: center;
+  color: var(--teal-dark);
+  background: var(--sky);
+  border-radius: 50%;
+  font-size: 1.35rem;
+}
+
+.empty-state.compact {
+  min-height: 64px;
+  margin-top: 10px;
+  padding: 14px;
+}
+
+.note-list {
+  display: grid;
+  gap: 12px;
+  padding: 0;
+  margin: 20px 0 0;
+  list-style: none;
+}
+
+.note-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 18px;
+  background: var(--mist);
+  border-left: 6px solid var(--teal);
+  border-radius: 5px 12px 12px 5px;
+}
+
+.note-item code {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--ink-soft);
+  font-family: var(--utility);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.note-item p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.consent-panel {
+  margin-top: 24px;
+  padding: 22px;
+  background: #fff8e9;
+  border: 1px solid #d49b38;
+  border-radius: 14px;
+}
+
+.consent-panel > p {
+  margin: 8px 0 18px 36px;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.check-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  cursor: pointer;
+}
+
+.check-row input,
+.card-choice input,
+.segmented-control input {
+  width: 22px;
+  height: 22px;
+  min-height: 22px;
+  margin: 2px 0 0;
+  accent-color: var(--teal);
+}
+
+.summary-strip {
+  display: flex;
+  gap: 18px;
+  margin: 18px 0 0;
+  padding: 12px 16px;
+  background: var(--mist);
+  border-radius: 10px;
+}
+
+.summary-strip strong {
+  font-size: 1.25rem;
+}
+
+.card-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.support-card {
+  position: relative;
+  display: flex;
+  min-height: 260px;
+  flex-direction: column;
+  padding: 22px 20px 18px 24px;
+  overflow: hidden;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 4px 16px 16px 4px;
+}
+
+.support-card::before,
+.public-card::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 7px;
+  content: "";
+  background: var(--category-color, var(--teal));
+}
+
+.support-card[data-category="sensory"],
+.public-card[data-category="sensory"] {
+  --category-color: #8e5c90;
+}
+.support-card[data-category="transitions"],
+.public-card[data-category="transitions"] {
+  --category-color: #c27625;
+}
+.support-card[data-category="communication"],
+.public-card[data-category="communication"] {
+  --category-color: #176b89;
+}
+.support-card[data-category="environment"],
+.public-card[data-category="environment"] {
+  --category-color: #39774c;
+}
+.support-card[data-category="regulation"],
+.public-card[data-category="regulation"] {
+  --category-color: #a14755;
+}
+.support-card[data-category="interests"],
+.public-card[data-category="interests"] {
+  --category-color: #64599b;
+}
+.support-card[data-category="other"],
+.public-card[data-category="other"] {
+  --category-color: #5d6b72;
+}
+
+.card-topline {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 15px;
+}
+
+.status-pill,
+.category-pill {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.status-pill.draft {
+  color: var(--ink);
+  background: var(--saffron);
+}
+
+.status-pill.approved {
+  color: white;
+  background: var(--teal);
+}
+
+.category-pill {
+  color: var(--ink-soft);
+  background: var(--mist);
+}
+
+.support-card blockquote {
+  margin: 4px 0 18px;
+  font-family: var(--display);
+  font-size: 1.18rem;
+  line-height: 1.42;
+}
+
+.card-dates {
+  display: grid;
+  gap: 4px;
+  margin: auto 0 16px;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.card-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.card-actions .button:last-child:nth-child(3) {
+  grid-column: 1 / -1;
+}
+
+fieldset {
+  padding: 0;
+  margin: 24px 0;
+  border: 0;
+}
+
+legend {
+  margin-bottom: 10px;
+}
+
+.card-choice {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  min-height: 52px;
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+}
+
+.card-choice small {
+  display: block;
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+
+.segmented-control {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.segmented-control label {
+  position: relative;
+}
+
+.segmented-control input {
+  position: absolute;
+  opacity: 0;
+}
+
+.segmented-control span {
+  display: grid;
+  min-height: 46px;
+  place-items: center;
+  padding: 8px;
+  background: white;
+  border: 1.5px solid var(--line);
+  border-radius: 9px;
+  cursor: pointer;
+}
+
+.segmented-control input:checked + span {
+  color: white;
+  background: var(--ink);
+  border-color: var(--ink);
+}
+
+.segmented-control input:focus-visible + span {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.custom-time {
+  display: grid;
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.new-link {
+  margin-top: 22px;
+  padding: 18px;
+  background: var(--sky);
+  border: 1px solid #7eaab3;
+  border-radius: 12px;
+}
+
+.new-link textarea {
+  margin: 8px 0 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.new-link > p:last-child {
+  margin: 10px 0 0;
+  font-size: 0.82rem;
+}
+
+.grant-card {
+  padding: 15px 0;
+  border-top: 1px solid var(--line);
+}
+
+.grant-card:first-child {
+  border-top: 0;
+}
+
+.grant-card p {
+  margin-bottom: 5px;
+}
+
+.grant-meta {
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+}
+
+.grant-card .button {
+  width: 100%;
+  margin-top: 10px;
+}
+
+.connect-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(320px, 1.2fr);
+  gap: clamp(28px, 6vw, 80px);
+  align-items: center;
+  max-width: 980px;
+  min-height: 360px;
+  padding: clamp(28px, 6vw, 64px);
+  margin: 8vh auto;
+  border-top: 9px solid var(--saffron);
+  box-shadow: var(--shadow);
+}
+
+.connect-panel h1 {
+  font-size: clamp(2.6rem, 6vw, 4.6rem);
+}
+
+.helper-hero {
+  min-height: 300px;
+}
+
+.helper-time {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-width: 210px;
+  gap: 4px;
+  padding: 20px;
+  background: var(--saffron);
+  border: 2px solid var(--ink);
+  border-radius: 4px 18px 18px 4px;
+}
+
+.helper-time span {
+  font-family: var(--utility);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.helper-loading {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  min-height: 160px;
+  justify-content: center;
+  color: var(--ink-soft);
+}
+
+.helper-loading p {
+  margin: 0;
+}
+
+.loading-pulse {
+  width: 18px;
+  height: 18px;
+  background: var(--teal);
+  border-radius: 50%;
+  animation: breathe 1.4s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  50% {
+    transform: scale(0.55);
+    opacity: 0.45;
+  }
+}
+
+.guide-group + .guide-group {
+  margin-top: 28px;
+}
+
+.guide-group h3 {
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--ink);
+  font-family: var(--utility);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.public-card {
+  position: relative;
+  padding: 20px 20px 20px 26px;
+  margin-top: 12px;
+  background: #f8fbfc;
+  border: 1px solid var(--line);
+  border-radius: 4px 14px 14px 4px;
+}
+
+.public-card p {
+  margin-bottom: 0;
+  font-family: var(--display);
+  font-size: 1.18rem;
+}
+
+.question-panel {
+  position: sticky;
+  top: 18px;
+}
+
+.question-panel textarea {
+  margin-top: 7px;
+}
+
+.character-count {
+  margin-bottom: 12px;
+  text-align: right;
+}
+
+.answer-panel {
+  margin-top: 24px;
+  padding: 19px;
+  background: var(--sky);
+  border-left: 6px solid var(--teal);
+  border-radius: 5px 12px 12px 5px;
+}
+
+.answer-copy {
+  font-family: var(--display);
+  font-size: 1.2rem;
+}
+
+.citation-list {
+  display: grid;
+  gap: 7px;
+}
+
+.citation {
+  padding: 9px 11px;
+  background: white;
+  border: 1px solid #7eaab3;
+  border-radius: 8px;
+  font-size: 0.86rem;
+  font-weight: 750;
+}
+
+.locked-view {
+  display: grid;
+  max-width: 720px;
+  min-height: 480px;
+  place-items: center;
+  place-content: center;
+  padding: 48px;
+  margin: 6vh auto;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 32px 32px 32px 8px;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.locked-view h1 {
+  font-size: clamp(2.5rem, 7vw, 4.8rem);
+}
+
+.locked-view > p:last-child {
+  max-width: 520px;
+  color: var(--ink-soft);
+  font-size: 1.08rem;
+}
+
+.lock-seal {
+  display: grid;
+  width: 112px;
+  height: 112px;
+  place-items: center;
+  margin-bottom: 28px;
+  background: var(--sky);
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+}
+
+.lock-seal span {
+  position: relative;
+  width: 42px;
+  height: 34px;
+  background: var(--ink);
+  border-radius: 6px;
+}
+
+.lock-seal span::before {
+  position: absolute;
+  top: -23px;
+  left: 8px;
+  width: 22px;
+  height: 27px;
+  content: "";
+  border: 5px solid var(--ink);
+  border-bottom: 0;
+  border-radius: 16px 16px 0 0;
+}
+
+.site-footer {
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  padding: 26px clamp(20px, 5vw, 72px);
+  color: white;
+  background: var(--ink);
+  font-size: 0.86rem;
+}
+
+.site-footer a {
+  color: white;
+}
+
+.card-dialog {
+  width: min(620px, calc(100% - 28px));
+  padding: 0;
+  color: var(--ink);
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: 0 30px 90px rgba(23, 50, 77, 0.32);
+}
+
+.card-dialog::backdrop {
+  background: rgba(14, 35, 52, 0.66);
+}
+
+.card-dialog form {
+  position: relative;
+  display: grid;
+  gap: 8px;
+  padding: 32px;
+}
+
+.card-dialog textarea,
+.card-dialog select,
+.card-dialog input {
+  margin-bottom: 8px;
+}
+
+.dialog-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 44px;
+  height: 44px;
+  background: var(--mist);
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 1.5rem;
+}
+
+.dialog-actions {
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+.toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 80;
+  max-width: min(420px, calc(100% - 40px));
+  padding: 14px 18px;
+  color: white;
+  background: var(--ink);
+  border-left: 6px solid var(--saffron);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(18px);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 1000px) {
+  .owner-layout,
+  .helper-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .share-column,
+  .question-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 760px) {
+  body {
+    background: var(--mist);
+  }
+
+  .site-header {
+    min-height: 68px;
+    padding: 10px 16px;
+  }
+
+  .wordmark-mark {
+    width: 42px;
+    height: 42px;
+  }
+
+  .wordmark small {
+    display: none;
+  }
+
+  .view-marker {
+    padding: 8px 10px;
+    font-size: 0.82rem;
+  }
+
+  main {
+    width: min(100% - 24px, 680px);
+    padding-top: 18px;
+  }
+
+  .owner-hero,
+  .helper-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    border-radius: 22px 22px 22px 7px;
+  }
+
+  .passport-seal {
+    width: 150px;
+    justify-self: center;
+  }
+
+  .helper-time {
+    min-width: 0;
+  }
+
+  .card-list {
+    grid-template-columns: 1fr;
+  }
+
+  .connect-panel {
+    grid-template-columns: 1fr;
+    margin-top: 2vh;
+  }
+
+  .input-action {
+    grid-template-columns: 1fr;
+  }
+
+  .input-action .button {
+    width: 100%;
+  }
+
+  .site-footer {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 430px) {
+  .replay-banner span {
+    display: block;
+  }
+
+  .folio-section,
+  .guide-panel,
+  .share-panel,
+  .question-panel,
+  .live-links {
+    padding: 20px 17px;
+  }
+
+  .owner-hero,
+  .helper-hero,
+  .connect-panel,
+  .locked-view {
+    padding: 28px 20px;
+  }
+
+  .section-heading {
+    flex-direction: column;
+  }
+
+  .section-heading .button {
+    width: 100%;
+  }
+
+  .journey {
+    display: grid;
+  }
+
+  .segmented-control {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .card-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .card-actions .button:last-child:nth-child(3) {
+    grid-column: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -111,7 +111,7 @@ Backward compatibility note:
 | `agentAccessHttp.maxBodyBytes` | `131072` | Maximum accepted JSON request body size |
 | `agentAccessHttp.writeRateLimitMaxRequests` | `30` | Max write requests (memory stores, observes) per rolling window before the HTTP API returns `429 write_rate_limited`. Positive integer; invalid values are rejected at config parse time (issue #1937). |
 | `agentAccessHttp.writeRateLimitWindowMs` | `60000` | Rolling window for the write rate limit, in milliseconds. Positive integer (issue #1937). |
-| `supportPassport.enabled` | `false` | Enable What Helps Me owner routes, MCP tools, and public helper grants. See [support-passport.md](support-passport.md). |
+| `supportPassport.enabled` | `false` | Enable What Helps Me owner routes, MCP tools, public helper grants, and browser assets. See [support-passport.md](support-passport.md). |
 | `supportPassport.trustedProxyAddresses` | `[]` | Exact reverse-proxy IP addresses allowed to supply `X-Forwarded-For` for public helper limits. Leave empty without a trusted proxy. |
 
 When `agentAccessHttp.enabled` is on (or `openclaw engram access http-serve` is running), the same loopback server also serves the browser-based admin console shell at `/engram/ui/`. The shell is static, ships with packaged plugin builds, and still requires the configured bearer token over `/engram/v1/...` for memory data and operator actions.

--- a/docs/security/support-passport-threat-model.md
+++ b/docs/security/support-passport-threat-model.md
@@ -28,6 +28,7 @@ Model output is untrusted input. Strict schemas and citation checks validate it.
 | Threat | Control |
 |---|---|
 | A client supplies another owner or namespace. | Owner inputs contain neither field. The trusted principal resolves the namespace. |
+| A leaked link appears in server logs. | The UI keeps the secret in the URL fragment. It removes the fragment after reading it. |
 | A guessed or stolen grant opens wider access. | Grants use random 32-byte secrets, constant-time hash checks, expiry, and exact card revisions. |
 | A stopped link remains usable through a cache. | Every helper call reads durable state. Public responses use `private, no-store`. |
 | One changed card leaks a partial guide. | Any state or revision mismatch returns `410 grant_stale` with no cards. |
@@ -60,6 +61,9 @@ Support cards use the normal Remnic memory store. Grant records use
 
 Grant files contain a secret hash and an owner-principal hash. They never
 contain the raw secret. Owner grant listings return neither secret hash.
+
+The UI stores no owner token or helper secret in cookies, local storage, or
+session storage.
 
 ## Response rules
 

--- a/docs/support-passport.md
+++ b/docs/support-passport.md
@@ -76,6 +76,10 @@ Set `REMNIC_AUTH_TOKEN` before the server starts. The `principal` value defines
 the owner for every authenticated owner request. When namespaces are enabled,
 give that principal access through the matching namespace policy.
 
+The browser app is available at `/remnic/ui/what-helps-me/`. The legacy
+`/engram/ui/what-helps-me/` path also works. The support passport setting serves
+this app even when the separate admin console stays disabled.
+
 ## Choose a model route
 
 What Helps Me does not require the OpenAI API. It uses the same model routing
@@ -106,6 +110,47 @@ API client.
 Manual cards, approval, sharing, and revocation need no model. Draft and
 question requests return `503 provider_unavailable` when no route can run.
 Remnic never inserts a fixed answer.
+
+## Owner flow
+
+1. Open the browser app and enter the normal Remnic bearer token.
+2. Add one to 20 exact memory IDs.
+3. Review the full selected note text.
+4. Check the outbound consent box.
+5. Draft up to eight support cards.
+6. Edit, approve, or reject each draft.
+7. Select approved cards and choose a share time.
+8. Copy the one-time share link.
+
+The consent box starts unchecked. The request includes `consent: true`. Remnic
+rejects any other value before a model call.
+
+An edit to an approved card creates a new draft. The old approved revision stays
+unchanged until the owner approves the replacement. Existing links become stale
+instead of showing a changed card.
+
+## Helper flow
+
+The link has this shape:
+
+```text
+/remnic/ui/what-helps-me/?grant=<grantId>#secret=<secret>
+```
+
+The fragment keeps the secret out of HTTP request logs. The browser removes the
+fragment after it reads the secret. It keeps the owner token and helper secret
+in memory only. It uses no cookies, local storage, or session storage.
+
+A helper can do two things:
+
+- Read the shared support cards.
+- Ask a question grounded in those cards.
+
+The question model receives the public cards and question only. It receives no
+other Remnic context or tools. A grounded answer must cite an included card. An
+uncovered question returns this exact text:
+
+> That is not covered in this person's support guide.
 
 ## Security model
 
@@ -184,3 +229,19 @@ POST /engram/v1/support-passport/public/grants/:grantId/ask
 
 The same owner actions are available as feature-gated MCP tools. Public helper
 actions never enter the generic operation list.
+
+## Accessibility checks
+
+The browser app uses semantic HTML, keyboard controls, visible focus, large
+touch targets, reduced-motion support, and text labels for every state. The
+Playwright suite runs at 375, 768, 1024, and 1440 pixels. Axe must report no
+serious or critical findings.
+
+```bash
+npm run test:support-passport-ui
+```
+
+The design also follows the NHS
+[Accessible Information Standard](https://www.england.nhs.uk/accessible-information-standard/how-to-meet-the-standard/).
+The [HSSIB investigation](https://www.hssib.org.uk/patient-safety-investigations/caring-for-adults-with-learning-disabilities-in-acute-hospitals/investigation-report/)
+explains why portable, current, accessible support information matters.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5468,7 +5468,7 @@
           "enabled": {
             "type": "boolean",
             "default": false,
-            "description": "Enable support passport owner routes, MCP tools, and public share links."
+            "description": "Enable support passport owner routes, MCP tools, browser assets, and public share links."
           },
           "trustedProxyAddresses": {
             "type": "array",

--- a/package.json
+++ b/package.json
@@ -1001,6 +1001,7 @@
     "test:openclaw-scenarios": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/orchestrator-characterization.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts tests/entity-alias-isolation.test.ts tests/cache-invalidation-coherence.test.ts",
+    "test:support-passport-ui": "playwright test --config playwright.config.ts",
     "demo:coding-agent-memory": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx examples/coding-agent-memory-demo/demo.mts",
     "test:coding-agent-memory-demo": "node examples/coding-agent-memory-demo/smoke-test.mjs",
     "test:release-smoke": "pnpm run build && node scripts/check-release-artifacts.mjs",
@@ -1036,8 +1037,10 @@
     "prepack": "pnpm run check-types && pnpm run build"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@biomejs/biome": "1.9.4",
     "@openclaw/plugin-inspector": "0.3.10",
+    "@playwright/test": "^1.62.1",
     "@remnic/bench": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "semver": "^7.7.4",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -5468,7 +5468,7 @@
           "enabled": {
             "type": "boolean",
             "default": false,
-            "description": "Enable support passport owner routes, MCP tools, and public share links."
+            "description": "Enable support passport owner routes, MCP tools, browser assets, and public share links."
           },
           "trustedProxyAddresses": {
             "type": "array",

--- a/packages/remnic-core/scripts/build-with-heap.mjs
+++ b/packages/remnic-core/scripts/build-with-heap.mjs
@@ -5,6 +5,9 @@
 // A Node wrapper (not a NODE_OPTIONS= shell prefix) keeps the build
 // script portable to Windows' cmd.exe script shell.
 import { spawnSync } from "node:child_process";
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const HEAP_DEFAULT = "--max-old-space-size=8192";
 const existing = process.env.NODE_OPTIONS?.trim();
@@ -22,4 +25,11 @@ const result = spawnSync("tsup", process.argv.slice(2), {
 if (result.error) {
   console.error(`[build-with-heap] failed to launch tsup: ${result.error.message}`);
 }
-process.exit(result.status ?? 1);
+if (result.status !== 0) process.exit(result.status ?? 1);
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = path.resolve(packageRoot, "../../admin-console/public/what-helps-me");
+const targetDir = path.resolve(packageRoot, "dist/admin-console/public/what-helps-me");
+await rm(targetDir, { recursive: true, force: true });
+await mkdir(path.dirname(targetDir), { recursive: true });
+await cp(sourceDir, targetDir, { recursive: true });

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -615,6 +615,35 @@ test("HTTP admin console safely serializes a prefill token into its inline boots
   }
 });
 
+test("HTTP admin console does not disclose the primary token to a dynamic token", async () => {
+  const service = {} as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "primary-token",
+    authTokenEntriesGetter: () => [
+      {
+        token: "scoped-token",
+        capabilities: { version: 1, ops: ["support_passport_cards_list"] },
+      },
+    ],
+    adminConsolePrefillToken: true,
+  });
+
+  const status = await server.start();
+  try {
+    const shell = await fetch(`http://127.0.0.1:${status.port}/engram/ui/`, {
+      headers: { authorization: "Bearer scoped-token" },
+    });
+    assert.equal(shell.status, 200);
+    const body = await shell.text();
+    assert.doesNotMatch(body, /primary-token/);
+    assert.doesNotMatch(body, /__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__/);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP admin dashboard endpoints require bearer authentication and apply config patches", async () => {
   const service = {} as EngramAccessService;
   const patches: unknown[] = [];

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -213,14 +213,12 @@ export interface RemnicAdminControls {
   update?: (patch: RemnicAdminConfigPatch) => Promise<RemnicAdminDashboardStatus>;
 }
 
-function resolveDefaultAdminConsolePublicDir(): string {
-  const thisDir = path.dirname(fileURLToPath(import.meta.url));
+export function resolveDefaultAdminConsolePublicDir(sourceUrl = import.meta.url): string {
+  const thisDir = path.dirname(fileURLToPath(sourceUrl));
   const candidates = [
-    // Standard: admin-console sibling to src/ (development layout)
-    path.resolve(thisDir, "../admin-console/public"),
-    // Bundled: admin-console inside dist/ alongside the bundle
+    path.resolve(thisDir, "../../../admin-console/public"),
+    path.resolve(thisDir, "../dist/admin-console/public"),
     path.resolve(thisDir, "./admin-console/public"),
-    // Package root: walk up from dist/ to the package root
     path.resolve(thisDir, "../../admin-console/public"),
   ];
   return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
@@ -398,7 +396,7 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
   private readonly authenticatedPrincipal?: string;
   private readonly maxBodyBytes: number;
   private readonly adminConsoleEnabled: boolean;
-  private readonly adminConsolePublicDir: string;
+  protected readonly adminConsolePublicDir: string;
   private readonly adminConsolePrefillToken?: string;
   private readonly adminControls?: RemnicAdminControls;
   private readonly trustPrincipalHeader: boolean;
@@ -815,10 +813,9 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
   ): Promise<void> {
     const parsed = new URL(req.url ?? "/", `http://${hostToUrlAuthority(this.host)}`);
     const pathname = parsed.pathname;
+    if (await this.handleSupportPassportUi(req, res, pathname)) return;
 
-    if (this.adminConsoleEnabled && await this.handleAdminConsole(req, res, pathname)) {
-      return;
-    }
+    if (this.adminConsoleEnabled && await this.handleAdminConsole(req, res, pathname)) return;
 
     if (req.method === "GET" && (pathname === "/engram/v1/live" || pathname === "/engram/v1/health")) {
       const { ready, warmupAttempts, lastError } = this.readiness();
@@ -831,9 +828,7 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
     }
 
     if (await this.handleSupportPassportPublicRequest(req, res)) return;
-
-    // Run any host-supplied pre-auth request handler. It runs AFTER the
-    // admin-console branch (admin assets are public) and BEFORE the
+    // Run any host-supplied pre-auth request handler after public UI assets and before the
     // operator bearer gate. The handler decides whether it has fully
     // owned the response (return true) or wants the request to fall
     // through to the normal pipeline. `ctx.authorized` is computed
@@ -3540,7 +3535,7 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
     return false;
   }
 
-  private async respondAdminConsoleShell(
+  protected async respondAdminConsoleShell(
     req: IncomingMessage,
     res: ServerResponse,
     pathname: string,
@@ -3548,7 +3543,12 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
   ): Promise<void> {
     try {
       let body = await readFile(path.join(this.adminConsolePublicDir, relativePath), "utf-8");
-      const canPrefillToken = this.adminConsolePrefillToken && this.isAuthorized(req, pathname);
+      const matched = this.resolveAuthorizedEntry(req, pathname);
+      const canPrefillToken =
+        this.adminConsolePrefillToken &&
+        matched !== null &&
+        matched.capabilities === undefined &&
+        this.timingSafeStringEqual(matched.token, this.adminConsolePrefillToken);
       if (canPrefillToken) {
         const serializedToken = serializeInlineScriptValue(this.adminConsolePrefillToken);
         const script = `<script>(function(token,script){const key="__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__";const clear=function(){token="";try{delete window[key]}catch{window[key]=""}};window.addEventListener("pagehide",clear,{once:true});window.addEventListener("beforeunload",clear,{once:true});try{Object.defineProperty(window,key,{configurable:true,get:function(){const value=token;clear();return value}})}finally{if(script){script.textContent="";script.remove()}}})(${serializedToken},document.currentScript);</script>`;
@@ -3567,7 +3567,7 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
     }
   }
 
-  private async respondStatic(res: ServerResponse, filePath: string, contentType: string): Promise<void> {
+  protected async respondStatic(res: ServerResponse, filePath: string, contentType: string): Promise<void> {
     try {
       const body = await readFile(filePath, "utf-8");
       res.statusCode = 200;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -3540,11 +3540,13 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
     res: ServerResponse,
     pathname: string,
     relativePath = "index.html",
+    allowPrefill = true,
   ): Promise<void> {
     try {
       let body = await readFile(path.join(this.adminConsolePublicDir, relativePath), "utf-8");
       const matched = this.resolveAuthorizedEntry(req, pathname);
       const canPrefillToken =
+        allowPrefill &&
         this.adminConsolePrefillToken &&
         matched !== null &&
         matched.capabilities === undefined &&

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -3553,7 +3553,7 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
         this.timingSafeStringEqual(matched.token, this.adminConsolePrefillToken);
       if (canPrefillToken) {
         const serializedToken = serializeInlineScriptValue(this.adminConsolePrefillToken);
-        const script = `<script>(function(token,script){const key="__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__";const clear=function(){token="";try{delete window[key]}catch{window[key]=""}};window.addEventListener("pagehide",clear,{once:true});window.addEventListener("beforeunload",clear,{once:true});try{Object.defineProperty(window,key,{configurable:true,get:function(){const value=token;clear();return value}})}finally{if(script){script.textContent="";script.remove()}}})(${serializedToken},document.currentScript);</script>`;
+        const script = `<script>(function(token,script){const key="__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__";const clear=function(){token="";try{delete window[key]}catch{window[key]=""}};window.addEventListener("pagehide",clear,{once:true});window.addEventListener("beforeunload",clear,{once:true});try{if(new URLSearchParams(location.hash.slice(1)).has("secret")){clear();return}Object.defineProperty(window,key,{configurable:true,get:function(){const value=token;clear();return value}})}finally{if(script){script.textContent="";script.remove()}}})(${serializedToken},document.currentScript);</script>`;
         body = body.includes("</head>")
           ? body.replace("</head>", `${script}</head>`)
           : `${script}${body}`;

--- a/packages/remnic-core/src/support-passport/access-http-base.ts
+++ b/packages/remnic-core/src/support-passport/access-http-base.ts
@@ -44,7 +44,8 @@ export abstract class SupportPassportAccessHttpBase {
     req: IncomingMessage,
     res: ServerResponse,
     pathname: string,
-    relativePath?: string
+    relativePath?: string,
+    allowPrefill?: boolean,
   ): Promise<void>;
   protected abstract respondStatic(res: ServerResponse, filePath: string, contentType: string): Promise<void>;
 
@@ -124,7 +125,8 @@ export abstract class SupportPassportAccessHttpBase {
       return true;
     }
     if (pathname === "/remnic/ui/what-helps-me/" || pathname === "/engram/ui/what-helps-me/") {
-      await this.respondAdminConsoleShell(req, res, pathname, "what-helps-me/index.html");
+      const helperRequest = new URL(req.url ?? pathname, "http://placeholder").searchParams.has("grant");
+      await this.respondAdminConsoleShell(req, res, pathname, "what-helps-me/index.html", !helperRequest);
       return true;
     }
     const fileName = pathname.split("/").at(-1) ?? "";

--- a/packages/remnic-core/src/support-passport/access-http-base.ts
+++ b/packages/remnic-core/src/support-passport/access-http-base.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import path from "node:path";
 
 import { EngramAccessForbiddenError } from "../access-errors.js";
 import type { EngramAccessService } from "../access-service.js";
@@ -25,14 +26,27 @@ const SUPPORT_PASSPORT_QUOTA_LIMITED_WRITE_TOOLS = new Set([
   "engram.support_passport_grant_revoke",
   "remnic.support_passport_grant_revoke",
 ]);
+const SUPPORT_PASSPORT_ADMIN_CONSOLE_ASSETS = new Map<string, string>([
+  ["what-helps-me.css", "text/css; charset=utf-8"],
+  ["model.js", "application/javascript; charset=utf-8"],
+  ["app.js", "application/javascript; charset=utf-8"],
+]);
 
 export abstract class SupportPassportAccessHttpBase {
   private supportPassportPublicHandler: ReturnType<typeof buildSupportPassportPublicRequestHandler> | undefined;
   protected abstract readonly service: EngramAccessService;
+  protected abstract readonly adminConsolePublicDir: string;
   protected abstract resolveRequestPrincipal(req: IncomingMessage): string | undefined;
   protected abstract readJsonBody(req: IncomingMessage, maxBodyBytes?: number): Promise<Record<string, unknown>>;
   protected abstract respondJson(res: ServerResponse, status: number, payload: unknown): void;
   protected abstract reserveWriteRateLimitSlot(req?: IncomingMessage): WriteRateLimitReservation;
+  protected abstract respondAdminConsoleShell(
+    req: IncomingMessage,
+    res: ServerResponse,
+    pathname: string,
+    relativePath?: string
+  ): Promise<void>;
+  protected abstract respondStatic(res: ServerResponse, filePath: string, contentType: string): Promise<void>;
 
   protected handleSupportPassportOwnerRequest(
     req: IncomingMessage,
@@ -84,5 +98,42 @@ export abstract class SupportPassportAccessHttpBase {
 
   protected isSupportPassportQuotaLimitedWriteTool(toolName: string): boolean {
     return SUPPORT_PASSPORT_QUOTA_LIMITED_WRITE_TOOLS.has(toolName);
+  }
+
+  protected async handleSupportPassportUi(
+    req: IncomingMessage,
+    res: ServerResponse,
+    pathname: string
+  ): Promise<boolean> {
+    if (req.method !== "GET") return false;
+    const isSupportPassportPath =
+      pathname === "/remnic/ui/what-helps-me" ||
+      pathname === "/engram/ui/what-helps-me" ||
+      pathname.startsWith("/remnic/ui/what-helps-me/") ||
+      pathname.startsWith("/engram/ui/what-helps-me/");
+    if (!isSupportPassportPath) return false;
+    if (!this.service.supportPassportEnabled) {
+      this.respondJson(res, 404, { error: "not_found" });
+      return true;
+    }
+    if (pathname === "/remnic/ui/what-helps-me" || pathname === "/engram/ui/what-helps-me") {
+      const search = new URL(req.url ?? pathname, "http://placeholder").search;
+      res.statusCode = 301;
+      res.setHeader("location", `${pathname}/${search}`);
+      res.end();
+      return true;
+    }
+    if (pathname === "/remnic/ui/what-helps-me/" || pathname === "/engram/ui/what-helps-me/") {
+      await this.respondAdminConsoleShell(req, res, pathname, "what-helps-me/index.html");
+      return true;
+    }
+    const fileName = pathname.split("/").at(-1) ?? "";
+    const assetType = SUPPORT_PASSPORT_ADMIN_CONSOLE_ASSETS.get(fileName);
+    if (assetType && pathname.split("/").length === 5) {
+      await this.respondStatic(res, path.join(this.adminConsolePublicDir, "what-helps-me", fileName), assetType);
+      return true;
+    }
+    this.respondJson(res, 404, { error: "not_found" });
+    return true;
   }
 }

--- a/packages/remnic-core/src/support-passport/access-http-base.ts
+++ b/packages/remnic-core/src/support-passport/access-http-base.ts
@@ -126,6 +126,8 @@ export abstract class SupportPassportAccessHttpBase {
     }
     if (pathname === "/remnic/ui/what-helps-me/" || pathname === "/engram/ui/what-helps-me/") {
       const helperRequest = new URL(req.url ?? pathname, "http://placeholder").searchParams.has("grant");
+      res.setHeader("content-security-policy", "frame-ancestors 'none'");
+      res.setHeader("x-frame-options", "DENY");
       await this.respondAdminConsoleShell(req, res, pathname, "what-helps-me/index.html", !helperRequest);
       return true;
     }

--- a/packages/remnic-core/src/support-passport/access-http.ts
+++ b/packages/remnic-core/src/support-passport/access-http.ts
@@ -131,6 +131,8 @@ export async function handleSupportPassportOwnerHttp(
     }
 
     if (!operation) return false;
+    dependencies.res.setHeader("cache-control", "private, no-store");
+    dependencies.res.setHeader("vary", "Authorization");
     if (dependencies.hasQuery) {
       throw new SupportPassportError("invalid_input", "Support passport routes do not accept query values.", 400);
     }

--- a/packages/remnic-core/src/support-passport/ui.test.ts
+++ b/packages/remnic-core/src/support-passport/ui.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { EngramAccessHttpServer, resolveDefaultAdminConsolePublicDir } from "../access-http.js";
+import type { EngramAccessService } from "../access-service.js";
+import type { StorageManager } from "../storage.js";
+
+const adminConsolePublicDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../admin-console/public"
+);
+
+async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-support-passport-ui-"));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function fakeService(root: string, enabled: boolean): EngramAccessService {
+  const storage = { dir: root } as StorageManager;
+  return {
+    supportPassportEnabled: enabled,
+    configRef: { defaultNamespace: "support-passport", namespacesEnabled: true },
+    getReadableStorageForNamespace: async () => ({ namespace: "support-passport", storage }),
+    getWritableStorageForNamespace: async () => ({ namespace: "support-passport", storage }),
+  } as unknown as EngramAccessService;
+}
+
+test("What Helps Me serves both aliases from one exact feature-gated allow-list", async () => {
+  await withTempRoot(async (root) => {
+    const server = new EngramAccessHttpServer({
+      service: fakeService(root, true),
+      host: "127.0.0.1",
+      port: 0,
+      authToken: "owner-token",
+      principal: "support-passport-owner",
+      adminConsoleEnabled: false,
+      adminConsolePublicDir,
+      adminConsolePrefillToken: true,
+    });
+    const status = await server.start();
+    const origin = `http://127.0.0.1:${status.port}`;
+    try {
+      for (const prefix of ["remnic", "engram"]) {
+        const redirect = await fetch(`${origin}/${prefix}/ui/what-helps-me`, { redirect: "manual" });
+        assert.equal(redirect.status, 301);
+        assert.equal(redirect.headers.get("location"), `/${prefix}/ui/what-helps-me/`);
+        const redirectWithGrant = await fetch(`${origin}/${prefix}/ui/what-helps-me?grant=grant-one&mode=replay`, {
+          redirect: "manual",
+        });
+        assert.equal(
+          redirectWithGrant.headers.get("location"),
+          `/${prefix}/ui/what-helps-me/?grant=grant-one&mode=replay`
+        );
+
+        const shell = await fetch(`${origin}/${prefix}/ui/what-helps-me/`);
+        assert.equal(shell.status, 200);
+        assert.match(shell.headers.get("content-type") ?? "", /^text\/html/);
+        assert.doesNotMatch(await shell.text(), /__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__/);
+
+        const authorizedShell = await fetch(`${origin}/${prefix}/ui/what-helps-me/`, {
+          headers: { authorization: "Bearer owner-token" },
+        });
+        assert.equal(authorizedShell.status, 200);
+        assert.equal(authorizedShell.headers.get("cache-control"), "private, no-store");
+        assert.match(await authorizedShell.text(), /__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__="owner-token"/);
+
+        const expectedAssets = new Map([
+          ["what-helps-me.css", /^text\/css/],
+          ["model.js", /^application\/javascript/],
+          ["app.js", /^application\/javascript/],
+        ]);
+        for (const [fileName, contentType] of expectedAssets) {
+          const asset = await fetch(`${origin}/${prefix}/ui/what-helps-me/${fileName}`);
+          assert.equal(asset.status, 200, `${prefix}/${fileName}`);
+          assert.match(asset.headers.get("content-type") ?? "", contentType);
+          assert.ok((await asset.text()).length > 100);
+        }
+
+        const unknown = await fetch(`${origin}/${prefix}/ui/what-helps-me/not-allowed.js`);
+        assert.equal(unknown.status, 404);
+        const nested = await fetch(`${origin}/${prefix}/ui/what-helps-me/app.js/extra`);
+        assert.equal(nested.status, 404);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+test("What Helps Me finds repository assets without a source-mode path override", async () => {
+  const sourceModuleUrl = new URL("../access-http.ts", import.meta.url);
+  assert.equal(resolveDefaultAdminConsolePublicDir(sourceModuleUrl.href), adminConsolePublicDir);
+  await withTempRoot(async (root) => {
+    const server = new EngramAccessHttpServer({
+      service: fakeService(root, true),
+      host: "127.0.0.1",
+      port: 0,
+      authToken: "owner-token",
+      principal: "support-passport-owner",
+      adminConsoleEnabled: false,
+    });
+    const status = await server.start();
+    try {
+      const shell = await fetch(`http://127.0.0.1:${status.port}/remnic/ui/what-helps-me/`);
+      assert.equal(shell.status, 200);
+      assert.match(await shell.text(), /What Helps Me/);
+      const asset = await fetch(`http://127.0.0.1:${status.port}/remnic/ui/what-helps-me/app.js`);
+      assert.equal(asset.status, 200);
+      assert.ok((await asset.text()).length > 100);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+test("What Helps Me finds copied assets from the published source export", async () => {
+  await withTempRoot(async (root) => {
+    const sourceModulePath = path.join(root, "package", "src", "access-http.ts");
+    const publishedAssets = path.join(root, "package", "dist", "admin-console", "public");
+    await mkdir(path.dirname(sourceModulePath), { recursive: true });
+    await mkdir(publishedAssets, { recursive: true });
+    await writeFile(sourceModulePath, "");
+    assert.equal(resolveDefaultAdminConsolePublicDir(new URL(`file://${sourceModulePath}`).href), publishedAssets);
+  });
+});
+
+test("What Helps Me assets stay hidden while support passport is disabled", async () => {
+  await withTempRoot(async (root) => {
+    const server = new EngramAccessHttpServer({
+      service: fakeService(root, false),
+      host: "127.0.0.1",
+      port: 0,
+      authToken: "owner-token",
+      principal: "support-passport-owner",
+      adminConsoleEnabled: true,
+      adminConsolePublicDir,
+    });
+    const status = await server.start();
+    try {
+      const response = await fetch(`http://127.0.0.1:${status.port}/remnic/ui/what-helps-me/`);
+      assert.equal(response.status, 404);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+test("What Helps Me disables the browser cache for credentialed API requests", async () => {
+  const source = await readFile(path.join(adminConsolePublicDir, "what-helps-me", "app.js"), "utf8");
+  assert.match(source, /fetch\(path, \{[\s\S]*?cache: "no-store"/);
+});

--- a/packages/remnic-core/src/support-passport/ui.test.ts
+++ b/packages/remnic-core/src/support-passport/ui.test.ts
@@ -157,3 +157,8 @@ test("What Helps Me disables the browser cache for credentialed API requests", a
   const source = await readFile(path.join(adminConsolePublicDir, "what-helps-me", "app.js"), "utf8");
   assert.match(source, /fetch\(path, \{[\s\S]*?cache: "no-store"/);
 });
+
+test("What Helps Me wordmark does not depend on the optional admin console", async () => {
+  const source = await readFile(path.join(adminConsolePublicDir, "what-helps-me", "index.html"), "utf8");
+  assert.doesNotMatch(source, /class="wordmark"[^>]*href=/);
+});

--- a/packages/remnic-core/src/support-passport/ui.test.ts
+++ b/packages/remnic-core/src/support-passport/ui.test.ts
@@ -63,6 +63,8 @@ test("What Helps Me serves both aliases from one exact feature-gated allow-list"
         const shell = await fetch(`${origin}/${prefix}/ui/what-helps-me/`);
         assert.equal(shell.status, 200);
         assert.match(shell.headers.get("content-type") ?? "", /^text\/html/);
+        assert.equal(shell.headers.get("content-security-policy"), "frame-ancestors 'none'");
+        assert.equal(shell.headers.get("x-frame-options"), "DENY");
         assert.doesNotMatch(await shell.text(), /__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__/);
 
         const authorizedShell = await fetch(`${origin}/${prefix}/ui/what-helps-me/`, {

--- a/packages/remnic-core/src/support-passport/ui.test.ts
+++ b/packages/remnic-core/src/support-passport/ui.test.ts
@@ -74,6 +74,12 @@ test("What Helps Me serves both aliases from one exact feature-gated allow-list"
         assert.match(authorizedShellText, /Object\.defineProperty\(window,key/);
         assert.match(authorizedShellText, /\}\)\("owner-token",document\.currentScript\)/);
 
+        const helperShell = await fetch(`${origin}/${prefix}/ui/what-helps-me/?grant=grant-one`, {
+          headers: { authorization: "Bearer owner-token" },
+        });
+        assert.equal(helperShell.status, 200);
+        assert.doesNotMatch(await helperShell.text(), /__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__|owner-token/);
+
         const expectedAssets = new Map([
           ["what-helps-me.css", /^text\/css/],
           ["model.js", /^application\/javascript/],
@@ -158,6 +164,12 @@ test("What Helps Me assets stay hidden while support passport is disabled", asyn
 test("What Helps Me disables the browser cache for credentialed API requests", async () => {
   const source = await readFile(path.join(adminConsolePublicDir, "what-helps-me", "app.js"), "utf8");
   assert.match(source, /fetch\(path, \{[\s\S]*?cache: "no-store"/);
+});
+
+test("What Helps Me clears any prefill getter before helper initialization", async () => {
+  const source = await readFile(path.join(adminConsolePublicDir, "what-helps-me", "app.js"), "utf8");
+  assert.match(source, /if \(grantId \|\| hasSecretFragment\) \{\s+clearPrefillToken\(\);/);
+  assert.match(source, /delete window\.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__/);
 });
 
 test("What Helps Me wordmark does not depend on the optional admin console", async () => {

--- a/packages/remnic-core/src/support-passport/ui.test.ts
+++ b/packages/remnic-core/src/support-passport/ui.test.ts
@@ -70,7 +70,9 @@ test("What Helps Me serves both aliases from one exact feature-gated allow-list"
         });
         assert.equal(authorizedShell.status, 200);
         assert.equal(authorizedShell.headers.get("cache-control"), "private, no-store");
-        assert.match(await authorizedShell.text(), /__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__="owner-token"/);
+        const authorizedShellText = await authorizedShell.text();
+        assert.match(authorizedShellText, /Object\.defineProperty\(window,key/);
+        assert.match(authorizedShellText, /\}\)\("owner-token",document\.currentScript\)/);
 
         const expectedAssets = new Map([
           ["what-helps-me.css", /^text\/css/],

--- a/packages/remnic-core/src/support-passport/ui.test.ts
+++ b/packages/remnic-core/src/support-passport/ui.test.ts
@@ -74,6 +74,7 @@ test("What Helps Me serves both aliases from one exact feature-gated allow-list"
         assert.equal(authorizedShell.headers.get("cache-control"), "private, no-store");
         const authorizedShellText = await authorizedShell.text();
         assert.match(authorizedShellText, /Object\.defineProperty\(window,key/);
+        assert.match(authorizedShellText, /new URLSearchParams\(location\.hash\.slice\(1\)\)\.has\("secret"\)/);
         assert.match(authorizedShellText, /\}\)\("owner-token",document\.currentScript\)/);
 
         const helperShell = await fetch(`${origin}/${prefix}/ui/what-helps-me/?grant=grant-one`, {

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -5468,7 +5468,7 @@
           "enabled": {
             "type": "boolean",
             "default": false,
-            "description": "Enable support passport owner routes, MCP tools, and public share links."
+            "description": "Enable support passport owner routes, MCP tools, browser assets, and public share links."
           },
           "trustedProxyAddresses": {
             "type": "array",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+const widths = [375, 768, 1024, 1440] as const;
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "support-passport-ui.spec.ts",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: true,
+  reporter: "line",
+  outputDir: "output/playwright/what-helps-me",
+  use: {
+    browserName: "chromium",
+    colorScheme: "light",
+    locale: "en-US",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: widths.map((width) => ({
+    name: `chromium-${width}`,
+    use: { viewport: { width, height: width === 375 ? 812 : 900 } },
+  })),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,12 +54,18 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.13.0(playwright-core@1.62.1)
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
       '@openclaw/plugin-inspector':
         specifier: 0.3.10
         version: 0.3.10
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@remnic/bench':
         specifier: workspace:*
         version: link:packages/bench
@@ -684,6 +690,11 @@ importers:
 
 packages:
 
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
+
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -1192,6 +1203,11 @@ packages:
   '@orama/plugin-data-persistence@3.1.18':
     resolution: {integrity: sha512-pfBbpK96VRW/7IkdMHn2HaW3/+4k2C9Uwyup0IONNuz5bG3L1orCNFZPBmu+zcokOU2YH+IAVuQz6MlvqOe3iw==}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1496,6 +1512,10 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1815,6 +1835,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2133,6 +2158,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -2573,6 +2608,11 @@ packages:
 
 snapshots:
 
+  '@axe-core/playwright@4.13.0(playwright-core@1.62.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.62.1
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3004,6 +3044,10 @@ snapshots:
       dpack: 0.6.22
       seqproto: 0.2.3
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
@@ -3267,6 +3311,8 @@ snapshots:
   array-back@6.2.3: {}
 
   array-flatten@1.1.1: {}
+
+  axe-core@4.13.0: {}
 
   base64-js@1.5.1: {}
 
@@ -3653,6 +3699,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3891,6 +3940,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@6.0.1(postcss@8.5.16)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:

--- a/scripts/check-release-artifacts.mjs
+++ b/scripts/check-release-artifacts.mjs
@@ -29,6 +29,14 @@ const requiredFiles = [
   "dist/admin-console/public/relay/relay-model.js",
   "dist/admin-console/public/relay/relay.js",
   "dist/admin-console/public/relay/replay.json",
+  "dist/admin-console/public/what-helps-me/index.html",
+  "dist/admin-console/public/what-helps-me/what-helps-me.css",
+  "dist/admin-console/public/what-helps-me/model.js",
+  "dist/admin-console/public/what-helps-me/app.js",
+  "packages/remnic-core/dist/admin-console/public/what-helps-me/index.html",
+  "packages/remnic-core/dist/admin-console/public/what-helps-me/what-helps-me.css",
+  "packages/remnic-core/dist/admin-console/public/what-helps-me/model.js",
+  "packages/remnic-core/dist/admin-console/public/what-helps-me/app.js",
 ];
 
 const rootPackageJson = JSON.parse(await readFile(rootPackageJsonPath, "utf8"));

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -828,8 +828,14 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
   });
   let grantReads = 0;
+  const reconciliationStarted = Promise.withResolvers<void>();
+  const releaseReconciliation = Promise.withResolvers<void>();
   await page.route("**/engram/v1/support-passport/grants", async (route) => {
     grantReads += 1;
+    if (grantReads === 2) {
+      reconciliationStarted.resolve();
+      await releaseReconciliation.promise;
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -851,6 +857,9 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
       )
     )
     .toBe(true);
+  await reconciliationStarted.promise;
+  await expect(page.getByRole("button", { name: "Creating link…" })).toBeDisabled();
+  releaseReconciliation.resolve();
 
   await expect(
     page.getByText(

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -1631,7 +1631,7 @@ test("a stalled helper question aborts and restores its action", async ({ page }
   await button.click();
   await expect(page.getByRole("button", { name: "Checking shared cards…" })).toBeDisabled();
   await expect(page.getByLabel("Your question")).toBeDisabled();
-  await page.clock.fastForward(60_000);
+  await page.clock.fastForward(15 * 60_000);
 
   await expect
     .poll(() =>

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -165,6 +165,7 @@ test("the owner note preview preserves API text and binds consent to its revisio
   });
 
   await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await expect(page.getByLabel("Bearer token")).not.toHaveAttribute("name");
   await page.getByLabel("Bearer token").fill("owner-token");
   await page.getByRole("button", { name: "Open my guide" }).click();
   await page.getByLabel("Memory ID").fill("note-with-attributes");

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -244,7 +244,7 @@ test("an owner page clears private state before browser-cache restoration", asyn
       contentType: "text/html; charset=utf-8",
       body: ownerShell.replace(
         "</head>",
-        '<script>window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__="prefilled-owner-token";</script></head>'
+        '<script>(function(token,script){const key="__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__";const clear=function(){token="";try{delete window[key]}catch{window[key]=""}};window.addEventListener("pagehide",clear,{once:true});window.addEventListener("beforeunload",clear,{once:true});try{Object.defineProperty(window,key,{configurable:true,get:function(){const value=token;clear();return value}})}finally{if(script){script.textContent="";script.remove()}}})("prefilled-owner-token",document.currentScript);</script></head>'
       ),
     });
   });
@@ -1819,13 +1819,14 @@ test("a restored helper view stays locked without its removed secret", async ({ 
   await expect(page.locator(".public-card")).toHaveCount(1);
   await page.getByLabel("Your question").fill("What should I do?");
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
-  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "This helper session ended." })).toBeVisible();
+  await expect(page.getByText("Open the original share link again to view this support passport.")).toBeVisible();
   await expect(page.locator(".public-card")).toHaveCount(0);
   await expect(page.getByLabel("Your question")).toHaveValue("");
   revoked = true;
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
 
-  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "This helper session ended." })).toBeVisible();
   expect(reads).toBe(1);
   await expect(page.locator(".public-card")).toHaveCount(0);
 });

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -1,0 +1,1470 @@
+import { readFile } from "node:fs/promises";
+import { type Server, createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { AxeBuilder } from "@axe-core/playwright";
+import { type Page, expect, test } from "@playwright/test";
+
+const publicDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../admin-console/public/what-helps-me");
+const assets = new Map<string, readonly [string, string]>([
+  ["/remnic/ui/what-helps-me/", ["index.html", "text/html; charset=utf-8"]],
+  ["/remnic/ui/what-helps-me/what-helps-me.css", ["what-helps-me.css", "text/css; charset=utf-8"]],
+  ["/remnic/ui/what-helps-me/model.js", ["model.js", "application/javascript; charset=utf-8"]],
+  ["/remnic/ui/what-helps-me/app.js", ["app.js", "application/javascript; charset=utf-8"]],
+]);
+
+interface WhatHelpsMeBrowserModel {
+  expiryForChoice(choice: string, customValue: string, nowMs: number): string;
+  buildShareUrl(currentUrl: string, grantId: string, secret: string, legacyPath: boolean): string;
+  stripAttributesSuffix(content: string): string;
+}
+
+let server: Server;
+let origin = "";
+
+test.beforeAll(async () => {
+  server = createServer(async (request, response) => {
+    const pathname = new URL(request.url ?? "/", "http://placeholder").pathname;
+    const asset = assets.get(pathname);
+    if (!asset) {
+      response.writeHead(404).end();
+      return;
+    }
+    const body = await readFile(path.join(publicDir, asset[0]));
+    response.writeHead(200, { "content-type": asset[1], "content-length": String(body.length) });
+    response.end(body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("The UI test server did not bind a TCP port.");
+  origin = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+});
+
+async function expectNoSeriousAxeFindings(page: Page): Promise<void> {
+  const report = await new AxeBuilder({ page }).analyze();
+  const findings = report.violations.filter(
+    (violation) => violation.impact === "serious" || violation.impact === "critical"
+  );
+  expect(findings).toEqual([]);
+}
+
+function helperUrl(suffix = "") {
+  return `${origin}/remnic/ui/what-helps-me/?mode=replay&grant=replay-grant${suffix}#secret=${"s".repeat(43)}`;
+}
+
+test("the owner reviews one card at a time and controls sharing", async ({ page }, testInfo) => {
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
+
+  await expect(page.getByText("Synthetic replay")).toBeVisible();
+  await expect(page.getByText("No support cards yet.")).toBeVisible();
+  await expect(page.locator(".note-item")).toHaveCount(3);
+  expect(await page.evaluate(() => ({ local: localStorage.length, session: sessionStorage.length }))).toEqual({
+    local: 0,
+    session: 0,
+  });
+
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  await expect(page.getByText("Select the consent box before any model call.")).toBeVisible();
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).focus();
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".support-card")).toHaveCount(3);
+  await expect(page.locator(".status-pill.draft")).toHaveCount(3);
+
+  await page.getByRole("button", { name: "Edit" }).first().click();
+  await page.getByLabel("Card title").fill("Softer lighting");
+  await page.getByRole("button", { name: "Save draft" }).click();
+  await expect(page.getByRole("heading", { name: "Softer lighting" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Approve" }).first().click();
+  await expect(page.locator(".status-pill.approved")).toHaveCount(1);
+  await page.locator('input[name="shareCard"]').first().check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+  await expect(page.getByText("Share link ready")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop sharing" })).toBeVisible();
+
+  await expectNoSeriousAxeFindings(page);
+  await page.screenshot({ path: testInfo.outputPath(`owner-${testInfo.project.name}.png`), fullPage: true });
+
+  await page.getByRole("button", { name: "Stop sharing" }).click();
+  await expect(page.getByText("Sharing stopped", { exact: true })).toBeVisible();
+});
+
+test("the owner note preview binds consent to the reviewed revision", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers note preview content.");
+
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/note-with-attributes", async (route) => {
+    expect(route.request().headers().authorization).toBe("Bearer owner-token");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: {
+          id: "note-with-attributes",
+          content: "Tell me before plans change.",
+          revision: "b".repeat(64),
+        },
+      }),
+    });
+  });
+  let generationInput: unknown;
+  await page.route("**/engram/v1/support-passport/drafts/generate", async (route) => {
+    generationInput = route.request().postDataJSON();
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("note-with-attributes");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+
+  await expect(page.getByText("Tell me before plans change.", { exact: true })).toBeVisible();
+  await expect(page.getByText(/\[Attributes:/)).toHaveCount(0);
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  expect(generationInput).toEqual({
+    sourceMemoryIds: ["note-with-attributes"],
+    sourceMemoryRevisions: [{ memoryId: "note-with-attributes", revision: "b".repeat(64) }],
+    consent: true,
+  });
+});
+
+test("a missing selected memory shows the specific not-found message", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers missing memory feedback.");
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/missing-note", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ found: false }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("missing-note");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+
+  await expect(page.getByText("That memory was not found in your Remnic scope.")).toBeVisible();
+});
+
+test("the owner cannot select more than eight cards for one share link", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the share-card limit.");
+  const now = new Date();
+  const cards = Array.from({ length: 9 }, (_, index) => ({
+    cardId: `card-${index + 1}`,
+    title: `Support card ${index + 1}`,
+    statement: `Support statement ${index + 1}.`,
+    category: "other",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: String(index + 1).repeat(64),
+  }));
+  let createCalls = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() === "POST") createCalls += 1;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  const choices = page.locator('input[name="shareCard"]');
+  for (let index = 0; index < 8; index += 1) await choices.nth(index).check();
+  await expect(choices.nth(8)).toBeDisabled();
+  expect(
+    await choices.evaluateAll(
+      (inputs) => inputs.filter((input) => input instanceof HTMLInputElement && input.checked).length
+    )
+  ).toBe(8);
+
+  await choices.nth(8).evaluate((input) => {
+    if (!(input instanceof HTMLInputElement)) throw new Error("The share choice must be a checkbox.");
+    input.disabled = false;
+    input.checked = true;
+  });
+  await page.getByRole("button", { name: "Create share link" }).click();
+  await expect(page.getByText("Select no more than eight approved support cards.")).toBeVisible();
+  expect(createCalls).toBe(0);
+});
+
+test("a created share link remains visible when its list refresh fails", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner refresh recovery.");
+  const now = new Date();
+  const card = {
+    cardId: "card-approved",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  let cardReads = 0;
+  let grantInput: unknown;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    cardReads += 1;
+    if (cardReads > 1) {
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "offline" }) });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() === "POST") {
+      grantInput = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+          secret: "s".repeat(43),
+          expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+          version: 1,
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+
+  expect(grantInput).toEqual({
+    cardIds: [card.cardId],
+    cardRevisions: [{ cardId: card.cardId, revision: card.revision }],
+    expiresAt: expect.any(String),
+  });
+  await expect(page.getByText("Share link ready")).toBeVisible();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue(
+    /grant=3b998a98-d48d-4f5c-887c-617af9228847#secret=/
+  );
+  await expect(page.getByText("The share link was created, but the share list did not refresh.")).toBeVisible();
+  await expect(page.getByText("The share link was not created.")).toHaveCount(0);
+});
+
+test("a malformed grant response never becomes a share link", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers response validation.");
+  const now = new Date();
+  const card = {
+    cardId: "card-approved",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+          secret: "not-a-share-secret",
+          expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+          version: 1,
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+
+  await expect(page.getByText("The new share link response is invalid.")).toBeVisible();
+  await expect(page.getByText("Share link ready")).toBeHidden();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+});
+
+test("a new share attempt clears the prior link before a later failure", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers stale share-link cleanup.");
+  const now = new Date();
+  const card = {
+    cardId: "card-approved",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "b".repeat(64),
+  };
+  let createCalls = 0;
+  const secondResponse = Promise.withResolvers<void>();
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+      return;
+    }
+    createCalls += 1;
+    if (createCalls === 1) {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+          secret: "s".repeat(43),
+          expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+          version: 1,
+        }),
+      });
+      return;
+    }
+    await secondResponse.promise;
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "The share service is unavailable." }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+  await expect(page.getByText("Share link ready")).toBeVisible();
+  await expect(page.locator('input[name="shareCard"]')).not.toBeChecked();
+  await page.locator('input[name="shareCard"]').check();
+
+  await page.getByRole("button", { name: "Create share link" }).click();
+  await expect(page.getByText("Share link ready")).toBeHidden();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+  secondResponse.resolve();
+
+  await expect(page.getByText("The share service is unavailable.")).toBeVisible();
+  await expect(page.getByText("Share link ready")).toBeHidden();
+});
+
+test("a saved manual draft stays successful when its list refresh fails", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers draft refresh recovery.");
+  let cardReads = 0;
+  let draftWrites = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    cardReads += 1;
+    if (cardReads > 1) {
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "offline" }) });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/drafts", async (route) => {
+    draftWrites += 1;
+    await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ cardId: "draft-one" }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Write a card" }).click();
+  await page.getByLabel("Card title").fill("Quiet place");
+  await page.getByLabel("What helps me").fill("Offer me a quiet place and time.");
+  await page.getByRole("button", { name: "Save draft" }).click();
+
+  await expect(page.locator("#toast")).toHaveText("Draft saved. Review and approve it before sharing.");
+  await expect(page.locator("#generateError")).toContainText("The draft was saved, but the card list did not refresh.");
+  await expect(page.getByText("The draft did not save.")).toHaveCount(0);
+  await expect(page.locator("#cardDialog")).toBeHidden();
+  expect(draftWrites).toBe(1);
+});
+
+test("an overdue card can be edited without changing its review reminder", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers overdue card edits.");
+  const overdueReview = "2026-01-15T10:30:00.000Z";
+  const card = {
+    cardId: "card-overdue",
+    title: "Plan changes",
+    statement: "Tell me before plans change.",
+    category: "transitions",
+    status: "active",
+    updatedAt: "2026-01-01T12:00:00.000Z",
+    reviewBy: overdueReview,
+    revision: "a".repeat(64),
+  };
+  let replacementInput: unknown;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/cards/card-overdue", async (route) => {
+    replacementInput = route.request().postDataJSON();
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ card }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Edit" }).click();
+  await page.getByLabel("Card title").fill("Early plan changes");
+  await page.getByRole("button", { name: "Save draft" }).click();
+
+  expect(replacementInput).toEqual({
+    title: "Early plan changes",
+    statement: card.statement,
+    category: card.category,
+    reviewBy: overdueReview,
+    expectedRevision: card.revision,
+  });
+  await expect(page.locator("#toast")).toHaveText("Draft saved. Review and approve it before sharing.");
+  await expect(page.getByText("Choose a future review reminder.")).toHaveCount(0);
+});
+
+test("successful owner mutations stay successful when their list refresh fails", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner mutation recovery.");
+  const now = new Date();
+  const card = {
+    cardId: "card-pending",
+    title: "Plan changes",
+    statement: "Tell me before plans change.",
+    category: "transitions",
+    status: "pending_review",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const grant = {
+    grantId: "grant-active",
+    stateVersion: 1,
+    cards: [{ cardId: card.cardId, revision: card.revision }],
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+    status: "active",
+  };
+  let failCardRefresh = false;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    if (failCardRefresh) {
+      failCardRefresh = false;
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "offline" }) });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [grant] }) });
+  });
+  await page.route("**/engram/v1/support-passport/cards/card-pending/approve", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ card }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants/grant-active/revoke", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grant }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/note-one", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: { id: "note-one", content: "Tell me before plans change.", revision: "b".repeat(64) },
+      }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/drafts/generate", async (route) => {
+    await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+
+  failCardRefresh = true;
+  await page.getByRole("button", { name: "Approve" }).click();
+  await expect(page.locator("#toast")).toHaveText("Approved Plan changes. It can now be shared.");
+  await expect(page.locator("#generateError")).toContainText("The card list did not refresh.");
+  await expect(page.getByText("The support card did not change.")).toHaveCount(0);
+
+  await page.getByLabel("Memory ID").fill("note-one");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  failCardRefresh = true;
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  await expect(page.locator("#toast")).toHaveText("Drafts ready. Review each card before approval.");
+  await expect(page.locator("#generateError")).toContainText("The card list did not refresh.");
+  await expect(page.getByText("The configured model did not return valid drafts.")).toHaveCount(0);
+
+  failCardRefresh = true;
+  await page.getByRole("button", { name: "Stop sharing" }).click();
+  await expect(page.locator("#toast")).toHaveText("Sharing stopped. The helper link is now locked.");
+  await expect(page.locator("#shareError")).toContainText("The share list did not refresh.");
+  await expect(page.getByText("The share link did not stop.")).toHaveCount(0);
+});
+
+test("a stalled owner read aborts and restores the connect action", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the owner request timeout.");
+  await page.clock.install({ time: new Date("2026-08-11T12:00:00.000Z") });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __ownerReadAbortObserved: false });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/cards")) {
+        return await new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __ownerReadAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  const button = page.getByRole("button", { name: "Open my guide" });
+  await button.click();
+  await expect(page.getByRole("button", { name: "Opening guide…" })).toBeDisabled();
+  await page.clock.fastForward(30_000);
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __ownerReadAbortObserved?: boolean }).__ownerReadAbortObserved
+      )
+    )
+    .toBe(true);
+  await expect(page.getByText("The owner request took too long. Try again.")).toBeVisible();
+  await expect(button).toBeEnabled();
+});
+
+test("a stalled manual draft aborts without leaving a retryable duplicate", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner write cancellation.");
+  await page.clock.install({ time: new Date("2026-08-11T12:00:00.000Z") });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __ownerDraftAbortObserved: false, __ownerDraftCalls: 0 });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/drafts") && init?.method === "POST") {
+        Object.assign(window, {
+          __ownerDraftCalls:
+            ((window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls ?? 0) + 1,
+        });
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __ownerDraftAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Write a card" }).click();
+  await page.getByLabel("Card title").fill("Quiet place");
+  await page.getByLabel("What helps me").fill("Offer me a quiet place and time.");
+  await page.getByRole("button", { name: "Save draft" }).click();
+  await expect(page.getByRole("button", { name: "Saving draft…" })).toBeDisabled();
+  await page.clock.fastForward(60_000);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved
+      )
+    )
+    .toBe(true);
+  await page.clock.fastForward(750);
+
+  await expect(page.getByText("The request stopped before the draft saved.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
+  expect(
+    await page.evaluate(() => (window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls)
+  ).toBe(1);
+});
+
+test("a stalled model draft shows uncertain state without claiming another draft", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers model draft cancellation.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  const unrelatedDraft = {
+    cardId: "unrelated-draft",
+    title: "A separate draft",
+    statement: "This draft came from another request.",
+    category: "other",
+    status: "pending_review",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "c".repeat(64),
+  };
+  await page.clock.install({ time: now });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __ownerModelAbortObserved: false, __ownerModelCalls: 0 });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/drafts/generate") && init?.method === "POST") {
+        Object.assign(window, {
+          __ownerModelCalls:
+            ((window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls ?? 0) + 1,
+        });
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __ownerModelAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  let cardReads = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    cardReads += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ cards: cardReads === 1 ? [] : [unrelatedDraft] }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/note-one", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: { id: "note-one", content: "Tell me before plans change.", revision: "b".repeat(64) },
+      }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("note-one");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  await expect(page.getByRole("button", { name: "Drafting cards…" })).toBeDisabled();
+  await page.clock.fastForward(15 * 60_000);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __ownerModelAbortObserved?: boolean }).__ownerModelAbortObserved
+      )
+    )
+    .toBe(true);
+
+  await expect(
+    page.getByText("Drafting timed out. Review the current guide before deciding whether to draft again.")
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: unrelatedDraft.title })).toBeVisible();
+  await expect(page.locator("#toast")).not.toHaveText("Drafts ready. Review each card before approval.");
+  await expect(page.getByLabel("Send these selected notes to my configured model to draft my cards.")).not.toBeChecked();
+  expect(
+    await page.evaluate(() => (window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls)
+  ).toBe(1);
+});
+
+test("a stalled share creation shows uncertain state without revoking a grant", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers share write cancellation.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  const expiresAt = new Date(now.getTime() + 2 * 60 * 60_000).toISOString();
+  const card = {
+    cardId: "card-approved",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const activeGrant = {
+    grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+    stateVersion: 1,
+    cards: [{ cardId: card.cardId, revision: card.revision }],
+    createdAt: now.toISOString(),
+    expiresAt,
+    status: "active",
+  };
+  await page.clock.install({ time: now });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __ownerShareAbortObserved: false, __ownerShareCalls: 0, __ownerRevokeCalls: 0 });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/grants") && init?.method === "POST") {
+        Object.assign(window, {
+          __ownerShareCalls:
+            ((window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls ?? 0) + 1,
+        });
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __ownerShareAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      if (url.endsWith("/revoke") && init?.method === "POST") {
+        Object.assign(window, {
+          __ownerRevokeCalls:
+            ((window as typeof window & { __ownerRevokeCalls?: number }).__ownerRevokeCalls ?? 0) + 1,
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  let grantReads = 0;
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    grantReads += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ grants: grantReads === 1 ? [] : [activeGrant] }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+  await expect(page.getByRole("button", { name: "Creating link…" })).toBeDisabled();
+  await page.clock.fastForward(60_000);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __ownerShareAbortObserved?: boolean }).__ownerShareAbortObserved
+      )
+    )
+    .toBe(true);
+
+  await expect(
+    page.getByText(
+      "The server did not confirm whether it created a link. Review the live share list and stop any link you do not recognize before creating another."
+    )
+  ).toBeVisible();
+  await expect(page.getByText("Live share", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop sharing" })).toBeVisible();
+  await expect(page.getByText("Share link ready")).toBeHidden();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+  await expect(page.getByRole("button", { name: "Create share link" })).toBeEnabled();
+  expect(
+    await page.evaluate(() => (window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls)
+  ).toBe(1);
+  expect(
+    await page.evaluate(() => (window as typeof window & { __ownerRevokeCalls?: number }).__ownerRevokeCalls)
+  ).toBe(0);
+});
+
+test("the owner view bounds rendered share history", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers bounded share history.");
+  const now = new Date();
+  const grants = Array.from({ length: 150 }, (_, index) => ({
+    grantId: `grant-${index}`,
+    stateVersion: 1,
+    cards: [{ cardId: "card-one", revision: "a".repeat(64) }],
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+    status: "expired",
+  }));
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+
+  await expect(page.locator(".grant-card")).toHaveCount(100);
+});
+
+test("the helper sees only shared cards and grounded citations", async ({ page }, testInfo) => {
+  await page.goto(helperUrl());
+
+  await expect(page.getByRole("heading", { name: "What helps me" })).toBeVisible();
+  await expect(page.locator(".public-card")).toHaveCount(3);
+  await expect(page.locator("#tokenInput")).toHaveCount(0);
+  await expect(page.getByText("Selected notes", { exact: true })).toHaveCount(0);
+
+  await page.getByLabel("Your question").fill("What should I do when this person is overwhelmed?");
+  await page.getByRole("button", { name: "Ask from this guide" }).click();
+  await expect(page.getByText("Offer a quiet place and time. Give the person space to respond.")).toBeVisible();
+  await expect(page.locator(".citation")).toContainText("Support card");
+
+  await expectNoSeriousAxeFindings(page);
+  await page.screenshot({ path: testInfo.outputPath(`helper-${testInfo.project.name}.png`), fullPage: true });
+});
+
+test("a new helper question clears the prior answer before dispatch", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers stale-answer prevention.");
+  const now = new Date();
+  const secondStarted = Promise.withResolvers<void>();
+  const releaseSecond = Promise.withResolvers<void>();
+  let asks = 0;
+  await page.route(
+    /\/engram\/v1\/support-passport\/public\/grants\/replay-grant-new-question(?:\/ask)?$/,
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          headers: { date: now.toUTCString() },
+          contentType: "application/json",
+          body: JSON.stringify({
+            schemaVersion: 1,
+            grantId: "replay-grant-new-question",
+            expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+            updatedAt: now.toISOString(),
+            cards: [
+              {
+                cardId: "card-quiet",
+                title: "Quiet place",
+                statement: "Offer me a quiet place and time.",
+                category: "environment",
+                updatedAt: now.toISOString(),
+              },
+            ],
+          }),
+        });
+        return;
+      }
+      asks += 1;
+      if (asks === 1) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            answer: "Offer a quiet place.",
+            citedCardIds: ["card-quiet"],
+            coverage: "grounded",
+          }),
+        });
+        return;
+      }
+      secondStarted.resolve();
+      await releaseSecond.promise;
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "The configured model is unavailable.", code: "provider_unavailable" }),
+      });
+    }
+  );
+
+  await page.goto(
+    `${origin}/remnic/ui/what-helps-me/?grant=replay-grant-new-question#secret=${"s".repeat(43)}`
+  );
+  await page.getByLabel("Your question").fill("What helps right now?");
+  await page.getByRole("button", { name: "Ask from this guide" }).click();
+  await expect(page.getByText("Offer a quiet place.", { exact: true })).toBeVisible();
+
+  await page.getByLabel("Your question").fill("What food helps?");
+  await page.getByRole("button", { name: "Ask from this guide" }).click();
+  await secondStarted.promise;
+  await expect(page.locator("#answerPanel")).toBeHidden();
+  releaseSecond.resolve();
+  await expect(page.getByText("The configured model is unavailable.")).toBeVisible();
+  await expect(page.getByText("Offer a quiet place.", { exact: true })).toHaveCount(0);
+  await expect(page.locator("#answerPanel")).toBeHidden();
+});
+
+test("a bad helper link has a clear locked view", async ({ page }, testInfo) => {
+  await page.goto(`${origin}/remnic/ui/what-helps-me/#secret=${"s".repeat(43)}`);
+
+  await expect(page.getByRole("heading", { name: "This link does not open a support passport." })).toBeVisible();
+  await expect(page.locator("#tokenInput")).toHaveCount(0);
+  expect(new URL(page.url()).hash).toBe("");
+  await expect(page.locator("#lockedTitle")).toBeFocused();
+  await expectNoSeriousAxeFindings(page);
+  await page.screenshot({ path: testInfo.outputPath(`locked-${testInfo.project.name}.png`), fullPage: true });
+});
+
+test("a transient initial helper failure can retry without the removed URL secret", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers initial helper retry.");
+  const now = new Date();
+  let reads = 0;
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-retry", async (route) => {
+    reads += 1;
+    expect(route.request().headers().authorization).toBe(`SupportPassport ${"s".repeat(43)}`);
+    if (reads === 1) {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "The service is temporarily unavailable.", code: "provider_unavailable" }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { date: now.toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-retry",
+        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+        updatedAt: now.toISOString(),
+        cards: [
+          {
+            cardId: "card-retry",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt: now.toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-retry").replace("mode=replay&", ""));
+  expect(new URL(page.url()).hash).toBe("");
+  await expect(page.getByRole("heading", { name: "The support passport did not load." })).toBeVisible();
+  await page.getByRole("button", { name: "Try again" }).click();
+
+  await expect(page.getByRole("heading", { name: "What helps me" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Quiet place" })).toBeVisible();
+  expect(reads).toBe(2);
+});
+
+test("owner navigation avoids smooth scrolling when reduced motion is requested", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers reduced motion.");
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.addInitScript(() => {
+    Object.assign(window, { __scrollBehaviors: [] });
+    Element.prototype.scrollIntoView = function (options) {
+      const behavior = typeof options === "object" && options ? options.behavior : undefined;
+      (window as typeof window & { __scrollBehaviors: Array<ScrollBehavior | undefined> }).__scrollBehaviors.push(
+        behavior
+      );
+    };
+  });
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+
+  expect(
+    await page.evaluate(
+      () => (window as typeof window & { __scrollBehaviors?: Array<ScrollBehavior | undefined> }).__scrollBehaviors
+    )
+  ).toEqual(["auto"]);
+});
+
+test("share links use the canonical path and reserve time for grant creation", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the browser policy helpers.");
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
+
+  const result = await page.evaluate(() => {
+    const now = Date.parse("2026-08-11T12:00:00.000Z");
+    const model = (window as typeof window & { WhatHelpsMeModel: WhatHelpsMeBrowserModel }).WhatHelpsMeModel;
+    let boundaryError = "";
+    try {
+      model.expiryForChoice("custom", new Date(now + 359_999).toISOString(), now);
+    } catch (error) {
+      boundaryError = error instanceof Error ? error.message : "unknown error";
+    }
+    return {
+      boundaryError,
+      expiresAt: model.expiryForChoice("custom", new Date(now + 360_000).toISOString(), now),
+      shareUrl: model.buildShareUrl(
+        "https://example.test/engram/ui/what-helps-me/?old=value#old=value",
+        "grant-one",
+        "secret-one",
+        false
+      ),
+      notePreview: model.stripAttributesSuffix(
+        "Tell me before plans change.\n[Attributes: support-passport: source]"
+      ),
+    };
+  });
+
+  expect(result).toEqual({
+    boundaryError: "Choose a share time at least six minutes from now and no more than seven days away.",
+    expiresAt: "2026-08-11T12:06:00.000Z",
+    shareUrl: "https://example.test/remnic/ui/what-helps-me/?grant=grant-one#secret=secret-one",
+    notePreview: "Tell me before plans change.",
+  });
+});
+
+test("helper load, error, stale, stopped, and expired states fail closed", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the state matrix.");
+
+  const cases = [
+    ["server-error", 503, "provider_unavailable", "The support passport did not load."],
+    ["stale", 410, "grant_stale", "This share link is no longer current."],
+    ["stopped", 410, "grant_gone", "This support passport is locked."],
+    ["expired-before-load", 410, "grant_expired", "This share link has expired."],
+  ] as const;
+  for (const [name, status, code, heading] of cases) {
+    const releaseResponse = Promise.withResolvers<void>();
+    await page.route(`**/engram/v1/support-passport/public/grants/replay-grant-${name}`, async (route) => {
+      await releaseResponse.promise;
+      await route.fulfill({ status, contentType: "application/json", body: JSON.stringify({ error: name, code }) });
+    });
+    await page.goto(helperUrl(`-${name}`).replace("mode=replay&", ""));
+    await expect(page.getByText("Opening the shared guide…")).toBeVisible();
+    releaseResponse.resolve();
+    await expect(page.getByRole("heading", { name: heading })).toBeVisible();
+    await page.unrouteAll({ behavior: "wait" });
+  }
+
+  const expiresAt = new Date(Date.now() + 250).toISOString();
+  const publicCard = {
+    cardId: "card-expiring",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    updatedAt: new Date().toISOString(),
+  };
+  await page.route(/\/engram\/v1\/support-passport\/public\/grants\/replay-grant-expired(?:\/ask)?$/, async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          schemaVersion: 1,
+          grantId: "replay-grant-expired",
+          expiresAt,
+          updatedAt: publicCard.updatedAt,
+          cards: [publicCard],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 410,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+    });
+  });
+  await page.goto(helperUrl("-expired").replace("mode=replay&", ""));
+  await expect(page.locator(".public-card")).toHaveCount(1);
+  await expect(page.getByRole("heading", { name: "This share link has expired." })).toBeVisible();
+  await expect(page.locator(".public-card")).toHaveCount(0);
+});
+
+test("a fast helper clock does not expire a server-authorized guide", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers helper clock calibration.");
+
+  await page.addInitScript(() => {
+    const realNow = Date.now.bind(Date);
+    Date.now = () => realNow() + 24 * 60 * 60_000;
+  });
+  const serverNow = Date.now();
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-fast-clock", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { date: new Date(serverNow).toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-fast-clock",
+        expiresAt: new Date(serverNow + 60 * 60_000).toISOString(),
+        updatedAt: new Date(serverNow).toISOString(),
+        cards: [
+          {
+            cardId: "card-fast-clock",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt: new Date(serverNow).toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-fast-clock").replace("mode=replay&", ""));
+
+  await expect(page.locator(".public-card")).toHaveCount(1);
+  await expect(page.locator("#lockedView")).toBeHidden();
+});
+
+test("a stalled initial helper read aborts and fails closed", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the initial helper timeout.");
+  await page.clock.install({ time: new Date("2026-08-11T12:00:00.000Z") });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __initialHelperAbortObserved: false });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("replay-grant-initial-stalled") && (init?.method ?? "GET") === "GET") {
+        return await new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __initialHelperAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+
+  await page.goto(helperUrl("-initial-stalled").replace("mode=replay&", ""));
+  await expect(page.getByText("Opening the shared guide…")).toBeVisible();
+  await page.clock.fastForward(10_000);
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __initialHelperAbortObserved?: boolean }).__initialHelperAbortObserved
+      )
+    )
+    .toBe(true);
+  await expect(page.getByRole("heading", { name: "The support passport did not load." })).toBeVisible();
+});
+
+test("a stalled helper question aborts and restores its action", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the helper question timeout.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  await page.clock.install({ time: now });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __helperQuestionAbortObserved: false });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/ask") && init?.method === "POST") {
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __helperQuestionAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-question-stalled", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { date: now.toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-question-stalled",
+        expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+        updatedAt: now.toISOString(),
+        cards: [
+          {
+            cardId: "card-question",
+            title: "Plan changes",
+            statement: "Tell me before plans change.",
+            category: "transitions",
+            updatedAt: now.toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-question-stalled").replace("mode=replay&", ""));
+  await page.getByLabel("Your question").fill("What should I do when plans change?");
+  const button = page.getByRole("button", { name: "Ask from this guide" });
+  await button.click();
+  await expect(page.getByRole("button", { name: "Checking shared cards…" })).toBeDisabled();
+  await page.clock.fastForward(60_000);
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __helperQuestionAbortObserved?: boolean }).__helperQuestionAbortObserved
+      )
+    )
+    .toBe(true);
+  await expect(page.getByText("The question took too long. Try again.")).toBeVisible();
+  await expect(button).toBeEnabled();
+});
+
+test("a live helper view locks after the owner revokes its grant", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers live grant revalidation.");
+
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  await page.clock.install({ time: now });
+  let reads = 0;
+  const updatedAt = now.toISOString();
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-live-revoked", async (route) => {
+    reads += 1;
+    if (reads > 1) {
+      await route.fulfill({
+        status: 410,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-live-revoked",
+        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+        updatedAt,
+        cards: [
+          {
+            cardId: "card-live",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-live-revoked").replace("mode=replay&", ""));
+  await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.clock.fastForward(30_000);
+  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  expect(reads).toBeGreaterThanOrEqual(2);
+  await expect(page.locator(".public-card")).toHaveCount(0);
+});
+
+test("a restored helper view immediately revalidates its grant", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers browser-cache restoration.");
+  const now = new Date();
+  let revoked = false;
+  let reads = 0;
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-restored", async (route) => {
+    reads += 1;
+    if (revoked) {
+      await route.fulfill({
+        status: 410,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { date: now.toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-restored",
+        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+        updatedAt: now.toISOString(),
+        cards: [
+          {
+            cardId: "card-restored",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt: now.toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-restored").replace("mode=replay&", ""));
+  await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+  revoked = true;
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
+
+  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  expect(reads).toBeGreaterThanOrEqual(2);
+  await expect(page.locator(".public-card")).toHaveCount(0);
+});
+
+test("helper revalidation backs off after a rate limit", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers helper polling backoff.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  await page.clock.install({ time: now });
+  let reads = 0;
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-rate-limit", async (route) => {
+    reads += 1;
+    if (reads === 2) {
+      await route.fulfill({
+        status: 429,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Too many helper requests.", code: "rate_limited" }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { date: now.toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-rate-limit",
+        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+        updatedAt: now.toISOString(),
+        cards: [
+          {
+            cardId: "card-rate-limit",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt: now.toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-rate-limit").replace("mode=replay&", ""));
+  await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.clock.fastForward(30_000);
+  await expect.poll(() => reads).toBe(2);
+  await page.clock.fastForward(59_000);
+  expect(reads).toBe(2);
+  await page.clock.fastForward(1_000);
+  await expect.poll(() => reads).toBe(3);
+});
+
+test("a stalled helper revalidation aborts and later observes revocation", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers revalidation recovery.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  await page.clock.install({ time: now });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    let grantReads = 0;
+    Object.assign(window, { __revalidationAbortObserved: false });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("replay-grant-stalled") && (init?.method ?? "GET") === "GET") {
+        grantReads += 1;
+        if (grantReads === 2) {
+          return await new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                Object.assign(window, { __revalidationAbortObserved: true });
+                reject(new DOMException("The request was aborted.", "AbortError"));
+              },
+              { once: true }
+            );
+          });
+        }
+      }
+      return await realFetch(input, init);
+    };
+  });
+  let serverReads = 0;
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-stalled", async (route) => {
+    serverReads += 1;
+    if (serverReads > 1) {
+      await route.fulfill({
+        status: 410,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { date: now.toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-stalled",
+        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+        updatedAt: now.toISOString(),
+        cards: [
+          {
+            cardId: "card-stalled",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt: now.toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(helperUrl("-stalled").replace("mode=replay&", ""));
+  await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.clock.fastForward(30_000);
+  await page.clock.fastForward(10_000);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __revalidationAbortObserved?: boolean }).__revalidationAbortObserved
+      )
+    )
+    .toBe(true);
+  await page.clock.fastForward(30_000);
+  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  expect(serverReads).toBe(2);
+});

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -55,6 +55,11 @@ function helperUrl(suffix = "") {
   return `${origin}/remnic/ui/what-helps-me/?mode=replay&grant=replay-grant${suffix}#secret=${"s".repeat(43)}`;
 }
 
+function injectOwnerPrefill(shell: string, token: string): string {
+  const script = `<script>(function(token,script){const key="__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__";const clear=function(){token="";try{delete window[key]}catch{window[key]=""}};window.addEventListener("pagehide",clear,{once:true});window.addEventListener("beforeunload",clear,{once:true});try{if(new URLSearchParams(location.hash.slice(1)).has("secret")){clear();return}Object.defineProperty(window,key,{configurable:true,get:function(){const value=token;clear();return value}})}finally{if(script){script.textContent="";script.remove()}}})(${JSON.stringify(token)},document.currentScript);</script>`;
+  return shell.replace("</head>", `${script}</head>`);
+}
+
 async function createReplayShare(page: Page): Promise<void> {
   await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
   await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
@@ -285,6 +290,60 @@ test("a note preview preserves a newer memory ID while its request settles", asy
   await expect(page.getByLabel("Memory ID")).toHaveValue("next-note");
 });
 
+test("drafting waits for a pending note preview", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers pending note previews.");
+  const releasePreview = Promise.withResolvers<void>();
+  let generationCalls = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route(/\/engram\/v1\/support-passport\/memories\/(first-note|second-note)$/, async (route) => {
+    const memoryId = new URL(route.request().url()).pathname.split("/").at(-1) ?? "";
+    if (memoryId === "second-note") await releasePreview.promise;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: {
+          id: memoryId,
+          content: `${memoryId} content.`,
+          revision: (memoryId === "first-note" ? "a" : "b").repeat(64),
+        },
+      }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/drafts/generate", async (route) => {
+    generationCalls += 1;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("first-note");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByLabel("Memory ID").fill("second-note");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+
+  await expect(page.getByRole("button", { name: "Adding note…" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Draft my support cards" })).toBeDisabled();
+  await page.locator("#generateButton").dispatchEvent("click");
+  await expect(page.getByText("Wait for the selected note to finish loading before drafting.")).toBeVisible();
+  expect(generationCalls).toBe(0);
+
+  releasePreview.resolve();
+  await expect(page.locator(".note-item")).toHaveCount(2);
+  await expect(page.getByRole("button", { name: "Draft my support cards" })).toBeEnabled();
+  await expect(
+    page.getByLabel("Send these selected notes to my configured model to draft my cards.")
+  ).not.toBeChecked();
+});
+
 test("an owner page clears private state before browser-cache restoration", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner browser-cache cleanup.");
   const now = new Date();
@@ -311,10 +370,7 @@ test("an owner page clears private state before browser-cache restoration", asyn
     await route.fulfill({
       status: 200,
       contentType: "text/html; charset=utf-8",
-      body: ownerShell.replace(
-        "</head>",
-        '<script>(function(token,script){const key="__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__";const clear=function(){token="";try{delete window[key]}catch{window[key]=""}};window.addEventListener("pagehide",clear,{once:true});window.addEventListener("beforeunload",clear,{once:true});try{Object.defineProperty(window,key,{configurable:true,get:function(){const value=token;clear();return value}})}finally{if(script){script.textContent="";script.remove()}}})("prefilled-owner-token",document.currentScript);</script></head>'
-      ),
+      body: injectOwnerPrefill(ownerShell, "prefilled-owner-token"),
     });
   });
   await page.route("**/engram/v1/support-passport/cards", async (route) => {
@@ -372,6 +428,50 @@ test("an owner page clears private state before browser-cache restoration", asyn
   await expect(page.locator("#customTimeField")).toBeHidden();
   await expect(page.locator("#customTimeInput")).toHaveValue("");
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+});
+
+test("owner cleanup cancels delayed private announcements", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers announcement cleanup.");
+  const now = new Date("2026-08-13T12:00:00.000Z");
+  const card = {
+    cardId: "private-announcement-card",
+    title: "Private support title",
+    statement: "Private support text.",
+    category: "other",
+    status: "pending_review",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  let approved = false;
+  await page.clock.install({ time: now });
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        cards: approved ? [{ ...card, status: "active", revision: "b".repeat(64) }] : [card],
+      }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/cards/private-announcement-card/approve", async (route) => {
+    approved = true;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ card }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Approve" }).click();
+  await expect(page.locator("#toast")).toContainText("Private support title");
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+  await page.clock.fastForward(20);
+
+  await expect(page.locator("#announcer")).toHaveText("");
+  await expect(page.locator("#ownerView")).toBeHidden();
 });
 
 test("a hidden owner write cannot add an error after reconnect", async ({ page }, testInfo) => {
@@ -568,6 +668,58 @@ test("two share submissions create one grant", async ({ page }, testInfo) => {
   releaseGrant.resolve();
   await expect(page.getByRole("button", { name: "Create share link" })).toBeEnabled();
   expect(createCalls).toBe(1);
+});
+
+test("sharing waits while a selected card is being withdrawn", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the card and share write lock.");
+  const now = new Date();
+  const card = {
+    cardId: "card-being-withdrawn",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const releaseWithdrawal = Promise.withResolvers<void>();
+  let withdrawn = false;
+  let createCalls = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ cards: withdrawn ? [] : [card] }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/cards/card-being-withdrawn/withdraw", async (route) => {
+    await releaseWithdrawal.promise;
+    withdrawn = true;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ card }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() === "POST") createCalls += 1;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.getByRole("button", { name: "Withdraw" }).click();
+
+  await expect(page.getByRole("button", { name: "Stopping…" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Create share link" })).toBeDisabled();
+  await page.locator("#shareForm").dispatchEvent("submit");
+  await expect(
+    page.getByText("Wait for the selected support card to finish changing before sharing it.")
+  ).toBeVisible();
+  expect(createCalls).toBe(0);
+
+  releaseWithdrawal.resolve();
+  await expect(page.locator('input[name="shareCard"]')).toHaveCount(0);
+  expect(createCalls).toBe(0);
 });
 
 test("a created share link remains visible when its list refresh fails", async ({ page }, testInfo) => {
@@ -1111,11 +1263,27 @@ test("a stalled owner read aborts and restores the connect action", async ({ pag
   await expect(button).toBeEnabled();
 });
 
-test("a stalled manual draft aborts without leaving a retryable duplicate", async ({ page }, testInfo) => {
+test("a timed-out manual draft stays uncertain when an identical draft appears", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner write cancellation.");
   await page.clock.install({ time: new Date("2026-08-11T12:00:00.000Z") });
   await page.addInitScript(() => {
     const realFetch = window.fetch.bind(window);
+    let submittedDraft: Record<string, string> | undefined;
+    const identicalDraftResponse = () =>
+      new Response(
+        JSON.stringify({
+          cards: [
+            {
+              ...submittedDraft,
+              cardId: "identical-other-tab-draft",
+              status: "pending_review",
+              updatedAt: new Date().toISOString(),
+              revision: "c".repeat(64),
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
     Object.assign(window, {
       __ownerDraftAbortObserved: false,
       __ownerDraftCalls: 0,
@@ -1125,6 +1293,7 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
     window.fetch = async (input, init) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith("/engram/v1/support-passport/drafts") && init?.method === "POST") {
+        submittedDraft = JSON.parse(typeof init.body === "string" ? init.body : "{}") as Record<string, string>;
         Object.assign(window, {
           __ownerDraftCalls: ((window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls ?? 0) + 1,
         });
@@ -1141,19 +1310,15 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
       }
       if (
         url.endsWith("/engram/v1/support-passport/cards") &&
-        (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved &&
-        !(window as typeof window & { __ownerDraftReconciliationStarted?: boolean }).__ownerDraftReconciliationStarted
+        (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved
       ) {
+        if ((window as typeof window & { __ownerDraftReconciliationStarted?: boolean }).__ownerDraftReconciliationStarted) {
+          return identicalDraftResponse();
+        }
         Object.assign(window, { __ownerDraftReconciliationStarted: true });
         return await new Promise<Response>((resolve) => {
           Object.assign(window, {
-            __releaseOwnerDraftReconciliation: () =>
-              resolve(
-                new Response(JSON.stringify({ cards: [] }), {
-                  status: 200,
-                  headers: { "content-type": "application/json" },
-                })
-              ),
+            __releaseOwnerDraftReconciliation: () => resolve(identicalDraftResponse()),
           });
         });
       }
@@ -1200,7 +1365,14 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
   });
   await page.clock.fastForward(750);
 
-  await expect(page.getByText("The request stopped before the draft saved.")).toBeVisible();
+  await expect(
+    page.getByText(
+      "The request timed out. Review the current guide to see whether the draft saved before trying again."
+    )
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Quiet place" })).toBeVisible();
+  await expect(page.locator("#cardDialog")).toBeVisible();
+  await expect(page.locator("#toast")).not.toHaveText("Draft saved. Review and approve it before sharing.");
   await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
   expect(await page.evaluate(() => (window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls)).toBe(
     1
@@ -1486,6 +1658,8 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
   await expect(page.getByRole("button", { name: "Creating link…" })).toBeDisabled();
   await expect(page.locator('input[name="shareCard"]')).toBeDisabled();
   await expect(page.locator('input[name="duration"][value="30m"]')).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Edit" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Withdraw" })).toBeDisabled();
   await page.clock.fastForward(60_000);
   await expect
     .poll(() =>
@@ -1629,6 +1803,98 @@ test("a new helper question clears the prior answer before dispatch", async ({ p
   await expect(page.locator("#answerPanel")).toBeHidden();
 });
 
+test("an older helper ask cannot unlock a newer ask", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers overlapping helper asks.");
+  const now = new Date();
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    let askCalls = 0;
+    Object.assign(window, { __helperAskCalls: 0, __releaseSecondHelperAsk: undefined });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (!url.endsWith("/ask") || init?.method !== "POST") return await realFetch(input, init);
+      askCalls += 1;
+      Object.assign(window, { __helperAskCalls: askCalls });
+      if (askCalls === 1) {
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The request was aborted.", "AbortError")),
+            { once: true }
+          );
+        });
+      }
+      return await new Promise<Response>((resolve) => {
+        Object.assign(window, {
+          __releaseSecondHelperAsk: () =>
+            resolve(
+              new Response(
+                JSON.stringify({
+                  answer: "Offer a quiet place.",
+                  citedCardIds: ["card-quiet"],
+                  coverage: "grounded",
+                }),
+                { status: 200, headers: { "content-type": "application/json" } }
+              )
+            ),
+        });
+      });
+    };
+  });
+  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-overlap", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { date: now.toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: 1,
+        grantId: "replay-grant-overlap",
+        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+        updatedAt: now.toISOString(),
+        cards: [
+          {
+            cardId: "card-quiet",
+            title: "Quiet place",
+            statement: "Offer me a quiet place and time.",
+            category: "environment",
+            updatedAt: now.toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?grant=replay-grant-overlap#secret=${"s".repeat(43)}`);
+  await page.getByLabel("Your question").fill("What helps first?");
+  await page.getByRole("button", { name: "Ask from this guide" }).click();
+  await expect
+    .poll(() => page.evaluate(() => (window as typeof window & { __helperAskCalls?: number }).__helperAskCalls))
+    .toBe(1);
+  await page.evaluate(() => {
+    const input = document.getElementById("questionInput");
+    const form = document.getElementById("questionForm");
+    if (!(input instanceof HTMLTextAreaElement) || !(form instanceof HTMLFormElement)) return;
+    input.disabled = false;
+    input.value = "What helps second?";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+  });
+  await expect
+    .poll(() => page.evaluate(() => (window as typeof window & { __helperAskCalls?: number }).__helperAskCalls))
+    .toBe(2);
+
+  await expect(page.getByLabel("Your question")).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Checking shared cards…" })).toBeDisabled();
+  await expect(page.locator("#questionError")).toHaveText("");
+  await page.evaluate(() => {
+    const release = (window as typeof window & { __releaseSecondHelperAsk?: () => void }).__releaseSecondHelperAsk;
+    release?.();
+  });
+
+  await expect(page.getByText("Offer a quiet place.", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Your question")).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Ask from this guide" })).toBeEnabled();
+});
+
 test("a bad helper link has a clear locked view", async ({ page }, testInfo) => {
   await page.goto(`${origin}/remnic/ui/what-helps-me/#secret=${"s".repeat(43)}`);
 
@@ -1638,6 +1904,40 @@ test("a bad helper link has a clear locked view", async ({ page }, testInfo) => 
   await expect(page.locator("#lockedTitle")).toBeFocused();
   await expectNoSeriousAxeFindings(page);
   await page.screenshot({ path: testInfo.outputPath(`locked-${testInfo.project.name}.png`), fullPage: true });
+});
+
+test("a fragment helper suppresses owner prefill when the model bundle fails", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers bootstrap secret cleanup.");
+  const ownerShell = await readFile(path.join(publicDir, "index.html"), "utf8");
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  await page.route(`${origin}/remnic/ui/what-helps-me/`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: injectOwnerPrefill(ownerShell, "prefilled-owner-token"),
+    });
+  });
+  await page.route("**/what-helps-me/model.js", async (route) => {
+    await route.fulfill({ status: 404, contentType: "application/javascript", body: "" });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/#secret=${"s".repeat(43)}`);
+
+  expect(new URL(page.url()).hash).toBe("");
+  expect(
+    await page.evaluate(
+      () =>
+        (window as typeof window & { __REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__?: string })
+          .__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__
+    )
+  ).toBeUndefined();
+  expect(
+    await page
+      .locator("script")
+      .evaluateAll((scripts) => scripts.some((script) => script.textContent?.includes("prefilled-owner-token")))
+  ).toBe(false);
+  expect(pageErrors).toContain("What Helps Me model did not load.");
 });
 
 test("a transient initial helper failure can retry without the removed URL secret", async ({ page }, testInfo) => {
@@ -1821,12 +2121,23 @@ test("helper load, error, stale, stopped, and expired states fail closed", async
 test("a fast helper clock does not expire a server-authorized guide", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers helper clock calibration.");
 
+  const serverNow = Date.parse("2026-08-13T12:00:00.000Z");
+  await page.clock.install({ time: new Date(serverNow) });
   await page.addInitScript(() => {
     const realNow = Date.now.bind(Date);
     Date.now = () => realNow() + 24 * 60 * 60_000;
   });
-  const serverNow = Date.now();
+  let reads = 0;
   await page.route("**/engram/v1/support-passport/public/grants/replay-grant-fast-clock", async (route) => {
+    reads += 1;
+    if (reads > 1) {
+      await route.fulfill({
+        status: 410,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+      });
+      return;
+    }
     await route.fulfill({
       status: 200,
       headers: { date: new Date(serverNow).toUTCString() },
@@ -1853,6 +2164,9 @@ test("a fast helper clock does not expire a server-authorized guide", async ({ p
 
   await expect(page.locator(".public-card")).toHaveCount(1);
   await expect(page.locator("#lockedView")).toBeHidden();
+  await page.clock.fastForward(30_000);
+  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "This share link has expired." })).toHaveCount(0);
 });
 
 test("a stalled initial helper read aborts and fails closed", async ({ page }, testInfo) => {

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -2497,8 +2497,8 @@ test("helper revalidation backs off after a rate limit", async ({ page }, testIn
   await expect.poll(() => reads).toBe(3);
 });
 
-test("a stalled helper revalidation aborts and later observes revocation", async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers revalidation recovery.");
+test("a stalled helper revalidation fails closed before a retry observes revocation", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers fail-closed revalidation.");
   const now = new Date("2026-08-11T12:00:00.000Z");
   await page.clock.install({ time: now });
   await page.addInitScript(() => {
@@ -2569,7 +2569,12 @@ test("a stalled helper revalidation aborts and later observes revocation", async
       )
     )
     .toBe(true);
-  await page.clock.fastForward(30_000);
+  await expect(page.getByRole("heading", { name: "The support passport did not load." })).toBeVisible();
+  await expect(page.locator(".public-card")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  expect(serverReads).toBe(1);
+
+  await page.getByRole("button", { name: "Try again" }).click();
   await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
   expect(serverReads).toBe(2);
 });

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -486,11 +486,9 @@ test("a hidden owner write cannot add an error after reconnect", async ({ page }
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith("/engram/v1/support-passport/drafts/generate") && init?.method === "POST") {
         return await new Promise((_resolve, reject) => {
-          init.signal?.addEventListener(
-            "abort",
-            () => Object.assign(window, { __hiddenOwnerWriteAborted: true }),
-            { once: true }
-          );
+          init.signal?.addEventListener("abort", () => Object.assign(window, { __hiddenOwnerWriteAborted: true }), {
+            once: true,
+          });
           Object.assign(window, {
             __releaseHiddenOwnerWrite: () => reject(new Error("late hidden owner write failure")),
           });
@@ -532,17 +530,13 @@ test("a hidden owner write cannot add an error after reconnect", async ({ page }
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
   await expect
     .poll(() =>
-      page.evaluate(
-        () => (window as typeof window & { __hiddenOwnerWriteAborted?: boolean }).__hiddenOwnerWriteAborted
-      )
+      page.evaluate(() => (window as typeof window & { __hiddenOwnerWriteAborted?: boolean }).__hiddenOwnerWriteAborted)
     )
     .toBe(true);
   await page.getByLabel("Bearer token").fill("owner-token");
   await page.getByRole("button", { name: "Open my guide" }).click();
   await page.evaluate(() => {
-    const release = (
-      window as typeof window & { __releaseHiddenOwnerWrite?: () => void }
-    ).__releaseHiddenOwnerWrite;
+    const release = (window as typeof window & { __releaseHiddenOwnerWrite?: () => void }).__releaseHiddenOwnerWrite;
     release?.();
   });
 
@@ -1312,7 +1306,9 @@ test("a timed-out manual draft stays uncertain when an identical draft appears",
         url.endsWith("/engram/v1/support-passport/cards") &&
         (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved
       ) {
-        if ((window as typeof window & { __ownerDraftReconciliationStarted?: boolean }).__ownerDraftReconciliationStarted) {
+        if (
+          (window as typeof window & { __ownerDraftReconciliationStarted?: boolean }).__ownerDraftReconciliationStarted
+        ) {
           return identicalDraftResponse();
         }
         Object.assign(window, { __ownerDraftReconciliationStarted: true });
@@ -1940,6 +1936,22 @@ test("a fragment helper suppresses owner prefill when the model bundle fails", a
   expect(pageErrors).toContain("What Helps Me model did not load.");
 });
 
+test("a manual owner token clears when the app bundles fail", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers bundle-independent token cleanup.");
+  await page.route(/\/what-helps-me\/(?:model|app)\.js$/, async (route) => {
+    await route.abort();
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("manual-owner-token");
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+
+  await expect(page.getByLabel("Bearer token")).toHaveValue("");
+  await page.getByLabel("Bearer token").fill("restored-owner-token");
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
+  await expect(page.getByLabel("Bearer token")).toHaveValue("");
+});
+
 test("a transient initial helper failure can retry without the removed URL secret", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers initial helper retry.");
   const now = new Date();
@@ -2010,7 +2022,9 @@ test("owner navigation avoids smooth scrolling when reduced motion is requested"
   ).toEqual(["auto"]);
 });
 
-test("share links use the canonical path and keep preset duration independent from browser time", async ({ page }, testInfo) => {
+test("share links use the canonical path and keep preset duration independent from browser time", async ({
+  page,
+}, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the browser policy helpers.");
   await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
 
@@ -2281,43 +2295,64 @@ test("a live helper view locks after the owner revokes its grant", async ({ page
   await page.clock.install({ time: now });
   let reads = 0;
   const updatedAt = now.toISOString();
-  await page.route("**/engram/v1/support-passport/public/grants/replay-grant-live-revoked", async (route) => {
-    reads += 1;
-    if (reads > 1) {
+  await page.route(
+    /\/engram\/v1\/support-passport\/public\/grants\/replay-grant-live-revoked(?:\/ask)?$/,
+    async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            answer: "Offer a quiet place.",
+            citedCardIds: ["card-live"],
+            coverage: "grounded",
+          }),
+        });
+        return;
+      }
+      reads += 1;
+      if (reads > 1) {
+        await route.fulfill({
+          status: 410,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+        });
+        return;
+      }
       await route.fulfill({
-        status: 410,
+        status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ error: "ended", code: "grant_gone" }),
+        body: JSON.stringify({
+          schemaVersion: 1,
+          grantId: "replay-grant-live-revoked",
+          expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+          updatedAt,
+          cards: [
+            {
+              cardId: "card-live",
+              title: "Quiet place",
+              statement: "Offer me a quiet place and time.",
+              category: "environment",
+              updatedAt,
+            },
+          ],
+        }),
       });
-      return;
     }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        schemaVersion: 1,
-        grantId: "replay-grant-live-revoked",
-        expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
-        updatedAt,
-        cards: [
-          {
-            cardId: "card-live",
-            title: "Quiet place",
-            statement: "Offer me a quiet place and time.",
-            category: "environment",
-            updatedAt,
-          },
-        ],
-      }),
-    });
-  });
+  );
 
   await page.goto(helperUrl("-live-revoked").replace("mode=replay&", ""));
   await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.getByLabel("Your question").fill("What helps right now?");
+  await page.getByRole("button", { name: "Ask from this guide" }).click();
+  await expect(page.getByText("Offer a quiet place.", { exact: true })).toBeVisible();
   await page.clock.fastForward(30_000);
   await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
   expect(reads).toBeGreaterThanOrEqual(2);
   await expect(page.locator(".public-card")).toHaveCount(0);
+  await expect(page.getByLabel("Your question")).toHaveValue("");
+  await expect(page.locator("#answerCopy")).toHaveText("");
+  await expect(page.locator("#citationList")).toBeEmpty();
 });
 
 test("a restored helper view stays locked without its removed secret", async ({ page }, testInfo) => {
@@ -2385,11 +2420,9 @@ test("a late helper load failure cannot replace the hidden-page lock", async ({ 
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.includes("replay-grant-hidden-helper") && (init?.method ?? "GET") === "GET") {
         return await new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener(
-            "abort",
-            () => Object.assign(window, { __hiddenHelperReadAborted: true }),
-            { once: true }
-          );
+          init?.signal?.addEventListener("abort", () => Object.assign(window, { __hiddenHelperReadAborted: true }), {
+            once: true,
+          });
           Object.assign(window, {
             __releaseHiddenHelperRead: () => reject(new Error("late hidden helper read failure")),
           });
@@ -2405,15 +2438,11 @@ test("a late helper load failure cannot replace the hidden-page lock", async ({ 
   await expect(page.getByRole("heading", { name: "This helper session ended." })).toBeVisible();
   await expect
     .poll(() =>
-      page.evaluate(
-        () => (window as typeof window & { __hiddenHelperReadAborted?: boolean }).__hiddenHelperReadAborted
-      )
+      page.evaluate(() => (window as typeof window & { __hiddenHelperReadAborted?: boolean }).__hiddenHelperReadAborted)
     )
     .toBe(true);
   await page.evaluate(() => {
-    const release = (
-      window as typeof window & { __releaseHiddenHelperRead?: () => void }
-    ).__releaseHiddenHelperRead;
+    const release = (window as typeof window & { __releaseHiddenHelperRead?: () => void }).__releaseHiddenHelperRead;
     release?.();
   });
 

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -1075,7 +1075,9 @@ test("helper load, error, stale, stopped, and expired states fail closed", async
     await page.unrouteAll({ behavior: "wait" });
   }
 
-  const expiresAt = new Date(Date.now() + 250).toISOString();
+  const expiryClock = new Date("2026-08-11T12:00:00.000Z");
+  await page.clock.install({ time: expiryClock });
+  const expiresAt = new Date(expiryClock.getTime() + 5_000).toISOString();
   const publicCard = {
     cardId: "card-expiring",
     title: "Quiet place",
@@ -1106,6 +1108,7 @@ test("helper load, error, stale, stopped, and expired states fail closed", async
   });
   await page.goto(helperUrl("-expired").replace("mode=replay&", ""));
   await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.clock.fastForward(5_000);
   await expect(page.getByRole("heading", { name: "This share link has expired." })).toBeVisible();
   await expect(page.locator(".public-card")).toHaveCount(0);
 });

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -390,7 +390,11 @@ test("a saved manual draft stays successful when its list refresh fails", async 
   });
   await page.route("**/engram/v1/support-passport/drafts", async (route) => {
     draftWrites += 1;
-    await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ cardId: "draft-one" }) });
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({ cardId: "draft-one" }),
+    });
   });
 
   await page.goto(`${origin}/remnic/ui/what-helps-me/`);
@@ -614,9 +618,7 @@ test("a stalled owner read aborts and restores the connect action", async ({ pag
 
   await expect
     .poll(() =>
-      page.evaluate(
-        () => (window as typeof window & { __ownerReadAbortObserved?: boolean }).__ownerReadAbortObserved
-      )
+      page.evaluate(() => (window as typeof window & { __ownerReadAbortObserved?: boolean }).__ownerReadAbortObserved)
     )
     .toBe(true);
   await expect(page.getByText("The owner request took too long. Try again.")).toBeVisible();
@@ -628,13 +630,17 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
   await page.clock.install({ time: new Date("2026-08-11T12:00:00.000Z") });
   await page.addInitScript(() => {
     const realFetch = window.fetch.bind(window);
-    Object.assign(window, { __ownerDraftAbortObserved: false, __ownerDraftCalls: 0 });
+    Object.assign(window, {
+      __ownerDraftAbortObserved: false,
+      __ownerDraftCalls: 0,
+      __ownerDraftReconciliationStarted: false,
+      __releaseOwnerDraftReconciliation: undefined,
+    });
     window.fetch = async (input, init) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith("/engram/v1/support-passport/drafts") && init?.method === "POST") {
         Object.assign(window, {
-          __ownerDraftCalls:
-            ((window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls ?? 0) + 1,
+          __ownerDraftCalls: ((window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls ?? 0) + 1,
         });
         return await new Promise((_resolve, reject) => {
           init.signal?.addEventListener(
@@ -645,6 +651,24 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
             },
             { once: true }
           );
+        });
+      }
+      if (
+        url.endsWith("/engram/v1/support-passport/cards") &&
+        (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved &&
+        !(window as typeof window & { __ownerDraftReconciliationStarted?: boolean }).__ownerDraftReconciliationStarted
+      ) {
+        Object.assign(window, { __ownerDraftReconciliationStarted: true });
+        return await new Promise<Response>((resolve) => {
+          Object.assign(window, {
+            __releaseOwnerDraftReconciliation: () =>
+              resolve(
+                new Response(JSON.stringify({ cards: [] }), {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                })
+              ),
+          });
         });
       }
       return await realFetch(input, init);
@@ -668,18 +692,33 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
   await page.clock.fastForward(60_000);
   await expect
     .poll(() =>
+      page.evaluate(() => (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved)
+    )
+    .toBe(true);
+  await expect
+    .poll(() =>
       page.evaluate(
-        () => (window as typeof window & { __ownerDraftAbortObserved?: boolean }).__ownerDraftAbortObserved
+        () =>
+          (window as typeof window & { __ownerDraftReconciliationStarted?: boolean }).__ownerDraftReconciliationStarted
       )
     )
     .toBe(true);
+  await expect(page.getByRole("button", { name: "Saving draft…" })).toBeDisabled();
+  await page.evaluate(() => {
+    const release = (
+      window as typeof window & {
+        __releaseOwnerDraftReconciliation?: () => void;
+      }
+    ).__releaseOwnerDraftReconciliation;
+    release?.();
+  });
   await page.clock.fastForward(750);
 
   await expect(page.getByText("The request stopped before the draft saved.")).toBeVisible();
   await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
-  expect(
-    await page.evaluate(() => (window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls)
-  ).toBe(1);
+  expect(await page.evaluate(() => (window as typeof window & { __ownerDraftCalls?: number }).__ownerDraftCalls)).toBe(
+    1
+  );
 });
 
 test("a stalled model draft shows uncertain state without claiming another draft", async ({ page }, testInfo) => {
@@ -703,8 +742,7 @@ test("a stalled model draft shows uncertain state without claiming another draft
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith("/engram/v1/support-passport/drafts/generate") && init?.method === "POST") {
         Object.assign(window, {
-          __ownerModelCalls:
-            ((window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls ?? 0) + 1,
+          __ownerModelCalls: ((window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls ?? 0) + 1,
         });
         return await new Promise((_resolve, reject) => {
           init.signal?.addEventListener(
@@ -754,9 +792,7 @@ test("a stalled model draft shows uncertain state without claiming another draft
   await page.clock.fastForward(15 * 60_000);
   await expect
     .poll(() =>
-      page.evaluate(
-        () => (window as typeof window & { __ownerModelAbortObserved?: boolean }).__ownerModelAbortObserved
-      )
+      page.evaluate(() => (window as typeof window & { __ownerModelAbortObserved?: boolean }).__ownerModelAbortObserved)
     )
     .toBe(true);
 
@@ -765,10 +801,12 @@ test("a stalled model draft shows uncertain state without claiming another draft
   ).toBeVisible();
   await expect(page.getByRole("heading", { name: unrelatedDraft.title })).toBeVisible();
   await expect(page.locator("#toast")).not.toHaveText("Drafts ready. Review each card before approval.");
-  await expect(page.getByLabel("Send these selected notes to my configured model to draft my cards.")).not.toBeChecked();
-  expect(
-    await page.evaluate(() => (window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls)
-  ).toBe(1);
+  await expect(
+    page.getByLabel("Send these selected notes to my configured model to draft my cards.")
+  ).not.toBeChecked();
+  expect(await page.evaluate(() => (window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls)).toBe(
+    1
+  );
 });
 
 test("a stalled share creation shows uncertain state without revoking a grant", async ({ page }, testInfo) => {
@@ -801,8 +839,7 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith("/engram/v1/support-passport/grants") && init?.method === "POST") {
         Object.assign(window, {
-          __ownerShareCalls:
-            ((window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls ?? 0) + 1,
+          __ownerShareCalls: ((window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls ?? 0) + 1,
         });
         return await new Promise((_resolve, reject) => {
           init.signal?.addEventListener(
@@ -817,8 +854,7 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
       }
       if (url.endsWith("/revoke") && init?.method === "POST") {
         Object.assign(window, {
-          __ownerRevokeCalls:
-            ((window as typeof window & { __ownerRevokeCalls?: number }).__ownerRevokeCalls ?? 0) + 1,
+          __ownerRevokeCalls: ((window as typeof window & { __ownerRevokeCalls?: number }).__ownerRevokeCalls ?? 0) + 1,
         });
       }
       return await realFetch(input, init);
@@ -852,9 +888,7 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
   await page.clock.fastForward(60_000);
   await expect
     .poll(() =>
-      page.evaluate(
-        () => (window as typeof window & { __ownerShareAbortObserved?: boolean }).__ownerShareAbortObserved
-      )
+      page.evaluate(() => (window as typeof window & { __ownerShareAbortObserved?: boolean }).__ownerShareAbortObserved)
     )
     .toBe(true);
   await reconciliationStarted.promise;
@@ -871,9 +905,9 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
   await expect(page.getByText("Share link ready")).toBeHidden();
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
   await expect(page.getByRole("button", { name: "Create share link" })).toBeEnabled();
-  expect(
-    await page.evaluate(() => (window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls)
-  ).toBe(1);
+  expect(await page.evaluate(() => (window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls)).toBe(
+    1
+  );
   expect(
     await page.evaluate(() => (window as typeof window & { __ownerRevokeCalls?: number }).__ownerRevokeCalls)
   ).toBe(0);
@@ -976,9 +1010,7 @@ test("a new helper question clears the prior answer before dispatch", async ({ p
     }
   );
 
-  await page.goto(
-    `${origin}/remnic/ui/what-helps-me/?grant=replay-grant-new-question#secret=${"s".repeat(43)}`
-  );
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?grant=replay-grant-new-question#secret=${"s".repeat(43)}`);
   await page.getByLabel("Your question").fill("What helps right now?");
   await page.getByRole("button", { name: "Ask from this guide" }).click();
   await expect(page.getByText("Offer a quiet place.", { exact: true })).toBeVisible();
@@ -1056,7 +1088,7 @@ test("owner navigation avoids smooth scrolling when reduced motion is requested"
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.addInitScript(() => {
     Object.assign(window, { __scrollBehaviors: [] });
-    Element.prototype.scrollIntoView = function (options) {
+    Element.prototype.scrollIntoView = (options) => {
       const behavior = typeof options === "object" && options ? options.behavior : undefined;
       (window as typeof window & { __scrollBehaviors: Array<ScrollBehavior | undefined> }).__scrollBehaviors.push(
         behavior
@@ -1096,9 +1128,7 @@ test("share links use the canonical path and reserve time for grant creation", a
         "secret-one",
         false
       ),
-      notePreview: model.stripAttributesSuffix(
-        "Tell me before plans change.\n[Attributes: support-passport: source]"
-      ),
+      notePreview: model.stripAttributesSuffix("Tell me before plans change.\n[Attributes: support-passport: source]"),
     };
   });
 
@@ -1238,8 +1268,7 @@ test("a stalled initial helper read aborts and fails closed", async ({ page }, t
   await expect
     .poll(() =>
       page.evaluate(
-        () =>
-          (window as typeof window & { __initialHelperAbortObserved?: boolean }).__initialHelperAbortObserved
+        () => (window as typeof window & { __initialHelperAbortObserved?: boolean }).__initialHelperAbortObserved
       )
     )
     .toBe(true);

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -412,6 +412,45 @@ test("a saved manual draft stays successful when its list refresh fails", async 
   expect(draftWrites).toBe(1);
 });
 
+test("a manual draft locks its editor until the save settles", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the draft editor lock.");
+  const releaseDraft = Promise.withResolvers<void>();
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/drafts", async (route) => {
+    await releaseDraft.promise;
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({ cardId: "draft-one" }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Write a card" }).click();
+  await page.getByLabel("Card title").fill("Quiet place");
+  await page.getByLabel("What helps me").fill("Offer me a quiet place and time.");
+  await page.getByRole("button", { name: "Save draft" }).click();
+
+  await expect(page.getByRole("button", { name: "Saving draft…" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Close support card editor" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Keep reviewing" })).toBeDisabled();
+  await expect(page.getByLabel("Card title")).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Write a card" })).toBeDisabled();
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#cardDialog")).toBeVisible();
+
+  releaseDraft.resolve();
+  await expect(page.locator("#cardDialog")).toBeHidden();
+  await expect(page.getByRole("button", { name: "Write a card" })).toBeEnabled();
+});
+
 test("an overdue card can be edited without changing its review reminder", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers overdue card edits.");
   const overdueReview = "2026-01-15T10:30:00.000Z";

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -14,7 +14,7 @@ const assets = new Map<string, readonly [string, string]>([
 ]);
 
 interface WhatHelpsMeBrowserModel {
-  expiryForChoice(choice: string, customValue: string, nowMs: number): string;
+  expiryForChoice(choice: string, customValue: string, nowMs: number): { durationMs: number } | { expiresAt: string };
   buildShareUrl(currentUrl: string, grantId: string, secret: string, legacyPath: boolean): string;
 }
 
@@ -1552,7 +1552,7 @@ test("owner navigation avoids smooth scrolling when reduced motion is requested"
   ).toEqual(["auto"]);
 });
 
-test("share links use the canonical path and reserve time for grant creation", async ({ page }, testInfo) => {
+test("share links use the canonical path and keep preset duration independent from browser time", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the browser policy helpers.");
   await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
 
@@ -1561,13 +1561,14 @@ test("share links use the canonical path and reserve time for grant creation", a
     const model = (window as typeof window & { WhatHelpsMeModel: WhatHelpsMeBrowserModel }).WhatHelpsMeModel;
     let boundaryError = "";
     try {
-      model.expiryForChoice("custom", new Date(now + 359_999).toISOString(), now);
+      model.expiryForChoice("custom", new Date(now + 299_999).toISOString(), now);
     } catch (error) {
       boundaryError = error instanceof Error ? error.message : "unknown error";
     }
     return {
       boundaryError,
-      expiresAt: model.expiryForChoice("custom", new Date(now + 360_000).toISOString(), now),
+      customExpiry: model.expiryForChoice("custom", new Date(now + 300_000).toISOString(), now),
+      presetExpiry: model.expiryForChoice("30m", "", now + 60 * 60_000),
       shareUrl: model.buildShareUrl(
         "https://example.test/engram/ui/what-helps-me/?old=value#old=value",
         "grant-one",
@@ -1578,8 +1579,9 @@ test("share links use the canonical path and reserve time for grant creation", a
   });
 
   expect(result).toEqual({
-    boundaryError: "Choose a share time at least six minutes from now and no more than seven days away.",
-    expiresAt: "2026-08-11T12:06:00.000Z",
+    boundaryError: "Choose a share time at least five minutes from now and no more than seven days away.",
+    customExpiry: { expiresAt: "2026-08-11T12:05:00.000Z" },
+    presetExpiry: { durationMs: 1_800_000 },
     shareUrl: "https://example.test/remnic/ui/what-helps-me/?grant=grant-one#secret=secret-one",
   });
 });

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -769,6 +769,103 @@ test("a stalled manual draft aborts without leaving a retryable duplicate", asyn
   );
 });
 
+test("a timed-out edit does not claim an identical draft for another card", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers edit reconciliation.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  const reviewBy = new Date(now.getTime() + 24 * 60 * 60_000).toISOString();
+  const sourceCard = {
+    cardId: "source-card",
+    title: "Plan changes",
+    statement: "Tell me before plans change.",
+    category: "transitions",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy,
+    revision: "a".repeat(64),
+  };
+  const otherCard = { ...sourceCard, cardId: "other-card", revision: "b".repeat(64) };
+  const unrelatedDraft = {
+    ...sourceCard,
+    cardId: "unrelated-draft",
+    title: "Early plan changes",
+    status: "pending_review",
+    revision: "c".repeat(64),
+  };
+  await page.clock.install({ time: now });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, { __ownerEditAbortObserved: false, __ownerEditCalls: 0 });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/cards/source-card") && init?.method === "PUT") {
+        Object.assign(window, {
+          __ownerEditCalls: ((window as typeof window & { __ownerEditCalls?: number }).__ownerEditCalls ?? 0) + 1,
+        });
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => {
+              Object.assign(window, { __ownerEditAbortObserved: true });
+              reject(new DOMException("The request was aborted.", "AbortError"));
+            },
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  let cardReads = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    cardReads += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ cards: cardReads === 1 ? [sourceCard, otherCard] : [sourceCard, unrelatedDraft] }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Edit" }).first().click();
+  await page.getByLabel("Card title").fill(unrelatedDraft.title);
+  await page.getByRole("button", { name: "Save draft" }).click();
+  await page.clock.fastForward(60_000);
+  await expect
+    .poll(() =>
+      page.evaluate(() => (window as typeof window & { __ownerEditAbortObserved?: boolean }).__ownerEditAbortObserved)
+    )
+    .toBe(true);
+  await page.clock.fastForward(1_000);
+
+  await expect(page.getByText("The edit timed out. Review the current guide before trying again.")).toBeVisible();
+  await expect(page.locator("#cardDialog")).toBeVisible();
+  await expect(page.getByLabel("Card title")).toHaveValue(unrelatedDraft.title);
+  await expect(page.locator("#toast")).not.toHaveText("Draft saved. Review and approve it before sharing.");
+  expect(await page.evaluate(() => (window as typeof window & { __ownerEditCalls?: number }).__ownerEditCalls)).toBe(1);
+});
+
+test("a successful response with invalid JSON does not open the owner guide", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers response decoding.");
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "not-json" });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+
+  await expect(page.getByText("The server returned invalid JSON with HTTP 200.")).toBeVisible();
+  await expect(page.locator("#ownerView")).toBeHidden();
+});
+
 test("a stalled model draft shows uncertain state without claiming another draft", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers model draft cancellation.");
   const now = new Date("2026-08-11T12:00:00.000Z");

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -141,6 +141,40 @@ test("the owner note preview preserves API text and binds consent to its revisio
   });
 });
 
+test("a note preview preserves a newer memory ID while its request settles", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers note preview input state.");
+  const releasePreview = Promise.withResolvers<void>();
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/first-note", async (route) => {
+    await releasePreview.promise;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: { id: "first-note", content: "First selected note.", revision: "b".repeat(64) },
+      }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("first-note");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+  await expect(page.getByRole("button", { name: "Adding note…" })).toBeDisabled();
+  await page.getByLabel("Memory ID").fill("next-note");
+  releasePreview.resolve();
+
+  await expect(page.getByText("First selected note.")).toBeVisible();
+  await expect(page.getByLabel("Memory ID")).toHaveValue("next-note");
+});
+
 test("an owner page clears private state before browser-cache restoration", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner browser-cache cleanup.");
   const now = new Date();
@@ -207,6 +241,9 @@ test("an owner page clears private state before browser-cache restoration", asyn
   await page.getByRole("button", { name: "Open my guide" }).click();
   await page.getByLabel("Memory ID").fill("private-note");
   await page.getByRole("button", { name: "Add selected note" }).click();
+  await page.locator('input[name="duration"][value="custom"]').check();
+  await page.locator("#customTimeInput").fill("2026-08-14T12:00");
+  await expect(page.locator("#customTimeField")).toBeVisible();
   await page.getByRole("button", { name: "Edit" }).click();
   await page.getByLabel("Card title").fill("Unsaved private edit");
   await expect(page.getByText("Private selected note.")).toBeVisible();
@@ -222,6 +259,8 @@ test("an owner page clears private state before browser-cache restoration", asyn
   await expect(page.locator(".grant-card")).toHaveCount(0);
   await expect(page.locator("#cardDialog")).toBeHidden();
   await expect(page.getByLabel("Card title")).toHaveValue("");
+  await expect(page.locator("#customTimeField")).toBeHidden();
+  await expect(page.locator("#customTimeInput")).toHaveValue("");
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
 });
 

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -759,8 +759,14 @@ test("a stalled model draft shows uncertain state without claiming another draft
     };
   });
   let cardReads = 0;
+  const reconciliationStarted = Promise.withResolvers<void>();
+  const releaseReconciliation = Promise.withResolvers<void>();
   await page.route("**/engram/v1/support-passport/cards", async (route) => {
     cardReads += 1;
+    if (cardReads === 2) {
+      reconciliationStarted.resolve();
+      await releaseReconciliation.promise;
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -795,6 +801,9 @@ test("a stalled model draft shows uncertain state without claiming another draft
       page.evaluate(() => (window as typeof window & { __ownerModelAbortObserved?: boolean }).__ownerModelAbortObserved)
     )
     .toBe(true);
+  await reconciliationStarted.promise;
+  await expect(page.getByRole("button", { name: "Drafting cards…" })).toBeDisabled();
+  releaseReconciliation.resolve();
 
   await expect(
     page.getByText("Drafting timed out. Review the current guide before deciding whether to draft again.")
@@ -885,6 +894,8 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
   await page.locator('input[name="shareCard"]').check();
   await page.getByRole("button", { name: "Create share link" }).click();
   await expect(page.getByRole("button", { name: "Creating link…" })).toBeDisabled();
+  await expect(page.locator('input[name="shareCard"]')).toBeDisabled();
+  await expect(page.locator('input[name="duration"][value="30m"]')).toBeDisabled();
   await page.clock.fastForward(60_000);
   await expect
     .poll(() =>
@@ -905,6 +916,9 @@ test("a stalled share creation shows uncertain state without revoking a grant", 
   await expect(page.getByText("Share link ready")).toBeHidden();
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
   await expect(page.getByRole("button", { name: "Create share link" })).toBeEnabled();
+  await expect(page.locator('input[name="shareCard"]')).toBeChecked();
+  await expect(page.locator('input[name="shareCard"]')).toBeEnabled();
+  await expect(page.locator('input[name="duration"][value="30m"]')).toBeEnabled();
   expect(await page.evaluate(() => (window as typeof window & { __ownerShareCalls?: number }).__ownerShareCalls)).toBe(
     1
   );

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -530,6 +530,54 @@ test("successful owner mutations stay successful when their list refresh fails",
   await expect(page.getByText("The share link did not stop.")).toHaveCount(0);
 });
 
+test("an expired share confirms a timed-out stop request", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers stop reconciliation.");
+  const now = new Date("2026-08-11T12:00:00.000Z");
+  const grant = {
+    grantId: "grant-active",
+    stateVersion: 1,
+    cards: [{ cardId: "card-one", revision: "a".repeat(64) }],
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+    status: "active",
+  };
+  let grantReads = 0;
+  await page.clock.install({ time: now });
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/grants/grant-active/revoke")) {
+        return await new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The request was aborted.", "AbortError")),
+            { once: true }
+          );
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    grantReads += 1;
+    const current = grantReads === 1 ? grant : { ...grant, status: "expired" };
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [current] }) });
+  });
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByRole("button", { name: "Stop sharing" }).click();
+  await page.clock.fastForward(60_000);
+
+  await expect(page.locator("#toast")).toHaveText("Sharing stopped. The helper link is now locked.");
+  await expect(page.getByText("Share time ended", { exact: true })).toBeVisible();
+  await expect(page.locator("#shareError")).toHaveText("");
+});
+
 test("a stalled owner read aborts and restores the connect action", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the owner request timeout.");
   await page.clock.install({ time: new Date("2026-08-11T12:00:00.000Z") });

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -139,6 +139,8 @@ test("the owner link disappears at its expiry time", async ({ page }, testInfo) 
 
   await expect(page.getByText("Share link ready")).toBeHidden();
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+  await expect(page.getByText("Share time ended", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop sharing" })).toHaveCount(0);
 });
 
 test("a fast owner clock keeps a server-authorized share link visible", async ({ page }, testInfo) => {
@@ -167,6 +169,7 @@ test("a fast owner clock keeps a server-authorized share link visible", async ({
     status: "active",
   };
   let created = false;
+  let createInput: Record<string, unknown> | undefined;
   await page.route("**/engram/v1/support-passport/cards", async (route) => {
     await route.fulfill({
       status: 200,
@@ -178,6 +181,7 @@ test("a fast owner clock keeps a server-authorized share link visible", async ({
   await page.route("**/engram/v1/support-passport/grants", async (route) => {
     if (route.request().method() === "POST") {
       created = true;
+      createInput = route.request().postDataJSON() as Record<string, unknown>;
       await route.fulfill({
         status: 201,
         headers: { date: new Date(serverNow).toUTCString() },
@@ -203,10 +207,20 @@ test("a fast owner clock keeps a server-authorized share link visible", async ({
   await page.getByLabel("Bearer token").fill("owner-token");
   await page.getByRole("button", { name: "Open my guide" }).click();
   await page.locator('input[name="shareCard"]').check();
+  await page.locator('input[name="duration"][value="custom"]').check();
+  const customExpiry = serverNow + 60 * 60_000;
+  await page.locator("#customTimeInput").fill(
+    await page.evaluate((timestamp) => {
+      const date = new Date(timestamp);
+      const offset = date.getTimezoneOffset() * 60_000;
+      return new Date(timestamp - offset).toISOString().slice(0, 16);
+    }, customExpiry)
+  );
   await page.getByRole("button", { name: "Create share link" }).click();
 
   await expect(page.getByText("Share link ready")).toBeVisible();
   await expect(page.getByLabel("Copy this link once")).toHaveValue(/#secret=/);
+  expect(createInput?.expiresAt).toBe(new Date(Math.floor(customExpiry / 60_000) * 60_000).toISOString());
 });
 
 test("the owner note preview preserves API text and binds consent to its revision", async ({ page }, testInfo) => {
@@ -530,6 +544,8 @@ test("a hidden owner write cannot add an error after reconnect", async ({ page }
   await expect(page.getByRole("button", { name: "Drafting cards…" })).toBeDisabled();
 
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+  await expect(page.locator("#generateButton")).toHaveText("Draft my support cards");
+  await expect(page.locator('#shareForm button[type="submit"]')).toHaveText("Create share link");
   await expect
     .poll(() =>
       page.evaluate(() => (window as typeof window & { __hiddenOwnerWriteAborted?: boolean }).__hiddenOwnerWriteAborted)

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -129,7 +129,9 @@ test("the owner note preview preserves API text and binds consent to its revisio
   await page.getByLabel("Memory ID").fill("note-with-attributes");
   await page.getByRole("button", { name: "Add selected note" }).click();
 
-  await expect(page.getByText("Tell me before plans change. [Attributes: this is part of my note]", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Tell me before plans change. [Attributes: this is part of my note]", { exact: true })
+  ).toBeVisible();
   await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
   await page.getByRole("button", { name: "Draft my support cards" }).click();
   expect(generationInput).toEqual({
@@ -137,6 +139,77 @@ test("the owner note preview preserves API text and binds consent to its revisio
     sourceMemoryRevisions: [{ memoryId: "note-with-attributes", revision: "b".repeat(64) }],
     consent: true,
   });
+});
+
+test("an owner page clears private state before browser-cache restoration", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner browser-cache cleanup.");
+  const now = new Date();
+  const card = {
+    cardId: "private-card",
+    title: "Private support",
+    statement: "Private support text.",
+    category: "other",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const grant = {
+    grantId: "private-grant",
+    stateVersion: 1,
+    cards: [{ cardId: card.cardId, revision: card.revision }],
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
+    status: "active",
+  };
+  await page.addInitScript(() => {
+    Object.assign(window, { __REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__: "prefilled-owner-token" });
+  });
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [grant] }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/private-note", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: { id: "private-note", content: "Private selected note.", revision: "b".repeat(64) },
+      }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await expect(page.getByLabel("Bearer token")).toHaveValue("prefilled-owner-token");
+  expect(
+    await page.evaluate(
+      () =>
+        (window as typeof window & { __REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__?: string })
+          .__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__
+    )
+  ).toBe("");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("private-note");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+  await page.getByRole("button", { name: "Edit" }).click();
+  await page.getByLabel("Card title").fill("Unsaved private edit");
+  await expect(page.getByText("Private selected note.")).toBeVisible();
+  await expect(page.locator("#cardList").getByText("Private support text.")).toBeVisible();
+
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+
+  await expect(page.locator("#connectPanel")).toBeVisible();
+  await expect(page.locator("#ownerView")).toBeHidden();
+  await expect(page.getByLabel("Bearer token")).toHaveValue("");
+  await expect(page.locator(".note-item")).toHaveCount(0);
+  await expect(page.locator(".support-card")).toHaveCount(0);
+  await expect(page.locator(".grant-card")).toHaveCount(0);
+  await expect(page.locator("#cardDialog")).toBeHidden();
+  await expect(page.getByLabel("Card title")).toHaveValue("");
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
 });
 
 test("a missing selected memory shows the specific not-found message", async ({ page }, testInfo) => {

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -134,6 +134,74 @@ test("the owner link disappears at its expiry time", async ({ page }, testInfo) 
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
 });
 
+test("a fast owner clock keeps a server-authorized share link visible", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner clock calibration.");
+  await page.addInitScript(() => {
+    const realNow = Date.now.bind(Date);
+    Date.now = () => realNow() + 24 * 60 * 60_000;
+  });
+  const serverNow = Date.now();
+  const card = {
+    cardId: "card-fast-owner-clock",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: new Date(serverNow).toISOString(),
+    reviewBy: new Date(serverNow + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const grant = {
+    grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+    stateVersion: 1,
+    cards: [{ cardId: card.cardId, revision: card.revision }],
+    createdAt: new Date(serverNow).toISOString(),
+    expiresAt: new Date(serverNow + 60 * 60_000).toISOString(),
+    status: "active",
+  };
+  let created = false;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { date: new Date(serverNow).toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({ cards: [card] }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() === "POST") {
+      created = true;
+      await route.fulfill({
+        status: 201,
+        headers: { date: new Date(serverNow).toUTCString() },
+        contentType: "application/json",
+        body: JSON.stringify({
+          grantId: grant.grantId,
+          secret: "s".repeat(43),
+          expiresAt: grant.expiresAt,
+          version: grant.stateVersion,
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { date: new Date(serverNow).toUTCString() },
+      contentType: "application/json",
+      body: JSON.stringify({ grants: created ? [grant] : [] }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+
+  await expect(page.getByText("Share link ready")).toBeVisible();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue(/#secret=/);
+});
+
 test("the owner note preview preserves API text and binds consent to its revision", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers note preview content.");
 
@@ -274,7 +342,7 @@ test("an owner page clears private state before browser-cache restoration", asyn
         (window as typeof window & { __REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__?: string })
           .__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__
     )
-  ).toBe("");
+  ).toBeUndefined();
   expect(
     await page
       .locator("script")
@@ -304,6 +372,83 @@ test("an owner page clears private state before browser-cache restoration", asyn
   await expect(page.locator("#customTimeField")).toBeHidden();
   await expect(page.locator("#customTimeInput")).toHaveValue("");
   await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+});
+
+test("a hidden owner write cannot add an error after reconnect", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner lifecycle isolation.");
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, {
+      __hiddenOwnerWriteAborted: false,
+      __releaseHiddenOwnerWrite: undefined,
+    });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/engram/v1/support-passport/drafts/generate") && init?.method === "POST") {
+        return await new Promise((_resolve, reject) => {
+          init.signal?.addEventListener(
+            "abort",
+            () => Object.assign(window, { __hiddenOwnerWriteAborted: true }),
+            { once: true }
+          );
+          Object.assign(window, {
+            __releaseHiddenOwnerWrite: () => reject(new Error("late hidden owner write failure")),
+          });
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/memories/note-hidden-owner", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        found: true,
+        memory: {
+          id: "note-hidden-owner",
+          content: "Tell me before plans change.",
+          revision: "b".repeat(64),
+        },
+      }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.getByLabel("Memory ID").fill("note-hidden-owner");
+  await page.getByRole("button", { name: "Add selected note" }).click();
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  await expect(page.getByRole("button", { name: "Drafting cards…" })).toBeDisabled();
+
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __hiddenOwnerWriteAborted?: boolean }).__hiddenOwnerWriteAborted
+      )
+    )
+    .toBe(true);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.evaluate(() => {
+    const release = (
+      window as typeof window & { __releaseHiddenOwnerWrite?: () => void }
+    ).__releaseHiddenOwnerWrite;
+    release?.();
+  });
+
+  await expect(page.locator("#generateError")).toHaveText("");
+  await expect(page.getByText("late hidden owner write failure")).toHaveCount(0);
+  await expect(page.locator("#ownerView")).toBeVisible();
 });
 
 test("a missing selected memory shows the specific not-found message", async ({ page }, testInfo) => {
@@ -475,7 +620,7 @@ test("a created share link remains visible when its list refresh fails", async (
   expect(grantInput).toEqual({
     cardIds: [card.cardId],
     cardRevisions: [{ cardId: card.cardId, revision: card.revision }],
-    expiresAt: expect.any(String),
+    durationMs: 2 * 60 * 60_000,
   });
   await expect(page.getByText("Share link ready")).toBeVisible();
   await expect(page.getByLabel("Copy this link once")).toHaveValue(
@@ -543,13 +688,25 @@ test("a new share attempt clears the prior link before a later failure", async (
     revision: "b".repeat(64),
   };
   let createCalls = 0;
+  const activeGrant = {
+    grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+    stateVersion: 1,
+    cards: [{ cardId: card.cardId, revision: card.revision }],
+    createdAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+    status: "active",
+  };
   const secondResponse = Promise.withResolvers<void>();
   await page.route("**/engram/v1/support-passport/cards", async (route) => {
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
   });
   await page.route("**/engram/v1/support-passport/grants", async (route) => {
     if (route.request().method() !== "POST") {
-      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ grants: createCalls > 0 ? [activeGrant] : [] }),
+      });
       return;
     }
     createCalls += 1;
@@ -558,9 +715,9 @@ test("a new share attempt clears the prior link before a later failure", async (
         status: 201,
         contentType: "application/json",
         body: JSON.stringify({
-          grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+          grantId: activeGrant.grantId,
           secret: "s".repeat(43),
-          expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+          expiresAt: activeGrant.expiresAt,
           version: 1,
         }),
       });
@@ -1900,6 +2057,55 @@ test("a restored helper view stays locked without its removed secret", async ({ 
   await expect(page.getByRole("heading", { name: "This helper session ended." })).toBeVisible();
   expect(reads).toBe(1);
   await expect(page.locator(".public-card")).toHaveCount(0);
+});
+
+test("a late helper load failure cannot replace the hidden-page lock", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers helper lifecycle isolation.");
+  await page.addInitScript(() => {
+    const realFetch = window.fetch.bind(window);
+    Object.assign(window, {
+      __hiddenHelperReadAborted: false,
+      __releaseHiddenHelperRead: undefined,
+    });
+    window.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("replay-grant-hidden-helper") && (init?.method ?? "GET") === "GET") {
+        return await new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => Object.assign(window, { __hiddenHelperReadAborted: true }),
+            { once: true }
+          );
+          Object.assign(window, {
+            __releaseHiddenHelperRead: () => reject(new Error("late hidden helper read failure")),
+          });
+        });
+      }
+      return await realFetch(input, init);
+    };
+  });
+
+  await page.goto(helperUrl("-hidden-helper").replace("mode=replay&", ""));
+  await expect(page.getByText("Opening the shared guide…")).toBeVisible();
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+  await expect(page.getByRole("heading", { name: "This helper session ended." })).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as typeof window & { __hiddenHelperReadAborted?: boolean }).__hiddenHelperReadAborted
+      )
+    )
+    .toBe(true);
+  await page.evaluate(() => {
+    const release = (
+      window as typeof window & { __releaseHiddenHelperRead?: () => void }
+    ).__releaseHiddenHelperRead;
+    release?.();
+  });
+
+  await expect(page.getByRole("heading", { name: "This helper session ended." })).toBeVisible();
+  await expect(page.getByText("Open the original share link again to view this support passport.")).toBeVisible();
+  await expect(page.getByText("late hidden helper read failure")).toHaveCount(0);
 });
 
 test("helper revalidation backs off after a rate limit", async ({ page }, testInfo) => {

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -546,6 +546,8 @@ test("an expired share confirms a timed-out stop request", async ({ page }, test
     status: "active",
   };
   let grantReads = 0;
+  const reconciliationStarted = Promise.withResolvers<void>();
+  const releaseReconciliation = Promise.withResolvers<void>();
   await page.clock.install({ time: now });
   await page.addInitScript(() => {
     const realFetch = window.fetch.bind(window);
@@ -568,6 +570,10 @@ test("an expired share confirms a timed-out stop request", async ({ page }, test
   });
   await page.route("**/engram/v1/support-passport/grants", async (route) => {
     grantReads += 1;
+    if (grantReads === 2) {
+      reconciliationStarted.resolve();
+      await releaseReconciliation.promise;
+    }
     const current = grantReads === 1 ? grant : { ...grant, status: "expired" };
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [current] }) });
   });
@@ -576,6 +582,9 @@ test("an expired share confirms a timed-out stop request", async ({ page }, test
   await page.getByRole("button", { name: "Open my guide" }).click();
   await page.getByRole("button", { name: "Stop sharing" }).click();
   await page.clock.fastForward(60_000);
+  await reconciliationStarted.promise;
+  await expect(page.getByRole("button", { name: "Stopping sharing…" })).toBeDisabled();
+  releaseReconciliation.resolve();
 
   await expect(page.locator("#toast")).toHaveText("Sharing stopped. The helper link is now locked.");
   await expect(page.getByText("Share time ended", { exact: true })).toBeVisible();

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -657,6 +657,68 @@ test("successful owner mutations stay successful when their list refresh fails",
   await expect(page.getByText("The share link did not stop.")).toHaveCount(0);
 });
 
+test("an older owner refresh cannot replace newer owner state", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner refresh ordering.");
+  const now = new Date();
+  const oldCard = {
+    cardId: "card-current",
+    title: "Old support state",
+    statement: "This response started first.",
+    category: "other",
+    status: "pending_review",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const newCard = {
+    ...oldCard,
+    title: "New support state",
+    statement: "This response started second.",
+    status: "active",
+    revision: "b".repeat(64),
+  };
+  let cardReads = 0;
+  const oldReadStarted = Promise.withResolvers<void>();
+  const releaseOldRead = Promise.withResolvers<void>();
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    cardReads += 1;
+    if (cardReads === 2) {
+      oldReadStarted.resolve();
+      await releaseOldRead.promise;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ cards: [oldCard] }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ cards: cardReads === 1 ? [oldCard] : [newCard] }),
+    });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+  });
+  await page.route("**/engram/v1/support-passport/cards/card-current/approve", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ card: newCard }) });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  const refresh = page.getByRole("button", { name: "Refresh cards and share links" });
+  await refresh.click();
+  await oldReadStarted.promise;
+  await page.getByRole("button", { name: "Approve" }).click();
+  await expect(page.getByRole("heading", { name: newCard.title })).toBeVisible();
+  releaseOldRead.resolve();
+  await expect(refresh).toBeEnabled();
+  await expect(page.getByRole("heading", { name: newCard.title })).toBeVisible();
+  await expect(page.getByRole("heading", { name: oldCard.title })).toHaveCount(0);
+});
+
 test("an expired share confirms a timed-out stop request", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers stop reconciliation.");
   const now = new Date("2026-08-11T12:00:00.000Z");

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -370,6 +370,60 @@ test("the owner cannot select more than eight cards for one share link", async (
   expect(createCalls).toBe(0);
 });
 
+test("two share submissions create one grant", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers duplicate share submission.");
+  const now = new Date();
+  const card = {
+    cardId: "card-approved",
+    title: "Quiet place",
+    statement: "Offer me a quiet place and time.",
+    category: "environment",
+    status: "active",
+    updatedAt: now.toISOString(),
+    reviewBy: new Date(now.getTime() + 24 * 60 * 60_000).toISOString(),
+    revision: "a".repeat(64),
+  };
+  const releaseGrant = Promise.withResolvers<void>();
+  let createCalls = 0;
+  await page.route("**/engram/v1/support-passport/cards", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
+  });
+  await page.route("**/engram/v1/support-passport/grants", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ grants: [] }) });
+      return;
+    }
+    createCalls += 1;
+    await releaseGrant.promise;
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        grantId: "3b998a98-d48d-4f5c-887c-617af9228847",
+        secret: "s".repeat(43),
+        expiresAt: new Date(now.getTime() + 2 * 60 * 60_000).toISOString(),
+        version: 1,
+      }),
+    });
+  });
+
+  await page.goto(`${origin}/remnic/ui/what-helps-me/`);
+  await page.getByLabel("Bearer token").fill("owner-token");
+  await page.getByRole("button", { name: "Open my guide" }).click();
+  await page.locator('input[name="shareCard"]').check();
+  await page.locator("#shareForm").evaluate((form) => {
+    for (let index = 0; index < 2; index += 1) {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    }
+  });
+
+  await expect.poll(() => createCalls).toBe(1);
+  await expect(page.getByRole("button", { name: "Creating link…" })).toBeDisabled();
+  releaseGrant.resolve();
+  await expect(page.getByRole("button", { name: "Create share link" })).toBeEnabled();
+  expect(createCalls).toBe(1);
+});
+
 test("a created share link remains visible when its list refresh fails", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner refresh recovery.");
   const now = new Date();

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -76,6 +76,8 @@ test("the owner reviews one card at a time and controls sharing", async ({ page 
   await expect(page.getByText("Synthetic replay")).toBeVisible();
   await expect(page.getByText("No support cards yet.")).toBeVisible();
   await expect(page.locator(".note-item")).toHaveCount(3);
+  await expect(page.getByLabel("Memory ID")).toHaveAttribute("maxlength", "512");
+  await expect(page.getByLabel("Memory ID")).not.toHaveAttribute("pattern");
   expect(await page.evaluate(() => ({ local: localStorage.length, session: sessionStorage.length }))).toEqual({
     local: 0,
     session: 0,
@@ -1902,11 +1904,9 @@ test("a bad helper link has a clear locked view", async ({ page }, testInfo) => 
   await page.screenshot({ path: testInfo.outputPath(`locked-${testInfo.project.name}.png`), fullPage: true });
 });
 
-test("a fragment helper suppresses owner prefill when the model bundle fails", async ({ page }, testInfo) => {
+test("a fragment helper clears secrets when both app bundles fail", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers bootstrap secret cleanup.");
   const ownerShell = await readFile(path.join(publicDir, "index.html"), "utf8");
-  const pageErrors: string[] = [];
-  page.on("pageerror", (error) => pageErrors.push(error.message));
   await page.route(`${origin}/remnic/ui/what-helps-me/`, async (route) => {
     await route.fulfill({
       status: 200,
@@ -1914,8 +1914,8 @@ test("a fragment helper suppresses owner prefill when the model bundle fails", a
       body: injectOwnerPrefill(ownerShell, "prefilled-owner-token"),
     });
   });
-  await page.route("**/what-helps-me/model.js", async (route) => {
-    await route.fulfill({ status: 404, contentType: "application/javascript", body: "" });
+  await page.route(/\/what-helps-me\/(?:model|app)\.js$/, async (route) => {
+    await route.abort();
   });
 
   await page.goto(`${origin}/remnic/ui/what-helps-me/#secret=${"s".repeat(43)}`);
@@ -1933,7 +1933,6 @@ test("a fragment helper suppresses owner prefill when the model bundle fails", a
       .locator("script")
       .evaluateAll((scripts) => scripts.some((script) => script.textContent?.includes("prefilled-owner-token")))
   ).toBe(false);
-  expect(pageErrors).toContain("What Helps Me model did not load.");
 });
 
 test("a manual owner token clears when the app bundles fail", async ({ page }, testInfo) => {

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -162,8 +162,16 @@ test("an owner page clears private state before browser-cache restoration", asyn
     expiresAt: new Date(now.getTime() + 60 * 60_000).toISOString(),
     status: "active",
   };
-  await page.addInitScript(() => {
-    Object.assign(window, { __REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__: "prefilled-owner-token" });
+  const ownerShell = await readFile(path.join(publicDir, "index.html"), "utf8");
+  await page.route(`${origin}/remnic/ui/what-helps-me/`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: ownerShell.replace(
+        "</head>",
+        '<script>window.__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__="prefilled-owner-token";</script></head>'
+      ),
+    });
   });
   await page.route("**/engram/v1/support-passport/cards", async (route) => {
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ cards: [card] }) });
@@ -191,6 +199,11 @@ test("an owner page clears private state before browser-cache restoration", asyn
           .__REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN__
     )
   ).toBe("");
+  expect(
+    await page
+      .locator("script")
+      .evaluateAll((scripts) => scripts.some((script) => script.textContent?.includes("prefilled-owner-token")))
+  ).toBe(false);
   await page.getByRole("button", { name: "Open my guide" }).click();
   await page.getByLabel("Memory ID").fill("private-note");
   await page.getByRole("button", { name: "Add selected note" }).click();
@@ -1555,6 +1568,7 @@ test("a stalled helper question aborts and restores its action", async ({ page }
   const button = page.getByRole("button", { name: "Ask from this guide" });
   await button.click();
   await expect(page.getByRole("button", { name: "Checking shared cards…" })).toBeDisabled();
+  await expect(page.getByLabel("Your question")).toBeDisabled();
   await page.clock.fastForward(60_000);
 
   await expect
@@ -1566,6 +1580,7 @@ test("a stalled helper question aborts and restores its action", async ({ page }
     .toBe(true);
   await expect(page.getByText("The question took too long. Try again.")).toBeVisible();
   await expect(button).toBeEnabled();
+  await expect(page.getByLabel("Your question")).toBeEnabled();
 });
 
 test("a live helper view locks after the owner revokes its grant", async ({ page }, testInfo) => {
@@ -1614,8 +1629,8 @@ test("a live helper view locks after the owner revokes its grant", async ({ page
   await expect(page.locator(".public-card")).toHaveCount(0);
 });
 
-test("a restored helper view immediately revalidates its grant", async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers browser-cache restoration.");
+test("a restored helper view stays locked without its removed secret", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers helper browser-cache cleanup.");
   const now = new Date();
   let revoked = false;
   let reads = 0;
@@ -1653,12 +1668,16 @@ test("a restored helper view immediately revalidates its grant", async ({ page }
 
   await page.goto(helperUrl("-restored").replace("mode=replay&", ""));
   await expect(page.locator(".public-card")).toHaveCount(1);
+  await page.getByLabel("Your question").fill("What should I do?");
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true })));
+  await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
+  await expect(page.locator(".public-card")).toHaveCount(0);
+  await expect(page.getByLabel("Your question")).toHaveValue("");
   revoked = true;
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true })));
 
   await expect(page.getByRole("heading", { name: "This support passport is locked." })).toBeVisible();
-  expect(reads).toBeGreaterThanOrEqual(2);
+  expect(reads).toBe(1);
   await expect(page.locator(".public-card")).toHaveCount(0);
 });
 

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -1586,6 +1586,20 @@ test("share links use the canonical path and keep preset duration independent fr
   });
 });
 
+test("replay share presets create a finite share link", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers replay expiry.");
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  await page.getByRole("button", { name: "Approve" }).first().click();
+  await page.locator('input[name="shareCard"]').first().check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+
+  await expect(page.locator("#toast")).toContainText(/Share link created\. It ends/);
+  await expect(page.locator("#shareLinkInput")).toHaveValue(/grant=/);
+  await expect(page.locator("#grantList")).not.toContainText("Invalid Date");
+});
+
 test("helper load, error, stale, stopped, and expired states fail closed", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers the state matrix.");
 

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -16,7 +16,6 @@ const assets = new Map<string, readonly [string, string]>([
 interface WhatHelpsMeBrowserModel {
   expiryForChoice(choice: string, customValue: string, nowMs: number): string;
   buildShareUrl(currentUrl: string, grantId: string, secret: string, legacyPath: boolean): string;
-  stripAttributesSuffix(content: string): string;
 }
 
 let server: Server;
@@ -94,7 +93,7 @@ test("the owner reviews one card at a time and controls sharing", async ({ page 
   await expect(page.getByText("Sharing stopped", { exact: true })).toBeVisible();
 });
 
-test("the owner note preview binds consent to the reviewed revision", async ({ page }, testInfo) => {
+test("the owner note preview preserves API text and binds consent to its revision", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== "chromium-375", "One viewport covers note preview content.");
 
   await page.route("**/engram/v1/support-passport/cards", async (route) => {
@@ -112,7 +111,7 @@ test("the owner note preview binds consent to the reviewed revision", async ({ p
         found: true,
         memory: {
           id: "note-with-attributes",
-          content: "Tell me before plans change.",
+          content: "Tell me before plans change.\n[Attributes: this is part of my note]",
           revision: "b".repeat(64),
         },
       }),
@@ -130,8 +129,7 @@ test("the owner note preview binds consent to the reviewed revision", async ({ p
   await page.getByLabel("Memory ID").fill("note-with-attributes");
   await page.getByRole("button", { name: "Add selected note" }).click();
 
-  await expect(page.getByText("Tell me before plans change.", { exact: true })).toBeVisible();
-  await expect(page.getByText(/\[Attributes:/)).toHaveCount(0);
+  await expect(page.getByText("Tell me before plans change. [Attributes: this is part of my note]", { exact: true })).toBeVisible();
   await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
   await page.getByRole("button", { name: "Draft my support cards" }).click();
   expect(generationInput).toEqual({
@@ -1287,7 +1285,6 @@ test("share links use the canonical path and reserve time for grant creation", a
         "secret-one",
         false
       ),
-      notePreview: model.stripAttributesSuffix("Tell me before plans change.\n[Attributes: support-passport: source]"),
     };
   });
 
@@ -1295,7 +1292,6 @@ test("share links use the canonical path and reserve time for grant creation", a
     boundaryError: "Choose a share time at least six minutes from now and no more than seven days away.",
     expiresAt: "2026-08-11T12:06:00.000Z",
     shareUrl: "https://example.test/remnic/ui/what-helps-me/?grant=grant-one#secret=secret-one",
-    notePreview: "Tell me before plans change.",
   });
 });
 

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -1561,13 +1561,13 @@ test("share links use the canonical path and keep preset duration independent fr
     const model = (window as typeof window & { WhatHelpsMeModel: WhatHelpsMeBrowserModel }).WhatHelpsMeModel;
     let boundaryError = "";
     try {
-      model.expiryForChoice("custom", new Date(now + 299_999).toISOString(), now);
+      model.expiryForChoice("custom", new Date(now + 359_999).toISOString(), now);
     } catch (error) {
       boundaryError = error instanceof Error ? error.message : "unknown error";
     }
     return {
       boundaryError,
-      customExpiry: model.expiryForChoice("custom", new Date(now + 300_000).toISOString(), now),
+      customExpiry: model.expiryForChoice("custom", new Date(now + 360_000).toISOString(), now),
       presetExpiry: model.expiryForChoice("30m", "", now + 60 * 60_000),
       shareUrl: model.buildShareUrl(
         "https://example.test/engram/ui/what-helps-me/?old=value#old=value",
@@ -1579,8 +1579,8 @@ test("share links use the canonical path and keep preset duration independent fr
   });
 
   expect(result).toEqual({
-    boundaryError: "Choose a share time at least five minutes from now and no more than seven days away.",
-    customExpiry: { expiresAt: "2026-08-11T12:05:00.000Z" },
+    boundaryError: "Choose a share time at least six minutes from now and no more than seven days away.",
+    customExpiry: { expiresAt: "2026-08-11T12:06:00.000Z" },
     presetExpiry: { durationMs: 1_800_000 },
     shareUrl: "https://example.test/remnic/ui/what-helps-me/?grant=grant-one#secret=secret-one",
   });

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -55,6 +55,16 @@ function helperUrl(suffix = "") {
   return `${origin}/remnic/ui/what-helps-me/?mode=replay&grant=replay-grant${suffix}#secret=${"s".repeat(43)}`;
 }
 
+async function createReplayShare(page: Page): Promise<void> {
+  await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
+  await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
+  await page.getByRole("button", { name: "Draft my support cards" }).click();
+  await page.getByRole("button", { name: "Approve" }).first().click();
+  await page.locator('input[name="shareCard"]').first().check();
+  await page.getByRole("button", { name: "Create share link" }).click();
+  await expect(page.getByText("Share link ready")).toBeVisible();
+}
+
 test("the owner reviews one card at a time and controls sharing", async ({ page }, testInfo) => {
   await page.goto(`${origin}/remnic/ui/what-helps-me/?mode=replay`);
 
@@ -91,6 +101,37 @@ test("the owner reviews one card at a time and controls sharing", async ({ page 
 
   await page.getByRole("button", { name: "Stop sharing" }).click();
   await expect(page.getByText("Sharing stopped", { exact: true })).toBeVisible();
+});
+
+test("the owner link disappears when sharing stops", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner link revocation.");
+  await createReplayShare(page);
+
+  await page.getByRole("button", { name: "Stop sharing" }).click();
+
+  await expect(page.getByText("Share link ready")).toBeHidden();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+});
+
+test("the owner link disappears when a shared card is withdrawn", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers stale owner links.");
+  await createReplayShare(page);
+
+  await page.getByRole("button", { name: "Withdraw" }).first().click();
+
+  await expect(page.getByText("Share link ready")).toBeHidden();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
+});
+
+test("the owner link disappears at its expiry time", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "chromium-375", "One viewport covers owner link expiry.");
+  await page.clock.install({ time: new Date("2026-08-13T12:00:00.000Z") });
+  await createReplayShare(page);
+
+  await page.clock.fastForward(2 * 60 * 60_000);
+
+  await expect(page.getByText("Share link ready")).toBeHidden();
+  await expect(page.getByLabel("Copy this link once")).toHaveValue("");
 });
 
 test("the owner note preview preserves API text and binds consent to its revision", async ({ page }, testInfo) => {

--- a/tests/support-passport-ui.spec.ts
+++ b/tests/support-passport-ui.spec.ts
@@ -1125,6 +1125,10 @@ test("a stalled model draft shows uncertain state without claiming another draft
   await page.getByLabel("Send these selected notes to my configured model to draft my cards.").check();
   await page.getByRole("button", { name: "Draft my support cards" }).click();
   await expect(page.getByRole("button", { name: "Drafting cards…" })).toBeDisabled();
+  await expect(page.getByLabel("Memory ID")).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Add selected note" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Remove selected note note-one" })).toBeDisabled();
+  await expect(page.getByLabel("Send these selected notes to my configured model to draft my cards.")).toBeDisabled();
   await page.clock.fastForward(15 * 60_000);
   await expect
     .poll(() =>
@@ -1143,6 +1147,9 @@ test("a stalled model draft shows uncertain state without claiming another draft
   await expect(
     page.getByLabel("Send these selected notes to my configured model to draft my cards.")
   ).not.toBeChecked();
+  await expect(page.getByLabel("Memory ID")).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Add selected note" })).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Remove selected note note-one" })).toBeEnabled();
   expect(await page.evaluate(() => (window as typeof window & { __ownerModelCalls?: number }).__ownerModelCalls)).toBe(
     1
   );


### PR DESCRIPTION
## Summary

Add the What Helps Me owner and helper interface.

Owners review cards, approve exact text, choose what to share, and revoke links. Helpers see only selected cards.

The UI reports timed-out writes as uncertain. It never guesses a draft or revokes an unrelated share.

## Validation

- [x] 44 browser flows pass across four widths.
- [x] Accessibility, reduced-motion, cancellation, timeout, stale-link, and revocation cases pass.
- [x] `npm run preflight:quick`

## Stack

This is layer 6 of 7. It depends on https://github.com/joshuaswarren/remnic/pull/2375.

Part of #2355.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user-facing surface for consent, sharing, and helper Q&A on sensitive support data, with meaningful auth and caching changes on the HTTP path; mitigated by feature flag, strict static allow-list, and explicit secret/token handling.
> 
> **Overview**
> Introduces the **What Helps Me** support passport as a static app under `admin-console/public/what-helps-me/` (HTML, CSS, `model.js`, `app.js`). Owners connect with a bearer token, pick memory notes, consent to model drafting, review/approve cards, and create time-bounded share links; helpers open `?grant=` URLs with the secret in the **hash fragment**, read pinned card versions, and ask grounded questions. A **`mode=replay`** path uses an in-browser fake API for demos and tests.
> 
> The access HTTP layer now serves the UI at **`/remnic/ui/what-helps-me/`** and **`/engram/ui/what-helps-me/`** when `supportPassport.enabled` is on, independent of the main admin console. Only an allow-listed set of static files is exposed; helper grant URLs skip owner token prefill, and admin prefill is limited to the **primary** bearer token (not scoped capability tokens). Owner support-passport API responses gain **`Cache-Control: private, no-store`**. Assets are copied into **`remnic-core` dist** on build; release artifact checks and plugin schema text mention browser assets.
> 
> **`npm run test:support-passport-ui`** runs Playwright flows (multiple viewports) with Axe serious/critical checks. Docs and the threat model describe fragment-based secrets, in-memory-only credentials, and the owner/helper flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52330a7d6d319f5bd11f3bfd04541cbbb84a71e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->