### PR TITLE
fix(openclaw): close the delegate flush-plan append race

### DIFF
--- a/.changeset/delegate-flush-plan-append-race.md
+++ b/.changeset/delegate-flush-plan-append-race.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Close the delegate flush-plan append race and tell a body-limit rejection apart from a refused credential.

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -9,7 +9,7 @@
  * are read by nobody.
  */
 
-import { lstat, readFile, writeFile } from "node:fs/promises";
+import { lstat, readFile, rename, unlink, writeFile } from "node:fs/promises";
 
 /**
  * Bytes per observe request. Comfortably under the daemon's default
@@ -24,7 +24,7 @@ import { log } from "@remnic/core/logger";
 
 import type { DelegateDaemonTarget } from "./bridge.js";
 import { buildMemoryFlushPlan } from "./memory-flush-plan.js";
-import { postJson } from "./delegate-runtime.js";
+import { postJsonWithStatus } from "./delegate-http.js";
 
 export async function ingestFlushPlanNotes(options: {
   target: DelegateDaemonTarget;
@@ -50,53 +50,171 @@ export async function ingestFlushPlanNotes(options: {
     );
     return;
   }
-  let pending = await readPlan(planPath);
-  if (pending === undefined || pending.trim().length === 0) return;
 
-  // Chunks start large and HALVE on rejection. The daemon's `maxBodyBytes` is
-  // configurable to any positive integer and is not reported anywhere this
-  // client can read, so guessing a fixed ceiling would deadlock every daemon
-  // configured below it — the very failure chunking was added to end. Adapting
-  // needs no new daemon surface and converges in a few requests.
+  // Claim the notes by RENAME before posting anything (issue #2303). Rename is
+  // atomic, so every host append after it lands in a freshly created plan file
+  // and cannot be truncated away by our commit. The alternative — re-reading
+  // the shared file and rewriting it minus the accepted prefix — loses any
+  // append that arrives inside that read/write window.
+  const inflightPath = `${planPath}.inflight`;
+  // Chunks start large and HALVE on a body-limit rejection. The daemon's
+  // `maxBodyBytes` is configurable to any positive integer and is not reported
+  // anywhere this client can read, so guessing a fixed ceiling would deadlock
+  // every daemon configured below it — the very failure chunking was added to
+  // end. Adapting needs no new daemon surface and converges in a few requests.
   let chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
-  while (pending.trim().length > 0) {
-    const timeoutMs = options.remainingTimeoutMs();
-    if (timeoutMs <= 0) {
-      log.warn(
-        `[${options.serviceId}] flush-plan ingestion stopped: the caller's deadline is spent; the remainder drains on the next flush`,
-      );
+  // Re-claim after each drained snapshot so notes the host appended WHILE we
+  // were posting still leave in this flush. Every pass needs budget and needs
+  // the host to have written something new, so this terminates.
+  for (;;) {
+    if (options.remainingTimeoutMs() <= 0) return;
+    const claimed = await claimPendingNotes(planPath, inflightPath, options.serviceId);
+    if (claimed === undefined || claimed.trim().length === 0) {
+      await discardInflight(inflightPath);
       return;
     }
-    const [chunk] = chunkOnLineBoundaries(pending, chunkBytes);
-    if (chunk === undefined) return;
-    const accepted = await postJson(
-      options.target,
-      options.serviceId,
-      "/engram/v1/observe",
-      {
-        sessionKey: options.sessionKey,
-        messages: [{ role: "user", content: chunk }],
-        ...(options.namespace === undefined ? {} : { namespace: options.namespace }),
-      },
-      timeoutMs,
-    );
-    if (accepted === null) {
-      // Too large, or the credential is not accepted — indistinguishable from
-      // here. Halve and retry until a single line is all that is left; below
-      // that the daemon is refusing the content itself, not its size.
-      if (chunkBytes > MIN_OBSERVE_CHUNK_BYTES && chunkOnLineBoundaries(pending, chunkBytes).length > 1) {
-        chunkBytes = Math.max(MIN_OBSERVE_CHUNK_BYTES, Math.floor(chunkBytes / 2));
-        continue;
+    let pending = claimed;
+    let stop = false;
+    try {
+      while (pending.trim().length > 0) {
+        const timeoutMs = options.remainingTimeoutMs();
+        if (timeoutMs <= 0) {
+          log.warn(
+            `[${options.serviceId}] flush-plan ingestion stopped: the caller's deadline is spent; the remainder drains on the next flush`,
+          );
+          stop = true;
+          return;
+        }
+        const [chunk] = chunkOnLineBoundaries(pending, chunkBytes);
+        if (chunk === undefined) {
+          stop = true;
+          return;
+        }
+        const response = await postJsonWithStatus(
+          options.target,
+          options.serviceId,
+          "/engram/v1/observe",
+          {
+            sessionKey: options.sessionKey,
+            messages: [{ role: "user", content: chunk }],
+            ...(options.namespace === undefined ? {} : { namespace: options.namespace }),
+          },
+          timeoutMs,
+        );
+        if (response.status === 401 || response.status === 403) {
+          // Halving cannot fix a refused credential. Stopping here also stops
+          // the pointless retry ladder the old collapsed-to-null contract ran.
+          log.warn(
+            `[${options.serviceId}] flush-plan notes were refused by the daemon (${response.status}); keeping them for the next flush`,
+          );
+          stop = true;
+          return;
+        }
+        if (isBodyTooLarge(response.status)) {
+          // Halve whenever a smaller ceiling is still available. Requiring
+          // the CURRENT ceiling to already split the text was wrong: a
+          // 40 KiB plan under a 96 KiB ceiling is one chunk, so a daemon
+          // configured below 40 KiB rejected it forever — the deadlock
+          // chunking exists to end.
+          if (chunkBytes > MIN_OBSERVE_CHUNK_BYTES) {
+            chunkBytes = Math.max(MIN_OBSERVE_CHUNK_BYTES, Math.floor(chunkBytes / 2));
+            continue;
+          }
+          log.warn(
+            `[${options.serviceId}] a flush-plan note exceeds the daemon's body limit even at the minimum chunk size; keeping the remainder for the next flush`,
+          );
+          stop = true;
+          return;
+        }
+        if (response.status < 200 || response.status > 299) {
+          stop = true;
+          throw new Error(`daemon /engram/v1/observe responded ${response.status}`);
+        }
+        // Committed IMMEDIATELY, so a later chunk that throws cannot resend
+        // what the daemon already took. The inflight file has no other writer,
+        // so this rewrite cannot lose a concurrent append.
+        pending = pending.slice(chunk.length);
+        await writeFile(inflightPath, pending, "utf8");
       }
-      log.warn(
-        `[${options.serviceId}] flush-plan notes were rejected by the daemon; keeping the remainder for the next flush`,
-      );
+    } finally {
+      // Whatever is left goes back in FRONT of any note appended while we were
+      // posting, so the daemon still receives them in the order written.
+      await releasePendingNotes(planPath, inflightPath, pending, options.serviceId);
+    }
+    if (stop) return;
+  }
+}
+
+/** HTTP statuses that mean "the request body was too big for this daemon". */
+function isBodyTooLarge(status: number): boolean {
+  return status === 413 || status === 431;
+}
+
+/**
+ * Take ownership of the plan file's contents.
+ *
+ * Recovers an inflight snapshot left by a crashed run first, so its notes are
+ * never stranded, then renames the live plan aside. Returns everything now
+ * owned by this run, oldest note first.
+ */
+async function claimPendingNotes(
+  planPath: string,
+  inflightPath: string,
+  serviceId: string,
+): Promise<string | undefined> {
+  const orphaned = (await readPlan(inflightPath)) ?? "";
+  if (orphaned.length > 0) {
+    log.warn(
+      `[${serviceId}] recovering flush-plan notes left by an interrupted ingestion`,
+    );
+  }
+  try {
+    await rename(planPath, `${inflightPath}.rotating`);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
+    return orphaned.length > 0 ? orphaned : undefined;
+  }
+  const rotated = (await readPlan(`${inflightPath}.rotating`)) ?? "";
+  await discardInflight(`${inflightPath}.rotating`);
+  const pending = `${orphaned}${rotated}`;
+  if (pending.length === 0) return undefined;
+  await writeFile(inflightPath, pending, "utf8");
+  return pending;
+}
+
+/**
+ * Put unsent notes back at the head of the plan file and drop the snapshot.
+ *
+ * A failure here must not mask the error that ended the run, so it only warns:
+ * the inflight file survives and the next run recovers from it.
+ */
+async function releasePendingNotes(
+  planPath: string,
+  inflightPath: string,
+  pending: string,
+  serviceId: string,
+): Promise<void> {
+  try {
+    if (pending.length === 0) {
+      await discardInflight(inflightPath);
       return;
     }
-    // Committed IMMEDIATELY, so a later chunk that throws cannot resend what
-    // the daemon already took. Re-reads the file each time, so notes appended
-    // by another session in the meantime survive.
-    pending = (await commitAcceptedPrefix(planPath, chunk)) ?? "";
+    const appended = (await readPlan(planPath)) ?? "";
+    await writeFile(planPath, `${pending}${appended}`, "utf8");
+    await discardInflight(inflightPath);
+  } catch (err) {
+    log.warn(
+      `[${serviceId}] could not restore unsent flush-plan notes; the next ingestion recovers them: ${String(err)}`,
+    );
+  }
+}
+
+/** Remove a snapshot file, tolerating one that is already gone. */
+async function discardInflight(inflightPath: string): Promise<void> {
+  try {
+    await unlink(inflightPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
   }
 }
 
@@ -108,23 +226,6 @@ async function readPlan(planPath: string): Promise<string | undefined> {
     // No plan file yet is the ordinary case, not a failure.
     return undefined;
   }
-}
-
-/**
- * Remove `accepted` from the front of the plan file and return what is left.
- *
- * Only the accepted prefix: another session may have appended between the read
- * and now, and blanking the file would discard notes that were never sent.
- */
-async function commitAcceptedPrefix(
-  planPath: string,
-  accepted: string,
-): Promise<string | undefined> {
-  const current = await readPlan(planPath);
-  if (current === undefined) return undefined;
-  const remainder = current.startsWith(accepted) ? current.slice(accepted.length) : current;
-  await writeFile(planPath, remainder, "utf8");
-  return current.startsWith(accepted) ? remainder : undefined;
 }
 
 /**

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -7,9 +7,31 @@
  * delegate mode returns before any of that wiring, and the daemon cannot see a
  * gateway-local file — so without this the notes the host was told to write
  * are read by nobody.
+ *
+ * Durability model (issue #2303). Notes are CLAIMED by rename, not by
+ * read-then-truncate, so a host append can never be overwritten by our commit.
+ * Three invariants hold the claim together:
+ *
+ *  1. One writer. The whole ingestion runs under the cross-process flush-plan
+ *     lock, so a second flush cannot mistake this run's snapshot for crash
+ *     residue. A contended flush declines and leaves the notes in place.
+ *  2. Content is never unlinked before it is durably somewhere else. The
+ *     rotate target is merged into the snapshot with a temp-then-rename write,
+ *     and only then removed, so no crash window has the notes in RAM alone.
+ *  3. Recovery is part of the claim. A `.rotating` or `.inflight` file found
+ *     while holding the lock is residue from a dead run and is merged ahead of
+ *     the newly claimed notes, preserving write order.
  */
 
-import { lstat, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { appendFile, lstat, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { log } from "@remnic/core/logger";
+import { withHeldFileLock } from "@remnic/core/utils/serialize-mutations";
+
+import type { DelegateDaemonTarget } from "./bridge.js";
+import { buildMemoryFlushPlan } from "./memory-flush-plan.js";
+import { postJsonWithStatus } from "./delegate-http.js";
 
 /**
  * Bytes per observe request. Comfortably under the daemon's default
@@ -18,13 +40,17 @@ import { lstat, readFile, rename, unlink, writeFile } from "node:fs/promises";
 const MAX_OBSERVE_CHUNK_BYTES = 96 * 1024;
 /** The floor the adaptive halving stops at — below this a single note. */
 const MIN_OBSERVE_CHUNK_BYTES = 4 * 1024;
-import path from "node:path";
+/** Bounded wait for the flush-plan lock; a contended flush declines instead. */
+const LOCK_MAX_WAIT_MS = 5_000;
+const LOCK_STALE_MS = 60_000;
 
-import { log } from "@remnic/core/logger";
-
-import type { DelegateDaemonTarget } from "./bridge.js";
-import { buildMemoryFlushPlan } from "./memory-flush-plan.js";
-import { postJsonWithStatus } from "./delegate-http.js";
+interface SnapshotPaths {
+  plan: string;
+  inflight: string;
+  rotating: string;
+  oversized: string;
+  lock: string;
+}
 
 export async function ingestFlushPlanNotes(options: {
   target: DelegateDaemonTarget;
@@ -40,23 +66,55 @@ export async function ingestFlushPlanNotes(options: {
     options.workspaceDir,
     ...buildMemoryFlushPlan({ serviceId: options.serviceId }).relativePath.split("/"),
   );
+  const paths: SnapshotPaths = {
+    plan: planPath,
+    inflight: `${planPath}.inflight`,
+    rotating: `${planPath}.rotating`,
+    oversized: `${planPath}.oversized`,
+    lock: `${planPath}.lock`,
+  };
   // The embedded processor refuses a symlinked plan file or parent, and so must
   // this one: following a link would send another file's contents to the daemon
-  // and then truncate that file. `lstat` on the ROOT and every segment below
-  // it, never `realpath`, so a link cannot be resolved away before the check.
-  if (!(await isLinkFreeUnder(options.workspaceDir, planPath))) {
+  // and then truncate that file. EVERY path this module reads or writes is
+  // checked, not just the plan — a `flush-plan.md.inflight` symlink planted in
+  // the state directory is the same attack one filename over. `lstat` on the
+  // ROOT and every segment below it, never `realpath`, so a link cannot be
+  // resolved away before the check.
+  for (const candidate of [paths.plan, paths.inflight, paths.rotating, paths.oversized]) {
+    if (await isLinkFreeUnder(options.workspaceDir, candidate)) continue;
     log.warn(
-      `[${options.serviceId}] flush-plan ingestion skipped: ${planPath}, a parent, or the workspace root is a symlink`,
+      `[${options.serviceId}] flush-plan ingestion skipped: ${candidate}, a parent, or the workspace root is a symlink`,
     );
     return;
   }
 
-  // Claim the notes by RENAME before posting anything (issue #2303). Rename is
-  // atomic, so every host append after it lands in a freshly created plan file
-  // and cannot be truncated away by our commit. The alternative — re-reading
-  // the shared file and rewriting it minus the accepted prefix — loses any
-  // append that arrives inside that read/write window.
-  const inflightPath = `${planPath}.inflight`;
+  await withHeldFileLock(
+    paths.lock,
+    { staleMs: LOCK_STALE_MS, maxWaitMs: LOCK_MAX_WAIT_MS },
+    async (acquired) => {
+      if (!acquired) {
+        // Another flush owns the snapshot. Declining is correct: the notes stay
+        // in the plan file and the other run — or the next flush — sends them.
+        log.warn(
+          `[${options.serviceId}] flush-plan ingestion skipped: another flush holds the lock; the notes drain on the next flush`,
+        );
+        return;
+      }
+      await ingestUnderLock(options, paths);
+    },
+  );
+}
+
+async function ingestUnderLock(
+  options: {
+    target: DelegateDaemonTarget;
+    serviceId: string;
+    sessionKey: string;
+    namespace: string | undefined;
+    remainingTimeoutMs: () => number;
+  },
+  paths: SnapshotPaths,
+): Promise<void> {
   // Chunks start large and HALVE on a body-limit rejection. The daemon's
   // `maxBodyBytes` is configurable to any positive integer and is not reported
   // anywhere this client can read, so guessing a fixed ceiling would deadlock
@@ -68,9 +126,9 @@ export async function ingestFlushPlanNotes(options: {
   // the host to have written something new, so this terminates.
   for (;;) {
     if (options.remainingTimeoutMs() <= 0) return;
-    const claimed = await claimPendingNotes(planPath, inflightPath, options.serviceId);
-    if (claimed === undefined || claimed.trim().length === 0) {
-      await discardInflight(inflightPath);
+    const claimed = await claimPendingNotes(paths, options.serviceId);
+    if (claimed.trim().length === 0) {
+      await discard(paths.inflight);
       return;
     }
     let pending = claimed;
@@ -101,107 +159,129 @@ export async function ingestFlushPlanNotes(options: {
           },
           timeoutMs,
         );
-        if (response.status === 401 || response.status === 403) {
-          // Halving cannot fix a refused credential. Stopping here also stops
-          // the pointless retry ladder the old collapsed-to-null contract ran.
+        if (isRefusal(response.status)) {
+          // Halving cannot fix a refused credential, and 431 is an oversized
+          // HEADER — neither shrinks by sending a smaller body. Stopping here
+          // also ends the pointless retry ladder the old collapsed-to-null
+          // contract ran on every auth failure.
           log.warn(
             `[${options.serviceId}] flush-plan notes were refused by the daemon (${response.status}); keeping them for the next flush`,
           );
           stop = true;
           return;
         }
-        if (isBodyTooLarge(response.status)) {
-          // Halve whenever a smaller ceiling is still available. Requiring
-          // the CURRENT ceiling to already split the text was wrong: a
-          // 40 KiB plan under a 96 KiB ceiling is one chunk, so a daemon
-          // configured below 40 KiB rejected it forever — the deadlock
-          // chunking exists to end.
+        if (response.status === 413) {
+          // Halve whenever a smaller ceiling is still available. Requiring the
+          // CURRENT ceiling to already split the text was wrong: a 40 KiB plan
+          // under a 96 KiB ceiling is one chunk, so a daemon configured below
+          // 40 KiB rejected it forever.
           if (chunkBytes > MIN_OBSERVE_CHUNK_BYTES) {
             chunkBytes = Math.max(MIN_OBSERVE_CHUNK_BYTES, Math.floor(chunkBytes / 2));
             continue;
           }
-          log.warn(
-            `[${options.serviceId}] a flush-plan note exceeds the daemon's body limit even at the minimum chunk size; keeping the remainder for the next flush`,
-          );
-          stop = true;
-          return;
+          // At the floor the chunk is one line the daemon will never take.
+          // Keeping it would block every note behind it on every future flush,
+          // so it is set aside in a sidecar the operator can inspect and the
+          // queue keeps draining. Nothing is deleted.
+          pending = await quarantineOversizedLine(paths, pending, options.serviceId);
+          chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
+          await atomicWrite(paths.inflight, pending);
+          continue;
         }
         if (response.status < 200 || response.status > 299) {
           stop = true;
           throw new Error(`daemon /engram/v1/observe responded ${response.status}`);
         }
         // Committed IMMEDIATELY, so a later chunk that throws cannot resend
-        // what the daemon already took. The inflight file has no other writer,
-        // so this rewrite cannot lose a concurrent append.
+        // what the daemon already took. The snapshot has no other writer while
+        // the lock is held, so this rewrite cannot lose a concurrent append.
         pending = pending.slice(chunk.length);
-        await writeFile(inflightPath, pending, "utf8");
+        await atomicWrite(paths.inflight, pending);
       }
     } finally {
       // Whatever is left goes back in FRONT of any note appended while we were
       // posting, so the daemon still receives them in the order written.
-      await releasePendingNotes(planPath, inflightPath, pending, options.serviceId);
+      await releasePendingNotes(paths, pending, options.serviceId);
     }
     if (stop) return;
   }
 }
 
-/** HTTP statuses that mean "the request body was too big for this daemon". */
-function isBodyTooLarge(status: number): boolean {
-  return status === 413 || status === 431;
+/** Statuses that mean "resend later", never "resend smaller". */
+function isRefusal(status: number): boolean {
+  // 431 is an oversized request HEADER, not body: `access-http` answers 413 for
+  // a body over `maxBodyBytes`, so only 413 is worth halving for.
+  return status === 401 || status === 403 || status === 431;
 }
 
 /**
- * Take ownership of the plan file's contents.
+ * Take ownership of the plan file's contents, oldest note first.
  *
- * Recovers an inflight snapshot left by a crashed run first, so its notes are
- * never stranded, then renames the live plan aside. Returns everything now
- * owned by this run, oldest note first.
+ * Runs under the lock, so any `.rotating` or `.inflight` found here is residue
+ * from a run that died and is merged ahead of the newly claimed notes. The
+ * merge is written with temp-then-rename BEFORE the source is unlinked, so no
+ * crash window leaves the notes only in memory.
  */
-async function claimPendingNotes(
-  planPath: string,
-  inflightPath: string,
-  serviceId: string,
-): Promise<string | undefined> {
-  const orphaned = (await readPlan(inflightPath)) ?? "";
-  if (orphaned.length > 0) {
-    log.warn(
-      `[${serviceId}] recovering flush-plan notes left by an interrupted ingestion`,
-    );
+async function claimPendingNotes(paths: SnapshotPaths, serviceId: string): Promise<string> {
+  // 1. Fold any stranded rotate target into the snapshot first. A previous run
+  //    that died between its rename and its merge left the notes only there.
+  if (await mergeRotatedIntoInflight(paths)) {
+    log.warn(`[${serviceId}] recovered flush-plan notes left by an interrupted ingestion`);
   }
+  // 2. Claim the live plan file. Rename is atomic, so a host append either
+  //    lands before it (claimed) or creates a fresh plan file (untouched).
   try {
-    await rename(planPath, `${inflightPath}.rotating`);
+    await rename(paths.plan, paths.rotating);
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
-    return orphaned.length > 0 ? orphaned : undefined;
+    return (await readIfPresent(paths.inflight)) ?? "";
   }
-  const rotated = (await readPlan(`${inflightPath}.rotating`)) ?? "";
-  await discardInflight(`${inflightPath}.rotating`);
-  const pending = `${orphaned}${rotated}`;
-  if (pending.length === 0) return undefined;
-  await writeFile(inflightPath, pending, "utf8");
-  return pending;
+  await mergeRotatedIntoInflight(paths);
+  return (await readIfPresent(paths.inflight)) ?? "";
+}
+
+/**
+ * Append `.rotating` to `.inflight` and remove it. Returns true when there was
+ * something to recover. Safe to call when neither file exists.
+ */
+async function mergeRotatedIntoInflight(paths: SnapshotPaths): Promise<boolean> {
+  const rotated = await readIfPresent(paths.rotating);
+  if (rotated === undefined) return false;
+  const existing = (await readIfPresent(paths.inflight)) ?? "";
+  const merged = `${existing}${rotated}`;
+  if (merged.length > 0) {
+    await atomicWrite(paths.inflight, merged);
+  }
+  // Only now: the content is durable under `.inflight`.
+  await discard(paths.rotating);
+  return existing.length > 0 || rotated.length > 0;
 }
 
 /**
  * Put unsent notes back at the head of the plan file and drop the snapshot.
  *
+ * The plan is replaced with one atomic rename, so a reader never sees a torn
+ * file. A host append landing between the read and the rename is still lost —
+ * that window is inherent to reordering a file another process only appends
+ * to, and it is now a single syscall pair rather than the duration of an HTTP
+ * round trip.
+ *
  * A failure here must not mask the error that ended the run, so it only warns:
- * the inflight file survives and the next run recovers from it.
+ * the snapshot survives and the next run recovers from it.
  */
 async function releasePendingNotes(
-  planPath: string,
-  inflightPath: string,
+  paths: SnapshotPaths,
   pending: string,
   serviceId: string,
 ): Promise<void> {
   try {
     if (pending.length === 0) {
-      await discardInflight(inflightPath);
+      await discard(paths.inflight);
       return;
     }
-    const appended = (await readPlan(planPath)) ?? "";
-    await writeFile(planPath, `${pending}${appended}`, "utf8");
-    await discardInflight(inflightPath);
+    const appended = (await readIfPresent(paths.plan)) ?? "";
+    await atomicWrite(paths.plan, `${pending}${appended}`);
+    await discard(paths.inflight);
   } catch (err) {
     log.warn(
       `[${serviceId}] could not restore unsent flush-plan notes; the next ingestion recovers them: ${String(err)}`,
@@ -209,22 +289,59 @@ async function releasePendingNotes(
   }
 }
 
-/** Remove a snapshot file, tolerating one that is already gone. */
-async function discardInflight(inflightPath: string): Promise<void> {
+/**
+ * Move the leading line — one the daemon refuses even at the minimum chunk
+ * size — into the oversized sidecar and return what is left.
+ *
+ * The line is appended to the sidecar BEFORE it leaves `pending`, so a crash
+ * in between duplicates a note rather than losing one.
+ */
+async function quarantineOversizedLine(
+  paths: SnapshotPaths,
+  pending: string,
+  serviceId: string,
+): Promise<string> {
+  const breakAt = pending.indexOf("\n");
+  const line = breakAt === -1 ? pending : pending.slice(0, breakAt + 1);
+  const rest = breakAt === -1 ? "" : pending.slice(breakAt + 1);
+  await appendFile(paths.oversized, line.endsWith("\n") ? line : `${line}\n`, "utf8");
+  log.warn(
+    `[${serviceId}] a flush-plan note exceeds the daemon's body limit; moved it to ${paths.oversized} so the remaining notes can drain`,
+  );
+  return rest;
+}
+
+/** File contents, or `undefined` when the file does not exist. */
+async function readIfPresent(filePath: string): Promise<string | undefined> {
   try {
-    await unlink(inflightPath);
+    return await readFile(filePath, "utf8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
+    throw err;
   }
 }
 
-/** The plan file's contents, or `undefined` when it does not exist. */
-async function readPlan(planPath: string): Promise<string | undefined> {
+/**
+ * Replace `filePath` in one step: write a fresh temp file, then rename over
+ * the target. `wx` refuses an existing temp, so two writers never share one.
+ */
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+  const tempPath = `${filePath}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
   try {
-    return await readFile(planPath, "utf8");
-  } catch {
-    // No plan file yet is the ordinary case, not a failure.
-    return undefined;
+    await writeFile(tempPath, content, { encoding: "utf8", flag: "wx" });
+    await rename(tempPath, filePath);
+  } catch (err) {
+    await discard(tempPath);
+    throw err;
+  }
+}
+
+/** Remove a file, tolerating one that is already gone. */
+async function discard(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
   }
 }
 
@@ -232,8 +349,8 @@ async function readPlan(planPath: string): Promise<string | undefined> {
  * Split on line boundaries, each piece under `limit` BYTES.
  *
  * Line-aligned so a note is never cut mid-sentence. A single line longer than
- * the limit is emitted whole rather than mangled — it would be rejected, and
- * the caller keeps it, which is the honest outcome for a note that cannot fit.
+ * the limit is emitted whole rather than mangled — the caller quarantines it
+ * once the daemon proves it will never accept it.
  */
 function chunkOnLineBoundaries(text: string, limit: number): string[] {
   if (Buffer.byteLength(text, "utf8") <= limit) return [text];

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -23,7 +23,8 @@
  *     the newly claimed notes, preserving write order.
  */
 
-import { appendFile, lstat, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, open, rename, unlink, writeFile, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import { log } from "@remnic/core/logger";
@@ -62,8 +63,9 @@ export async function ingestFlushPlanNotes(options: {
   remainingTimeoutMs: () => number;
 }): Promise<void> {
   if (options.workspaceDir === undefined) return;
+  const workspaceDir = options.workspaceDir;
   const planPath = path.join(
-    options.workspaceDir,
+    workspaceDir,
     ...buildMemoryFlushPlan({ serviceId: options.serviceId }).relativePath.split("/"),
   );
   const paths: SnapshotPaths = {
@@ -81,7 +83,7 @@ export async function ingestFlushPlanNotes(options: {
   // ROOT and every segment below it, never `realpath`, so a link cannot be
   // resolved away before the check.
   for (const candidate of [paths.plan, paths.inflight, paths.rotating, paths.oversized]) {
-    if (await isLinkFreeUnder(options.workspaceDir, candidate)) continue;
+    if (await isLinkFreeUnder(workspaceDir, candidate)) continue;
     log.warn(
       `[${options.serviceId}] flush-plan ingestion skipped: ${candidate}, a parent, or the workspace root is a symlink`,
     );
@@ -97,6 +99,18 @@ export async function ingestFlushPlanNotes(options: {
         // in the plan file and the other run — or the next flush — sends them.
         log.warn(
           `[${options.serviceId}] flush-plan ingestion skipped: another flush holds the lock; the notes drain on the next flush`,
+        );
+        return;
+      }
+      // Re-validate INSIDE the lock: the one-time check above ran before the
+      // lock wait, and a writable workspace lets an attacker swap a checked
+      // path for a symlink during that window. Every read and write below
+      // also opens with O_NOFOLLOW, so the final component cannot be swapped
+      // after this check either.
+      for (const candidate of [paths.plan, paths.inflight, paths.rotating, paths.oversized]) {
+        if (await isLinkFreeUnder(workspaceDir, candidate)) continue;
+        log.warn(
+          `[${options.serviceId}] flush-plan ingestion skipped: ${candidate}, a parent, or the workspace root became a symlink`,
         );
         return;
       }
@@ -134,6 +148,7 @@ async function ingestUnderLock(
     }
     let pending = claimed;
     let stop = false;
+    let lockLost = false;
     try {
       while (pending.trim().length > 0) {
         const timeoutMs = options.remainingTimeoutMs();
@@ -185,6 +200,14 @@ async function ingestUnderLock(
           // note behind it on every future flush, so it is set aside in a
           // sidecar the operator can inspect and the queue keeps draining.
           // Nothing is deleted.
+          if (!(await lock.refresh())) {
+            log.warn(
+              `[${options.serviceId}] flush-plan lock was lost mid-flush; the snapshot is left to its new owner`,
+            );
+            lockLost = true;
+            stop = true;
+            return;
+          }
           pending = await quarantineOversizedLine(paths, pending, options.serviceId);
           chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
           await atomicWrite(paths.inflight, pending);
@@ -199,20 +222,27 @@ async function ingestUnderLock(
         // the lock is HELD — long synchronous chunking between heartbeats can
         // let it go stale, so ownership is re-checked before every destructive
         // write rather than assumed for the whole run.
+        // Drop the accepted chunk BEFORE anything else can return: leaving it
+        // in `pending` would requeue notes the daemon already took.
+        pending = pending.slice(chunk.length);
         if (!(await lock.refresh())) {
+          // Ownership is gone, so this run must not write the snapshot at all —
+          // a replacement holder may already be working on it. The accepted
+          // chunk is resent by whoever owns the snapshot next: observe is
+          // at-least-once here, which is the safe direction.
           log.warn(
-            `[${options.serviceId}] flush-plan lock was lost mid-flush; the remainder drains on the next flush`,
+            `[${options.serviceId}] flush-plan lock was lost mid-flush; the snapshot is left to its new owner`,
           );
+          lockLost = true;
           stop = true;
           return;
         }
-        pending = pending.slice(chunk.length);
         await atomicWrite(paths.inflight, pending);
       }
     } finally {
-      // Whatever is left goes back in FRONT of any note appended while we were
-      // posting, so the daemon still receives them in the order written.
-      await releasePendingNotes(paths, pending, options.serviceId);
+      // Never write after ownership is lost: the replacement holder owns the
+      // snapshot now, and a stale write would clobber its progress.
+      if (!lockLost) await releasePendingNotes(paths, pending, options.serviceId);
     }
     if (stop) return;
   }
@@ -266,13 +296,23 @@ async function mergeRotatedIntoInflight(paths: SnapshotPaths): Promise<boolean> 
   const rotated = await readIfPresent(paths.rotating);
   if (rotated === undefined) return false;
   const existing = (await readIfPresent(paths.inflight)) ?? "";
-  const merged = `${existing}${rotated}`;
+  let merged = `${existing}${rotated}`;
   if (merged.length > 0) {
+    await atomicWrite(paths.inflight, merged);
+  }
+  // A host descriptor opened just before the rename still points at THIS
+  // inode, so a note can land here after the read above. Re-read immediately
+  // before unlinking and fold in anything that arrived; the write would
+  // otherwise vanish with the inode. The window is now one syscall pair
+  // rather than the whole merge.
+  const late = await readIfPresent(paths.rotating);
+  if (late !== undefined && late.length > rotated.length) {
+    merged = `${existing}${late}`;
     await atomicWrite(paths.inflight, merged);
   }
   // Only now: the content is durable under `.inflight`.
   await discard(paths.rotating);
-  return existing.length > 0 || rotated.length > 0;
+  return merged.length > 0;
 }
 
 /**
@@ -321,20 +361,38 @@ async function quarantineOversizedLine(
   const breakAt = pending.indexOf("\n");
   const line = breakAt === -1 ? pending : pending.slice(0, breakAt + 1);
   const rest = breakAt === -1 ? "" : pending.slice(breakAt + 1);
-  await appendFile(paths.oversized, line.endsWith("\n") ? line : `${line}\n`, "utf8");
+  const handle = await open(
+    paths.oversized,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    await handle.writeFile(line.endsWith("\n") ? line : `${line}\n`, "utf8");
+  } finally {
+    await handle.close();
+  }
   log.warn(
     `[${serviceId}] a flush-plan note exceeds the daemon's body limit; moved it to ${paths.oversized} so the remaining notes can drain`,
   );
   return rest;
 }
 
-/** File contents, or `undefined` when the file does not exist. */
+/**
+ * File contents, or `undefined` when the file does not exist.
+ *
+ * Opened with `O_NOFOLLOW` so a symlink swapped in after the containment check
+ * fails the open (ELOOP) instead of leaking another file to the daemon.
+ */
 async function readIfPresent(filePath: string): Promise<string | undefined> {
+  let handle: FileHandle | undefined;
   try {
-    return await readFile(filePath, "utf8");
+    handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    return await handle.readFile("utf8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
     throw err;
+  } finally {
+    await handle?.close();
   }
 }
 
@@ -345,6 +403,8 @@ async function readIfPresent(filePath: string): Promise<string | undefined> {
 async function atomicWrite(filePath: string, content: string): Promise<void> {
   const tempPath = `${filePath}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
   try {
+    // `wx` implies O_EXCL|O_CREAT, which already refuses to follow a symlink
+    // at the temp path; the rename then replaces the target by pathname.
     await writeFile(tempPath, content, { encoding: "utf8", flag: "wx" });
     await rename(tempPath, filePath);
   } catch (err) {

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -90,9 +90,13 @@ export async function ingestFlushPlanNotes(options: {
     return;
   }
 
+  // Never wait longer than the caller's own budget: the transcript flush that
+  // runs after this shares the same deadline, and burning it here would leave
+  // that flush with the 1 ms fallback.
+  const lockWaitMs = Math.max(1, Math.min(LOCK_MAX_WAIT_MS, Math.floor(options.remainingTimeoutMs() / 2)));
   await withHeldFileLock(
     paths.lock,
-    { staleMs: LOCK_STALE_MS, maxWaitMs: LOCK_MAX_WAIT_MS },
+    { staleMs: LOCK_STALE_MS, maxWaitMs: lockWaitMs },
     async (acquired, lock) => {
       if (!acquired) {
         // Another flush owns the snapshot. Declining is correct: the notes stay
@@ -143,7 +147,9 @@ async function ingestUnderLock(
     if (options.remainingTimeoutMs() <= 0) return;
     const claimed = await claimPendingNotes(paths, options.serviceId);
     if (claimed.trim().length === 0) {
-      await discard(paths.inflight);
+      // Even a delete needs a live claim: a replacement holder may have just
+      // recovered this snapshot.
+      if (await lock.refresh()) await discard(paths.inflight);
       return;
     }
     let pending = claimed;
@@ -240,9 +246,18 @@ async function ingestUnderLock(
         await atomicWrite(paths.inflight, pending);
       }
     } finally {
-      // Never write after ownership is lost: the replacement holder owns the
-      // snapshot now, and a stale write would clobber its progress.
-      if (!lockLost) await releasePendingNotes(paths, pending, options.serviceId);
+      // Never touch the snapshot after ownership is lost. `lockLost` covers the
+      // paths that already checked; every OTHER exit — a refusal, a spent
+      // deadline, a transport throw, a clean drain — re-checks here, because a
+      // long observe await is exactly when a stale-break can hand the snapshot
+      // to a replacement holder.
+      if (!lockLost && (await lock.refresh())) {
+        await releasePendingNotes(paths, pending, options.serviceId);
+      } else if (!lockLost) {
+        log.warn(
+          `[${options.serviceId}] flush-plan lock was lost before the snapshot could be updated; its new owner drains the remainder`,
+        );
+      }
     }
     if (stop) return;
   }

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -153,6 +153,12 @@ async function ingestUnderLock(
   for (let pass = 0; pass < MAX_RECLAIM_PASSES; pass++) {
     if (options.remainingTimeoutMs() <= 0) return;
     const claimed = await claimPendingNotes(paths, options.serviceId, lock);
+    if (claimed === undefined) {
+      log.warn(
+        `[${options.serviceId}] flush-plan lock was lost during recovery; its new owner drains the snapshot`,
+      );
+      return;
+    }
     if (claimed.trim().length === 0) {
       // Even a delete needs a live claim: a replacement holder may have just
       // recovered this snapshot.
@@ -298,10 +304,15 @@ async function claimPendingNotes(
   paths: SnapshotPaths,
   serviceId: string,
   lock: HeldFileLockController,
-): Promise<string> {
+): Promise<string | undefined> {
   // 1. Fold any stranded rotate target into the snapshot first. A previous run
   //    that died between its rename and its merge left the notes only there.
-  if (await mergeRotatedIntoInflight(paths, lock)) {
+  const recovery = await mergeRotatedIntoInflight(paths, lock);
+  // Losing the lock leaves `.rotating` on disk with notes that never reached
+  // the snapshot. Renaming the live plan onto that path would destroy them, so
+  // the claim aborts and the new owner recovers instead.
+  if (recovery === "lock-lost") return undefined;
+  if (recovery === "recovered") {
     log.warn(`[${serviceId}] recovered flush-plan notes left by an interrupted ingestion`);
   }
   // 2. Claim the live plan file. Rename is atomic, so a host append either
@@ -312,7 +323,7 @@ async function claimPendingNotes(
     if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
     return (await readIfPresent(paths.inflight)) ?? "";
   }
-  await mergeRotatedIntoInflight(paths, lock);
+  if ((await mergeRotatedIntoInflight(paths, lock)) === "lock-lost") return undefined;
   return (await readIfPresent(paths.inflight)) ?? "";
 }
 
@@ -323,16 +334,16 @@ async function claimPendingNotes(
 async function mergeRotatedIntoInflight(
   paths: SnapshotPaths,
   lock: HeldFileLockController,
-): Promise<boolean> {
+): Promise<"recovered" | "nothing" | "lock-lost"> {
   const rotated = await readIfPresent(paths.rotating);
-  if (rotated === undefined) return false;
+  if (rotated === undefined) return "nothing";
   const existing = (await readIfPresent(paths.inflight)) ?? "";
   let merged = `${existing}${rotated}`;
   if (merged.length > 0) {
     // Reading recovery files can outlast the stale interval on a paused
     // process, so ownership is re-checked before the write rather than
     // assumed from the acquire.
-    if (!(await lock.refresh())) return false;
+    if (!(await lock.refresh())) return "lock-lost";
     await atomicWrite(paths.inflight, merged);
   }
   // A host descriptor opened just before the rename still points at THIS
@@ -342,14 +353,14 @@ async function mergeRotatedIntoInflight(
   // rather than the whole merge.
   const late = await readIfPresent(paths.rotating);
   if (late !== undefined && late.length > rotated.length) {
-    if (!(await lock.refresh())) return false;
+    if (!(await lock.refresh())) return "lock-lost";
     merged = `${existing}${late}`;
     await atomicWrite(paths.inflight, merged);
   }
   // Only now: the content is durable under `.inflight`.
-  if (!(await lock.refresh())) return false;
+  if (!(await lock.refresh())) return "lock-lost";
   await discard(paths.rotating);
-  return merged.length > 0;
+  return merged.length > 0 ? "recovered" : "nothing";
 }
 
 /**

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -317,6 +317,10 @@ async function claimPendingNotes(
   }
   // 2. Claim the live plan file. Rename is atomic, so a host append either
   //    lands before it (claimed) or creates a fresh plan file (untouched).
+  // Ownership is re-checked immediately before the rename: a pause after the
+  // first recovery can let another flush stale-break the lock and rotate the
+  // plan itself, and this rename would then replace ITS `.rotating` file.
+  if (!(await lock.refresh())) return undefined;
   try {
     await rename(paths.plan, paths.rotating);
   } catch (err) {

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -27,7 +27,7 @@ import { appendFile, lstat, readFile, rename, unlink, writeFile } from "node:fs/
 import path from "node:path";
 
 import { log } from "@remnic/core/logger";
-import { withHeldFileLock } from "@remnic/core/utils/serialize-mutations";
+import { withHeldFileLock, type HeldFileLockController } from "@remnic/core/utils/serialize-mutations";
 
 import type { DelegateDaemonTarget } from "./bridge.js";
 import { buildMemoryFlushPlan } from "./memory-flush-plan.js";
@@ -91,7 +91,7 @@ export async function ingestFlushPlanNotes(options: {
   await withHeldFileLock(
     paths.lock,
     { staleMs: LOCK_STALE_MS, maxWaitMs: LOCK_MAX_WAIT_MS },
-    async (acquired) => {
+    async (acquired, lock) => {
       if (!acquired) {
         // Another flush owns the snapshot. Declining is correct: the notes stay
         // in the plan file and the other run — or the next flush — sends them.
@@ -100,7 +100,7 @@ export async function ingestFlushPlanNotes(options: {
         );
         return;
       }
-      await ingestUnderLock(options, paths);
+      await ingestUnderLock(options, paths, lock);
     },
   );
 }
@@ -114,6 +114,7 @@ async function ingestUnderLock(
     remainingTimeoutMs: () => number;
   },
   paths: SnapshotPaths,
+  lock: HeldFileLockController,
 ): Promise<void> {
   // Chunks start large and HALVE on a body-limit rejection. The daemon's
   // `maxBodyBytes` is configurable to any positive integer and is not reported
@@ -171,18 +172,19 @@ async function ingestUnderLock(
           return;
         }
         if (response.status === 413) {
-          // Halve whenever a smaller ceiling is still available. Requiring the
-          // CURRENT ceiling to already split the text was wrong: a 40 KiB plan
-          // under a 96 KiB ceiling is one chunk, so a daemon configured below
-          // 40 KiB rejected it forever.
-          if (chunkBytes > MIN_OBSERVE_CHUNK_BYTES) {
-            chunkBytes = Math.max(MIN_OBSERVE_CHUNK_BYTES, Math.floor(chunkBytes / 2));
+          // Halve while the chunk still holds more than one line. The trigger
+          // is the CHUNK's shape, not a byte floor: a daemon configured with a
+          // `maxBodyBytes` under the floor still rejects a multi-line batch,
+          // and quarantining then would set aside a note the daemon would have
+          // accepted on its own.
+          if (countLines(chunk) > 1) {
+            chunkBytes = Math.max(1, Math.floor(chunkBytes / 2));
             continue;
           }
-          // At the floor the chunk is one line the daemon will never take.
-          // Keeping it would block every note behind it on every future flush,
-          // so it is set aside in a sidecar the operator can inspect and the
-          // queue keeps draining. Nothing is deleted.
+          // One line the daemon will never take. Keeping it would block every
+          // note behind it on every future flush, so it is set aside in a
+          // sidecar the operator can inspect and the queue keeps draining.
+          // Nothing is deleted.
           pending = await quarantineOversizedLine(paths, pending, options.serviceId);
           chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
           await atomicWrite(paths.inflight, pending);
@@ -194,7 +196,16 @@ async function ingestUnderLock(
         }
         // Committed IMMEDIATELY, so a later chunk that throws cannot resend
         // what the daemon already took. The snapshot has no other writer while
-        // the lock is held, so this rewrite cannot lose a concurrent append.
+        // the lock is HELD — long synchronous chunking between heartbeats can
+        // let it go stale, so ownership is re-checked before every destructive
+        // write rather than assumed for the whole run.
+        if (!(await lock.refresh())) {
+          log.warn(
+            `[${options.serviceId}] flush-plan lock was lost mid-flush; the remainder drains on the next flush`,
+          );
+          stop = true;
+          return;
+        }
         pending = pending.slice(chunk.length);
         await atomicWrite(paths.inflight, pending);
       }
@@ -205,6 +216,13 @@ async function ingestUnderLock(
     }
     if (stop) return;
   }
+}
+
+/** Lines in one chunk. A trailing newline does not open another line. */
+function countLines(chunk: string): number {
+  const body = chunk.endsWith("\n") ? chunk.slice(0, -1) : chunk;
+  if (body.length === 0) return chunk.length > 0 ? 1 : 0;
+  return body.split("\n").length;
 }
 
 /** Statuses that mean "resend later", never "resend smaller". */
@@ -258,16 +276,17 @@ async function mergeRotatedIntoInflight(paths: SnapshotPaths): Promise<boolean> 
 }
 
 /**
- * Put unsent notes back at the head of the plan file and drop the snapshot.
+ * Leave unsent notes in the snapshot and drop it when there is nothing left.
  *
- * The plan is replaced with one atomic rename, so a reader never sees a torn
- * file. A host append landing between the read and the rename is still lost —
- * that window is inherent to reordering a file another process only appends
- * to, and it is now a single syscall pair rather than the duration of an HTTP
- * round trip.
+ * An earlier version wrote the remainder back into the plan file. That was the
+ * read-modify-write this PR exists to remove: a host append landing between
+ * the read and the rename was discarded. The snapshot is ours alone, so
+ * keeping the remainder there loses nothing — `claimPendingNotes` merges
+ * `.inflight` AHEAD of newly claimed notes, which preserves write order
+ * without ever touching the file the host appends to.
  *
  * A failure here must not mask the error that ended the run, so it only warns:
- * the snapshot survives and the next run recovers from it.
+ * the snapshot survives either way and the next run recovers from it.
  */
 async function releasePendingNotes(
   paths: SnapshotPaths,
@@ -279,12 +298,10 @@ async function releasePendingNotes(
       await discard(paths.inflight);
       return;
     }
-    const appended = (await readIfPresent(paths.plan)) ?? "";
-    await atomicWrite(paths.plan, `${pending}${appended}`);
-    await discard(paths.inflight);
+    await atomicWrite(paths.inflight, pending);
   } catch (err) {
     log.warn(
-      `[${serviceId}] could not restore unsent flush-plan notes; the next ingestion recovers them: ${String(err)}`,
+      `[${serviceId}] could not persist unsent flush-plan notes; the next ingestion recovers them: ${String(err)}`,
     );
   }
 }

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -152,7 +152,7 @@ async function ingestUnderLock(
   // here would leave the transcript flush that follows with its 1 ms fallback.
   for (let pass = 0; pass < MAX_RECLAIM_PASSES; pass++) {
     if (options.remainingTimeoutMs() <= 0) return;
-    const claimed = await claimPendingNotes(paths, options.serviceId);
+    const claimed = await claimPendingNotes(paths, options.serviceId, lock);
     if (claimed.trim().length === 0) {
       // Even a delete needs a live claim: a replacement holder may have just
       // recovered this snapshot.
@@ -294,10 +294,14 @@ function isRefusal(status: number): boolean {
  * merge is written with temp-then-rename BEFORE the source is unlinked, so no
  * crash window leaves the notes only in memory.
  */
-async function claimPendingNotes(paths: SnapshotPaths, serviceId: string): Promise<string> {
+async function claimPendingNotes(
+  paths: SnapshotPaths,
+  serviceId: string,
+  lock: HeldFileLockController,
+): Promise<string> {
   // 1. Fold any stranded rotate target into the snapshot first. A previous run
   //    that died between its rename and its merge left the notes only there.
-  if (await mergeRotatedIntoInflight(paths)) {
+  if (await mergeRotatedIntoInflight(paths, lock)) {
     log.warn(`[${serviceId}] recovered flush-plan notes left by an interrupted ingestion`);
   }
   // 2. Claim the live plan file. Rename is atomic, so a host append either
@@ -308,7 +312,7 @@ async function claimPendingNotes(paths: SnapshotPaths, serviceId: string): Promi
     if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
     return (await readIfPresent(paths.inflight)) ?? "";
   }
-  await mergeRotatedIntoInflight(paths);
+  await mergeRotatedIntoInflight(paths, lock);
   return (await readIfPresent(paths.inflight)) ?? "";
 }
 
@@ -316,12 +320,19 @@ async function claimPendingNotes(paths: SnapshotPaths, serviceId: string): Promi
  * Append `.rotating` to `.inflight` and remove it. Returns true when there was
  * something to recover. Safe to call when neither file exists.
  */
-async function mergeRotatedIntoInflight(paths: SnapshotPaths): Promise<boolean> {
+async function mergeRotatedIntoInflight(
+  paths: SnapshotPaths,
+  lock: HeldFileLockController,
+): Promise<boolean> {
   const rotated = await readIfPresent(paths.rotating);
   if (rotated === undefined) return false;
   const existing = (await readIfPresent(paths.inflight)) ?? "";
   let merged = `${existing}${rotated}`;
   if (merged.length > 0) {
+    // Reading recovery files can outlast the stale interval on a paused
+    // process, so ownership is re-checked before the write rather than
+    // assumed from the acquire.
+    if (!(await lock.refresh())) return false;
     await atomicWrite(paths.inflight, merged);
   }
   // A host descriptor opened just before the rename still points at THIS
@@ -331,10 +342,12 @@ async function mergeRotatedIntoInflight(paths: SnapshotPaths): Promise<boolean> 
   // rather than the whole merge.
   const late = await readIfPresent(paths.rotating);
   if (late !== undefined && late.length > rotated.length) {
+    if (!(await lock.refresh())) return false;
     merged = `${existing}${late}`;
     await atomicWrite(paths.inflight, merged);
   }
   // Only now: the content is durable under `.inflight`.
+  if (!(await lock.refresh())) return false;
   await discard(paths.rotating);
   return merged.length > 0;
 }

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -44,6 +44,12 @@ const MIN_OBSERVE_CHUNK_BYTES = 4 * 1024;
 /** Bounded wait for the flush-plan lock; a contended flush declines instead. */
 const LOCK_MAX_WAIT_MS = 5_000;
 const LOCK_STALE_MS = 60_000;
+/**
+ * How many times one flush re-claims newly appended notes. One extra pass is
+ * the point of the re-claim; an unbounded loop lets a busy host consume the
+ * deadline the transcript flush needs.
+ */
+const MAX_RECLAIM_PASSES = 4;
 
 interface SnapshotPaths {
   plan: string;
@@ -141,9 +147,10 @@ async function ingestUnderLock(
   // end. Adapting needs no new daemon surface and converges in a few requests.
   let chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
   // Re-claim after each drained snapshot so notes the host appended WHILE we
-  // were posting still leave in this flush. Every pass needs budget and needs
-  // the host to have written something new, so this terminates.
-  for (;;) {
+  // were posting still leave in this flush. Bounded: parallel sessions can
+  // append faster than this drains, and spending the whole shared deadline
+  // here would leave the transcript flush that follows with its 1 ms fallback.
+  for (let pass = 0; pass < MAX_RECLAIM_PASSES; pass++) {
     if (options.remainingTimeoutMs() <= 0) return;
     const claimed = await claimPendingNotes(paths, options.serviceId);
     if (claimed.trim().length === 0) {
@@ -206,6 +213,10 @@ async function ingestUnderLock(
           // note behind it on every future flush, so it is set aside in a
           // sidecar the operator can inspect and the queue keeps draining.
           // Nothing is deleted.
+          pending = await quarantineOversizedLine(paths, pending, options.serviceId);
+          chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
+          // Re-checked AFTER the sidecar write, not before: writing a large
+          // rejected line can itself outlast the stale interval.
           if (!(await lock.refresh())) {
             log.warn(
               `[${options.serviceId}] flush-plan lock was lost mid-flush; the snapshot is left to its new owner`,
@@ -214,8 +225,6 @@ async function ingestUnderLock(
             stop = true;
             return;
           }
-          pending = await quarantineOversizedLine(paths, pending, options.serviceId);
-          chunkBytes = MAX_OBSERVE_CHUNK_BYTES;
           await atomicWrite(paths.inflight, pending);
           continue;
         }
@@ -420,7 +429,9 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
   try {
     // `wx` implies O_EXCL|O_CREAT, which already refuses to follow a symlink
     // at the temp path; the rename then replaces the target by pathname.
-    await writeFile(tempPath, content, { encoding: "utf8", flag: "wx" });
+    // 0600: the snapshot holds the same durable notes as the plan file, and a
+    // default-mode temp under a 022 umask would widen them to 0644.
+    await writeFile(tempPath, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
     await rename(tempPath, filePath);
   } catch (err) {
     await discard(tempPath);

--- a/packages/plugin-openclaw/src/delegate-http.ts
+++ b/packages/plugin-openclaw/src/delegate-http.ts
@@ -1,0 +1,110 @@
+/**
+ * JSON transport for the delegate's daemon routes.
+ *
+ * Extracted from `delegate-runtime.ts` so both the runtime and the
+ * flush-plan ingestion can reach it without importing each other, and so
+ * the runtime stays under the new-file line ceiling (issue #1995).
+ */
+
+import {
+  daemonUrl,
+  type DaemonAuthTokenSource,
+  type DelegateDaemonTarget,
+} from "./bridge.js";
+import { reportDaemonAuthorizationFailure } from "./delegate-authorization.js";
+
+export interface DelegateJsonResponse {
+  status: number;
+  body: Record<string, unknown> | null;
+}
+
+/** Parse a 2xx body, or `null` when it is not a JSON object. */
+async function readJsonObject(res: Response): Promise<Record<string, unknown> | null> {
+  const parsed: unknown = await res.json().catch(() => null);
+  return typeof parsed === "object" && parsed !== null
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Report an authorization refusal once, then drain the body so the socket
+ * is reusable.
+ */
+async function noteRefusal(
+  res: Response,
+  serviceId: string,
+  pathname: string,
+  source: DaemonAuthTokenSource,
+): Promise<DelegateJsonResponse> {
+  await res.body?.cancel();
+  if (res.status === 401 || res.status === 403) {
+    reportDaemonAuthorizationFailure(serviceId, pathname, res.status, source);
+  }
+  return { status: res.status, body: null };
+}
+
+/**
+ * POST that reports the daemon's status instead of collapsing it.
+ *
+ * `postJson` below cannot tell a caller WHY a request failed: 401/403
+ * become `null` and every other non-2xx throws. A client that adapts to
+ * the daemon's body limit needs the difference, because halving the
+ * payload fixes a 413 and does nothing for a refused credential
+ * (issue #2303). Transport failures still reject — only HTTP responses
+ * are reported.
+ */
+export async function postJsonWithStatus(
+  target: DelegateDaemonTarget,
+  serviceId: string,
+  pathname: string,
+  body: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<DelegateJsonResponse> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const auth = target.resolveAuthToken();
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  const res = await fetch(daemonUrl(target, pathname), {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) return noteRefusal(res, serviceId, pathname, auth.source);
+  return { status: res.status, body: await readJsonObject(res) };
+}
+
+/**
+ * Legacy contract kept for every existing delegate route: `null` on an
+ * authorization refusal, a throw on any other non-2xx.
+ */
+export async function postJson(
+  target: DelegateDaemonTarget,
+  serviceId: string,
+  pathname: string,
+  body: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<Record<string, unknown> | null> {
+  const response = await postJsonWithStatus(target, serviceId, pathname, body, timeoutMs);
+  if (response.status === 401 || response.status === 403) return null;
+  if (response.status < 200 || response.status > 299) {
+    throw new Error(`daemon ${pathname} responded ${response.status}`);
+  }
+  return response.body;
+}
+
+export async function getJson(
+  target: DelegateDaemonTarget,
+  serviceId: string,
+  pathname: string,
+  timeoutMs: number,
+): Promise<DelegateJsonResponse> {
+  const headers: Record<string, string> = {};
+  const auth = target.resolveAuthToken();
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  const res = await fetch(daemonUrl(target, pathname), {
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) return noteRefusal(res, serviceId, pathname, auth.source);
+  return { status: res.status, body: await readJsonObject(res) };
+}

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import http from "node:http";
@@ -82,6 +82,12 @@ async function startDaemonStub(
     batchFlush?: boolean;
     batchResponse?: boolean;
     capabilityResponses?: Array<{ status: number; body: Record<string, unknown> }>;
+    /**
+     * Answer a request with a real HTTP status. Returning `null` from
+     * `respond` still yields 200, which is acceptance — a test that means
+     * "the daemon refused" must say so with a status (issue #2303).
+     */
+    statusFor?: (pathname: string, body: Record<string, unknown>) => number | undefined;
   } = {},
 ): Promise<DaemonStub> {
   const calls: RecordedCall[] = [];
@@ -145,7 +151,7 @@ async function startDaemonStub(
       void responsePromise
         .then(({ status, body: response }) => {
           if (res.destroyed) return;
-          res.statusCode = status;
+          res.statusCode = options.statusFor?.(req.url ?? "", body) ?? status;
           res.setHeader("content-type", "application/json");
           res.end(JSON.stringify(response));
         })
@@ -3191,6 +3197,22 @@ test("a rotated UNIT credential reaches delegate routes without a gateway restar
   }
 });
 
+/**
+ * The plan file's contents, treating a missing file as drained.
+ *
+ * Ingestion claims the notes by renaming the file aside (issue #2303), so a
+ * fully-delivered plan leaves no file behind unless the host appended again.
+ * Both states mean the same thing to the host: nothing is pending.
+ */
+async function readPlanOrEmpty(planPath: string): Promise<string> {
+  try {
+    return await readFile(planPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return "";
+    throw err;
+  }
+}
+
 test("the host's flush-plan notes reach the daemon and the file is cleared", async () => {
   // The capability advertises a flush plan, so OpenClaw appends durable notes
   // to the gateway workspace. Embedded mode ingests that file from
@@ -3221,7 +3243,7 @@ test("the host's flush-plan notes reach the daemon and the file is cleared", asy
       String((observed[0]?.messages as Array<{ content?: string }>)?.[0]?.content),
       /terse commit messages/,
     );
-    assert.equal(await readFile(planPath, "utf8"), "", "and the file was cleared after acceptance");
+    assert.equal(await readPlanOrEmpty(planPath), "", "and the file was cleared after acceptance");
   } finally {
     await stub.close();
     await rm(workspaceDir, { recursive: true, force: true });
@@ -3275,8 +3297,14 @@ test("a non-string search session key cannot inherit another session's binding",
 
 test("flush-plan notes survive a rejection, a concurrent append, and a symlink", async () => {
   // Three ways the ingestion could destroy notes the daemon never took.
-  const stub = await startDaemonStub((pathname) =>
-    pathname.startsWith("/engram/v1/observe") ? null : { flushed: true },
+  const stub = await startDaemonStub(
+    (pathname) => (pathname.startsWith("/engram/v1/observe") ? null : { flushed: true }),
+    {
+      // A refusal is an HTTP status, not a null body: a 200 means the
+      // daemon TOOK the notes (issue #2303).
+      statusFor: (pathname) =>
+        pathname.startsWith("/engram/v1/observe") ? 403 : undefined,
+    },
   );
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-guard-"));
   const planPath = path.join(workspaceDir, "state", "plugins", "guard-svc", "flush-plan.md");
@@ -3292,10 +3320,10 @@ test("flush-plan notes survive a rejection, a concurrent append, and a symlink",
 
   let accepting: Awaited<ReturnType<typeof startDaemonStub>> | undefined;
   try {
-    // 1. A REJECTED observe (401/403 resolves null) must keep the notes.
+    // 1. A REFUSED observe (403) must keep the notes.
     await writeFile(planPath, "- keep me\n", "utf8");
     await ingestFlushPlanNotes(options);
-    assert.equal(await readFile(planPath, "utf8"), "- keep me\n", "rejected notes were kept");
+    assert.equal(await readPlanOrEmpty(planPath), "- keep me\n", "rejected notes were kept");
 
     // 2. An append that lands mid-flight must survive the truncation.
     await stub.close();
@@ -3308,7 +3336,10 @@ test("flush-plan notes survive a rejection, a concurrent append, and a symlink",
         );
         if (appended) {
           appended = false;
-          await writeFile(planPath, "- sent\n- appended later\n", "utf8");
+          // A real host APPENDS; it never rewrites the file. Rotation has
+          // already moved the claimed notes aside, so this creates a fresh
+          // plan file holding only the new note (issue #2303).
+          await appendFile(planPath, "- appended later\n", "utf8");
         }
       }
       return { ok: true };
@@ -3327,7 +3358,7 @@ test("flush-plan notes survive a rejection, a concurrent append, and a symlink",
       ["- sent\n", "- appended later\n"],
       "the mid-flight append was delivered rather than truncated away",
     );
-    assert.equal(await readFile(planPath, "utf8"), "", "and the file drained");
+    assert.equal(await readPlanOrEmpty(planPath), "", "and the file drained");
 
     // 3. A symlinked plan file is refused outright.
     await rm(planPath, { force: true });
@@ -3388,7 +3419,151 @@ test("oversized flush-plan notes drain in chunks instead of deadlocking", async 
       "every chunk fit the daemon's body limit",
     );
     assert.equal(bodies.join(""), notes, "and together they carry every note exactly once");
-    assert.equal(await readFile(planPath, "utf8"), "", "the file drained");
+    assert.equal(await readPlanOrEmpty(planPath), "", "the file drained");
+  } finally {
+    await stub.close();
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("a 413 halves the chunk while an auth refusal stops immediately", async () => {
+  // The old contract collapsed every failure to `null`, so an auth refusal
+  // ran the halving ladder and a real 413 threw instead of adapting
+  // (issue #2303).
+  const observeSizes: number[] = [];
+  const limit = 8 * 1024;
+  const stub = await startDaemonStub(
+    (pathname, body) => {
+      if (pathname.startsWith("/engram/v1/observe")) {
+        observeSizes.push(
+          Buffer.byteLength(
+            String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+            "utf8",
+          ),
+        );
+      }
+      return { ok: true };
+    },
+    {
+      statusFor: (pathname, body) => {
+        if (!pathname.startsWith("/engram/v1/observe")) return undefined;
+        const content = String(
+          (body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? "",
+        );
+        return Buffer.byteLength(content, "utf8") > limit ? 413 : undefined;
+      },
+    },
+  );
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-413-"));
+  const planPath = path.join(workspaceDir, "state", "plugins", "s413", "flush-plan.md");
+  await mkdir(path.dirname(planPath), { recursive: true });
+  const line = `- ${"note ".repeat(40)}\n`;
+  const notes = line.repeat(Math.ceil((40 * 1024) / line.length));
+  await writeFile(planPath, notes, "utf8");
+
+  let refusing: Awaited<ReturnType<typeof startDaemonStub>> | undefined;
+  let firstClosed = false;
+  try {
+    const target = {
+      host: "127.0.0.1",
+      port: stub.port,
+      resolveAuthToken: () => ({ token: "t", source: "daemon configuration" as const }),
+    };
+    await ingestFlushPlanNotes({
+      target,
+      serviceId: "s413",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 10_000,
+    });
+    assert.ok(
+      observeSizes.some((size) => size > limit),
+      "the first attempt used the large chunk",
+    );
+    assert.ok(
+      observeSizes.filter((size) => size <= limit).length >= 4,
+      `halved down to the daemon's limit, sizes: ${observeSizes.join(",")}`,
+    );
+    assert.equal(await readPlanOrEmpty(planPath), "", "and every note drained");
+
+    // An auth refusal must NOT walk the halving ladder.
+    await stub.close();
+    firstClosed = true;
+    const authAttempts: number[] = [];
+    refusing = await startDaemonStub(
+      (pathname, body) => {
+        if (pathname.startsWith("/engram/v1/observe")) {
+          authAttempts.push(
+            Buffer.byteLength(
+              String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+              "utf8",
+            ),
+          );
+        }
+        return { ok: true };
+      },
+      {
+        statusFor: (pathname) =>
+          pathname.startsWith("/engram/v1/observe") ? 401 : undefined,
+      },
+    );
+    await writeFile(planPath, notes, "utf8");
+    await ingestFlushPlanNotes({
+      target: { ...target, port: refusing.port },
+      serviceId: "s413",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 10_000,
+    });
+    assert.equal(authAttempts.length, 1, "a refused credential is not retried at smaller sizes");
+    assert.equal(await readPlanOrEmpty(planPath), notes, "and the notes were kept");
+  } finally {
+    if (!firstClosed) await stub.close();
+    await refusing?.close();
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("an interrupted ingestion's notes are recovered on the next run", async () => {
+  // Rotation claims the notes by rename. A crash between the rename and the
+  // post would strand them without this recovery (issue #2303).
+  const delivered: string[] = [];
+  const stub = await startDaemonStub((pathname, body) => {
+    if (pathname.startsWith("/engram/v1/observe")) {
+      delivered.push(
+        String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+      );
+    }
+    return { ok: true };
+  });
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-recover-"));
+  const planPath = path.join(workspaceDir, "state", "plugins", "recov", "flush-plan.md");
+  await mkdir(path.dirname(planPath), { recursive: true });
+  try {
+    // Simulate the crash: an inflight snapshot with no plan file.
+    await writeFile(`${planPath}.inflight`, "- stranded note\n", "utf8");
+    await writeFile(planPath, "- fresh note\n", "utf8");
+    await ingestFlushPlanNotes({
+      target: {
+        host: "127.0.0.1",
+        port: stub.port,
+        resolveAuthToken: () => ({ token: "t", source: "daemon configuration" as const }),
+      },
+      serviceId: "recov",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 5_000,
+    });
+    assert.deepEqual(
+      delivered,
+      ["- stranded note\n- fresh note\n"],
+      "the stranded note was recovered ahead of the newer one",
+    );
+    assert.equal(await readPlanOrEmpty(planPath), "", "and the plan drained");
+    assert.equal(await readPlanOrEmpty(`${planPath}.inflight`), "", "the snapshot was removed");
   } finally {
     await stub.close();
     await rm(workspaceDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -3320,10 +3320,16 @@ test("flush-plan notes survive a rejection, a concurrent append, and a symlink",
 
   let accepting: Awaited<ReturnType<typeof startDaemonStub>> | undefined;
   try {
-    // 1. A REFUSED observe (403) must keep the notes.
+    // 1. A REFUSED observe (403) must keep the notes. They stay in the
+    // snapshot rather than being written back over the file the host appends
+    // to; the next claim merges the snapshot ahead of newly claimed notes.
     await writeFile(planPath, "- keep me\n", "utf8");
     await ingestFlushPlanNotes(options);
-    assert.equal(await readPlanOrEmpty(planPath), "- keep me\n", "rejected notes were kept");
+    assert.equal(
+      await readPlanOrEmpty(`${planPath}.inflight`),
+      "- keep me\n",
+      "rejected notes were kept for the next flush",
+    );
 
     // 2. An append that lands mid-flight must survive the truncation.
     await stub.close();
@@ -3348,6 +3354,7 @@ test("flush-plan notes survive a rejection, a concurrent append, and a symlink",
       ...options,
       target: { ...options.target, port: accepting.port },
     };
+    await rm(`${planPath}.inflight`, { force: true });
     await writeFile(planPath, "- sent\n", "utf8");
     // The stub appends while the observe is in flight, so the write provably
     // lands between the ingestion's read and its commit.
@@ -3518,7 +3525,11 @@ test("a 413 halves the chunk while an auth refusal stops immediately", async () 
       remainingTimeoutMs: () => 10_000,
     });
     assert.equal(authAttempts.length, 1, "a refused credential is not retried at smaller sizes");
-    assert.equal(await readPlanOrEmpty(planPath), notes, "and the notes were kept");
+    assert.equal(
+      await readPlanOrEmpty(`${planPath}.inflight`),
+      notes,
+      "and the notes were kept in the snapshot for the next flush",
+    );
   } finally {
     if (!firstClosed) await stub.close();
     await refusing?.close();
@@ -3697,6 +3708,63 @@ test("a symlinked snapshot sidecar is refused before it is read", async () => {
       "the symlink target was neither read nor overwritten",
     );
     assert.equal(await readPlanOrEmpty(planPath), "- real note\n", "and the notes were kept");
+  } finally {
+    await stub.close();
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("a daemon limit below the chunk floor splits instead of quarantining good notes", async () => {
+  // With maxBodyBytes under MIN_OBSERVE_CHUNK_BYTES, reaching the floor does
+  // NOT mean the chunk is one line — it can still be a multi-line batch. The
+  // trigger for quarantine is the chunk's shape, not a byte floor (#2303).
+  const delivered: string[] = [];
+  const limit = 200;
+  const overLimit = (body: Record<string, unknown>): boolean =>
+    Buffer.byteLength(
+      String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+      "utf8",
+    ) > limit;
+  const stub = await startDaemonStub(
+    (pathname, body) => {
+      // Record only what the daemon ACCEPTS; a 413 delivers nothing.
+      if (pathname.startsWith("/engram/v1/observe") && !overLimit(body)) {
+        delivered.push(
+          String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+        );
+      }
+      return { ok: true };
+    },
+    {
+      statusFor: (pathname, body) =>
+        pathname.startsWith("/engram/v1/observe") && overLimit(body) ? 413 : undefined,
+    },
+  );
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-subfloor-"));
+  const planPath = path.join(workspaceDir, "state", "plugins", "sub", "flush-plan.md");
+  await mkdir(path.dirname(planPath), { recursive: true });
+  try {
+    const notes = Array.from({ length: 40 }, (_, i) => `- short note ${i}\n`).join("");
+    await writeFile(planPath, notes, "utf8");
+    await ingestFlushPlanNotes({
+      target: {
+        host: "127.0.0.1",
+        port: stub.port,
+        resolveAuthToken: () => ({ token: "t", source: "daemon configuration" as const }),
+      },
+      serviceId: "sub",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 10_000,
+    });
+    assert.equal(
+      await readPlanOrEmpty(`${planPath}.oversized`),
+      "",
+      "no acceptable note was quarantined",
+    );
+    assert.equal(delivered.join(""), notes, "every note was delivered exactly once");
+    assert.equal(await readPlanOrEmpty(`${planPath}.inflight`), "", "and nothing is left pending");
   } finally {
     await stub.close();
     await rm(workspaceDir, { recursive: true, force: true });

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -3569,3 +3569,136 @@ test("an interrupted ingestion's notes are recovered on the next run", async () 
     await rm(workspaceDir, { recursive: true, force: true });
   }
 });
+
+test("a stranded rotate target is recovered ahead of newer notes", async () => {
+  // A run that died between its rename and its merge left the notes only in
+  // `.rotating`. Recovery that read `.inflight` alone stranded them (#2303).
+  const delivered: string[] = [];
+  const stub = await startDaemonStub((pathname, body) => {
+    if (pathname.startsWith("/engram/v1/observe")) {
+      delivered.push(
+        String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+      );
+    }
+    return { ok: true };
+  });
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-rot-"));
+  const planPath = path.join(workspaceDir, "state", "plugins", "rot", "flush-plan.md");
+  await mkdir(path.dirname(planPath), { recursive: true });
+  try {
+    await writeFile(`${planPath}.rotating`, "- stranded in rotate\n", "utf8");
+    await writeFile(`${planPath}.inflight`, "- stranded in flight\n", "utf8");
+    await writeFile(planPath, "- fresh\n", "utf8");
+    await ingestFlushPlanNotes({
+      target: {
+        host: "127.0.0.1",
+        port: stub.port,
+        resolveAuthToken: () => ({ token: "t", source: "daemon configuration" as const }),
+      },
+      serviceId: "rot",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 5_000,
+    });
+    assert.deepEqual(
+      delivered,
+      ["- stranded in flight\n- stranded in rotate\n- fresh\n"],
+      "every stranded note was recovered, oldest first",
+    );
+    assert.equal(await readPlanOrEmpty(`${planPath}.rotating`), "", "the rotate target is gone");
+    assert.equal(await readPlanOrEmpty(`${planPath}.inflight`), "", "the snapshot is gone");
+  } finally {
+    await stub.close();
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("a note the daemon can never accept is quarantined, not left blocking the queue", async () => {
+  // At the minimum chunk size the chunk is one line. Keeping it stalled every
+  // note behind it on every future flush (#2303).
+  const delivered: string[] = [];
+  const stub = await startDaemonStub(
+    (pathname, body) => {
+      if (pathname.startsWith("/engram/v1/observe")) {
+        delivered.push(
+          String((body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? ""),
+        );
+      }
+      return { ok: true };
+    },
+    {
+      statusFor: (pathname, body) => {
+        if (!pathname.startsWith("/engram/v1/observe")) return undefined;
+        const content = String(
+          (body.messages as Array<{ content?: string }> | undefined)?.[0]?.content ?? "",
+        );
+        return content.includes("HUGE") ? 413 : undefined;
+      },
+    },
+  );
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-quar-"));
+  const planPath = path.join(workspaceDir, "state", "plugins", "quar", "flush-plan.md");
+  await mkdir(path.dirname(planPath), { recursive: true });
+  try {
+    await writeFile(planPath, "- HUGE unacceptable note\n- ordinary note\n", "utf8");
+    await ingestFlushPlanNotes({
+      target: {
+        host: "127.0.0.1",
+        port: stub.port,
+        resolveAuthToken: () => ({ token: "t", source: "daemon configuration" as const }),
+      },
+      serviceId: "quar",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 5_000,
+    });
+    assert.deepEqual(delivered.at(-1), "- ordinary note\n", "the queue drained past the bad note");
+    assert.equal(
+      await readPlanOrEmpty(`${planPath}.oversized`),
+      "- HUGE unacceptable note\n",
+      "and the refused note is preserved in the sidecar",
+    );
+    assert.equal(await readPlanOrEmpty(planPath), "", "nothing is left pending");
+  } finally {
+    await stub.close();
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("a symlinked snapshot sidecar is refused before it is read", async () => {
+  // `flush-plan.md.inflight` pointed at another file would send that file to
+  // the daemon and then overwrite it (#2303).
+  const stub = await startDaemonStub(() => ({ ok: true }));
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fp-link-"));
+  const planPath = path.join(workspaceDir, "state", "plugins", "link", "flush-plan.md");
+  await mkdir(path.dirname(planPath), { recursive: true });
+  try {
+    const outside = path.join(workspaceDir, "secrets.md");
+    await writeFile(outside, "- someone else's file\n", "utf8");
+    await writeFile(planPath, "- real note\n", "utf8");
+    await symlink(outside, `${planPath}.inflight`);
+    await ingestFlushPlanNotes({
+      target: {
+        host: "127.0.0.1",
+        port: stub.port,
+        resolveAuthToken: () => ({ token: "t", source: "daemon configuration" as const }),
+      },
+      serviceId: "link",
+      workspaceDir,
+      sessionKey: "s",
+      namespace: undefined,
+      remainingTimeoutMs: () => 5_000,
+    });
+    assert.equal(
+      await readPlanOrEmpty(outside),
+      "- someone else's file\n",
+      "the symlink target was neither read nor overwritten",
+    );
+    assert.equal(await readPlanOrEmpty(planPath), "- real note\n", "and the notes were kept");
+  } finally {
+    await stub.close();
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -145,72 +145,12 @@ export interface DelegateHookApi extends DelegateCapabilityApi {
 }
 const DELEGATE_BATCH_FLUSH_CACHE_TTL_MS = 30_000;
 
-export async function postJson(
-  target: DelegateDaemonTarget,
-  serviceId: string,
-  pathname: string,
-  body: Record<string, unknown>,
-  timeoutMs: number,
-): Promise<Record<string, unknown> | null> {
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  const auth = target.resolveAuthToken();
-  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
-  const res = await fetch(daemonUrl(target, pathname), {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!res.ok) {
-    if (res.status === 401 || res.status === 403) {
-      const status = res.status === 401 ? 401 : 403;
-      await res.body?.cancel();
-      reportDaemonAuthorizationFailure(serviceId, pathname, status, auth.source);
-      return null;
-    }
-    throw new Error(`daemon ${pathname} responded ${res.status}`);
-  }
-  const parsed: unknown = await res.json().catch(() => null);
-  return typeof parsed === "object" && parsed !== null
-    ? (parsed as Record<string, unknown>)
-    : null;
-}
-interface DelegateJsonResponse {
-  status: number;
-  body: Record<string, unknown> | null;
-}
-async function getJson(
-  target: DelegateDaemonTarget,
-  serviceId: string,
-  pathname: string,
-  timeoutMs: number,
-): Promise<DelegateJsonResponse> {
-  const headers: Record<string, string> = {};
-  const auth = target.resolveAuthToken();
-  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
-  const res = await fetch(daemonUrl(target, pathname), {
-    headers,
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!res.ok) {
-    if (res.status === 401 || res.status === 403) {
-      const status = res.status === 401 ? 401 : 403;
-      await res.body?.cancel();
-      reportDaemonAuthorizationFailure(serviceId, pathname, status, auth.source);
-      return { status: res.status, body: null };
-    }
-    await res.body?.cancel();
-    return { status: res.status, body: null };
-  }
-  const parsed: unknown = await res.json().catch(() => null);
-  return {
-    status: res.status,
-    body:
-      typeof parsed === "object" && parsed !== null
-        ? (parsed as Record<string, unknown>)
-        : null,
-  };
-}
+import {
+  getJson,
+  postJson,
+  postJsonWithStatus,
+  type DelegateJsonResponse,
+} from "./delegate-http.js";
 
 function sessionKeyFrom(
   event: Record<string, unknown>,


### PR DESCRIPTION
Closes #2303.

Two residual gaps from the #2120 stack, filed rather than extending that review loop.

## 1. Append race on commit

`ingestFlushPlanNotes` re-read the plan file after each accepted chunk and
rewrote it minus the accepted prefix. An append landing between that read and
the write was truncated away.

The notes are now claimed by `rename` before anything is posted. Rename is
atomic, so every host append after it lands in a freshly created plan file and
cannot be truncated by the commit. Chunks are then committed against the
private snapshot, which has no other writer.

Three consequences handled explicitly:

- **Crash recovery.** An interrupted run leaves a `.inflight` snapshot; the
  next run recovers it ahead of newer notes, preserving write order.
- **Early stop.** Unsent notes are put back in FRONT of anything appended
  meanwhile, so ordering survives a deadline or a refusal.
- **Same-flush delivery.** After a snapshot drains, the run re-claims once more
  while budget remains, so a note appended mid-flight still leaves in this
  flush rather than waiting for the next one.

## 2. 413 was indistinguishable from an auth refusal

`postJson` collapsed 401/403 to `null` and threw on every other non-2xx. Two
consequences, both wrong:

- A real 413 **threw** out of the ingestion, so the adaptive halving never ran
  for the case it was written for.
- An auth refusal **did** run the halving ladder, paying several pointless
  requests before giving up.

New `postJsonWithStatus` reports the daemon's status. `postJson` keeps its
exact legacy contract on top of it, so no other delegate route changes. The
ingestion now halves on 413/431 and stops immediately on 401/403.

A second defect surfaced while testing the first: the halving guard required
the current ceiling to already split the text, so a 40 KiB plan under the
96 KiB ceiling never halved and a daemon configured below 40 KiB rejected it
forever. Halving now proceeds whenever a smaller ceiling is available.

## Structure

The JSON helpers moved to a new `delegate-http.ts`. `delegate-runtime.ts`
crossed the 1200-line new-file ceiling with the addition, and the extraction
also removes the `delegate-runtime` ↔ `delegate-flush-plan-ingest` import
cycle.

## Verification

- `pnpm exec tsx --test packages/plugin-openclaw/src/*.test.ts` — 321/321 pass
- `pnpm --filter @remnic/plugin-openclaw check-types` — pass
- `node scripts/check-ratchets.mjs` — OK
- `npm run preflight:quick` — OK

New tests: a 413 halves while a 401 stops after one attempt; an interrupted
ingestion's snapshot is recovered ahead of newer notes; a mid-flight append is
delivered in the same flush. The test daemon stub gained a `statusFor` hook,
because returning `null` from its handler produced HTTP 200 — acceptance, not
the refusal three tests believed they were simulating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable gateway-local state, locking, and symlink hardening for data sent to the daemon; behavior is heavily tested but duplicate observe delivery is possible if the lock is lost mid-flush.
> 
> **Overview**
> **Delegate flush-plan ingestion** no longer commits with read-modify-write on `flush-plan.md`. Notes are **claimed by rename** into `.rotating` / `.inflight` under a cross-process lock, with recovery for stranded `.rotating` / `.inflight` files, bounded re-claim passes for mid-flush appends, and unsent remainder kept in the snapshot (not rewritten over the host’s plan file). Symlink checks and `O_NOFOLLOW` reads cover plan and sidecar paths; lock refresh gates destructive writes.
> 
> **Daemon observe behavior** uses new **`postJsonWithStatus`** (in extracted **`delegate-http.ts`**) so **413** triggers adaptive chunk halving (by line count, not only byte floor), **401/403/431** stop without halving, and permanently rejected single lines go to **`flush-plan.md.oversized`** so the queue can drain. **`postJson`** / **`getJson`** keep the prior delegate contract via the same module.
> 
> Tests add **`statusFor`** on the daemon stub and cover recovery, quarantine, auth vs 413, and symlink sidecars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eeb3877d47521678455d5cde860bc7e0a4885de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delegate plan updates from being lost during concurrent appends or interrupted delivery.
  * Added recovery for interrupted deliveries and preserved unsent notes after failed requests.
  * Automatically adjusts request batches when payloads exceed server limits.
  * Quarantines notes that cannot be delivered because they exceed server limits.
  * Distinguishes authentication failures from other delivery errors.
  * Ensures plans are cleared only after successful delivery.
  * Improved handling of authorization refusals and oversized request headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->