### PR TITLE
fix(capture-audio): order cross-channel chunks before assembly

### DIFF
--- a/.changeset/capture-audio-reorder-buffer.md
+++ b/.changeset/capture-audio-reorder-buffer.md
@@ -1,0 +1,5 @@
+---
+"@remnic/capture-audio": patch
+---
+
+Group cross-channel audio by capture time, not arrival, and cluster speakers over the segments that survive dedup.

--- a/docs/desktop-capture.md
+++ b/docs/desktop-capture.md
@@ -349,6 +349,36 @@ table in [config-reference.md](config-reference.md) and [meetings.md](meetings.m
 }
 ```
 
+### Capture-audio daemon: cross-channel ordering
+
+`@remnic/capture-audio` has its own daemon config file, separate from the
+Remnic plugin config above.
+
+With `captureChannel: "both"` the native helper records the microphone and the
+system output as two independent chunk streams. A system chunk for an earlier
+window can arrive after a later microphone chunk. The daemon therefore holds
+each transcribed chunk in a bounded reorder buffer and releases it only when
+the newest observed chunk end is `reorderWindowSeconds` past its own end. The
+assembler then always sees a chronological stream, so a delayed segment is
+grouped into the conversation it belongs to (issue #2145).
+
+```jsonc
+{
+  "conversationGapMinutes": 10,   // silence that starts a new conversation
+  "reorderWindowSeconds": 60      // 0 releases every chunk on arrival
+}
+```
+
+Two consequences to know:
+
+- A held chunk is not marked complete and keeps its raw WAV, so a crash before
+  release replays it from the audio. Raising the window delays WAV reclaim by
+  the same amount.
+- Speaker clustering runs at finalize over the segments that survive
+  cross-channel dedup. A microphone copy of system audio that dedup prunes
+  therefore contributes nothing to a speaker cluster. Segment embeddings are
+  persisted so a restart re-derives the same clusters.
+
 ## Installation hints
 
 Base installs never pull a capture or connector package. Install only what you

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -161,6 +161,27 @@ export class ConversationAssembler {
     });
   }
 
+  /**
+   * Deep snapshot for rollback (issue #2145).
+   *
+   * `add` mutates the open conversation in place. A caller that fails BEFORE
+   * anything was persisted must be able to rewind, or the retry feeds earlier
+   * timestamps into an advanced assembler and collapses conversations the
+   * first attempt had split. A caller that already persisted something must
+   * NOT rewind: the durable ids would then diverge from the in-memory ones.
+   */
+  checkpoint(): AssembledConversation[] {
+    return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));
+  }
+
+  /** Rewind to a {@link checkpoint}. */
+  rewind(snapshot: readonly AssembledConversation[]): void {
+    this.#conversations.length = 0;
+    for (const conv of snapshot) {
+      this.#conversations.push({ ...conv, segments: conv.segments.slice() });
+    }
+  }
+
   /** Ordered snapshot; segments are cloned so callers cannot mutate internal state. */
   conversations(): AssembledConversation[] {
     return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -174,6 +174,22 @@ export class ConversationAssembler {
   }
 
   /**
+   * Drop finalized conversations the caller no longer needs.
+   *
+   * A long-running daemon would otherwise retain every conversation and every
+   * segment forever, which makes the rollback snapshot below O(capture
+   * history) and the daemon's per-chunk work quadratic (issue #2145). Only the
+   * open conversation can still be mutated, so nothing else needs keeping.
+   */
+  pruneFinalized(): number {
+    const open = this.#open();
+    const removed = this.#conversations.length - (open ? 1 : 0);
+    this.#conversations.length = 0;
+    if (open) this.#conversations.push(open);
+    return removed;
+  }
+
+  /**
    * Deep snapshot for rollback (issue #2145).
    *
    * `add` mutates the open conversation in place. A caller that fails BEFORE

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -161,26 +161,6 @@ export class ConversationAssembler {
     });
   }
 
-  /**
-   * Deep snapshot for rollback (issue #2145).
-   *
-   * `add` mutates the open conversation in place, so a caller that fails
-   * AFTER feeding a batch must be able to rewind — otherwise the retry feeds
-   * earlier timestamps into an advanced assembler and merges spans the first
-   * attempt had split.
-   */
-  checkpoint(): AssembledConversation[] {
-    return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));
-  }
-
-  /** Rewind to a {@link checkpoint}. */
-  rewind(snapshot: readonly AssembledConversation[]): void {
-    this.#conversations.length = 0;
-    for (const conv of snapshot) {
-      this.#conversations.push({ ...conv, segments: conv.segments.slice() });
-    }
-  }
-
   /** Ordered snapshot; segments are cloned so callers cannot mutate internal state. */
   conversations(): AssembledConversation[] {
     return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -161,6 +161,26 @@ export class ConversationAssembler {
     });
   }
 
+  /**
+   * Deep snapshot for rollback (issue #2145).
+   *
+   * `add` mutates the open conversation in place, so a caller that fails
+   * AFTER feeding a batch must be able to rewind — otherwise the retry feeds
+   * earlier timestamps into an advanced assembler and merges spans the first
+   * attempt had split.
+   */
+  checkpoint(): AssembledConversation[] {
+    return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));
+  }
+
+  /** Rewind to a {@link checkpoint}. */
+  rewind(snapshot: readonly AssembledConversation[]): void {
+    this.#conversations.length = 0;
+    for (const conv of snapshot) {
+      this.#conversations.push({ ...conv, segments: conv.segments.slice() });
+    }
+  }
+
   /** Ordered snapshot; segments are cloned so callers cannot mutate internal state. */
   conversations(): AssembledConversation[] {
     return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));

--- a/packages/capture-audio/src/assembly.ts
+++ b/packages/capture-audio/src/assembly.ts
@@ -78,6 +78,18 @@ export interface AssemblerOptions {
   makeId?: () => string;
 }
 
+/**
+ * Copy a segment for a rollback snapshot. `slice()` alone would keep the same
+ * mutable segment objects — and the same `embedding` array — so a later
+ * mutation would rewrite the snapshot it is supposed to restore from.
+ */
+function cloneSegment(segment: AssemblySegment): AssemblySegment {
+  return {
+    ...segment,
+    ...(segment.embedding ? { embedding: segment.embedding.slice() } : {}),
+  };
+}
+
 /** Parse an ISO-8601 timestamp to epoch ms, rejecting garbage loudly. */
 function epochMs(value: string, field: string): number {
   const ms = Date.parse(value);
@@ -171,14 +183,14 @@ export class ConversationAssembler {
    * NOT rewind: the durable ids would then diverge from the in-memory ones.
    */
   checkpoint(): AssembledConversation[] {
-    return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.slice() }));
+    return this.#conversations.map((conv) => ({ ...conv, segments: conv.segments.map(cloneSegment) }));
   }
 
   /** Rewind to a {@link checkpoint}. */
   rewind(snapshot: readonly AssembledConversation[]): void {
     this.#conversations.length = 0;
     for (const conv of snapshot) {
-      this.#conversations.push({ ...conv, segments: conv.segments.slice() });
+      this.#conversations.push({ ...conv, segments: conv.segments.map(cloneSegment) });
     }
   }
 

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -129,6 +129,10 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     resolveModel,
     transcribe,
     cleanupRawAudio,
+    // Cross-channel arrival skew: hold each transcribed chunk until the
+    // watermark passes it, so a delayed system chunk still assembles into the
+    // conversation it belongs to (issue #2145).
+    reorderWindowMs: config.reorderWindowSeconds * 1000,
     ...(options.detectSpeech ? { detectSpeech: options.detectSpeech } : {}),
     ...(options.embed ? { embed: options.embed } : {}),
     ...(diarizer ? { diarizer } : {}),

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -135,7 +135,7 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     reorderWindowMs: config.reorderWindowSeconds * 1000,
     ...(options.detectSpeech ? { detectSpeech: options.detectSpeech } : {}),
     ...(options.embed ? { embed: options.embed } : {}),
-    ...(diarizer ? { diarizer, restoreDiarizer: (clusters) => diarizer.restore(clusters) } : {}),
+    ...(diarizer ? { diarizer } : {}),
     ...(options.onError ? { onError: (error: Error) => options.onError?.(error) } : {}),
   });
 

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -132,7 +132,10 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     // Cross-channel arrival skew: hold each transcribed chunk until the
     // watermark passes it, so a delayed system chunk still assembles into the
     // conversation it belongs to (issue #2145).
-    reorderWindowMs: config.reorderWindowSeconds * 1000,
+    // Only "both" has two independent chunk streams to interleave. A single
+    // channel is already ordered, so buffering would add latency and widen the
+    // crash window for nothing (issue #2145).
+    reorderWindowMs: config.captureChannel === "both" ? config.reorderWindowSeconds * 1000 : 0,
     ...(options.detectSpeech ? { detectSpeech: options.detectSpeech } : {}),
     ...(options.embed ? { embed: options.embed } : {}),
     ...(diarizer ? { diarizer } : {}),

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -135,7 +135,7 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
     reorderWindowMs: config.reorderWindowSeconds * 1000,
     ...(options.detectSpeech ? { detectSpeech: options.detectSpeech } : {}),
     ...(options.embed ? { embed: options.embed } : {}),
-    ...(diarizer ? { diarizer } : {}),
+    ...(diarizer ? { diarizer, restoreDiarizer: (clusters) => diarizer.restore(clusters) } : {}),
     ...(options.onError ? { onError: (error: Error) => options.onError?.(error) } : {}),
   });
 

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -543,7 +543,7 @@ async function cmdStart(
           // their raw audio is still on disk. Swallowing that silently made a
           // recoverable state look like a clean exit (issue #2145).
           process.stderr.write(
-            `[capture-audio] shutdown flush failed; retained raw audio was NOT ingested: ${String(error)}\n`,
+            `[capture-audio] shutdown flush failed; retained raw audio was NOT ingested: ${describeError(error)}\n`,
           );
         })
         .then(() => {

--- a/packages/capture-audio/src/cli.ts
+++ b/packages/capture-audio/src/cli.ts
@@ -538,7 +538,14 @@ async function cmdStart(
       void replayTask
         .catch(() => undefined)
         .then(() => (live ? live.stop().then(() => undefined) : undefined))
-        .catch(() => undefined)
+        .catch((error: unknown) => {
+          // A failed shutdown flush means chunks are still held in memory and
+          // their raw audio is still on disk. Swallowing that silently made a
+          // recoverable state look like a clean exit (issue #2145).
+          process.stderr.write(
+            `[capture-audio] shutdown flush failed; retained raw audio was NOT ingested: ${String(error)}\n`,
+          );
+        })
         .then(() => {
           spool.finalizeOpenConversations();
           return handle.close().catch(() => undefined);

--- a/packages/capture-audio/src/config.test.ts
+++ b/packages/capture-audio/src/config.test.ts
@@ -125,3 +125,11 @@ test("captureChannel defaults to both and rejects anything but mic|system|both",
   assert.throws(() => parseDaemonConfig({ captureChannel: "speaker" }), CaptureConfigError);
   assert.throws(() => parseDaemonConfig({ captureChannel: 1 }), CaptureConfigError);
 });
+
+test("reorderWindowSeconds parses and defaults to a cross-channel window", () => {
+  assert.equal(defaultDaemonConfig().reorderWindowSeconds, 60);
+  assert.equal(parseDaemonConfig({ reorderWindowSeconds: 0 }).reorderWindowSeconds, 0);
+  assert.equal(parseDaemonConfig({ reorderWindowSeconds: 5 }).reorderWindowSeconds, 5);
+  assert.throws(() => parseDaemonConfig({ reorderWindowSeconds: -1 }), /reorderWindowSeconds/);
+  assert.throws(() => parseDaemonConfig({ reorderWindowSeconds: 3601 }), /reorderWindowSeconds/);
+});

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -161,12 +161,6 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
 
   if (obj.vad !== undefined) {
     const vad = asObject(obj.vad, "vad");
-  if (obj.reorderWindowSeconds !== undefined) {
-    cfg.reorderWindowSeconds = coerceNumber(obj.reorderWindowSeconds, "reorderWindowSeconds", {
-      min: 0,
-      max: 3600,
-    });
-  }
     warnUnknownKeys(
       vad,
       {

--- a/packages/capture-audio/src/config.ts
+++ b/packages/capture-audio/src/config.ts
@@ -42,6 +42,15 @@ export interface DaemonConfig {
   chunkSeconds: number;
   captureChannel: "mic" | "system" | "both";
   conversationGapMinutes: number;
+  /**
+   * Bounded reorder window, in seconds, for cross-channel arrival skew
+   * (issue #2145). Chunks are held until the newest observed chunk end is
+   * this far past their own end, then released oldest-first, so a delayed
+   * system chunk is grouped with the conversation it belongs to instead of
+   * a later mic chunk's. 0 disables buffering: every chunk is released on
+   * arrival, which is the pre-#2145 behavior.
+   */
+  reorderWindowSeconds: number;
   rawRetentionHours: number;
   spoolRetentionDays: number;
   vad: VadConfig;
@@ -68,6 +77,7 @@ export function defaultDaemonConfig(): DaemonConfig {
       threshold: 0.5,
       threads: 1,
     },
+    reorderWindowSeconds: 60,
     diarization: { similarityThreshold: 0.4 },
     stt: { engine: "whisper-cpp", modelPath: null, threads: null },
     denyApps: [],
@@ -81,6 +91,7 @@ const KNOWN_TOP_KEYS: Record<string, true> = {
   chunkSeconds: true,
   captureChannel: true,
   conversationGapMinutes: true,
+  reorderWindowSeconds: true,
   rawRetentionHours: true,
   spoolRetentionDays: true,
   vad: true,
@@ -141,9 +152,21 @@ export function parseDaemonConfig(raw: unknown): DaemonConfig {
   if (obj.spoolRetentionDays !== undefined) {
     cfg.spoolRetentionDays = coerceNumber(obj.spoolRetentionDays, "spoolRetentionDays", { integer: true, min: 1 });
   }
+  if (obj.reorderWindowSeconds !== undefined) {
+    cfg.reorderWindowSeconds = coerceNumber(obj.reorderWindowSeconds, "reorderWindowSeconds", {
+      min: 0,
+      max: 3600,
+    });
+  }
 
   if (obj.vad !== undefined) {
     const vad = asObject(obj.vad, "vad");
+  if (obj.reorderWindowSeconds !== undefined) {
+    cfg.reorderWindowSeconds = coerceNumber(obj.reorderWindowSeconds, "reorderWindowSeconds", {
+      min: 0,
+      max: 3600,
+    });
+  }
     warnUnknownKeys(
       vad,
       {

--- a/packages/capture-audio/src/constants.ts
+++ b/packages/capture-audio/src/constants.ts
@@ -12,7 +12,7 @@ export const DEFAULT_HOST = "127.0.0.1";
 export const DEFAULT_PORT = 4340;
 
 /** Spool schema version, persisted in the `meta` table. */
-export const SPOOL_SCHEMA_VERSION = 1;
+export const SPOOL_SCHEMA_VERSION = 2;
 
 /** Upper bound for the conversations `limit` query parameter. */
 export const MAX_CONVERSATIONS_LIMIT = 500;

--- a/packages/capture-audio/src/diarization.ts
+++ b/packages/capture-audio/src/diarization.ts
@@ -152,6 +152,28 @@ export class SpeakerClusterer {
     return cluster.id;
   }
 
+  /**
+   * Replace every cluster with `snapshot` (issue #2145).
+   *
+   * `assign` mutates centroids and counts in place, so a diarization commit
+   * that rolls back in SQLite must roll back here too — otherwise the retry
+   * counts the same embeddings twice. Deep-copied, so the caller's snapshot
+   * cannot alias internal state.
+   */
+  restore(snapshot: readonly SpeakerCluster[]): void {
+    this.#clusters = snapshot.map((cluster) => ({
+      ...cluster,
+      centroid: cluster.centroid.slice(),
+      examples: cluster.examples.map((example) => example.slice()),
+    }));
+    let highest = 0;
+    for (const cluster of this.#clusters) {
+      const parsed = /^spk_(\d+)$/.exec(cluster.id);
+      if (parsed) highest = Math.max(highest, Number(parsed[1]));
+    }
+    this.#next = highest + 1;
+  }
+
   /** Snapshot for persistence. */
   clusters(): SpeakerCluster[] {
     return this.#clusters.map((c) => ({

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -7,6 +7,7 @@ import {
   chunkStableId,
   createChunkProcessor,
   segmentStableKey,
+  transcriptManifestHash,
   transcriptManifestKey,
   type ChunkProcessorDeps,
 } from "./processor.js";
@@ -1380,6 +1381,79 @@ test("the assembler does not retain closed conversations", async () => {
     await proc.finalize();
     assert.equal(spool.stats().conversations, 2, "the gap split two conversations");
     assert.ok(assembler.conversations().length <= 1, "but at most the open one is retained");
+  } finally {
+    spool.close();
+  }
+});
+
+test("a silent chunk completes and reclaims its audio", async () => {
+  // A silent transcript records no manifest, so it must not be judged against
+  // one: doing so would hold every silent chunk open forever (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const cleaned: string[] = [];
+    const speech = chunk({ path: "/tmp/raw/speech.wav" });
+    const ev = chunk();
+    const proc = createChunkProcessor(
+      deps(spool, {
+        // Speech first, then silence, on ONE processor: the silent chunk must
+        // not hold the conversation the speech chunk opened.
+        transcribe: async (input) =>
+          input.wavPath.endsWith("speech.wav") ? [{ text: "hello", startUtc: t(1), endUtc: t(2) }] : [],
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    proc.enqueue(speech);
+    proc.enqueue(ev);
+    await proc.finalize();
+    assert.equal(spool.isChunkApplied(`${chunkStableId(ev)}:done`), true, "the silent chunk completed");
+    assert.ok(cleaned.includes(ev.path), "and its raw audio was reclaimed");
+    assert.deepEqual(
+      [...spool.capturingConversationIds()],
+      [],
+      "and it did not hold an earlier conversation open",
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("a conflicting retranscription appends nothing", async () => {
+  // Appending it would interleave content the first transcript never had, and
+  // a later correct replay would then skip the segments it already stored.
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk();
+    const cid = chunkStableId(ev);
+    // A first run recorded its manifest and then died before completing.
+    spool.markApplied(
+      transcriptManifestKey(cid),
+      transcriptManifestHash(cid, [
+        { text: "A", startUtc: t(1), endUtc: t(2) },
+        { text: "B", startUtc: t(40), endUtc: t(41) },
+      ]),
+    );
+
+    const errors: Error[] = [];
+    const divergent = createChunkProcessor(
+      deps(spool, {
+        onError: (error) => errors.push(error),
+        transcribe: async () => [
+          { text: "X", startUtc: t(1), endUtc: t(2) },
+          { text: "B", startUtc: t(40), endUtc: t(41) },
+        ],
+      }),
+    );
+    divergent.enqueue(ev);
+    await divergent.finalize();
+    assert.equal(spool.stats().segments, 0, "the divergent transcript persisted nothing");
+    assert.equal(spool.isChunkApplied(`${cid}:done`), false, "and the chunk stays open");
+    assert.ok(
+      errors.some((error) => /does not match the recorded manifest/.test(error.message)),
+      "and the conflict was reported",
+    );
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1149,7 +1149,7 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     partial.enqueue(ev);
     await partial.drain();
     assert.equal(spool.stats().segments, 1, "only A persisted");
-    assert.equal(spool.isChunkApplied(`${cid}:n2`), true, "the two-segment transcript was recorded");
+    assert.ok(spool.hasAppliedChunkPrefix(`${cid}:m`), "the transcript manifest was recorded");
     assert.equal(spool.isChunkApplied(`${cid}:done`), false, "and the chunk is not complete");
 
     // The replay now produces only A.
@@ -1190,6 +1190,63 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     await ok.finalize();
     assert.equal(spool.isChunkApplied(`${stableId}:done`), true);
     assert.deepEqual(cleaned, ["/tmp/raw/stable.wav"]);
+  } finally {
+    spool.close();
+  }
+});
+
+test("a replay with the same segment count but different content stays open", async () => {
+  // A count is too weak a manifest: [A, B] recording n2 and committing only A,
+  // then replaying as [X, B], would match on count and be marked complete with
+  // mixed content (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk({ path: "/tmp/raw/swap.wav" });
+    const cid = chunkStableId(ev);
+    const a: TranscribedSegment = { text: "A", startUtc: t(1), endUtc: t(2) };
+    const b: TranscribedSegment = { text: "B", startUtc: t(40), endUtc: t(41) };
+    const x: TranscribedSegment = { text: "X", startUtc: t(1), endUtc: t(2) };
+    const cleaned: string[] = [];
+
+    let appends = 0;
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "appendAssembledSegments") {
+          return (input: Parameters<Spool["appendAssembledSegments"]>[0]) => {
+            appends += 1;
+            if (appends === 2) throw new Error("sqlite busy");
+            return target.appendAssembledSegments(input);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+
+    const partial = createChunkProcessor(
+      deps(guarded, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [a, b],
+      }),
+    );
+    partial.enqueue(ev);
+    await partial.drain();
+    assert.equal(spool.stats().segments, 1, "only A persisted");
+
+    // Same COUNT, different content.
+    const swapped = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [x, b],
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    swapped.enqueue(chunk({ path: "/tmp/raw/swap.wav" }));
+    await swapped.finalize();
+    assert.equal(spool.isChunkApplied(`${cid}:done`), false, "a changed transcript never completes the chunk");
+    assert.equal(cleaned.length, 0, "and its raw audio is retained");
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1527,16 +1527,21 @@ test("a gap-crossing chunk cannot close a conversation held for replay", async (
     });
 
     // The silent replay and a much later healthy chunk release in ONE batch.
+    // A real instant hours later: `t()` only formats seconds, so a large value
+    // would build an invalid ISO string and the chunk would fail before it
+    // could join the batch, making this test vacuous.
     const later = chunk({
       path: "/tmp/raw/later.wav",
-      startedAtUtc: t(9000),
-      endedAtUtc: t(9001),
+      startedAtUtc: "2026-07-24T03:00:00.000Z",
+      endedAtUtc: "2026-07-24T03:00:30.000Z",
     });
     const proc = createChunkProcessor(
       deps(spool, {
         onError: () => undefined,
         transcribe: async (input) =>
-          input.wavPath.endsWith("later.wav") ? [{ text: "later", startUtc: t(9000), endUtc: t(9001) }] : [],
+          input.wavPath.endsWith("later.wav")
+            ? [{ text: "later", startUtc: "2026-07-24T03:00:00.000Z", endUtc: "2026-07-24T03:00:10.000Z" }]
+            : [],
       }),
     );
     proc.enqueue(stale);
@@ -1546,6 +1551,47 @@ test("a gap-crossing chunk cannot close a conversation held for replay", async (
       [...spool.capturingConversationIds()].includes("conv_prefix"),
       "the held prefix was not flipped to final",
     );
+  } finally {
+    spool.close();
+  }
+});
+
+test("a hold is released once the retained chunk is complete", async () => {
+  // Retention must not be a latch: after the matching replay completes the
+  // chunk, the conversation finalizes normally (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk();
+    const cid = chunkStableId(ev);
+    const segs = [
+      { text: "A", startUtc: t(1), endUtc: t(2) },
+      { text: "B", startUtc: t(40), endUtc: t(41) },
+    ];
+    spool.markApplied(transcriptManifestKey(cid), transcriptManifestHash(cid, segs));
+    spool.appendAssembledSegments({
+      idempotencyKey: segmentStableKey(cid, segs[0]),
+      chunkId: cid,
+      conversationId: "conv_prefix",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "A", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+
+    const silent = createChunkProcessor(
+      deps(spool, { onError: () => undefined, transcribe: async () => [] }),
+    );
+    silent.enqueue(ev);
+    await silent.finalize();
+    assert.ok([...spool.capturingConversationIds()].includes("conv_prefix"), "held after the silent replay");
+
+    // The matching replay reproduces the manifest, so the chunk completes.
+    const matching = createChunkProcessor(
+      deps(spool, { assembler: new ConversationAssembler({ gapMinutes: 0 }), transcribe: async () => segs }),
+    );
+    matching.enqueue(ev);
+    await matching.finalize();
+    assert.equal(spool.isChunkApplied(`${cid}:done`), true, "the chunk completed");
+    assert.deepEqual([...spool.capturingConversationIds()], [], "and nothing stayed held");
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -894,7 +894,6 @@ test("a crash between cluster and assignment cannot double-count embeddings", as
     const failing = createChunkProcessor(
       deps(spool, {
         diarizer: clusterer,
-        restoreDiarizer: (clusters) => clusterer.restore(clusters),
         embed: () => voice,
         transcribe: async () => [{ text: "one utterance", startUtc: t(1), endUtc: t(2) }],
       }),
@@ -921,7 +920,6 @@ test("a crash between cluster and assignment cannot double-count embeddings", as
     const recovered = createChunkProcessor(
       deps(spool, {
         diarizer: clusterer,
-        restoreDiarizer: (clusters) => clusterer.restore(clusters),
         embed: () => voice,
       }),
     );

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1105,3 +1105,72 @@ test("a retranscription that inserts a segment does not rebind an existing key",
     spool.close();
   }
 });
+
+test("a shortened retranscription keeps the chunk open instead of losing its tail", async () => {
+  // Crash after segment A of an [A, B] transcript, then an STT change makes the
+  // replay produce only A. The recorded segment COUNT is what tells the two
+  // cases apart (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk({ path: "/tmp/raw/shrink.wav" });
+    const cid = chunkStableId(ev);
+    const cleaned: string[] = [];
+    const two = [
+      { text: "A", startUtc: t(1), endUtc: t(2) },
+      { text: "B", startUtc: t(40), endUtc: t(41) },
+    ];
+
+    // Run 1 records the two-segment count, then we simulate losing B by
+    // deleting its row while leaving the count marker in place.
+    const first = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => two,
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    first.enqueue(ev);
+    await first.drain();
+    assert.equal(spool.isChunkApplied(`${cid}:n2`), true, "the transcript size was recorded");
+
+    // Run 2 sees a SHORTER transcript for the same chunk.
+    const shortened = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [two[0]],
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    shortened.enqueue(chunk({ path: "/tmp/raw/shrink.wav" }));
+    await shortened.finalize();
+    assert.equal(
+      spool.isChunkApplied(`${cid}:done`),
+      true,
+      "run 1 already completed the chunk, so the replay short-circuits on :done",
+    );
+
+    // A chunk that was NEVER completed and retranscribes shorter must stay open.
+    const other = chunk({ path: "/tmp/raw/shrink2.wav" });
+    const otherId = chunkStableId(other);
+    spool.markApplied(`${otherId}:n2`, "-");
+    const partial = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [two[0]],
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    partial.enqueue(other);
+    await partial.finalize();
+    assert.equal(spool.isChunkApplied(`${otherId}:done`), false, "not completed on a shorter transcript");
+    assert.ok(!cleaned.includes("/tmp/raw/shrink2.wav"), "and its raw audio is retained");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -939,3 +939,65 @@ test("a crash between cluster and assignment cannot double-count embeddings", as
     spool.close();
   }
 });
+
+test("a pre-commit failure rewinds the assembler; a partial commit does not", async () => {
+  // Two halves of one invariant (issue #2145): the in-memory assembler and the
+  // durable ids must never diverge. Nothing persisted -> rewind, so the retry
+  // re-splits. Something persisted -> keep, so the durable id is reused.
+  const spool = new Spool(":memory:");
+  try {
+    let minted = 0;
+    const assembler = new ConversationAssembler({ gapMinutes: 0, makeId: () => `conv_${++minted}` });
+    let failAppends = true;
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "appendAssembledSegments" && failAppends) {
+          return () => {
+            throw new Error("sqlite busy");
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+
+    const proc = createChunkProcessor(
+      deps(guarded, {
+        assembler,
+        transcribe: async () => [
+          { text: "one", startUtc: t(1), endUtc: t(2) },
+          { text: "two", startUtc: t(40), endUtc: t(41) },
+        ],
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(spool.stats().segments, 0, "nothing persisted");
+    assert.deepEqual(assembler.conversations(), [], "the assembler rewound to its pre-batch state");
+
+    // The retry now succeeds and must still split the two segments at gap 0.
+    failAppends = false;
+    const retry = createChunkProcessor(
+      deps(guarded, {
+        assembler,
+        transcribe: async () => [
+          { text: "one", startUtc: t(1), endUtc: t(2) },
+          { text: "two", startUtc: t(40), endUtc: t(41) },
+        ],
+      }),
+    );
+    retry.enqueue(chunk());
+    await retry.finalize();
+    assert.equal(spool.stats().segments, 2);
+    // Ids are never reused, so `minted` also counts the discarded attempt; what
+    // matters is that the retry produced TWO conversations, not one collapsed.
+    const retried = assembler.conversations();
+    assert.equal(retried.length, 2, "the retry re-split instead of collapsing into one conversation");
+    assert.deepEqual(
+      retried.map((conv) => spool.conversationSegmentsForDedup(conv.id).map((seg) => seg.text)),
+      [["one"], ["two"]],
+    );
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -409,7 +409,11 @@ test("cross-channel dedup is order-independent: a mic chunk processed BEFORE its
   }
 });
 
-test("kill-9 durability: a diarized append persists its speaker cluster before finalize", async () => {
+test("kill-9 durability: an appended segment keeps the embedding its cluster is derived from", async () => {
+  // Clustering moved to finalize (issue #2145), so a kill before finalize
+  // leaves no cluster — but the EMBEDDING is durable, so the next finalize
+  // derives the same cluster. Nothing is lost, and a duplicate that dedup
+  // later prunes never got to move a centroid.
   const spool = new Spool(":memory:");
   try {
     const guest: Embedding = [0, 1, 0, 0];
@@ -422,9 +426,53 @@ test("kill-9 durability: a diarized append persists its speaker cluster before f
     );
     proc.enqueue(chunk());
     await proc.drain(); // process is killed (-9) here: no finalize() runs
+    assert.deepEqual(spool.readSpeakerClusters(), [], "no cluster before finalize");
+    const open = spool.latestCapturingConversation();
+    assert.ok(open);
+    assert.equal(
+      spool.conversationSegmentsForDiarization(open.id).length,
+      1,
+      "the embedding survived the crash and is still pending clustering",
+    );
+
+    // Restart: a fresh processor + clusterer over the same spool.
+    const restarted = createChunkProcessor(
+      deps(spool, { diarizer: new SpeakerClusterer(0.7), embed: () => guest }),
+    );
+    await restarted.finalize();
     const clusters = spool.readSpeakerClusters();
-    assert.equal(clusters.length, 1, "the new cluster is durable as soon as its segment is appended");
+    assert.equal(clusters.length, 1, "finalize derived the cluster from the persisted embedding");
     assert.equal(clusters[0].isSelf, false);
+    assert.equal(clusters[0].embeddingCount, 1, "counted exactly once");
+  } finally {
+    spool.close();
+  }
+});
+
+test("a pruned loopback duplicate contributes nothing to any speaker cluster (issue #2145)", async () => {
+  // The same utterance heard on both channels: dedup keeps the system copy.
+  // With append-time clustering the mic copy still moved the centroid and
+  // bumped the count before it was pruned.
+  const spool = new Spool(":memory:");
+  try {
+    const voice: Embedding = [1, 0, 0, 0];
+    const proc = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7),
+        embed: () => voice,
+        transcribe: async () => [{ text: "hello there world", startUtc: t(1), endUtc: t(3) }],
+      }),
+    );
+    proc.enqueue(chunk({ path: "/tmp/raw/sys.wav", channel: "system", startedAtUtc: t(0), endedAtUtc: t(4) }));
+    proc.enqueue(chunk({ path: "/tmp/raw/mic.wav", channel: "mic", startedAtUtc: t(0), endedAtUtc: t(4) }));
+    await proc.drain();
+    assert.equal(spool.stats().segments, 2, "both copies are stored before dedup");
+    await proc.finalize();
+
+    assert.equal(finalSegments(spool).length, 1, "the loopback dup was pruned");
+    const clusters = spool.readSpeakerClusters();
+    assert.equal(clusters.length, 1, "one speaker, not a phantom pair");
+    assert.equal(clusters[0].embeddingCount, 1, "the pruned duplicate never counted");
   } finally {
     spool.close();
   }
@@ -643,3 +691,118 @@ test("pruning the earliest duplicate recomputes the conversation's time bounds",
     spool.close();
   }
 });
+
+test("a delayed cross-channel chunk groups by time, not arrival (issue #2145)", async () => {
+  // conversationGapMinutes: 0 splits on ANY gap, so arrival order decides the
+  // grouping outright. The mic chunk covering 00:01 arrives first; the system
+  // chunk covering 00:00 arrives after it. Without the reorder buffer the
+  // earlier system segment is appended to the LATER conversation.
+  const spool = new Spool(":memory:");
+  try {
+    let minted = 0;
+    const byPath: Record<string, TranscribedSegment[]> = {
+      "/tmp/raw/mic-late.wav": [
+        { text: "second", startUtc: "2026-07-24T00:01:00.000Z", endUtc: "2026-07-24T00:01:05.000Z" },
+      ],
+      "/tmp/raw/sys-early.wav": [
+        { text: "first", startUtc: "2026-07-24T00:00:00.000Z", endUtc: "2026-07-24T00:00:05.000Z" },
+      ],
+    };
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0, makeId: () => `conv_${++minted}` }),
+        reorderWindowMs: 120_000,
+        transcribe: async ({ wavPath }) => byPath[wavPath] ?? [],
+      }),
+    );
+    // Arrival order is deliberately reversed relative to capture time.
+    proc.enqueue(
+      chunk({
+        path: "/tmp/raw/mic-late.wav",
+        channel: "mic",
+        startedAtUtc: "2026-07-24T00:01:00.000Z",
+        endedAtUtc: "2026-07-24T00:01:30.000Z",
+      }),
+    );
+    proc.enqueue(
+      chunk({
+        path: "/tmp/raw/sys-early.wav",
+        channel: "system",
+        startedAtUtc: "2026-07-24T00:00:00.000Z",
+        endedAtUtc: "2026-07-24T00:00:30.000Z",
+      }),
+    );
+    await proc.drain();
+    // Still inside the reorder window: nothing has been released yet, so the
+    // WAVs are retained and no conversation exists.
+    assert.equal(spool.stats().segments, 0, "held until the watermark passes");
+    await proc.finalize();
+    // Ids are minted in RELEASE order, so conv_1 must hold the earlier
+    // (system) segment even though its chunk arrived second.
+    assert.equal(minted, 2, "each segment opened its own conversation at gap 0");
+    assert.deepEqual(
+      spool.conversationSegmentsForDedup("conv_1").map((seg) => seg.text),
+      ["first"],
+    );
+    assert.deepEqual(
+      spool.conversationSegmentsForDedup("conv_2").map((seg) => seg.text),
+      ["second"],
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("the reorder buffer releases once the watermark passes a held chunk", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const byPath: Record<string, TranscribedSegment[]> = {
+      "/tmp/raw/a.wav": [
+        { text: "early", startUtc: "2026-07-24T00:00:00.000Z", endUtc: "2026-07-24T00:00:05.000Z" },
+      ],
+      "/tmp/raw/b.wav": [
+        { text: "later", startUtc: "2026-07-24T00:02:00.000Z", endUtc: "2026-07-24T00:02:05.000Z" },
+      ],
+    };
+    const cleaned: string[] = [];
+    const proc = createChunkProcessor(
+      deps(spool, {
+        reorderWindowMs: 30_000,
+        transcribe: async ({ wavPath }) => byPath[wavPath] ?? [],
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    proc.enqueue(chunk({ path: "/tmp/raw/a.wav", endedAtUtc: "2026-07-24T00:00:30.000Z" }));
+    await proc.drain();
+    assert.equal(spool.stats().segments, 0, "the newest chunk is never its own watermark");
+    assert.deepEqual(cleaned, [], "a held chunk keeps its WAV for replay");
+
+    proc.enqueue(
+      chunk({
+        path: "/tmp/raw/b.wav",
+        startedAtUtc: "2026-07-24T00:02:00.000Z",
+        endedAtUtc: "2026-07-24T00:02:30.000Z",
+      }),
+    );
+    await proc.drain();
+    assert.equal(spool.stats().segments, 1, "the older chunk released once the watermark passed it");
+    assert.deepEqual(cleaned, ["/tmp/raw/a.wav"], "and only then is its WAV reclaimed");
+  } finally {
+    spool.close();
+  }
+});
+
+test("reorderWindowMs 0 keeps the pre-#2145 release-on-arrival behavior", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(deps(spool, { reorderWindowMs: 0 }));
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(spool.stats().segments, 2, "released without waiting for a later chunk");
+  } finally {
+    spool.close();
+  }
+});
+

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1503,3 +1503,50 @@ test("a chunk retained for replay keeps its conversation resumable", async () =>
     }
   }
 });
+
+test("a gap-crossing chunk cannot close a conversation held for replay", async () => {
+  // The retain decision must be made BEFORE the idle close: otherwise a later
+  // healthy chunk past the gap flips the durable prefix to final mid-batch,
+  // before the completion loop ever consults the flag (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const stale = chunk();
+    const cid = chunkStableId(stale);
+    const segs = [
+      { text: "A", startUtc: t(1), endUtc: t(2) },
+      { text: "B", startUtc: t(40), endUtc: t(41) },
+    ];
+    spool.markApplied(transcriptManifestKey(cid), transcriptManifestHash(cid, segs));
+    spool.appendAssembledSegments({
+      idempotencyKey: segmentStableKey(cid, segs[0]),
+      chunkId: cid,
+      conversationId: "conv_prefix",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "A", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+
+    // The silent replay and a much later healthy chunk release in ONE batch.
+    const later = chunk({
+      path: "/tmp/raw/later.wav",
+      startedAtUtc: t(9000),
+      endedAtUtc: t(9001),
+    });
+    const proc = createChunkProcessor(
+      deps(spool, {
+        onError: () => undefined,
+        transcribe: async (input) =>
+          input.wavPath.endsWith("later.wav") ? [{ text: "later", startUtc: t(9000), endUtc: t(9001) }] : [],
+      }),
+    );
+    proc.enqueue(stale);
+    proc.enqueue(later);
+    await proc.finalize();
+    assert.ok(
+      [...spool.capturingConversationIds()].includes("conv_prefix"),
+      "the held prefix was not flipped to final",
+    );
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -648,11 +648,10 @@ test("a zero-segment replay of a partially-applied chunk does NOT mark it done (
   }
 });
 
-test("a chunk applied under the pre-#2145 group keys is never re-appended", async () => {
-  // Legacy `chunkId` / `chunkId:<n>` keys cannot be mapped onto per-segment
-  // keys, so such a chunk is treated as applied and closed out. Losing the
-  // tail of one in-flight chunk across the upgrade beats duplicating the
-  // segments that were already stored.
+test("a chunk applied under the pre-#2145 group keys is left strictly alone", async () => {
+  // Legacy `chunkId` / `chunkId:<n>` keys prove only that SOME group persisted,
+  // so the chunk is neither re-appended (duplicating stored groups) nor closed
+  // out (discarding an unpersisted tail). Its raw audio stays for replay.
   const spool = new Spool(":memory:");
   try {
     const ev = chunk({ path: "/tmp/raw/legacy.wav" });
@@ -665,9 +664,13 @@ test("a chunk applied under the pre-#2145 group keys is never re-appended", asyn
       state: "capturing",
       segments: [{ channel: "mic", text: "legacy group", startUtc: t(1), endUtc: t(2), isWearer: true }],
     });
+    const cleaned: string[] = [];
     const proc = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
         transcribe: async () => [
           { text: "legacy group", startUtc: t(1), endUtc: t(2) },
           { text: "tail", startUtc: t(30), endUtc: t(31) },
@@ -676,8 +679,13 @@ test("a chunk applied under the pre-#2145 group keys is never re-appended", asyn
     );
     proc.enqueue(ev);
     await proc.finalize();
+    assert.deepEqual(cleaned, [], "the raw audio is retained for replay");
     assert.equal(spool.stats().segments, 1, "no duplicate of the legacy-applied segment");
-    assert.equal(spool.isChunkApplied(`${cid}:done`), true, "and the chunk is closed out");
+    assert.equal(
+      spool.isChunkApplied(`${cid}:done`),
+      false,
+      "and it is NOT closed out, so the unpersisted tail stays recoverable",
+    );
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1001,3 +1001,56 @@ test("a pre-commit failure rewinds the assembler; a partial commit does not", as
     spool.close();
   }
 });
+
+test("a pre-commit failure also rewinds restart-recovery state", async () => {
+  // `resume()` and `openConversationId` are set INSIDE applyBatch, so a
+  // rollback that restored only the assembler would leave the recovery flags
+  // claiming a conversation the assembler no longer holds; the retry would
+  // then mint a new id for a conversation that is durably open (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    // A prior run left a capturing conversation.
+    const priorId = spool.insertConversation({
+      startedAtUtc: t(1),
+      endedAtUtc: t(2),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "before restart", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+    let failAppends = true;
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "appendAssembledSegments" && failAppends) {
+          return () => {
+            throw new Error("sqlite busy");
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+    let minted = 0;
+    const assembler = new ConversationAssembler({ gapMinutes: 10, makeId: () => `conv_new_${++minted}` });
+    const withinGap = { ...deps(guarded, { assembler }), transcribe: async () => [
+      { text: "after restart", startUtc: t(3), endUtc: t(4) },
+    ] };
+
+    const failing = createChunkProcessor(withinGap);
+    failing.enqueue(chunk({ startedAtUtc: t(3), endedAtUtc: t(5) }));
+    await failing.drain();
+    assert.equal(spool.stats().segments, 1, "nothing new persisted");
+
+    failAppends = false;
+    const retry = createChunkProcessor(withinGap);
+    retry.enqueue(chunk({ startedAtUtc: t(3), endedAtUtc: t(5) }));
+    await retry.finalize();
+
+    assert.equal(minted, 0, "the retry resumed the durable conversation instead of minting a new id");
+    assert.deepEqual(
+      spool.conversationSegmentsForDedup(priorId).map((seg) => seg.text),
+      ["before restart", "after restart"],
+      "and the within-gap segment joined it",
+    );
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1596,3 +1596,101 @@ test("a hold is released once the retained chunk is complete", async () => {
     spool.close();
   }
 });
+
+test("a restart rebuilds replay holds from the durable markers", async () => {
+  // The in-memory record of incomplete chunks dies with the process, so a
+  // later healthy chunk would otherwise close a prefix whose WAV is still
+  // waiting for its replay (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const stale = chunk();
+    const cid = chunkStableId(stale);
+    const segs = [
+      { text: "A", startUtc: t(1), endUtc: t(2) },
+      { text: "B", startUtc: t(40), endUtc: t(41) },
+    ];
+    // A prior run recorded the manifest and a prefix, then died: no `:done`.
+    spool.markApplied(transcriptManifestKey(cid), transcriptManifestHash(cid, segs));
+    spool.appendAssembledSegments({
+      idempotencyKey: segmentStableKey(cid, segs[0]),
+      chunkId: cid,
+      conversationId: "conv_prefix",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "A", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+    assert.deepEqual(spool.incompleteChunkIds(), [cid], "the marker pair names the incomplete chunk");
+
+    // A fresh process sees only a later, healthy chunk.
+    const later = chunk({
+      path: "/tmp/raw/later.wav",
+      startedAtUtc: "2026-07-24T03:00:00.000Z",
+      endedAtUtc: "2026-07-24T03:00:30.000Z",
+    });
+    const restarted = createChunkProcessor(
+      deps(spool, {
+        transcribe: async () => [
+          { text: "later", startUtc: "2026-07-24T03:00:00.000Z", endUtc: "2026-07-24T03:00:10.000Z" },
+        ],
+      }),
+    );
+    restarted.enqueue(later);
+    await restarted.finalize();
+    assert.ok(
+      [...spool.capturingConversationIds()].includes("conv_prefix"),
+      "the incomplete prefix stayed resumable across the restart",
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("a hold does not keep an unrelated conversation open", async () => {
+  // `trackRetention` snapshots what is resumable BEFORE the batch appends, so a
+  // conversation opened by a gap split in the same batch still finalizes.
+  const spool = new Spool(":memory:");
+  try {
+    const stale = chunk();
+    const cid = chunkStableId(stale);
+    spool.markApplied(
+      transcriptManifestKey(cid),
+      transcriptManifestHash(cid, [{ text: "A", startUtc: t(1), endUtc: t(2) }]),
+    );
+    spool.appendAssembledSegments({
+      idempotencyKey: segmentStableKey(cid, { text: "A", startUtc: t(1), endUtc: t(2) }),
+      chunkId: cid,
+      conversationId: "conv_prefix",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "A", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+
+    const fresh = chunk({
+      path: "/tmp/raw/fresh.wav",
+      startedAtUtc: "2026-07-24T05:00:00.000Z",
+      endedAtUtc: "2026-07-24T05:00:30.000Z",
+    });
+    const proc = createChunkProcessor(
+      deps(spool, {
+        onError: () => undefined,
+        // A window wider than the span keeps both chunks for ONE batch, which
+        // is where the pre-append snapshot matters.
+        reorderWindowMs: 24 * 60 * 60 * 1000,
+        // The retained chunk replays silently — so it reaches the completion
+        // loop, where retention is recorded — and the fresh one is fine.
+        transcribe: async (input) =>
+          input.wavPath.endsWith("fresh.wav")
+            ? [{ text: "fresh", startUtc: "2026-07-24T05:00:00.000Z", endUtc: "2026-07-24T05:00:10.000Z" }]
+            : [],
+      }),
+    );
+    proc.enqueue(stale);
+    proc.enqueue(fresh);
+    await proc.finalize();
+    const capturing = [...spool.capturingConversationIds()];
+    assert.ok(capturing.includes("conv_prefix"), "the held prefix stayed open");
+    assert.equal(capturing.length, 1, "and the unrelated conversation finalized");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -3,7 +3,12 @@ import test from "node:test";
 
 import { ConversationAssembler } from "./assembly.js";
 import type { ChunkEvent } from "./native.js";
-import { chunkStableId, createChunkProcessor, type ChunkProcessorDeps } from "./processor.js";
+import {
+  chunkStableId,
+  createChunkProcessor,
+  segmentStableKey,
+  type ChunkProcessorDeps,
+} from "./processor.js";
 import { Spool } from "./spool.js";
 import type { TranscribedSegment } from "./stt.js";
 import { SpeakerClusterer, type Embedding } from "./diarization.js";
@@ -581,9 +586,10 @@ test("partial-chunk replay appends the missing tail segment instead of duplicati
     // Simulate a kill-9 AFTER segment 0 appended but BEFORE segment 1 / the
     // :done marker. Keys are per-segment (`chunkId:i<index>`) so they mean the
     // same bytes on every replay, whatever batch the chunk lands in (#2145).
+    const seededKey = segmentStableKey(cid, { startUtc: t(1), endUtc: t(2), text: "first group" });
     spool.appendAssembledSegments({
-      idempotencyKey: `${cid}:i0`,
-      chunkId: `${cid}:i0`,
+      idempotencyKey: seededKey,
+      chunkId: seededKey,
       conversationId: "conv_grp0",
       startedAtUtc: t(1),
       state: "capturing",
@@ -614,9 +620,10 @@ test("a zero-segment replay of a partially-applied chunk does NOT mark it done (
   try {
     const ev = chunk({ path: "/tmp/raw/multi.wav" });
     const cid = chunkStableId(ev);
+    const seededKey = segmentStableKey(cid, { startUtc: t(1), endUtc: t(2), text: "first group" });
     spool.appendAssembledSegments({
-      idempotencyKey: `${cid}:i0`,
-      chunkId: `${cid}:i0`,
+      idempotencyKey: seededKey,
+      chunkId: seededKey,
       conversationId: "conv_grp0",
       startedAtUtc: t(1),
       state: "capturing",
@@ -1053,6 +1060,47 @@ test("a pre-commit failure also rewinds restart-recovery state", async () => {
       ["before restart", "after restart"],
       "and the within-gap segment joined it",
     );
+  } finally {
+    spool.close();
+  }
+});
+
+test("a retranscription that inserts a segment does not rebind an existing key", async () => {
+  // Keys are content-derived, not positional: replaying [A, B] as [X, A, B]
+  // must append X and skip A, not treat A as new because its index moved
+  // (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk({ path: "/tmp/raw/reseg.wav" });
+    const cid = chunkStableId(ev);
+    const keyA = segmentStableKey(cid, { startUtc: t(10), endUtc: t(11), text: "A" });
+    spool.appendAssembledSegments({
+      idempotencyKey: keyA,
+      chunkId: keyA,
+      conversationId: "conv_seeded",
+      startedAtUtc: t(10),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "A", startUtc: t(10), endUtc: t(11), isWearer: true }],
+    });
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 10 }),
+        transcribe: async () => [
+          { text: "X", startUtc: t(1), endUtc: t(2) },
+          { text: "A", startUtc: t(10), endUtc: t(11) },
+          { text: "B", startUtc: t(20), endUtc: t(21) },
+        ],
+      }),
+    );
+    proc.enqueue(ev);
+    await proc.finalize();
+
+    const stored = spool
+      .capturingConversationIds()
+      .concat(["conv_seeded"])
+      .flatMap((id) => spool.conversationSegmentsForDedup(id).map((seg) => seg.text));
+    assert.equal(spool.stats().segments, 3, "X and B were added; A was not duplicated");
+    assert.deepEqual([...new Set(stored)].sort(), ["A", "B", "X"]);
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -7,6 +7,7 @@ import {
   chunkStableId,
   createChunkProcessor,
   segmentStableKey,
+  transcriptManifestKey,
   type ChunkProcessorDeps,
 } from "./processor.js";
 import { Spool } from "./spool.js";
@@ -998,10 +999,12 @@ test("a pre-commit failure rewinds the assembler; a partial commit does not", as
     assert.equal(spool.stats().segments, 2);
     // Ids are never reused, so `minted` also counts the discarded attempt; what
     // matters is that the retry produced TWO conversations, not one collapsed.
-    const retried = assembler.conversations();
-    assert.equal(retried.length, 2, "the retry re-split instead of collapsing into one conversation");
+    // The assembler prunes closed conversations, so the spool is the record.
+    assert.equal(spool.stats().conversations, 2, "the retry re-split instead of collapsing into one");
     assert.deepEqual(
-      retried.map((conv) => spool.conversationSegmentsForDedup(conv.id).map((seg) => seg.text)),
+      [`conv_${minted - 1}`, `conv_${minted}`].map((id) =>
+        spool.conversationSegmentsForDedup(id).map((seg) => seg.text),
+      ),
       [["one"], ["two"]],
     );
   } finally {
@@ -1149,7 +1152,7 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     partial.enqueue(ev);
     await partial.drain();
     assert.equal(spool.stats().segments, 1, "only A persisted");
-    assert.ok(spool.hasAppliedChunkPrefix(`${cid}:m`), "the transcript manifest was recorded");
+    assert.ok(spool.appliedChunkValue(transcriptManifestKey(cid)) !== undefined, "the transcript manifest was recorded");
     assert.equal(spool.isChunkApplied(`${cid}:done`), false, "and the chunk is not complete");
 
     // The replay now produces only A.
@@ -1294,6 +1297,89 @@ test("a chunk is never released without its transcript manifest", async () => {
     failMarker = false;
     await proc.finalize();
     assert.equal(spool.stats().segments, 2, "the chunk released once its manifest was durable");
+  } finally {
+    spool.close();
+  }
+});
+
+test("a manifest failure holds the whole ready window, not just one chunk", async () => {
+  // applyBatch interleaves the ready set chronologically, so releasing peers
+  // without a held chunk would apply its segments out of order later (#2145).
+  const spool = new Spool(":memory:");
+  try {
+    let blocked: string | undefined = chunkStableId(chunk({ path: "/tmp/raw/a.wav" }));
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "markApplied") {
+          return (key: string, value: string) => {
+            if (blocked !== undefined && key === `${blocked}:manifest`) throw new Error("sqlite busy");
+            target.markApplied(key, value);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+    const proc = createChunkProcessor(
+      deps(guarded, {
+        reorderWindowMs: 0,
+        onError: () => undefined,
+        // Distinct, non-overlapping spans: cross-channel dedup must not be
+        // what makes this assertion pass.
+        transcribe: async (input) =>
+          input.wavPath.endsWith("a.wav")
+            ? [{ text: "first", startUtc: t(1), endUtc: t(2) }]
+            : [{ text: "second", startUtc: t(30), endUtc: t(31) }],
+      }),
+    );
+    proc.enqueue(chunk({ path: "/tmp/raw/a.wav" }));
+    proc.enqueue(chunk({ path: "/tmp/raw/b.wav", channel: "system" }));
+    await proc.drain();
+    assert.equal(spool.stats().segments, 0, "the peer was held with the blocked chunk");
+
+    blocked = undefined;
+    await proc.finalize();
+    assert.equal(spool.stats().segments, 2, "both released together once the manifest was durable");
+  } finally {
+    spool.close();
+  }
+});
+
+test("finalize fails loudly when a chunk cannot be released", async () => {
+  // Reporting success would let the daemon close the spool while a one-shot
+  // event was never appended, and retention would then reclaim its WAV.
+  const spool = new Spool(":memory:");
+  try {
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "markApplied") {
+          return () => {
+            throw new Error("sqlite busy");
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+    const proc = createChunkProcessor(deps(guarded, { onError: () => undefined }));
+    proc.enqueue(chunk());
+    await assert.rejects(() => proc.finalize(), /retained for replay/);
+  } finally {
+    spool.close();
+  }
+});
+
+test("the assembler does not retain closed conversations", async () => {
+  // Otherwise every rollback checkpoint clones the whole capture history and
+  // the daemon's per-chunk work grows without bound (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const assembler = new ConversationAssembler({ gapMinutes: 0 });
+    const proc = createChunkProcessor(deps(spool, { assembler }));
+    proc.enqueue(chunk());
+    await proc.finalize();
+    assert.equal(spool.stats().conversations, 2, "the gap split two conversations");
+    assert.ok(assembler.conversations().length <= 1, "but at most the open one is retained");
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1107,9 +1107,10 @@ test("a retranscription that inserts a segment does not rebind an existing key",
 });
 
 test("a shortened retranscription keeps the chunk open instead of losing its tail", async () => {
-  // Crash after segment A of an [A, B] transcript, then an STT change makes the
-  // replay produce only A. The recorded segment COUNT is what tells the two
-  // cases apart (issue #2145).
+  // A REAL partial apply: the first run persists A and then fails on B, so the
+  // chunk is never completed. A later STT change makes the replay produce only
+  // A. The recorded segment COUNT is what tells that apart from a chunk whose
+  // transcript legitimately has one segment (issue #2145).
   const spool = new Spool(":memory:");
   try {
     const ev = chunk({ path: "/tmp/raw/shrink.wav" });
@@ -1119,11 +1120,24 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
       { text: "A", startUtc: t(1), endUtc: t(2) },
       { text: "B", startUtc: t(40), endUtc: t(41) },
     ];
+    // Fail the SECOND append so segment A lands durably and B never does.
+    let appends = 0;
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "appendAssembledSegments") {
+          return (input: Parameters<Spool["appendAssembledSegments"]>[0]) => {
+            appends += 1;
+            if (appends === 2) throw new Error("sqlite busy");
+            return target.appendAssembledSegments(input);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
 
-    // Run 1 records the two-segment count, then we simulate losing B by
-    // deleting its row while leaving the count marker in place.
-    const first = createChunkProcessor(
-      deps(spool, {
+    const partial = createChunkProcessor(
+      deps(guarded, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
         transcribe: async () => two,
         cleanupRawAudio: async (event) => {
@@ -1131,11 +1145,13 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
         },
       }),
     );
-    first.enqueue(ev);
-    await first.drain();
-    assert.equal(spool.isChunkApplied(`${cid}:n2`), true, "the transcript size was recorded");
+    partial.enqueue(ev);
+    await partial.drain();
+    assert.equal(spool.stats().segments, 1, "only A persisted");
+    assert.equal(spool.isChunkApplied(`${cid}:n2`), true, "the two-segment transcript was recorded");
+    assert.equal(spool.isChunkApplied(`${cid}:done`), false, "and the chunk is not complete");
 
-    // Run 2 sees a SHORTER transcript for the same chunk.
+    // The replay now produces only A.
     const shortened = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
@@ -1147,17 +1163,18 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     );
     shortened.enqueue(chunk({ path: "/tmp/raw/shrink.wav" }));
     await shortened.finalize();
+
     assert.equal(
       spool.isChunkApplied(`${cid}:done`),
-      true,
-      "run 1 already completed the chunk, so the replay short-circuits on :done",
+      false,
+      "a shorter transcript never completes the chunk",
     );
+    assert.deepEqual(cleaned, [], "and its raw audio is retained for another replay");
 
-    // A chunk that was NEVER completed and retranscribes shorter must stay open.
-    const other = chunk({ path: "/tmp/raw/shrink2.wav" });
-    const otherId = chunkStableId(other);
-    spool.markApplied(`${otherId}:n2`, "-");
-    const partial = createChunkProcessor(
+    // A chunk whose transcript legitimately matches DOES complete.
+    const stable = chunk({ path: "/tmp/raw/stable.wav" });
+    const stableId = chunkStableId(stable);
+    const ok = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
         transcribe: async () => [two[0]],
@@ -1166,10 +1183,10 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
         },
       }),
     );
-    partial.enqueue(other);
-    await partial.finalize();
-    assert.equal(spool.isChunkApplied(`${otherId}:done`), false, "not completed on a shorter transcript");
-    assert.ok(!cleaned.includes("/tmp/raw/shrink2.wav"), "and its raw audio is retained");
+    ok.enqueue(stable);
+    await ok.finalize();
+    assert.equal(spool.isChunkApplied(`${stableId}:done`), true);
+    assert.deepEqual(cleaned, ["/tmp/raw/stable.wav"]);
   } finally {
     spool.close();
   }

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -573,16 +573,17 @@ test("a durable replay does not re-consume the embedding or corrupt the cluster"
   }
 });
 
-test("partial-chunk replay appends the missing tail group instead of skipping the whole chunk", async () => {
+test("partial-chunk replay appends the missing tail segment instead of duplicating the first", async () => {
   const spool = new Spool(":memory:");
   try {
     const ev = chunk({ path: "/tmp/raw/multi.wav" });
     const cid = chunkStableId(ev);
-    // Simulate a kill-9 AFTER group 0 appended but BEFORE group 1 / the :done
-    // marker: persist only group 0 under its per-group key.
+    // Simulate a kill-9 AFTER segment 0 appended but BEFORE segment 1 / the
+    // :done marker. Keys are per-segment (`chunkId:i<index>`) so they mean the
+    // same bytes on every replay, whatever batch the chunk lands in (#2145).
     spool.appendAssembledSegments({
-      idempotencyKey: `${cid}:0`,
-      chunkId: `${cid}:0`,
+      idempotencyKey: `${cid}:i0`,
+      chunkId: `${cid}:i0`,
       conversationId: "conv_grp0",
       startedAtUtc: t(1),
       state: "capturing",
@@ -590,7 +591,6 @@ test("partial-chunk replay appends the missing tail group instead of skipping th
     });
     assert.equal(spool.stats().segments, 1);
     assert.equal(spool.isChunkApplied(`${cid}:done`), false);
-    // Replay the whole chunk; gapMinutes 0 splits its two segments into two groups.
     const proc = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
@@ -602,7 +602,7 @@ test("partial-chunk replay appends the missing tail group instead of skipping th
     );
     proc.enqueue(ev);
     await proc.finalize();
-    assert.equal(spool.stats().segments, 2, "the previously-lost tail group was appended; group 0 not duplicated");
+    assert.equal(spool.stats().segments, 2, "the lost tail segment was appended; segment 0 not duplicated");
     assert.equal(spool.isChunkApplied(`${cid}:done`), true, "the chunk is now marked complete");
   } finally {
     spool.close();
@@ -615,8 +615,8 @@ test("a zero-segment replay of a partially-applied chunk does NOT mark it done (
     const ev = chunk({ path: "/tmp/raw/multi.wav" });
     const cid = chunkStableId(ev);
     spool.appendAssembledSegments({
-      idempotencyKey: `${cid}:0`,
-      chunkId: `${cid}:0`,
+      idempotencyKey: `${cid}:i0`,
+      chunkId: `${cid}:i0`,
       conversationId: "conv_grp0",
       startedAtUtc: t(1),
       state: "capturing",
@@ -629,7 +629,7 @@ test("a zero-segment replay of a partially-applied chunk does NOT mark it done (
     empty.enqueue(ev);
     await empty.finalize();
     assert.equal(spool.isChunkApplied(`${cid}:done`), false, "not marked done while the tail is still missing");
-    // A later correct replay still recovers the missing tail group.
+    // A later correct replay still recovers the missing tail segment.
     const fixed = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
@@ -641,8 +641,43 @@ test("a zero-segment replay of a partially-applied chunk does NOT mark it done (
     );
     fixed.enqueue(ev);
     await fixed.finalize();
-    assert.equal(spool.stats().segments, 2, "the tail group was recovered on a correct replay");
+    assert.equal(spool.stats().segments, 2, "the tail segment was recovered on a correct replay");
     assert.equal(spool.isChunkApplied(`${cid}:done`), true);
+  } finally {
+    spool.close();
+  }
+});
+
+test("a chunk applied under the pre-#2145 group keys is never re-appended", async () => {
+  // Legacy `chunkId` / `chunkId:<n>` keys cannot be mapped onto per-segment
+  // keys, so such a chunk is treated as applied and closed out. Losing the
+  // tail of one in-flight chunk across the upgrade beats duplicating the
+  // segments that were already stored.
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk({ path: "/tmp/raw/legacy.wav" });
+    const cid = chunkStableId(ev);
+    spool.appendAssembledSegments({
+      idempotencyKey: `${cid}:0`,
+      chunkId: `${cid}:0`,
+      conversationId: "conv_legacy",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "legacy group", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [
+          { text: "legacy group", startUtc: t(1), endUtc: t(2) },
+          { text: "tail", startUtc: t(30), endUtc: t(31) },
+        ],
+      }),
+    );
+    proc.enqueue(ev);
+    await proc.finalize();
+    assert.equal(spool.stats().segments, 1, "no duplicate of the legacy-applied segment");
+    assert.equal(spool.isChunkApplied(`${cid}:done`), true, "and the chunk is closed out");
   } finally {
     spool.close();
   }
@@ -855,9 +890,11 @@ test("a crash between cluster and assignment cannot double-count embeddings", as
   const spool = new Spool(":memory:");
   try {
     const voice: Embedding = [1, 0, 0, 0];
+    const clusterer = new SpeakerClusterer(0.7);
     const failing = createChunkProcessor(
       deps(spool, {
-        diarizer: new SpeakerClusterer(0.7),
+        diarizer: clusterer,
+        restoreDiarizer: (clusters) => clusterer.restore(clusters),
         embed: () => voice,
         transcribe: async () => [{ text: "one utterance", startUtc: t(1), endUtc: t(2) }],
       }),
@@ -877,9 +914,16 @@ test("a crash between cluster and assignment cannot double-count embeddings", as
     };
     await assert.rejects(() => failing.finalize(), /sqlite exploded mid-commit/);
     assert.deepEqual(spool.readSpeakerClusters(), [], "the cluster write rolled back with the assignment");
+    assert.deepEqual(clusterer.clusters(), [], "and the in-memory clusterer rolled back with it");
 
+    // Reuse the SAME clusterer: a daemon that keeps running after the failure
+    // must not count the embedding twice on the retry.
     const recovered = createChunkProcessor(
-      deps(spool, { diarizer: new SpeakerClusterer(0.7), embed: () => voice }),
+      deps(spool, {
+        diarizer: clusterer,
+        restoreDiarizer: (clusters) => clusterer.restore(clusters),
+        embed: () => voice,
+      }),
     );
     await recovered.finalize();
     const clusters = spool.readSpeakerClusters();

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1116,10 +1116,11 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     const ev = chunk({ path: "/tmp/raw/shrink.wav" });
     const cid = chunkStableId(ev);
     const cleaned: string[] = [];
-    const two = [
-      { text: "A", startUtc: t(1), endUtc: t(2) },
-      { text: "B", startUtc: t(40), endUtc: t(41) },
-    ];
+    // Named, not indexed: `noUncheckedIndexedAccess` makes `two[0]` optional,
+    // which breaks contextual typing of the deps object it is passed through.
+    const segmentA: TranscribedSegment = { text: "A", startUtc: t(1), endUtc: t(2) };
+    const segmentB: TranscribedSegment = { text: "B", startUtc: t(40), endUtc: t(41) };
+    const two = [segmentA, segmentB];
     // Fail the SECOND append so segment A lands durably and B never does.
     let appends = 0;
     const guarded = new Proxy(spool, {
@@ -1155,7 +1156,7 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     const shortened = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
-        transcribe: async () => [two[0]],
+        transcribe: async () => [segmentA],
         cleanupRawAudio: async (event) => {
           cleaned.push(event.path);
         },
@@ -1169,7 +1170,9 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
       false,
       "a shorter transcript never completes the chunk",
     );
-    assert.deepEqual(cleaned, [], "and its raw audio is retained for another replay");
+    // `assert.deepEqual` is an assertion signature, so comparing against `[]`
+    // would narrow `cleaned` to `never[]` for the rest of the test.
+    assert.equal(cleaned.length, 0, "and its raw audio is retained for another replay");
 
     // A chunk whose transcript legitimately matches DOES complete.
     const stable = chunk({ path: "/tmp/raw/stable.wav" });
@@ -1177,7 +1180,7 @@ test("a shortened retranscription keeps the chunk open instead of losing its tai
     const ok = createChunkProcessor(
       deps(spool, {
         assembler: new ConversationAssembler({ gapMinutes: 0 }),
-        transcribe: async () => [two[0]],
+        transcribe: async () => [segmentA],
         cleanupRawAudio: async (event) => {
           cleaned.push(event.path);
         },

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1251,3 +1251,50 @@ test("a replay with the same segment count but different content stays open", as
     spool.close();
   }
 });
+
+test("a chunk is never released without its transcript manifest", async () => {
+  // Swallowing a failed manifest write and releasing anyway would let a later,
+  // changed retranscription record the FIRST manifest and complete a partially
+  // applied chunk (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    let failMarker = true;
+    const cleaned: string[] = [];
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "markApplied" && failMarker) {
+          return () => {
+            throw new Error("sqlite busy");
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+    const errors: Error[] = [];
+    const proc = createChunkProcessor(
+      deps(guarded, {
+        reorderWindowMs: 0,
+        onError: (error) => errors.push(error),
+        cleanupRawAudio: async (event) => {
+          cleaned.push(event.path);
+        },
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(spool.stats().segments, 0, "nothing was appended without a manifest");
+    assert.equal(cleaned.length, 0, "and the raw audio is retained");
+    assert.ok(
+      errors.some((error) => /sqlite busy/.test(error.message)),
+      "the failure was reported",
+    );
+
+    // The next pass retries the write and releases the chunk.
+    failMarker = false;
+    await proc.finalize();
+    assert.equal(spool.stats().segments, 2, "the chunk released once its manifest was durable");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -806,3 +806,86 @@ test("reorderWindowMs 0 keeps the pre-#2145 release-on-arrival behavior", async 
   }
 });
 
+
+test("overlapping cross-channel windows interleave by timestamp (issue #2145)", async () => {
+  // The mic chunk covers 00:00 and 00:20; the system chunk covers 00:10. With
+  // whole-chunk release the 00:10 segment landed AFTER 00:20 and could join the
+  // later conversation, splitting a cross-channel duplicate across two
+  // conversations where finalize-time dedup can no longer see it.
+  const spool = new Spool(":memory:");
+  try {
+    let minted = 0;
+    const byPath: Record<string, TranscribedSegment[]> = {
+      "/tmp/raw/mic-span.wav": [
+        { text: "mic first", startUtc: t(0), endUtc: t(1) },
+        { text: "mic third", startUtc: t(20), endUtc: t(21) },
+      ],
+      "/tmp/raw/sys-mid.wav": [{ text: "system second", startUtc: t(10), endUtc: t(11) }],
+    };
+    const proc = createChunkProcessor(
+      deps(spool, {
+        assembler: new ConversationAssembler({ gapMinutes: 0, makeId: () => `conv_${++minted}` }),
+        reorderWindowMs: 120_000,
+        transcribe: async ({ wavPath }) => byPath[wavPath] ?? [],
+      }),
+    );
+    proc.enqueue(
+      chunk({ path: "/tmp/raw/mic-span.wav", channel: "mic", startedAtUtc: t(0), endedAtUtc: t(30) }),
+    );
+    proc.enqueue(
+      chunk({ path: "/tmp/raw/sys-mid.wav", channel: "system", startedAtUtc: t(10), endedAtUtc: t(12) }),
+    );
+    await proc.drain();
+    await proc.finalize();
+
+    assert.equal(minted, 3, "gap 0 gives each segment its own conversation");
+    assert.deepEqual(
+      [1, 2, 3].map((n) => spool.conversationSegmentsForDedup(`conv_${n}`).map((s) => s.text)),
+      [["mic first"], ["system second"], ["mic third"]],
+      "conversations were minted in capture order, not chunk order",
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("a crash between cluster and assignment cannot double-count embeddings", async () => {
+  // The two writes are one transaction: a failure rolls both back, so the next
+  // finalize sees pending segments and unchanged counts (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const voice: Embedding = [1, 0, 0, 0];
+    const failing = createChunkProcessor(
+      deps(spool, {
+        diarizer: new SpeakerClusterer(0.7),
+        embed: () => voice,
+        transcribe: async () => [{ text: "one utterance", startUtc: t(1), endUtc: t(2) }],
+      }),
+    );
+    failing.enqueue(chunk());
+    await failing.drain();
+
+    // Force the assignment half to throw, mid-transaction.
+    const original = spool.commitDiarization.bind(spool);
+    let failed = false;
+    (spool as unknown as { commitDiarization: unknown }).commitDiarization = (input: never) => {
+      if (!failed) {
+        failed = true;
+        throw new Error("sqlite exploded mid-commit");
+      }
+      return original(input);
+    };
+    await assert.rejects(() => failing.finalize(), /sqlite exploded mid-commit/);
+    assert.deepEqual(spool.readSpeakerClusters(), [], "the cluster write rolled back with the assignment");
+
+    const recovered = createChunkProcessor(
+      deps(spool, { diarizer: new SpeakerClusterer(0.7), embed: () => voice }),
+    );
+    await recovered.finalize();
+    const clusters = spool.readSpeakerClusters();
+    assert.equal(clusters.length, 1);
+    assert.equal(clusters[0].embeddingCount, 1, "counted exactly once across the failure");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1034,15 +1034,18 @@ test("a pre-commit failure also rewinds restart-recovery state", async () => {
       { text: "after restart", startUtc: t(3), endUtc: t(4) },
     ] };
 
-    const failing = createChunkProcessor(withinGap);
-    failing.enqueue(chunk({ startedAtUtc: t(3), endedAtUtc: t(5) }));
-    await failing.drain();
+    // ONE processor for both attempts: a fresh instance would resume from its
+    // own untouched flags, which would let the test pass even if the rollback
+    // never restored them.
+    const proc = createChunkProcessor(withinGap);
+    proc.enqueue(chunk({ startedAtUtc: t(3), endedAtUtc: t(5) }));
+    await proc.drain();
     assert.equal(spool.stats().segments, 1, "nothing new persisted");
 
+    // The failed chunk was requeued, so finalize retries THAT chunk on THIS
+    // processor — the flags the rollback restored are the ones in play.
     failAppends = false;
-    const retry = createChunkProcessor(withinGap);
-    retry.enqueue(chunk({ startedAtUtc: t(3), endedAtUtc: t(5) }));
-    await retry.finalize();
+    await proc.finalize();
 
     assert.equal(minted, 0, "the retry resumed the durable conversation instead of minting a new id");
     assert.deepEqual(

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1756,3 +1756,99 @@ test("a restart holds only the conversation each incomplete chunk belongs to", a
     spool.close();
   }
 });
+
+test("a replay resumes its own conversation, not merely the newest", async () => {
+  // The missing tail of an OLDER chunk predates the newest capturing
+  // conversation, so resuming the newest would strand it (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const older = chunk({ path: "/tmp/raw/older.wav" });
+    const cid = chunkStableId(older);
+    const head = { text: "A", startUtc: t(1), endUtc: t(2) };
+    const tailSeg = { text: "tail", startUtc: t(3), endUtc: t(4) };
+    spool.markApplied(transcriptManifestKey(cid), transcriptManifestHash(cid, [head, tailSeg]));
+    spool.appendAssembledSegments({
+      idempotencyKey: segmentStableKey(cid, head),
+      chunkId: segmentStableKey(cid, head),
+      conversationId: "conv_older",
+      startedAtUtc: head.startUtc,
+      state: "capturing",
+      segments: [{ channel: "mic", text: "A", startUtc: head.startUtc, endUtc: head.endUtc, isWearer: true }],
+    });
+    // A NEWER conversation is also capturing, and is what `latestCapturing`
+    // would return.
+    spool.appendAssembledSegments({
+      idempotencyKey: "seg-newer",
+      chunkId: "chunk-newer",
+      conversationId: "conv_newer",
+      startedAtUtc: "2026-07-24T08:00:00.000Z",
+      state: "capturing",
+      segments: [
+        {
+          channel: "mic",
+          text: "later talk",
+          startUtc: "2026-07-24T08:00:00.000Z",
+          endUtc: "2026-07-24T08:00:05.000Z",
+          isWearer: true,
+        },
+      ],
+    });
+
+    const proc = createChunkProcessor(
+      deps(spool, { onError: () => undefined, transcribe: async () => [head, tailSeg] }),
+    );
+    proc.enqueue(older);
+    await proc.finalize();
+    assert.deepEqual(
+      spool.conversationSegmentsForDedup("conv_older").map((seg) => seg.text),
+      ["A", "tail"],
+      "the missing tail joined its own conversation",
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("a manifest with no stored segments still holds what a replay could resume", async () => {
+  // A crash between the manifest write and the first append leaves no mapping,
+  // so the hold must fall back to everything resumable (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const ev = chunk();
+    const cid = chunkStableId(ev);
+    spool.markApplied(
+      transcriptManifestKey(cid),
+      transcriptManifestHash(cid, [{ text: "A", startUtc: t(1), endUtc: t(2) }]),
+    );
+    spool.appendAssembledSegments({
+      idempotencyKey: "seg-open",
+      chunkId: "chunk-open",
+      conversationId: "conv_open",
+      startedAtUtc: t(1),
+      state: "capturing",
+      segments: [{ channel: "mic", text: "open", startUtc: t(1), endUtc: t(2), isWearer: true }],
+    });
+    assert.deepEqual(spool.conversationIdsForChunk(cid), [], "the chunk stored nothing yet");
+
+    const later = chunk({
+      path: "/tmp/raw/later.wav",
+      startedAtUtc: "2026-07-24T09:00:00.000Z",
+      endedAtUtc: "2026-07-24T09:00:30.000Z",
+    });
+    const proc = createChunkProcessor(
+      deps(spool, {
+        transcribe: async () => [
+          { text: "later", startUtc: "2026-07-24T09:00:00.000Z", endUtc: "2026-07-24T09:00:05.000Z" },
+        ],
+      }),
+    );
+    proc.enqueue(later);
+    await proc.finalize();
+    assert.ok(
+      [...spool.capturingConversationIds()].includes("conv_open"),
+      "the conversation a replay could still need stayed open",
+    );
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1694,3 +1694,65 @@ test("a hold does not keep an unrelated conversation open", async () => {
     spool.close();
   }
 });
+
+test("a restart holds only the conversation each incomplete chunk belongs to", async () => {
+  // Attaching every capturing conversation to every incomplete chunk would keep
+  // unrelated audio off the final-only path, and would stop a conversation from
+  // finalizing after ITS chunk replayed while another chunk waits (issue #2145).
+  const spool = new Spool(":memory:");
+  try {
+    const first = chunk({ path: "/tmp/raw/first.wav" });
+    const second = chunk({
+      path: "/tmp/raw/second.wav",
+      startedAtUtc: "2026-07-24T06:00:00.000Z",
+      endedAtUtc: "2026-07-24T06:00:30.000Z",
+    });
+    const pairs = [
+      { ev: first, conv: "conv_one", seg: { text: "A", startUtc: t(1), endUtc: t(2) } },
+      {
+        ev: second,
+        conv: "conv_two",
+        seg: { text: "C", startUtc: "2026-07-24T06:00:00.000Z", endUtc: "2026-07-24T06:00:05.000Z" },
+      },
+    ];
+    for (const { ev, conv, seg } of pairs) {
+      const cid = chunkStableId(ev);
+      spool.markApplied(
+        transcriptManifestKey(cid),
+        transcriptManifestHash(cid, [seg, { text: "tail", startUtc: t(50), endUtc: t(51) }]),
+      );
+      spool.appendAssembledSegments({
+        idempotencyKey: segmentStableKey(cid, seg),
+        chunkId: segmentStableKey(cid, seg),
+        conversationId: conv,
+        startedAtUtc: seg.startUtc,
+        state: "capturing",
+        segments: [{ channel: "mic", text: seg.text, startUtc: seg.startUtc, endUtc: seg.endUtc, isWearer: true }],
+      });
+    }
+    assert.deepEqual(
+      spool.conversationIdsForChunk(chunkStableId(first)),
+      ["conv_one"],
+      "each chunk maps to its own conversation",
+    );
+
+    // A fresh process replays the FIRST chunk correctly; the second still waits.
+    const proc = createChunkProcessor(
+      deps(spool, {
+        onError: () => undefined,
+        assembler: new ConversationAssembler({ gapMinutes: 0 }),
+        transcribe: async () => [
+          { text: "A", startUtc: t(1), endUtc: t(2) },
+          { text: "tail", startUtc: t(50), endUtc: t(51) },
+        ],
+      }),
+    );
+    proc.enqueue(first);
+    await proc.finalize();
+    const capturing = [...spool.capturingConversationIds()];
+    assert.ok(!capturing.includes("conv_one"), "the replayed chunk's conversation finalized");
+    assert.ok(capturing.includes("conv_two"), "the still-incomplete chunk's conversation stayed held");
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.test.ts
+++ b/packages/capture-audio/src/processor.test.ts
@@ -1458,3 +1458,48 @@ test("a conflicting retranscription appends nothing", async () => {
     spool.close();
   }
 });
+
+test("a chunk retained for replay keeps its conversation resumable", async () => {
+  // Both retain paths — a silent replay over a durable prefix, and a manifest
+  // conflict — must hold the conversation open. Once `finalize()` flips it to
+  // `final`, a matching replay cannot `resume` it and the missing tail lands
+  // in a new conversation, out of reach of cross-channel dedup (issue #2145).
+  for (const mode of ["silent", "conflict"] as const) {
+    const spool = new Spool(":memory:");
+    try {
+      const ev = chunk();
+      const cid = chunkStableId(ev);
+      const segs = [
+        { text: "A", startUtc: t(1), endUtc: t(2) },
+        { text: "B", startUtc: t(40), endUtc: t(41) },
+      ];
+      // A first run persisted a prefix under a capturing conversation and
+      // recorded its manifest, then died.
+      spool.markApplied(transcriptManifestKey(cid), transcriptManifestHash(cid, segs));
+      spool.appendAssembledSegments({
+        idempotencyKey: segmentStableKey(cid, segs[0]),
+        chunkId: cid,
+        conversationId: "conv_prefix",
+        startedAtUtc: t(1),
+        state: "capturing",
+        segments: [{ channel: "mic", text: "A", startUtc: t(1), endUtc: t(2), isWearer: true }],
+      });
+
+      const proc = createChunkProcessor(
+        deps(spool, {
+          onError: () => undefined,
+          transcribe: async () => (mode === "silent" ? [] : [{ text: "X", startUtc: t(1), endUtc: t(2) }]),
+        }),
+      );
+      proc.enqueue(ev);
+      await proc.finalize();
+      assert.deepEqual(
+        [...spool.capturingConversationIds()],
+        ["conv_prefix"],
+        `the ${mode} replay left the durable prefix resumable`,
+      );
+    } finally {
+      spool.close();
+    }
+  }
+});

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -478,12 +478,17 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // the holds from the durable markers: a manifest without a `:done` is a
       // chunk whose WAV is retained, and the conversations capturing right now
       // are the prefixes its replay could still resume (issue #2145).
-      const incomplete = deps.spool.incompleteChunkIds();
-      if (incomplete.length > 0) {
-        const resumableAtStartup = resumableConversations();
-        for (const chunkId of incomplete) {
-          trackRetention(chunkId, true, resumableAtStartup);
-        }
+      const capturingAtStartup = new Set(deps.spool.capturingConversationIds());
+      for (const chunkId of deps.spool.incompleteChunkIds()) {
+        // Scope each hold to the conversations that chunk actually contributed
+        // to: attaching every capturing conversation to every incomplete chunk
+        // would keep unrelated audio off the final-only read path, and would
+        // stop a completed conversation from finalizing while any OTHER chunk
+        // is still awaiting replay.
+        const held = deps.spool
+          .conversationIdsForChunk(chunkId)
+          .filter((id) => capturingAtStartup.has(id));
+        if (held.length > 0) retainedChunks.set(chunkId, new Set(held));
       }
     }
     // Decide retention BEFORE anything can close a conversation: a chunk kept

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -19,6 +19,7 @@ import { createHash } from "node:crypto";
 
 import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
 import { dedupeCrossChannel } from "./dedup.js";
+import { CaptureInputError } from "./errors.js";
 import type { Embedding, SpeakerClusterer } from "./diarization.js";
 import type { ChunkEvent } from "./native.js";
 import type { Spool } from "./spool.js";
@@ -56,6 +57,15 @@ export interface ChunkProcessorDeps {
   diarizer?: SpeakerClusterer;
   /** Cross-channel dedup window in ms; defaults to the dedup module's tolerance. */
   dedupWindowMs?: number;
+  /**
+   * Bounded reorder window in ms for cross-channel arrival skew (issue
+   * #2145). A transcribed chunk is HELD until the newest observed chunk end
+   * is this far past its own end, then released oldest-first, so a delayed
+   * system chunk is assembled into the conversation it temporally belongs to
+   * rather than joined to a later mic chunk's. 0 (the default here, so
+   * existing callers are unchanged) releases every chunk on arrival.
+   */
+  reorderWindowMs?: number;
   /** Reports a per-chunk failure; the chain keeps running afterwards. */
   onError?: (error: Error, event: ChunkEvent) => void;
 }
@@ -78,11 +88,66 @@ export function chunkStableId(event: ChunkEvent): string {
   return `chk_${createHash("sha1").update(event.path).digest("hex")}`;
 }
 
+/** One transcribed chunk waiting in the reorder buffer (issue #2145). */
+interface BufferedChunk {
+  event: ChunkEvent;
+  chunkId: string;
+  built: Array<{ seg: AssemblySegment; raw: TranscribedSegment }>;
+  /** Earliest segment start, or the chunk's own start when it is silent. */
+  startMs: number;
+  /** Latest segment end, never earlier than the chunk's own end. */
+  endMs: number;
+}
+
+/**
+ * Epoch ms for an instant the native layer already validated. A value that
+ * cannot be parsed would silently sort first and defeat the reorder buffer,
+ * so it is rejected instead.
+ */
+function instantMs(value: string, field: string): number {
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new CaptureInputError(`${field}: expected an ISO-8601 instant, got ${JSON.stringify(value)}`);
+  }
+  return ms;
+}
+
+function firstStartMs(event: ChunkEvent, raw: readonly TranscribedSegment[]): number {
+  let earliest = instantMs(event.startedAtUtc, "chunk.startedAtUtc");
+  for (const segment of raw) {
+    earliest = Math.min(earliest, instantMs(segment.startUtc, "segment.startUtc"));
+  }
+  return earliest;
+}
+
+function lastEndMs(event: ChunkEvent, raw: readonly TranscribedSegment[]): number {
+  let latest = instantMs(event.endedAtUtc, "chunk.endedAtUtc");
+  for (const segment of raw) {
+    latest = Math.max(latest, instantMs(segment.endUtc, "segment.endUtc"));
+  }
+  return latest;
+}
+
 export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let tail: Promise<void> = Promise.resolve();
   let recovered = false;
   let openConversationId: string | null = null;
   const processedThisRun = new Set<string>();
+  // Bounded reorder buffer (issue #2145). With `captureChannel: "both"` the
+  // native helper emits one chunk stream per channel, and a system chunk for
+  // an earlier window can arrive AFTER a later mic chunk. Feeding the
+  // assembler in arrival order then joins the delayed (earlier) segment to a
+  // conversation that started after it. Chunks are held here until the newest
+  // observed chunk end is `reorderWindowMs` past their own end, then released
+  // oldest-first, so the assembler always sees a chronological stream.
+  //
+  // A HELD chunk is not marked complete and keeps its WAV, so a crash before
+  // release replays it from the raw audio — the same durability contract as
+  // an untranscribed chunk.
+  const reorderWindowMs = Math.max(0, deps.reorderWindowMs ?? 0);
+  const buffer: BufferedChunk[] = [];
+  const bufferedIds = new Set<string>();
+  let watermarkSourceMs = Number.NEGATIVE_INFINITY;
   // Order-independent cross-channel dedup, applied at finalization: a mic
   // segment duplicating a system (loopback) segment in the same conversation is
   // pruned, keeping the cleaner system copy. Running at finalize — when every
@@ -96,8 +161,54 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     const drop = segs.filter((s) => !keep.has(s.id)).map((s) => s.id);
     if (drop.length > 0) deps.spool.deleteSegments(drop);
   };
+  /**
+   * Cluster one conversation's surviving segments (issue #2145).
+   *
+   * Runs AFTER dedup, so a pruned mic loopback contributes nothing: no
+   * inflated `embeddingCount`, no phantom cluster for a speaker that already
+   * exists. Only rows that still have no cluster are assigned, so a repeated
+   * finalize is idempotent. Diarization is therefore a pure function of the
+   * deduped segment set, independent of cross-channel arrival order.
+   */
+  const diarizeConversation = (id: string): void => {
+    const diarizer = deps.diarizer;
+    if (!diarizer) return;
+    const pending = deps.spool.conversationSegmentsForDiarization(id);
+    if (pending.length === 0) return;
+    // A label-only enrolled self can never match live audio, so the mic
+    // heuristic stays the wearer signal until voice enrollment lands.
+    const selfVoiceEnrolled = diarizer.clusters().some((c) => c.isSelf && c.embeddingCount > 0);
+    const assignments: Array<{ id: string; speakerCluster: string; isWearer: boolean }> = [];
+    const touched = new Set<string>();
+    for (const segment of pending) {
+      const clusterId = diarizer.assign(segment.embedding);
+      const assigned = diarizer.clusters().find((c) => c.id === clusterId);
+      const isWearer =
+        (assigned?.isSelf ?? false) || (segment.channel === "mic" && !selfVoiceEnrolled);
+      assignments.push({ id: segment.id, speakerCluster: clusterId, isWearer });
+      touched.add(clusterId);
+    }
+    // Clusters first: a segment row must never reference a cluster that is
+    // not persisted yet, so a crash between the two leaves the segments
+    // unassigned and the next finalize redoes them.
+    const byId = new Map(diarizer.clusters().map((c) => [c.id, c]));
+    for (const clusterId of touched) {
+      const cluster = byId.get(clusterId);
+      if (!cluster) continue;
+      deps.spool.upsertSpeaker({
+        id: cluster.id,
+        label: cluster.label,
+        isSelf: cluster.isSelf,
+        embeddingCount: cluster.embeddingCount,
+        centroid: cluster.centroid,
+        examples: cluster.examples,
+      });
+    }
+    deps.spool.assignSegmentSpeakers(assignments);
+  };
   const finalizeConv = (id: string): void => {
     dedupeConversation(id);
+    diarizeConversation(id);
     deps.spool.finalizeConversation(id);
   };
 
@@ -107,7 +218,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
 
   async function process(event: ChunkEvent): Promise<void> {
     const chunkId = chunkStableId(event);
-    if (processedThisRun.has(chunkId)) return; // in-run replay: already handled
+    // In-run replay: already applied, or already transcribed and waiting in
+    // the reorder buffer. Either way this event carries nothing new.
+    if (processedThisRun.has(chunkId) || bufferedIds.has(chunkId)) return;
     // Durable (cross-restart) FULL replay: a completed chunk wrote a per-chunk
     // ':done' marker, so its segments AND cluster updates are persisted. Skip
     // transcription + diarization entirely. A PARTIAL replay (crash between
@@ -137,10 +250,51 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           chunkStartedAtUtc: event.startedAtUtc,
         })
       : [];
+    buffer.push({
+      event,
+      chunkId,
+      built: buildSegments(event, raw),
+      startMs: firstStartMs(event, raw),
+      endMs: lastEndMs(event, raw),
+    });
+    bufferedIds.add(chunkId);
+    watermarkSourceMs = Math.max(watermarkSourceMs, lastEndMs(event, raw));
+    await releaseReady(false);
+  }
 
+  /** Build the base (undiarized) segments for one chunk's raw transcript. */
+  function buildSegments(
+    event: ChunkEvent,
+    raw: readonly TranscribedSegment[],
+  ): Array<{ seg: AssemblySegment; raw: TranscribedSegment }> {
+    const built: Array<{ seg: AssemblySegment; raw: TranscribedSegment }> = [];
+    for (const s of raw) {
+      const text = s.text.trim();
+      if (text === "") continue;
+      built.push({
+        seg: {
+          channel: event.channel,
+          text,
+          startUtc: s.startUtc,
+          endUtc: s.endUtc,
+          isWearer: event.channel === "mic",
+        },
+        raw: s,
+      });
+    }
+    return built;
+  }
+
+  /**
+   * Apply one buffered chunk: assemble, append, mark complete, reclaim the
+   * WAV. Everything here runs on the RELEASE timeline, not the arrival
+   * timeline, so a delayed chunk is assembled at its own place in time.
+   */
+  async function applyChunk(entry: BufferedChunk): Promise<void> {
+    const { event, chunkId, built } = entry;
     // Recover the newest still-open conversation once (any chunk, incl. silent)
     // so a post-restart chunk continues it; then finalize a stale open
-    // conversation when this chunk arrives a gap past it. Pure-silence runs
+    // conversation when this chunk is released a gap past it. Pure-silence runs
     // never call assembler.add, so closeIfIdle is what closes them.
     if (!recovered) {
       recovered = true;
@@ -156,25 +310,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       openConversationId = null;
     }
 
-    // Whether self is VOICE-enrolled (has an embedding to match), computed once:
-    // a label-only enroll-self can never match live audio, so the mic heuristic
-    // must remain the wearer signal until voice enrollment lands.
-    const selfVoiceEnrolled =
-      deps.diarizer !== undefined && deps.diarizer.clusters().some((c) => c.isSelf && c.embeddingCount > 0);
-    // Build base segments WITHOUT diarization; diarization is applied lazily per
-    // group below, only for groups that will actually be appended, so a partial
-    // replay never re-embeds an already-applied group (which would corrupt its
-    // speaker centroid/count). Each base segment carries its raw segment for the
-    // lazy embedding.
-    const built: Array<{ seg: AssemblySegment; raw: TranscribedSegment }> = [];
-    for (const s of raw) {
-      const text = s.text.trim();
-      if (text === "") continue;
-      built.push({
-        seg: { channel: event.channel, text, startUtc: s.startUtc, endUtc: s.endUtc, isWearer: event.channel === "mic" },
-        raw: s,
-      });
-    }
 
     if (built.length > 0) {
       // Segments usually land in one conversation, but a gap >= threshold (or
@@ -204,43 +339,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         if (openConversationId !== null && openConversationId !== grp.id) {
           finalizeConv(openConversationId);
         }
-        // Diarize this group now (lazily), only because it will be appended.
-        if (deps.embed && deps.diarizer) {
+        // Embed now — this is where the audio exists — but do NOT cluster.
+        // Clustering runs at finalize over the segments that SURVIVE
+        // cross-channel dedup (issue #2145), so a mic loopback duplicate that
+        // is later pruned can no longer inflate a centroid or invent a
+        // phantom speaker. The embedding rides along on the segment row.
+        if (deps.embed) {
           for (const item of grp.items) {
-            const embedding = await deps.embed(event, item.raw);
-            const clusterId = deps.diarizer.assign(embedding);
-            const assigned = deps.diarizer.clusters().find((c) => c.id === clusterId);
-            let isWearer = assigned?.isSelf ?? false;
-            // Label-only self can't match live audio: keep the mic=wearer heuristic.
-            if (!isWearer && event.channel === "mic" && !selfVoiceEnrolled) isWearer = true;
-            item.seg.isWearer = isWearer;
-            item.seg.speakerCluster = clusterId;
-          }
-        }
-        // Persist any speaker clusters this group references BEFORE appending its
-        // segments, so a durable append always implies its clusters are already
-        // persisted: a transient upsert failure aborts before the append commits
-        // (nothing applied, replay retries), leaving no window where applied
-        // segments reference an unpersisted cluster.
-        if (deps.diarizer) {
-          const touched = new Set(
-            grp.items.map((it) => it.seg.speakerCluster).filter((id): id is string => typeof id === "string"),
-          );
-          if (touched.size > 0) {
-            const byId = new Map(deps.diarizer.clusters().map((c) => [c.id, c]));
-            for (const cid of touched) {
-              const c = byId.get(cid);
-              if (c) {
-                deps.spool.upsertSpeaker({
-                  id: c.id,
-                  label: c.label,
-                  isSelf: c.isSelf,
-                  embeddingCount: c.embeddingCount,
-                  centroid: c.centroid,
-                  examples: c.examples,
-                });
-              }
-            }
+            item.seg.embedding = await deps.embed(event, item.raw);
           }
         }
         deps.spool.appendAssembledSegments({
@@ -279,6 +385,60 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
   }
 
+  /**
+   * Release every buffered chunk the watermark has passed, oldest first.
+   *
+   * Release is whole-chunk: a chunk's own segments are already chronological,
+   * and holding until its END clears the watermark is what makes the released
+   * stream chronological ACROSS chunks. Whole-chunk release also keeps the
+   * per-chunk idempotency keys (`chunkId`, `chunkId:g`, `chunkId:done`)
+   * exactly as they were, so replay and crash recovery are unchanged.
+   *
+   * `flushAll` ignores the watermark, for `finalize()`.
+   */
+  async function releaseReady(flushAll: boolean): Promise<void> {
+    const threshold = flushAll ? Number.POSITIVE_INFINITY : watermarkSourceMs - reorderWindowMs;
+    for (;;) {
+      const readyIndex = pickNextReleasable(threshold);
+      if (readyIndex === -1) return;
+      const [entry] = buffer.splice(readyIndex, 1);
+      if (entry === undefined) return;
+      bufferedIds.delete(entry.chunkId);
+      try {
+        await applyChunk(entry);
+      } catch (error) {
+        report(error, entry.event);
+      }
+    }
+  }
+
+  /**
+   * Index of the oldest releasable chunk, or -1. Ordering is by first
+   * segment start, then chunk end, then id: a total comparator, so the
+   * release order is identical across runs (rule 12).
+   */
+  function pickNextReleasable(threshold: number): number {
+    let best = -1;
+    for (let i = 0; i < buffer.length; i++) {
+      const candidate = buffer[i];
+      if (candidate.endMs > threshold) continue;
+      if (best === -1) {
+        best = i;
+        continue;
+      }
+      const incumbent = buffer[best];
+      if (
+        candidate.startMs < incumbent.startMs ||
+        (candidate.startMs === incumbent.startMs &&
+          (candidate.endMs < incumbent.endMs ||
+            (candidate.endMs === incumbent.endMs && candidate.chunkId < incumbent.chunkId)))
+      ) {
+        best = i;
+      }
+    }
+    return best;
+  }
+
   function enqueue(event: ChunkEvent): void {
     tail = tail.then(() => process(event)).catch((error) => report(error, event));
   }
@@ -288,13 +448,20 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   }
 
   async function finalize(): Promise<number> {
+    // Flush the reorder buffer ON the serialized chain, so a chunk still
+    // arriving cannot interleave with the flush.
+    tail = tail.then(() => releaseReady(true));
     await drain();
     deps.assembler.finalize();
-    // Dedup EVERY still-capturing conversation before the bulk flip to final —
-    // including one left by a crashed prior run that this process never touched
-    // (so it has no in-memory openConversationId) — so the served (final-only)
-    // output never contains a loopback duplicate.
-    for (const id of deps.spool.capturingConversationIds()) dedupeConversation(id);
+    // Dedup then cluster EVERY still-capturing conversation before the bulk
+    // flip to final — including one left by a crashed prior run that this
+    // process never touched (so it has no in-memory openConversationId) — so
+    // the served (final-only) output never contains a loopback duplicate and
+    // every surviving segment carries its speaker.
+    for (const id of deps.spool.capturingConversationIds()) {
+      dedupeConversation(id);
+      diarizeConversation(id);
+    }
     return deps.spool.finalizeOpenConversations();
   }
 

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -393,6 +393,15 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     const fresh = stream.filter(
       ({ entry, index }) => !deps.spool.isChunkApplied(`${entry.chunkId}:i${index}`),
     );
+    // Per chunk: did THIS run contribute anything new? A replay whose
+    // transcript is entirely already-applied proves nothing about a tail the
+    // original transcription produced and never persisted — an STT or
+    // segmentation change can shorten the transcript — so such a chunk is not
+    // closed out and keeps its raw audio (issue #2145).
+    const freshPerChunk = new Map<string, number>();
+    for (const { entry } of fresh) {
+      freshPerChunk.set(entry.chunkId, (freshPerChunk.get(entry.chunkId) ?? 0) + 1);
+    }
 
     // Embed before a single `assembler.add`. Embedding is the only await that
     // can throw before persistence, and the assembler has no undo: a throw
@@ -465,7 +474,8 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // applied (a partial crash) must NOT be marked done, or the missing tail
       // groups would be stranded forever.
       const fullyProcessed =
-        entry.built.length > 0 || !deps.spool.isChunkApplied(`${entry.chunkId}:i0`);
+        (freshPerChunk.get(entry.chunkId) ?? 0) > 0 ||
+        !deps.spool.isChunkApplied(`${entry.chunkId}:i0`);
       processedThisRun.add(entry.chunkId);
       if (!fullyProcessed) continue;
       // The chunk is fully durably transcribed: record completion and reclaim

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -359,9 +359,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     const closed = deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
     if (closed !== null && closed === openConversationId) {
       // Dedupes, diarizes and flips a conversation in the spool — durable, so
-      // the caller must not rewind past it.
-      progress.persisted = true;
+      // the caller must not rewind past it. Flagged AFTER the call: a throw
+      // inside it leaves nothing durable, and the batch should still rewind.
       finalizeConv(closed);
+      progress.persisted = true;
       openConversationId = null;
     }
 
@@ -438,8 +439,8 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       for (const item of run.items) {
         const key = `${chunkId}:i${item.index}`;
         if (openConversationId !== null && openConversationId !== run.id) {
-          progress.persisted = true;
           finalizeConv(openConversationId);
+          progress.persisted = true;
         }
         deps.spool.appendAssembledSegments({
           idempotencyKey: key,

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -336,7 +336,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
    *
    * Everything here runs on the RELEASE timeline, not the arrival timeline.
    */
-  async function applyBatch(batch: readonly BufferedChunk[]): Promise<void> {
+  async function applyBatch(
+    batch: readonly BufferedChunk[],
+    progress: { persisted: boolean },
+  ): Promise<void> {
     // Recover the newest still-open conversation once (any chunk, incl. silent)
     // so a post-restart chunk continues it; then finalize a stale open
     // conversation when this batch is released a gap past it. Pure-silence runs
@@ -444,6 +447,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           wavPath: event.path,
           segments: [item.seg],
         });
+        progress.persisted = true;
         openConversationId = run.id;
       }
     }
@@ -507,9 +511,17 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           left.endMs - right.endMs ||
           (left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0),
       );
+      // Rewind only matters when NOTHING was persisted: then the assembler is
+      // ahead of durable reality and the retry would collapse conversations
+      // the first attempt split. Once a segment is durable its conversation id
+      // is too, so rewinding past it would split that conversation across two
+      // ids instead (issue #2145).
+      const assemblerCheckpoint = deps.assembler.checkpoint();
+      const progress = { persisted: false };
       try {
-        await applyBatch(batch);
+        await applyBatch(batch, progress);
       } catch (error) {
+        if (!progress.persisted) deps.assembler.rewind(assemblerCheckpoint);
         // Requeue FIRST: `report` runs an operator callback that may itself
         // throw, and losing the batch to a broken telemetry sink would turn an
         // observer failure into data loss. A throw mid-batch leaves the chunks

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -246,6 +246,19 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // transcription + diarization entirely. A PARTIAL replay (crash between
     // group appends) has no marker, so it falls through and per-group
     // idempotency re-appends only the missing groups below.
+    if (deps.spool.isChunkApplied(`${chunkId}:done`)) {
+      processedThisRun.add(chunkId);
+      // Retry raw-WAV reclaim: the marker is written before cleanup, so if the
+      // first run's cleanup failed (or it died between marking and deleting), a
+      // replay is our chance to remove the file instead of waiting for the janitor.
+      try {
+        await deps.cleanupRawAudio(event);
+      } catch (err) {
+        report(err, event);
+      }
+      return;
+    }
+
     // Pre-#2145 runs keyed appends per GROUP (`chunkId` or `chunkId:<n>`).
     // Those keys cannot be mapped onto the new per-segment keys, so a chunk
     // carrying one is treated as already applied: re-appending under new keys
@@ -263,19 +276,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       );
       return;
     }
-    if (deps.spool.isChunkApplied(`${chunkId}:done`)) {
-      processedThisRun.add(chunkId);
-      // Retry raw-WAV reclaim: the marker is written before cleanup, so if the
-      // first run's cleanup failed (or it died between marking and deleting), a
-      // replay is our chance to remove the file instead of waiting for the janitor.
-      try {
-        await deps.cleanupRawAudio(event);
-      } catch (err) {
-        report(err, event);
-      }
-      return;
-    }
-
     // VAD gate: a non-speech chunk skips STT (and model resolution) entirely,
     // flowing through as a zero-segment chunk so idle-close + WAV reclaim still
     // run. Absent detectSpeech -> transcribe every chunk.
@@ -379,13 +379,19 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         return left.index - right.index;
       });
 
-    // Embed FIRST, before a single `assembler.add`. Embedding is the only
-    // await that can throw before persistence, and the assembler has no undo:
-    // a throw after it had consumed segments would leave it advanced, so the
-    // retry would feed earlier timestamps into a later conversation and merge
-    // spans the first attempt had split (issue #2145).
+    // Durable segments leave the stream before anything else touches them: a
+    // replay must not pay for their embedding again, and an input-specific
+    // embedding failure on an already-persisted segment would requeue the
+    // batch forever and block the segments that ARE missing (issue #2145).
+    const fresh = stream.filter(
+      ({ entry, index }) => !deps.spool.isChunkApplied(`${entry.chunkId}:i${index}`),
+    );
+
+    // Embed before a single `assembler.add`. Embedding is the only await that
+    // can throw before persistence, and the assembler has no undo: a throw
+    // after it had consumed segments would leave it advanced.
     if (deps.embed) {
-      for (const { entry, item } of stream) {
+      for (const { entry, item } of fresh) {
         item.seg.embedding = await deps.embed(entry.event, item.raw);
       }
     }
@@ -407,8 +413,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       startedAtUtc: string;
       items: Array<{ seg: AssemblySegment; raw: TranscribedSegment; index: number }>;
     }> = [];
-    for (const { entry, item, index } of stream) {
-      if (deps.spool.isChunkApplied(`${entry.chunkId}:i${index}`)) continue;
+    for (const { entry, item, index } of fresh) {
       const conv = deps.assembler.add(item.seg);
       const carried = { ...item, index };
       const last = runs[runs.length - 1];
@@ -565,7 +570,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     for (const id of deps.spool.capturingConversationIds()) {
       try {
         dedupeConversation(id);
-        diarizeConversation(id);
+        // Diarization is deferred while a flush failure means segments are
+        // still buffered: clustering only ever ADDS, so embedding a mic copy
+        // whose system duplicate has not arrived yet would leave that copy's
+        // contribution in the centroid after dedup deletes the segment.
+        if (flushFailure === undefined) diarizeConversation(id);
         // Flipped per conversation, not in bulk: a conversation whose
         // diarization failed must STAY capturing so a later finalize retries
         // it, while the ones that succeeded still reach the final-only read

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -111,15 +111,19 @@ export function segmentStableKey(chunkId: string, segment: { startUtc: string; e
  * chunk be marked complete with mixed content. Hashing every segment key
  * catches both a shortened and a changed transcript (issue #2145).
  */
-export function transcriptManifestKey(
+export function transcriptManifestHash(
   chunkId: string,
   segments: readonly { startUtc: string; endUtc: string; text: string }[],
 ): string {
-  const digest = createHash("sha1")
+  return createHash("sha1")
     .update(segments.map((segment) => segmentStableKey(chunkId, segment)).join("\n"))
     .digest("hex")
     .slice(0, 16);
-  return `${chunkId}:m${digest}`;
+}
+
+/** Fixed, indexed key holding a chunk's transcript manifest hash. */
+export function transcriptManifestKey(chunkId: string): string {
+  return `${chunkId}:manifest`;
 }
 
 export function chunkStableId(event: ChunkEvent): string {
@@ -522,14 +526,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // same length with different content. Either way a segment no run has
       // accounted for may be missing, so the chunk stays open and keeps its
       // audio.
-      const manifestMatches = deps.spool.isChunkApplied(
-        transcriptManifestKey(entry.chunkId, entry.built.map((item) => item.seg)),
-      );
+      const manifestMatches =
+        deps.spool.appliedChunkValue(transcriptManifestKey(entry.chunkId)) ===
+        transcriptManifestHash(entry.chunkId, entry.built.map((item) => item.seg));
+      // A chunk partially applied by a binary predating the manifest has none
+      // to match, so a silent replay must not be the first to record one.
       const fullyProcessed =
-        entry.built.length > 0
-          ? manifestMatches
-          : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
-      if (entry.built.length > 0 && !manifestMatches) {
+        entry.built.length > 0 ? manifestMatches : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
+      if (!manifestMatches) {
         retainedForReplay = true;
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
@@ -557,14 +561,18 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
    */
   function recordTranscriptManifest(entry: BufferedChunk): boolean {
     if (entry.built.length === 0) {
+      // A silent transcript has nothing to append, so it needs no manifest —
+      // and writing one would let an empty replay of a partially applied chunk
+      // become the authoritative manifest, stranding the real tail.
       entry.manifestRecorded = true;
       return true;
     }
     try {
-      if (!deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:m`)) {
+      const key = transcriptManifestKey(entry.chunkId);
+      if (deps.spool.appliedChunkValue(key) === undefined) {
         deps.spool.markApplied(
-          transcriptManifestKey(entry.chunkId, entry.built.map((item) => item.seg)),
-          "-",
+          key,
+          transcriptManifestHash(entry.chunkId, entry.built.map((item) => item.seg)),
         );
       }
       entry.manifestRecorded = true;
@@ -594,6 +602,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     for (;;) {
       const threshold = flushAll ? Number.POSITIVE_INFINITY : watermarkSourceMs - reorderWindowMs;
       const batch: BufferedChunk[] = [];
+      let manifestBlocked = false;
       for (let i = buffer.length - 1; i >= 0; i--) {
         const candidate = buffer[i];
         if (candidate.endMs > threshold) continue;
@@ -603,12 +612,34 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         // retranscription record the FIRST manifest and complete a partially
         // applied chunk (issue #2145). The event is not lost — the next pass
         // retries the write.
-        if (!candidate.manifestRecorded && !recordTranscriptManifest(candidate)) continue;
+        if (!candidate.manifestRecorded && !recordTranscriptManifest(candidate)) {
+          // Hold the WHOLE window, not just this entry: applyBatch interleaves
+          // the ready set together, and releasing peers without it would apply
+          // the held chunk's segments out of order later (issue #2145).
+          manifestBlocked = true;
+          break;
+        }
         buffer.splice(i, 1);
         bufferedIds.delete(candidate.chunkId);
         batch.push(candidate);
       }
-      if (batch.length === 0) return;
+      if (manifestBlocked) {
+        // Put back anything already taken so the window releases as one set.
+        for (const entry of batch) {
+          buffer.push(entry);
+          bufferedIds.add(entry.chunkId);
+        }
+        if (flushAll) {
+          throw new Error("flush-plan manifest could not be persisted; chunks are retained for replay");
+        }
+        return;
+      }
+      if (batch.length === 0) {
+        if (flushAll && buffer.length > 0) {
+          throw new Error("buffered chunks could not be released; they are retained for replay");
+        }
+        return;
+      }
       // Total order so the same batch always applies the same way (rule 12).
       batch.sort(
         (left, right) =>
@@ -656,6 +687,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         if (finalFailure !== undefined) throw finalFailure;
         return;
       }
+      // The batch is durable, so no rollback can need the conversations it
+      // closed. Drop them: retaining every conversation for the daemon's
+      // lifetime would make each checkpoint above O(capture history), and the
+      // per-chunk work quadratic (issue #2145).
+      deps.assembler.pruneFinalized();
     }
   }
 

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -427,11 +427,18 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         openConversationId = prior.id;
       }
     }
+    // Decide retention BEFORE anything can close a conversation: a chunk kept
+    // for a later replay must keep its durable prefix resumable, and the
+    // idle-close below (or a later gap-crossing chunk) would otherwise flip it
+    // to final while this batch is still being applied (issue #2145).
+    for (const entry of batch) {
+      if (!isFullyProcessed(entry)) retainedForReplay = true;
+    }
     const earliestStart = batch.reduce(
       (earliest, entry) => (entry.startMs < earliest.startMs ? entry : earliest),
       batch[0],
     );
-    const closed = deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
+    const closed = retainedForReplay ? null : deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
     if (closed !== null && closed === openConversationId) {
       // Dedupes, diarizes and flips a conversation in the spool — durable, so
       // the caller must not rewind past it. Flagged AFTER the call: a throw
@@ -550,21 +557,8 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // same length with different content. Either way a segment no run has
       // accounted for may be missing, so the chunk stays open and keeps its
       // audio.
-      const manifestMatches =
-        deps.spool.appliedChunkValue(transcriptManifestKey(entry.chunkId)) ===
-        transcriptManifestHash(entry.chunkId, entry.built.map((item) => item.seg));
-      // A chunk partially applied by a binary predating the manifest has none
-      // to match, so a silent replay must not be the first to record one.
-      const fullyProcessed =
-        entry.built.length > 0 ? manifestMatches : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
-      // Anything kept for a later replay must ALSO hold its conversation open:
-      // once `finalize()` flips a conversation to `final`, a replay that
-      // reproduces the manifest can no longer `resume` it and the missing tail
-      // lands in a new conversation, out of reach of cross-channel dedup.
-      if (!fullyProcessed) {
-        retainedForReplay = true;
-      }
-      if (entry.built.length > 0 && !manifestMatches) {
+      const fullyProcessed = isFullyProcessed(entry);
+      if (entry.built.length > 0 && !fullyProcessed) {
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
         );
@@ -583,6 +577,26 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         report(err, entry.event);
       }
     }
+  }
+
+  /**
+   * Whether every segment this chunk ever produced is now durably stored.
+   *
+   * Completeness needs one fact a replay cannot re-derive: the transcript the
+   * chunk produced the FIRST time. The manifest marker carries it, written
+   * before any append, so a mismatch here means an earlier run produced a
+   * DIFFERENT transcript — shorter, or the same length with different content.
+   * Either way a segment no run has accounted for may be missing, so the chunk
+   * stays open and keeps its audio. A chunk partially applied by a binary
+   * predating the manifest has none to match, so a silent replay must not be
+   * the first to record one (issue #2145).
+   */
+  function isFullyProcessed(entry: BufferedChunk): boolean {
+    if (entry.built.length === 0) return !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
+    return (
+      deps.spool.appliedChunkValue(transcriptManifestKey(entry.chunkId)) ===
+      transcriptManifestHash(entry.chunkId, entry.built.map((item) => item.seg))
+    );
   }
 
   /**
@@ -787,11 +801,12 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     for (const id of deps.spool.capturingConversationIds()) {
       try {
         dedupeConversation(id);
-        // Diarization is deferred while a flush failure means segments are
-        // still buffered: clustering only ever ADDS, so embedding a mic copy
-        // whose system duplicate has not arrived yet would leave that copy's
-        // contribution in the centroid after dedup deletes the segment.
-        if (flushFailure === undefined) diarizeConversation(id);
+        // Diarization is deferred whenever segments are still outstanding — a
+        // failed flush OR a chunk retained for replay: clustering only ever
+        // ADDS, so embedding a mic copy whose system duplicate has not arrived
+        // yet would leave that copy's contribution in the centroid after dedup
+        // deletes the segment.
+        if (!holdOpen) diarizeConversation(id);
         // Flipped per conversation, not in bulk: a conversation whose
         // diarization failed must STAY capturing so a later finalize retries
         // it, while the ones that succeeded still reach the final-only read

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -482,12 +482,27 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // A zero-segment run over a chunk whose earlier groups were already
       // applied (a partial crash) must NOT be marked done, or the missing tail
       // groups would be stranded forever.
-      // Content-keyed segments make "every segment already applied" mean the
-      // chunk IS fully persisted, so a nonempty transcript is again a sound
-      // proxy for completeness. The `:started` marker covers the zero-segment
-      // replay of a chunk that WAS partially applied.
+      // Completeness needs one fact a replay cannot re-derive: how many
+      // segments the transcript produced the FIRST time. Without it, a shorter
+      // retranscription is indistinguishable from a missing tail — mark done
+      // and a tail can be lost, refuse and a fully-applied chunk
+      // re-transcribes forever. So the count is persisted once and compared.
+      const segmentCount = entry.built.length;
+      const hadCount = deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:n`);
+      const countMatches =
+        !hadCount || deps.spool.isChunkApplied(`${entry.chunkId}:n${segmentCount}`);
       const fullyProcessed =
-        entry.built.length > 0 || !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
+        segmentCount > 0
+          ? countMatches
+          : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
+      if (segmentCount > 0 && !hadCount) {
+        deps.spool.markApplied(`${entry.chunkId}:n${segmentCount}`, openConversationId ?? "-");
+      }
+      if (segmentCount > 0 && !countMatches) {
+        log.warn(
+          `[capture-audio] chunk ${entry.chunkId} retranscribed to ${segmentCount} segments but an earlier run produced a different count; keeping its raw audio`,
+        );
+      }
       processedThisRun.add(entry.chunkId);
       if (!fullyProcessed) continue;
       // The chunk is fully durably transcribed: record completion and reclaim

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -20,7 +20,7 @@ import { createHash } from "node:crypto";
 import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
 import { dedupeCrossChannel } from "./dedup.js";
 import { CaptureInputError } from "./errors.js";
-import type { Embedding, SpeakerClusterer } from "./diarization.js";
+import type { Embedding, SpeakerCluster, SpeakerClusterer } from "./diarization.js";
 import type { ChunkEvent } from "./native.js";
 import type { Spool } from "./spool.js";
 import type { TranscribedSegment } from "./stt.js";
@@ -55,6 +55,12 @@ export interface ChunkProcessorDeps {
   embed?: (event: ChunkEvent, segment: TranscribedSegment) => Embedding | Promise<Embedding>;
   /** Speaker clusterer (seeded from the spool); its clusters are persisted on finalize. */
   diarizer?: SpeakerClusterer;
+  /**
+   * Roll the clusterer back to a snapshot after a failed diarization commit
+   * (issue #2145). Supplied by the owner of the clusterer, which is the only
+   * place that may replace its internal state.
+   */
+  restoreDiarizer?: (clusters: readonly SpeakerCluster[]) => void;
   /** Cross-channel dedup window in ms; defaults to the dedup module's tolerance. */
   dedupWindowMs?: number;
   /**
@@ -175,6 +181,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     if (!diarizer) return;
     const pending = deps.spool.conversationSegmentsForDiarization(id);
     if (pending.length === 0) return;
+    // `assign` mutates the in-memory centroids and counts. If the commit rolls
+    // back, those mutations must roll back too — otherwise the retry counts
+    // the same embeddings against an already-advanced clusterer and persists
+    // skewed snapshots. The snapshot below is the undo log.
+    const before = diarizer.clusters();
     // A label-only enrolled self can never match live audio, so the mic
     // heuristic stays the wearer signal until voice enrollment lands.
     const selfVoiceEnrolled = diarizer.clusters().some((c) => c.isSelf && c.embeddingCount > 0);
@@ -204,7 +215,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         centroid: cluster.centroid,
         examples: cluster.examples,
       }));
-    deps.spool.commitDiarization({ clusters, assignments });
+    try {
+      deps.spool.commitDiarization({ clusters, assignments });
+    } catch (err) {
+      // Restore the clusterer to its pre-assign state so the next finalize
+      // starts from the same place SQLite did.
+      deps.restoreDiarizer?.(before);
+      throw err;
+    }
   };
   const finalizeConv = (id: string): void => {
     dedupeConversation(id);
@@ -226,6 +244,21 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // transcription + diarization entirely. A PARTIAL replay (crash between
     // group appends) has no marker, so it falls through and per-group
     // idempotency re-appends only the missing groups below.
+    // Pre-#2145 runs keyed appends per GROUP (`chunkId` or `chunkId:<n>`).
+    // Those keys cannot be mapped onto the new per-segment keys, so a chunk
+    // carrying one is treated as already applied: re-appending under new keys
+    // would duplicate its segments, which is worse than leaving the tail of
+    // one in-flight chunk unsent across the upgrade.
+    if (deps.spool.isChunkApplied(chunkId) || deps.spool.isChunkApplied(`${chunkId}:0`)) {
+      processedThisRun.add(chunkId);
+      deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
+      try {
+        await deps.cleanupRawAudio(event);
+      } catch (err) {
+        report(err, event);
+      }
+      return;
+    }
     if (deps.spool.isChunkApplied(`${chunkId}:done`)) {
       processedThisRun.add(chunkId);
       // Retry raw-WAV reclaim: the marker is written before cleanup, so if the
@@ -350,53 +383,53 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       entry: BufferedChunk;
       id: string;
       startedAtUtc: string;
-      items: Array<{ seg: AssemblySegment; raw: TranscribedSegment }>;
+      items: Array<{ seg: AssemblySegment; raw: TranscribedSegment; index: number }>;
     }> = [];
-    for (const { entry, item } of stream) {
+    for (const { entry, item, index } of stream) {
       const conv = deps.assembler.add(item.seg);
+      const carried = { ...item, index };
       const last = runs[runs.length - 1];
-      if (last && last.id === conv.id && last.entry === entry) last.items.push(item);
-      else runs.push({ entry, id: conv.id, startedAtUtc: conv.startedAtUtc, items: [item] });
+      if (last && last.id === conv.id && last.entry === entry) last.items.push(carried);
+      else runs.push({ entry, id: conv.id, startedAtUtc: conv.startedAtUtc, items: [carried] });
     }
 
-    const runsPerChunk = new Map<string, number>();
-    for (const run of runs) {
-      runsPerChunk.set(run.entry.chunkId, (runsPerChunk.get(run.entry.chunkId) ?? 0) + 1);
-    }
-    const emitted = new Map<string, number>();
+    // Idempotency keys are derived from each segment's position in ITS OWN
+    // chunk, never from the batch: `chunkId:i<index>`. A key must mean the
+    // same bytes on every replay, and a replay rarely reproduces the same
+    // batch — so a positional `chunkId:g` could skip a group that now holds
+    // different segments, or miss an applied one and append twice. One append
+    // per segment costs one extra row per segment and makes the guard exact.
     for (const run of runs) {
       const { chunkId, event } = run.entry;
-      const index = emitted.get(chunkId) ?? 0;
-      emitted.set(chunkId, index + 1);
-      const key = runsPerChunk.get(chunkId) === 1 ? chunkId : `${chunkId}:${index}`;
-      if (deps.spool.isChunkApplied(key)) {
-        openConversationId = run.id;
-        continue;
-      }
-      if (openConversationId !== null && openConversationId !== run.id) {
-        finalizeConv(openConversationId);
-      }
-      // Embed now — this is where the audio exists — but do NOT cluster.
-      // Clustering runs at finalize over the segments that SURVIVE
-      // cross-channel dedup (issue #2145), so a mic loopback duplicate that
-      // is later pruned can no longer inflate a centroid or invent a
-      // phantom speaker. The embedding rides along on the segment row.
-      if (deps.embed) {
-        for (const item of run.items) {
+      for (const item of run.items) {
+        const key = `${chunkId}:i${item.index}`;
+        if (deps.spool.isChunkApplied(key)) {
+          openConversationId = run.id;
+          continue;
+        }
+        if (openConversationId !== null && openConversationId !== run.id) {
+          finalizeConv(openConversationId);
+        }
+        // Embed now — this is where the audio exists — but do NOT cluster.
+        // Clustering runs at finalize over the segments that SURVIVE
+        // cross-channel dedup (issue #2145), so a mic loopback duplicate that
+        // is later pruned can no longer inflate a centroid or invent a
+        // phantom speaker. The embedding rides along on the segment row.
+        if (deps.embed) {
           item.seg.embedding = await deps.embed(event, item.raw);
         }
+        deps.spool.appendAssembledSegments({
+          idempotencyKey: key,
+          chunkId: key,
+          conversationId: run.id,
+          startedAtUtc: run.startedAtUtc,
+          state: "capturing",
+          device: event.device,
+          wavPath: event.path,
+          segments: [item.seg],
+        });
+        openConversationId = run.id;
       }
-      deps.spool.appendAssembledSegments({
-        idempotencyKey: key,
-        chunkId: key,
-        conversationId: run.id,
-        startedAtUtc: run.startedAtUtc,
-        state: "capturing",
-        device: event.device,
-        wavPath: event.path,
-        segments: run.items.map((it) => it.seg),
-      });
-      openConversationId = run.id;
     }
 
     for (const entry of batch) {
@@ -407,7 +440,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // applied (a partial crash) must NOT be marked done, or the missing tail
       // groups would be stranded forever.
       const fullyProcessed =
-        entry.built.length > 0 || !deps.spool.isChunkApplied(`${entry.chunkId}:0`);
+        entry.built.length > 0 || !deps.spool.isChunkApplied(`${entry.chunkId}:i0`);
       processedThisRun.add(entry.chunkId);
       if (!fullyProcessed) continue;
       // The chunk is fully durably transcribed: record completion and reclaim

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -369,6 +369,17 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         return left.index - right.index;
       });
 
+    // Embed FIRST, before a single `assembler.add`. Embedding is the only
+    // await that can throw before persistence, and the assembler has no undo:
+    // a throw after it had consumed segments would leave it advanced, so the
+    // retry would feed earlier timestamps into a later conversation and merge
+    // spans the first attempt had split (issue #2145).
+    if (deps.embed) {
+      for (const { entry, item } of stream) {
+        item.seg.embedding = await deps.embed(entry.event, item.raw);
+      }
+    }
+
     // Assign conversations over the interleaved stream, then cut it into runs
     // that each belong to ONE chunk and ONE conversation. The runs are already
     // in chronological order, so a conversation is only finalized once the
@@ -403,14 +414,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         }
         if (openConversationId !== null && openConversationId !== run.id) {
           finalizeConv(openConversationId);
-        }
-        // Embed now — this is where the audio exists — but do NOT cluster.
-        // Clustering runs at finalize over the segments that SURVIVE
-        // cross-channel dedup (issue #2145), so a mic loopback duplicate that
-        // is later pruned can no longer inflate a centroid or invent a
-        // phantom speaker. The embedding rides along on the segment row.
-        if (deps.embed) {
-          item.seg.embedding = await deps.embed(event, item.raw);
         }
         deps.spool.appendAssembledSegments({
           idempotencyKey: key,
@@ -463,6 +466,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
    * `flushAll` ignores the watermark, for `finalize()`.
    */
   async function releaseReady(flushAll: boolean): Promise<void> {
+    // A failed FINAL flush must reach the caller: `stop()` discards the buffer
+    // afterwards, and reporting success would silently drop the retained
+    // chunks (issue #2145). A mid-run failure stays reported-and-retried.
+    let finalFailure: unknown;
     for (;;) {
       const threshold = flushAll ? Number.POSITIVE_INFINITY : watermarkSourceMs - reorderWindowMs;
       const batch: BufferedChunk[] = [];
@@ -485,6 +492,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         await applyBatch(batch);
       } catch (error) {
         report(error, batch[0].event);
+        if (flushAll) finalFailure ??= error;
         // A throw mid-batch leaves the chunks AFTER the failure point applied
         // to nothing: they were already spliced out of the buffer, and the
         // native helper emits each event once. Put every chunk this batch did
@@ -494,6 +502,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           buffer.push(entry);
           bufferedIds.add(entry.chunkId);
         }
+        if (finalFailure !== undefined) throw finalFailure;
         return;
       }
     }
@@ -510,19 +519,35 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   async function finalize(): Promise<number> {
     // Flush the reorder buffer ON the serialized chain, so a chunk still
     // arriving cannot interleave with the flush.
-    tail = tail.then(() => releaseReady(true));
-    await drain();
+    // `report` runs an operator-supplied callback that may itself throw, so the
+    // chain is recovered explicitly: a rejected `tail` would make every later
+    // drain/finalize reject with the same stale error (AGENTS.md #28).
+    const flush = tail.then(() => releaseReady(true));
+    tail = flush.catch(() => undefined);
+    await flush;
     deps.assembler.finalize();
     // Dedup then cluster EVERY still-capturing conversation before the bulk
     // flip to final — including one left by a crashed prior run that this
     // process never touched (so it has no in-memory openConversationId) — so
     // the served (final-only) output never contains a loopback duplicate and
     // every surviving segment carries its speaker.
+    let sweepFailure: unknown;
+    let closed = 0;
     for (const id of deps.spool.capturingConversationIds()) {
-      dedupeConversation(id);
-      diarizeConversation(id);
+      try {
+        dedupeConversation(id);
+        diarizeConversation(id);
+        // Flipped per conversation, not in bulk: a conversation whose
+        // diarization failed must STAY capturing so a later finalize retries
+        // it, while the ones that succeeded still reach the final-only read
+        // path instead of being stranded behind it.
+        if (deps.spool.finalizeConversation(id)) closed++;
+      } catch (error) {
+        sweepFailure ??= error;
+      }
     }
-    return deps.spool.finalizeOpenConversations();
+    if (sweepFailure !== undefined) throw sweepFailure;
+    return closed + deps.spool.finalizeOpenConversations();
   }
 
   return { enqueue, drain, finalize };

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -86,6 +86,23 @@ export interface ChunkProcessor {
  * depends on a freshly-generated conversation id, the same chunk yields the
  * same idempotency key across process restarts.
  */
+/**
+ * Stable per-segment idempotency key.
+ *
+ * Derived from the segment's CONTENT — its bounds and text — not its position.
+ * An index is not an identity: a retranscription that changes segment
+ * boundaries, or inserts a segment before a partially committed prefix, would
+ * bind an existing key to different audio (issue #2145). Content survives
+ * both, so a key always means the same bytes.
+ */
+export function segmentStableKey(chunkId: string, segment: { startUtc: string; endUtc: string; text: string }): string {
+  const digest = createHash("sha1")
+    .update(`${segment.startUtc}\u0000${segment.endUtc}\u0000${segment.text}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${chunkId}:h${digest}`;
+}
+
 export function chunkStableId(event: ChunkEvent): string {
   return `chk_${createHash("sha1").update(event.path).digest("hex")}`;
 }
@@ -391,17 +408,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // embedding failure on an already-persisted segment would requeue the
     // batch forever and block the segments that ARE missing (issue #2145).
     const fresh = stream.filter(
-      ({ entry, index }) => !deps.spool.isChunkApplied(`${entry.chunkId}:i${index}`),
+      ({ entry, item }) => !deps.spool.isChunkApplied(segmentStableKey(entry.chunkId, item.seg)),
     );
-    // Per chunk: did THIS run contribute anything new? A replay whose
-    // transcript is entirely already-applied proves nothing about a tail the
-    // original transcription produced and never persisted — an STT or
-    // segmentation change can shorten the transcript — so such a chunk is not
-    // closed out and keeps its raw audio (issue #2145).
-    const freshPerChunk = new Map<string, number>();
-    for (const { entry } of fresh) {
-      freshPerChunk.set(entry.chunkId, (freshPerChunk.get(entry.chunkId) ?? 0) + 1);
-    }
+
 
     // Embed before a single `assembler.add`. Embedding is the only await that
     // can throw before persistence, and the assembler has no undo: a throw
@@ -446,7 +455,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     for (const run of runs) {
       const { chunkId, event } = run.entry;
       for (const item of run.items) {
-        const key = `${chunkId}:i${item.index}`;
+        const key = segmentStableKey(chunkId, item.seg);
         if (openConversationId !== null && openConversationId !== run.id) {
           finalizeConv(openConversationId);
           progress.persisted = true;
@@ -473,9 +482,12 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // A zero-segment run over a chunk whose earlier groups were already
       // applied (a partial crash) must NOT be marked done, or the missing tail
       // groups would be stranded forever.
+      // Content-keyed segments make "every segment already applied" mean the
+      // chunk IS fully persisted, so a nonempty transcript is again a sound
+      // proxy for completeness. The `:started` marker covers the zero-segment
+      // replay of a chunk that WAS partially applied.
       const fullyProcessed =
-        (freshPerChunk.get(entry.chunkId) ?? 0) > 0 ||
-        !deps.spool.isChunkApplied(`${entry.chunkId}:i0`);
+        entry.built.length > 0 || !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
       processedThisRun.add(entry.chunkId);
       if (!fullyProcessed) continue;
       // The chunk is fully durably transcribed: record completion and reclaim

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -211,15 +211,27 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     return false;
   }
 
-  /** Record, or clear, the conversations a chunk's replay could still need. */
-  function trackRetention(chunkId: string, retained: boolean): void {
+  /**
+   * Record, or clear, the conversations a chunk's replay could still need.
+   *
+   * `resumable` is snapshotted BEFORE the batch appends anything: a healthy
+   * conversation opened by a gap split in the same batch is not a prefix any
+   * replay can resume, so holding it would keep unrelated audio out of the
+   * final-only read path until the retained chunk completes.
+   */
+  function trackRetention(chunkId: string, retained: boolean, resumable: ReadonlySet<string>): void {
     if (!retained) {
       retainedChunks.delete(chunkId);
       return;
     }
-    const held = new Set(deps.spool.capturingConversationIds());
-    if (openConversationId !== null) held.add(openConversationId);
-    retainedChunks.set(chunkId, held);
+    retainedChunks.set(chunkId, new Set(resumable));
+  }
+
+  /** Conversations a replay could resume right now. */
+  function resumableConversations(): Set<string> {
+    const ids = new Set(deps.spool.capturingConversationIds());
+    if (openConversationId !== null) ids.add(openConversationId);
+    return ids;
   }
   const processedThisRun = new Set<string>();
   // Bounded reorder buffer (issue #2145). With `captureChannel: "both"` the
@@ -307,16 +319,18 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       throw err;
     }
   };
-  const finalizeConv = (id: string): void => {
+  const finalizeConv = (id: string): boolean => {
     // A held prefix must stay `capturing` so a later replay can resume it. This
     // is the single durable choke point: the assembler closes conversations
     // from several paths (idle close, gap split inside `add`, shutdown), and
     // guarding each of them would leave the next one to be found.
-    if (isHeldForReplay(id)) return;
+    if (isHeldForReplay(id)) return false;
     dedupeConversation(id);
     diarizeConversation(id);
     deps.spool.finalizeConversation(id);
+    return true;
   };
+
 
   const report = (error: unknown, event: ChunkEvent): void => {
     // A throwing operator callback must not become a pipeline failure: it would
@@ -460,12 +474,24 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         deps.assembler.resume(prior);
         openConversationId = prior.id;
       }
+      // A restart loses which chunks are still awaiting a replay, so rebuild
+      // the holds from the durable markers: a manifest without a `:done` is a
+      // chunk whose WAV is retained, and the conversations capturing right now
+      // are the prefixes its replay could still resume (issue #2145).
+      const incomplete = deps.spool.incompleteChunkIds();
+      if (incomplete.length > 0) {
+        const resumableAtStartup = resumableConversations();
+        for (const chunkId of incomplete) {
+          trackRetention(chunkId, true, resumableAtStartup);
+        }
+      }
     }
     // Decide retention BEFORE anything can close a conversation: a chunk kept
     // for a later replay must keep its durable prefix resumable, and both the
     // idle-close below and the gap split inside `assembler.add` would otherwise
     // flip it to final while this batch is still being applied (issue #2145).
-    for (const entry of batch) trackRetention(entry.chunkId, !isFullyProcessed(entry));
+    const resumable = resumableConversations();
+    for (const entry of batch) trackRetention(entry.chunkId, !isFullyProcessed(entry), resumable);
     const earliestStart = batch.reduce(
       (earliest, entry) => (entry.startMs < earliest.startMs ? entry : earliest),
       batch[0],
@@ -475,9 +501,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // Dedupes, diarizes and flips a conversation in the spool — durable, so
       // the caller must not rewind past it. Flagged AFTER the call: a throw
       // inside it leaves nothing durable, and the batch should still rewind.
-      finalizeConv(closed);
-      progress.persisted = true;
-      openConversationId = null;
+      if (finalizeConv(closed)) {
+        progress.persisted = true;
+        openConversationId = null;
+      }
     }
 
     // One chronological stream across the batch. The comparator is total —
@@ -554,8 +581,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       for (const item of run.items) {
         const key = segmentStableKey(chunkId, item.seg);
         if (openConversationId !== null && openConversationId !== run.id) {
-          finalizeConv(openConversationId);
-          progress.persisted = true;
+          // A held conversation is left `capturing`, so nothing durable changed
+          // and the batch must still be able to rewind.
+          if (finalizeConv(openConversationId)) progress.persisted = true;
         }
         deps.spool.appendAssembledSegments({
           idempotencyKey: key,
@@ -590,7 +618,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // accounted for may be missing, so the chunk stays open and keeps its
       // audio.
       const fullyProcessed = isFullyProcessed(entry);
-      trackRetention(entry.chunkId, !fullyProcessed);
+      trackRetention(entry.chunkId, !fullyProcessed, resumable);
       if (entry.built.length > 0 && !fullyProcessed) {
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
@@ -700,7 +728,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           bufferedIds.delete(candidate.chunkId);
           // The chunk keeps its audio for a matching replay, so its durable
           // prefix must stay resumable — do not let the sweep close it.
-          trackRetention(candidate.chunkId, true);
+          trackRetention(candidate.chunkId, true, resumableConversations());
           report(
             new Error(
               `transcript for chunk ${candidate.chunkId} does not match the recorded manifest; raw audio retained`,

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -103,6 +103,25 @@ export function segmentStableKey(chunkId: string, segment: { startUtc: string; e
   return `${chunkId}:h${digest}`;
 }
 
+/**
+ * Marker key describing a chunk's WHOLE transcript.
+ *
+ * A segment count is too weak a manifest: a replay that returns the same
+ * number of DIFFERENT segments would match it and let a partially applied
+ * chunk be marked complete with mixed content. Hashing every segment key
+ * catches both a shortened and a changed transcript (issue #2145).
+ */
+export function transcriptManifestKey(
+  chunkId: string,
+  segments: readonly { startUtc: string; endUtc: string; text: string }[],
+): string {
+  const digest = createHash("sha1")
+    .update(segments.map((segment) => segmentStableKey(chunkId, segment)).join("\n"))
+    .digest("hex")
+    .slice(0, 16);
+  return `${chunkId}:m${digest}`;
+}
+
 export function chunkStableId(event: ChunkEvent): string {
   return `chk_${createHash("sha1").update(event.path).digest("hex")}`;
 }
@@ -151,6 +170,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let tail: Promise<void> = Promise.resolve();
   let recovered = false;
   let openConversationId: string | null = null;
+  // Set when a chunk is deliberately left unapplied for a later replay: its
+  // conversation must stay `capturing` so that replay can resume it.
+  let retainedForReplay = false;
   const processedThisRun = new Set<string>();
   // Bounded reorder buffer (issue #2145). With `captureChannel: "both"` the
   // native helper emits one chunk stream per channel, and a system chunk for
@@ -305,12 +327,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         })
       : [];
     const built = buildSegments(event, raw);
-    // Recorded BEFORE any append, and only once: this is the fact a later
-    // replay cannot re-derive, so it must survive a failure that happens
-    // partway through appending this chunk (issue #2145).
-    if (built.length > 0 && !deps.spool.hasAppliedChunkPrefix(`${chunkId}:n`)) {
-      deps.spool.markApplied(`${chunkId}:n${built.length}`, "-");
-    }
     buffer.push({
       event,
       chunkId,
@@ -319,6 +335,17 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       endMs: lastEndMs(event, raw),
     });
     bufferedIds.add(chunkId);
+    // Recorded AFTER buffering (so a throw here cannot drop the helper's
+    // one-shot event) but BEFORE any append, and only once: this is the fact a
+    // later replay cannot re-derive, so it must survive a failure partway
+    // through appending this chunk (issue #2145).
+    if (built.length > 0 && !deps.spool.hasAppliedChunkPrefix(`${chunkId}:m`)) {
+      try {
+        deps.spool.markApplied(transcriptManifestKey(chunkId, built.map((item) => item.seg)), "-");
+      } catch (err) {
+        report(err, event);
+      }
+    }
     watermarkSourceMs = Math.max(watermarkSourceMs, lastEndMs(event, raw));
     await releaseReady(false);
   }
@@ -494,18 +521,22 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // retranscription is indistinguishable from a missing tail — mark done
       // and a tail can be lost, refuse and a fully-applied chunk
       // re-transcribes forever. So the count is persisted once and compared.
-      const segmentCount = entry.built.length;
-      // The marker was written at transcribe time, so a mismatch here means an
-      // EARLIER run produced a different number of segments — a tail that no
-      // run has accounted for.
-      const countMatches = deps.spool.isChunkApplied(`${entry.chunkId}:n${segmentCount}`);
+      // The manifest marker was written at transcribe time, so a mismatch here
+      // means an EARLIER run produced a DIFFERENT transcript — shorter, or the
+      // same length with different content. Either way a segment no run has
+      // accounted for may be missing, so the chunk stays open and keeps its
+      // audio.
+      const manifestMatches = deps.spool.isChunkApplied(
+        transcriptManifestKey(entry.chunkId, entry.built.map((item) => item.seg)),
+      );
       const fullyProcessed =
-        segmentCount > 0
-          ? countMatches
+        entry.built.length > 0
+          ? manifestMatches
           : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
-      if (segmentCount > 0 && !countMatches) {
+      if (entry.built.length > 0 && !manifestMatches) {
+        retainedForReplay = true;
         log.warn(
-          `[capture-audio] chunk ${entry.chunkId} retranscribed to ${segmentCount} segments but an earlier run produced a different count; keeping its raw audio`,
+          `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
         );
       }
       processedThisRun.add(entry.chunkId);
@@ -631,7 +662,8 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // replay would open a NEW conversation instead of joining the original.
     // The sweep below still dedupes and diarizes, so anything a later
     // shutdown flips is clean.
-    if (flushFailure === undefined) deps.assembler.finalize();
+    const holdOpen = flushFailure !== undefined || retainedForReplay;
+    if (!holdOpen) deps.assembler.finalize();
     // Dedup then cluster EVERY still-capturing conversation before the bulk
     // flip to final — including one left by a crashed prior run that this
     // process never touched (so it has no in-memory openConversationId) — so
@@ -651,7 +683,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         // diarization failed must STAY capturing so a later finalize retries
         // it, while the ones that succeeded still reach the final-only read
         // path instead of being stranded behind it.
-        if (flushFailure === undefined && deps.spool.finalizeConversation(id)) closed++;
+        if (!holdOpen && deps.spool.finalizeConversation(id)) closed++;
       } catch (error) {
         sweepFailure ??= error;
       }
@@ -660,9 +692,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // above. Skipping it when the sweep failed is what keeps the FAILED
     // conversation `capturing` for the next finalize to retry.
     const total =
-      sweepFailure === undefined && flushFailure === undefined
-        ? closed + deps.spool.finalizeOpenConversations()
-        : closed;
+      sweepFailure === undefined && !holdOpen ? closed + deps.spool.finalizeOpenConversations() : closed;
     if (flushFailure !== undefined) throw flushFailure;
     if (sweepFailure !== undefined) throw sweepFailure;
     return total;

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -130,6 +130,15 @@ export function chunkStableId(event: ChunkEvent): string {
   return `chk_${createHash("sha1").update(event.path).digest("hex")}`;
 }
 
+/**
+ * Ceiling on chunks held in the reorder buffer.
+ *
+ * At the default 30-second chunks this is over four hours of audio per
+ * channel, so it is only reachable when persistence has been failing for a
+ * long time. Bounding it keeps memory and the per-release scan finite.
+ */
+const MAX_BUFFERED_CHUNKS = 512;
+
 /** One transcribed chunk waiting in the reorder buffer (issue #2145). */
 interface BufferedChunk {
   event: ChunkEvent;
@@ -347,6 +356,21 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     });
     bufferedIds.add(chunkId);
     watermarkSourceMs = Math.max(watermarkSourceMs, lastEndMs(event, raw));
+    if (buffer.length > MAX_BUFFERED_CHUNKS) {
+      // A sustained persistence outage would otherwise grow this buffer — and
+      // the work of every release scan — without bound. The OLDEST chunk is
+      // dropped from memory, not from disk: its WAV stays for replay.
+      const evicted = buffer.shift();
+      if (evicted !== undefined) {
+        bufferedIds.delete(evicted.chunkId);
+        report(
+          new Error(
+            `reorder buffer is full (${MAX_BUFFERED_CHUNKS}); chunk ${evicted.chunkId} was dropped with its raw audio retained`,
+          ),
+          evicted.event,
+        );
+      }
+    }
     await releaseReady(false);
   }
 
@@ -533,7 +557,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // to match, so a silent replay must not be the first to record one.
       const fullyProcessed =
         entry.built.length > 0 ? manifestMatches : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
-      if (!manifestMatches) {
+      if (entry.built.length > 0 && !manifestMatches) {
         retainedForReplay = true;
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
@@ -559,7 +583,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
    * Persist a buffered chunk's transcript manifest, once. Returns whether the
    * chunk may now be released.
    */
-  function recordTranscriptManifest(entry: BufferedChunk): boolean {
+  function recordTranscriptManifest(entry: BufferedChunk): boolean | "conflict" {
     if (entry.built.length === 0) {
       // A silent transcript has nothing to append, so it needs no manifest —
       // and writing one would let an empty replay of a partially applied chunk
@@ -569,11 +593,16 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
     try {
       const key = transcriptManifestKey(entry.chunkId);
-      if (deps.spool.appliedChunkValue(key) === undefined) {
-        deps.spool.markApplied(
-          key,
-          transcriptManifestHash(entry.chunkId, entry.built.map((item) => item.seg)),
-        );
+      const ours = transcriptManifestHash(entry.chunkId, entry.built.map((item) => item.seg));
+      const recorded = deps.spool.appliedChunkValue(key);
+      if (recorded === undefined) {
+        deps.spool.markApplied(key, ours);
+      } else if (recorded !== ours) {
+        // A divergent retranscription of a partially applied chunk. Appending
+        // it would interleave content the first transcript never had, so this
+        // chunk contributes NOTHING: it is dropped from the run and its raw
+        // audio is retained for a replay that reproduces the manifest.
+        return "conflict";
       }
       entry.manifestRecorded = true;
       return true;
@@ -612,7 +641,19 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         // retranscription record the FIRST manifest and complete a partially
         // applied chunk (issue #2145). The event is not lost — the next pass
         // retries the write.
-        if (!candidate.manifestRecorded && !recordTranscriptManifest(candidate)) {
+        const manifest = candidate.manifestRecorded ? true : recordTranscriptManifest(candidate);
+        if (manifest === "conflict") {
+          buffer.splice(i, 1);
+          bufferedIds.delete(candidate.chunkId);
+          report(
+            new Error(
+              `transcript for chunk ${candidate.chunkId} does not match the recorded manifest; raw audio retained`,
+            ),
+            candidate.event,
+          );
+          continue;
+        }
+        if (!manifest) {
           // Hold the WHOLE window, not just this entry: applyBatch interleaves
           // the ready set together, and releasing peers without it would apply
           // the held chunk's segments out of order later (issue #2145).

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -304,10 +304,17 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           chunkStartedAtUtc: event.startedAtUtc,
         })
       : [];
+    const built = buildSegments(event, raw);
+    // Recorded BEFORE any append, and only once: this is the fact a later
+    // replay cannot re-derive, so it must survive a failure that happens
+    // partway through appending this chunk (issue #2145).
+    if (built.length > 0 && !deps.spool.hasAppliedChunkPrefix(`${chunkId}:n`)) {
+      deps.spool.markApplied(`${chunkId}:n${built.length}`, "-");
+    }
     buffer.push({
       event,
       chunkId,
-      built: buildSegments(event, raw),
+      built,
       startMs: firstStartMs(event, raw),
       endMs: lastEndMs(event, raw),
     });
@@ -488,16 +495,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // and a tail can be lost, refuse and a fully-applied chunk
       // re-transcribes forever. So the count is persisted once and compared.
       const segmentCount = entry.built.length;
-      const hadCount = deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:n`);
-      const countMatches =
-        !hadCount || deps.spool.isChunkApplied(`${entry.chunkId}:n${segmentCount}`);
+      // The marker was written at transcribe time, so a mismatch here means an
+      // EARLIER run produced a different number of segments — a tail that no
+      // run has accounted for.
+      const countMatches = deps.spool.isChunkApplied(`${entry.chunkId}:n${segmentCount}`);
       const fullyProcessed =
         segmentCount > 0
           ? countMatches
           : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
-      if (segmentCount > 0 && !hadCount) {
-        deps.spool.markApplied(`${entry.chunkId}:n${segmentCount}`, openConversationId ?? "-");
-      }
       if (segmentCount > 0 && !countMatches) {
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to ${segmentCount} segments but an earlier run produced a different count; keeping its raw audio`,

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -488,9 +488,16 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           left.endMs - right.endMs ||
           (left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0),
       );
+      // Rewind point: persistence inside applyBatch is synchronous but can
+      // still throw (a busy/IO error from SQLite) AFTER segments have passed
+      // through the assembler. Without this the retry feeds earlier
+      // timestamps into an advanced assembler and merges spans the first
+      // attempt had split (issue #2145).
+      const assemblerCheckpoint = deps.assembler.checkpoint();
       try {
         await applyBatch(batch);
       } catch (error) {
+        deps.assembler.rewind(assemblerCheckpoint);
         // Requeue FIRST: `report` runs an operator callback that may itself
         // throw, and losing the batch to a broken telemetry sink would turn an
         // observer failure into data loss. A throw mid-batch leaves the chunks
@@ -535,7 +542,12 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     } catch (error) {
       flushFailure = error;
     }
-    deps.assembler.finalize();
+    // A failed flush left chunks in the buffer that may belong to the open
+    // conversation. Closing it now would strand them: a retry or a raw-WAV
+    // replay would open a NEW conversation instead of joining the original.
+    // The sweep below still dedupes and diarizes, so anything a later
+    // shutdown flips is clean.
+    if (flushFailure === undefined) deps.assembler.finalize();
     // Dedup then cluster EVERY still-capturing conversation before the bulk
     // flip to final — including one left by a crashed prior run that this
     // process never touched (so it has no in-memory openConversationId) — so
@@ -551,7 +563,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         // diarization failed must STAY capturing so a later finalize retries
         // it, while the ones that succeeded still reach the final-only read
         // path instead of being stranded behind it.
-        if (deps.spool.finalizeConversation(id)) closed++;
+        if (flushFailure === undefined && deps.spool.finalizeConversation(id)) closed++;
       } catch (error) {
         sweepFailure ??= error;
       }
@@ -559,7 +571,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // The bulk flip only catches conversations created after the id snapshot
     // above. Skipping it when the sweep failed is what keeps the FAILED
     // conversation `capturing` for the next finalize to retry.
-    const total = sweepFailure === undefined ? closed + deps.spool.finalizeOpenConversations() : closed;
+    const total =
+      sweepFailure === undefined && flushFailure === undefined
+        ? closed + deps.spool.finalizeOpenConversations()
+        : closed;
     if (flushFailure !== undefined) throw flushFailure;
     if (sweepFailure !== undefined) throw sweepFailure;
     return total;

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -191,7 +191,36 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let openConversationId: string | null = null;
   // Set when a chunk is deliberately left unapplied for a later replay: its
   // conversation must stay `capturing` so that replay can resume it.
-  let retainedForReplay = false;
+  /**
+   * Conversations each retained chunk may still need to `resume`, keyed by
+   * chunk id.
+   *
+   * Retention is per CHUNK and per CONVERSATION, never a run-wide latch: a
+   * sticky flag would stop the daemon from finalizing any conversation again
+   * after one retention event, and clearing it per batch would release the hold
+   * as soon as the NEXT batch had nothing retained. An entry lives exactly as
+   * long as its chunk is incomplete (issue #2145).
+   */
+  const retainedChunks = new Map<string, Set<string>>();
+
+  /** Whether a conversation is a prefix some retained chunk could resume. */
+  function isHeldForReplay(conversationId: string): boolean {
+    for (const held of retainedChunks.values()) {
+      if (held.has(conversationId)) return true;
+    }
+    return false;
+  }
+
+  /** Record, or clear, the conversations a chunk's replay could still need. */
+  function trackRetention(chunkId: string, retained: boolean): void {
+    if (!retained) {
+      retainedChunks.delete(chunkId);
+      return;
+    }
+    const held = new Set(deps.spool.capturingConversationIds());
+    if (openConversationId !== null) held.add(openConversationId);
+    retainedChunks.set(chunkId, held);
+  }
   const processedThisRun = new Set<string>();
   // Bounded reorder buffer (issue #2145). With `captureChannel: "both"` the
   // native helper emits one chunk stream per channel, and a system chunk for
@@ -279,6 +308,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
   };
   const finalizeConv = (id: string): void => {
+    // A held prefix must stay `capturing` so a later replay can resume it. This
+    // is the single durable choke point: the assembler closes conversations
+    // from several paths (idle close, gap split inside `add`, shutdown), and
+    // guarding each of them would leave the next one to be found.
+    if (isHeldForReplay(id)) return;
     dedupeConversation(id);
     diarizeConversation(id);
     deps.spool.finalizeConversation(id);
@@ -428,17 +462,15 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       }
     }
     // Decide retention BEFORE anything can close a conversation: a chunk kept
-    // for a later replay must keep its durable prefix resumable, and the
-    // idle-close below (or a later gap-crossing chunk) would otherwise flip it
-    // to final while this batch is still being applied (issue #2145).
-    for (const entry of batch) {
-      if (!isFullyProcessed(entry)) retainedForReplay = true;
-    }
+    // for a later replay must keep its durable prefix resumable, and both the
+    // idle-close below and the gap split inside `assembler.add` would otherwise
+    // flip it to final while this batch is still being applied (issue #2145).
+    for (const entry of batch) trackRetention(entry.chunkId, !isFullyProcessed(entry));
     const earliestStart = batch.reduce(
       (earliest, entry) => (entry.startMs < earliest.startMs ? entry : earliest),
       batch[0],
     );
-    const closed = retainedForReplay ? null : deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
+    const closed = deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
     if (closed !== null && closed === openConversationId) {
       // Dedupes, diarizes and flips a conversation in the spool — durable, so
       // the caller must not rewind past it. Flagged AFTER the call: a throw
@@ -558,6 +590,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // accounted for may be missing, so the chunk stays open and keeps its
       // audio.
       const fullyProcessed = isFullyProcessed(entry);
+      trackRetention(entry.chunkId, !fullyProcessed);
       if (entry.built.length > 0 && !fullyProcessed) {
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
@@ -667,7 +700,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           bufferedIds.delete(candidate.chunkId);
           // The chunk keeps its audio for a matching replay, so its durable
           // prefix must stay resumable — do not let the sweep close it.
-          retainedForReplay = true;
+          trackRetention(candidate.chunkId, true);
           report(
             new Error(
               `transcript for chunk ${candidate.chunkId} does not match the recorded manifest; raw audio retained`,
@@ -789,7 +822,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // replay would open a NEW conversation instead of joining the original.
     // The sweep below still dedupes and diarizes, so anything a later
     // shutdown flips is clean.
-    const holdOpen = flushFailure !== undefined || retainedForReplay;
+    const holdOpen = flushFailure !== undefined;
     if (!holdOpen) deps.assembler.finalize();
     // Dedup then cluster EVERY still-capturing conversation before the bulk
     // flip to final — including one left by a crashed prior run that this
@@ -806,12 +839,12 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         // ADDS, so embedding a mic copy whose system duplicate has not arrived
         // yet would leave that copy's contribution in the centroid after dedup
         // deletes the segment.
-        if (!holdOpen) diarizeConversation(id);
+        if (!holdOpen && !isHeldForReplay(id)) diarizeConversation(id);
         // Flipped per conversation, not in bulk: a conversation whose
         // diarization failed must STAY capturing so a later finalize retries
         // it, while the ones that succeeded still reach the final-only read
         // path instead of being stranded behind it.
-        if (!holdOpen && deps.spool.finalizeConversation(id)) closed++;
+        if (!holdOpen && !isHeldForReplay(id) && deps.spool.finalizeConversation(id)) closed++;
       } catch (error) {
         sweepFailure ??= error;
       }
@@ -819,8 +852,13 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // The bulk flip only catches conversations created after the id snapshot
     // above. Skipping it when the sweep failed is what keeps the FAILED
     // conversation `capturing` for the next finalize to retry.
+    // The bulk flip is unconditional in the spool, so it must not run while a
+    // conversation is held for replay — it would flip exactly the prefix the
+    // sweep above deliberately skipped.
     const total =
-      sweepFailure === undefined && !holdOpen ? closed + deps.spool.finalizeOpenConversations() : closed;
+      sweepFailure === undefined && !holdOpen && retainedChunks.size === 0
+        ? closed + deps.spool.finalizeOpenConversations()
+        : closed;
     if (flushFailure !== undefined) throw flushFailure;
     if (sweepFailure !== undefined) throw sweepFailure;
     return total;

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -557,8 +557,14 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // to match, so a silent replay must not be the first to record one.
       const fullyProcessed =
         entry.built.length > 0 ? manifestMatches : !deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:`);
-      if (entry.built.length > 0 && !manifestMatches) {
+      // Anything kept for a later replay must ALSO hold its conversation open:
+      // once `finalize()` flips a conversation to `final`, a replay that
+      // reproduces the manifest can no longer `resume` it and the missing tail
+      // lands in a new conversation, out of reach of cross-channel dedup.
+      if (!fullyProcessed) {
         retainedForReplay = true;
+      }
+      if (entry.built.length > 0 && !manifestMatches) {
         log.warn(
           `[capture-audio] chunk ${entry.chunkId} retranscribed to a different transcript than an earlier run; keeping its raw audio for replay`,
         );
@@ -645,6 +651,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         if (manifest === "conflict") {
           buffer.splice(i, 1);
           bufferedIds.delete(candidate.chunkId);
+          // The chunk keeps its audio for a matching replay, so its durable
+          // prefix must stay resumable — do not let the sweep close it.
+          retainedForReplay = true;
           report(
             new Error(
               `transcript for chunk ${candidate.chunkId} does not match the recorded manifest; raw audio retained`,

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -20,7 +20,7 @@ import { createHash } from "node:crypto";
 import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
 import { dedupeCrossChannel } from "./dedup.js";
 import { CaptureInputError } from "./errors.js";
-import type { Embedding, SpeakerCluster, SpeakerClusterer } from "./diarization.js";
+import type { Embedding, SpeakerClusterer } from "./diarization.js";
 import type { ChunkEvent } from "./native.js";
 import type { Spool } from "./spool.js";
 import type { TranscribedSegment } from "./stt.js";
@@ -55,12 +55,6 @@ export interface ChunkProcessorDeps {
   embed?: (event: ChunkEvent, segment: TranscribedSegment) => Embedding | Promise<Embedding>;
   /** Speaker clusterer (seeded from the spool); its clusters are persisted on finalize. */
   diarizer?: SpeakerClusterer;
-  /**
-   * Roll the clusterer back to a snapshot after a failed diarization commit
-   * (issue #2145). Supplied by the owner of the clusterer, which is the only
-   * place that may replace its internal state.
-   */
-  restoreDiarizer?: (clusters: readonly SpeakerCluster[]) => void;
   /** Cross-channel dedup window in ms; defaults to the dedup module's tolerance. */
   dedupWindowMs?: number;
   /**
@@ -220,7 +214,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     } catch (err) {
       // Restore the clusterer to its pre-assign state so the next finalize
       // starts from the same place SQLite did.
-      deps.restoreDiarizer?.(before);
+      diarizer.restore(before);
       throw err;
     }
   };
@@ -491,6 +485,16 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         await applyBatch(batch);
       } catch (error) {
         report(error, batch[0].event);
+        // A throw mid-batch leaves the chunks AFTER the failure point applied
+        // to nothing: they were already spliced out of the buffer, and the
+        // native helper emits each event once. Put every chunk this batch did
+        // not finish back so the next release retries it (issue #2145).
+        for (const entry of batch) {
+          if (processedThisRun.has(entry.chunkId) || bufferedIds.has(entry.chunkId)) continue;
+          buffer.push(entry);
+          bufferedIds.add(entry.chunkId);
+        }
+        return;
       }
     }
   }

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -224,7 +224,20 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       retainedChunks.delete(chunkId);
       return;
     }
-    retainedChunks.set(chunkId, new Set(resumable));
+    retainedChunks.set(chunkId, heldFor(chunkId, resumable));
+  }
+
+  /**
+   * The conversations one chunk's replay could still need.
+   *
+   * Scoped to the conversations the chunk actually contributed segments to, so
+   * a hold never keeps unrelated audio off the final-only read path. A chunk
+   * with a manifest but no stored segments — a crash between the two — has no
+   * mapping yet, so it conservatively holds everything currently resumable.
+   */
+  function heldFor(chunkId: string, resumable: ReadonlySet<string>): Set<string> {
+    const own = deps.spool.conversationIdsForChunk(chunkId).filter((id) => resumable.has(id));
+    return own.length > 0 ? new Set(own) : new Set(resumable);
   }
 
   /** Conversations a replay could resume right now. */
@@ -469,7 +482,15 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // never call assembler.add, so closeIfIdle is what closes them.
     if (!recovered) {
       recovered = true;
-      const prior = deps.spool.latestCapturingConversation();
+      // Prefer the conversation this batch's own chunks already contributed
+      // to: a replay of an OLDER chunk must resume its own prefix, or its
+      // missing tail predates the newest capturing conversation and lands in a
+      // new one instead (issue #2145).
+      const ownPrefix = batch
+        .flatMap((entry) => deps.spool.conversationIdsForChunk(entry.chunkId))
+        .map((id) => deps.spool.capturingConversationById(id))
+        .find((conversation) => conversation !== null);
+      const prior = ownPrefix ?? deps.spool.latestCapturingConversation();
       if (prior) {
         deps.assembler.resume(prior);
         openConversationId = prior.id;
@@ -480,15 +501,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // are the prefixes its replay could still resume (issue #2145).
       const capturingAtStartup = new Set(deps.spool.capturingConversationIds());
       for (const chunkId of deps.spool.incompleteChunkIds()) {
-        // Scope each hold to the conversations that chunk actually contributed
-        // to: attaching every capturing conversation to every incomplete chunk
-        // would keep unrelated audio off the final-only read path, and would
-        // stop a completed conversation from finalizing while any OTHER chunk
-        // is still awaiting replay.
-        const held = deps.spool
-          .conversationIdsForChunk(chunkId)
-          .filter((id) => capturingAtStartup.has(id));
-        if (held.length > 0) retainedChunks.set(chunkId, new Set(held));
+        // Each hold is scoped to that chunk's own conversation, so a completed
+        // one finalizes even while another chunk still awaits replay.
+        const held = heldFor(chunkId, capturingAtStartup);
+        if (held.size > 0) retainedChunks.set(chunkId, held);
       }
     }
     // Decide retention BEFORE anything can close a conversation: a chunk kept

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -358,6 +358,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     );
     const closed = deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
     if (closed !== null && closed === openConversationId) {
+      // Dedupes, diarizes and flips a conversation in the spool — durable, so
+      // the caller must not rewind past it.
+      progress.persisted = true;
       finalizeConv(closed);
       openConversationId = null;
     }
@@ -435,6 +438,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       for (const item of run.items) {
         const key = `${chunkId}:i${item.index}`;
         if (openConversationId !== null && openConversationId !== run.id) {
+          progress.persisted = true;
           finalizeConv(openConversationId);
         }
         deps.spool.appendAssembledSegments({
@@ -511,17 +515,30 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           left.endMs - right.endMs ||
           (left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0),
       );
-      // Rewind only matters when NOTHING was persisted: then the assembler is
-      // ahead of durable reality and the retry would collapse conversations
-      // the first attempt split. Once a segment is durable its conversation id
-      // is too, so rewinding past it would split that conversation across two
-      // ids instead (issue #2145).
-      const assemblerCheckpoint = deps.assembler.checkpoint();
+      // Rewind only matters when NOTHING durable changed: then the in-memory
+      // state is ahead of the spool and the retry would collapse conversations
+      // the first attempt split. Once anything is durable — an appended
+      // segment OR a finalized conversation — the spool cannot be rewound, so
+      // neither is the memory that mirrors it (issue #2145).
+      //
+      // The snapshot covers every piece of in-memory state `applyBatch`
+      // touches, not just the assembler: `resume()` and `openConversationId`
+      // are set inside it too, and rewinding the assembler alone would leave
+      // the recovery flags claiming a conversation the assembler no longer has.
+      const checkpoint = {
+        assembler: deps.assembler.checkpoint(),
+        recovered,
+        openConversationId,
+      };
       const progress = { persisted: false };
       try {
         await applyBatch(batch, progress);
       } catch (error) {
-        if (!progress.persisted) deps.assembler.rewind(assemblerCheckpoint);
+        if (!progress.persisted) {
+          deps.assembler.rewind(checkpoint.assembler);
+          recovered = checkpoint.recovered;
+          openConversationId = checkpoint.openConversationId;
+        }
         // Requeue FIRST: `report` runs an operator callback that may itself
         // throw, and losing the batch to a broken telemetry sink would turn an
         // observer failure into data loss. A throw mid-batch leaves the chunks

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -188,23 +188,23 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       assignments.push({ id: segment.id, speakerCluster: clusterId, isWearer });
       touched.add(clusterId);
     }
-    // Clusters first: a segment row must never reference a cluster that is
-    // not persisted yet, so a crash between the two leaves the segments
-    // unassigned and the next finalize redoes them.
+    // ONE transaction: a crash between persisting the cluster counts and
+    // persisting the assignments would leave the counts advanced while the
+    // segments still look pending, and the next finalize would count the same
+    // embeddings again (issue #2145).
     const byId = new Map(diarizer.clusters().map((c) => [c.id, c]));
-    for (const clusterId of touched) {
-      const cluster = byId.get(clusterId);
-      if (!cluster) continue;
-      deps.spool.upsertSpeaker({
+    const clusters = [...touched]
+      .map((clusterId) => byId.get(clusterId))
+      .filter((cluster): cluster is NonNullable<typeof cluster> => cluster !== undefined)
+      .map((cluster) => ({
         id: cluster.id,
         label: cluster.label,
         isSelf: cluster.isSelf,
         embeddingCount: cluster.embeddingCount,
         centroid: cluster.centroid,
         examples: cluster.examples,
-      });
-    }
-    deps.spool.assignSegmentSpeakers(assignments);
+      }));
+    deps.spool.commitDiarization({ clusters, assignments });
   };
   const finalizeConv = (id: string): void => {
     dedupeConversation(id);
@@ -286,15 +286,23 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   }
 
   /**
-   * Apply one buffered chunk: assemble, append, mark complete, reclaim the
-   * WAV. Everything here runs on the RELEASE timeline, not the arrival
-   * timeline, so a delayed chunk is assembled at its own place in time.
+   * Apply one batch of released chunks.
+   *
+   * Whole-chunk release alone is not enough: two chunks can COVER THE SAME
+   * WINDOW on different channels, so a mic segment at 00:00 and 00:20 must not
+   * be applied ahead of a system segment at 00:10 (issue #2145). The batch's
+   * segments are therefore interleaved into one chronological stream, fed to
+   * the assembler in that order, and appended as runs that each belong to one
+   * chunk — so the per-chunk idempotency keys (`chunkId`, `chunkId:g`,
+   * `chunkId:done`) keep their existing shape and a lone chunk still uses the
+   * bare `chunkId` exactly as before.
+   *
+   * Everything here runs on the RELEASE timeline, not the arrival timeline.
    */
-  async function applyChunk(entry: BufferedChunk): Promise<void> {
-    const { event, chunkId, built } = entry;
+  async function applyBatch(batch: readonly BufferedChunk[]): Promise<void> {
     // Recover the newest still-open conversation once (any chunk, incl. silent)
     // so a post-restart chunk continues it; then finalize a stale open
-    // conversation when this chunk is released a gap past it. Pure-silence runs
+    // conversation when this batch is released a gap past it. Pure-silence runs
     // never call assembler.add, so closeIfIdle is what closes them.
     if (!recovered) {
       recovered = true;
@@ -304,139 +312,154 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         openConversationId = prior.id;
       }
     }
-    const closed = deps.assembler.closeIfIdle(event.startedAtUtc);
+    const earliestStart = batch.reduce(
+      (earliest, entry) => (entry.startMs < earliest.startMs ? entry : earliest),
+      batch[0],
+    );
+    const closed = deps.assembler.closeIfIdle(earliestStart.event.startedAtUtc);
     if (closed !== null && closed === openConversationId) {
       finalizeConv(closed);
       openConversationId = null;
     }
 
+    // One chronological stream across the batch. The comparator is total —
+    // start, then end, then chunk id, then position — so the same batch always
+    // interleaves the same way (rule 12).
+    const stream = batch
+      .flatMap((entry) =>
+        entry.built.map((item, index) => ({ entry, item, index })),
+      )
+      .sort((left, right) => {
+        if (left.item.seg.startUtc !== right.item.seg.startUtc) {
+          return left.item.seg.startUtc < right.item.seg.startUtc ? -1 : 1;
+        }
+        if (left.item.seg.endUtc !== right.item.seg.endUtc) {
+          return left.item.seg.endUtc < right.item.seg.endUtc ? -1 : 1;
+        }
+        if (left.entry.chunkId !== right.entry.chunkId) {
+          return left.entry.chunkId < right.entry.chunkId ? -1 : 1;
+        }
+        return left.index - right.index;
+      });
 
-    if (built.length > 0) {
-      // Segments usually land in one conversation, but a gap >= threshold (or
-      // conversationGapMinutes = 0) can split them intra-chunk. Group by the
-      // conversation the assembler places each segment in.
-      const groups: Array<{
-        id: string;
-        startedAtUtc: string;
-        items: Array<{ seg: AssemblySegment; raw: TranscribedSegment }>;
-      }> = [];
-      for (const item of built) {
-        const conv = deps.assembler.add(item.seg);
-        const last = groups[groups.length - 1];
-        if (last && last.id === conv.id) last.items.push(item);
-        else groups.push({ id: conv.id, startedAtUtc: conv.startedAtUtc, items: [item] });
-      }
-      // Append each group, finalizing a conversation only once we move past it
-      // (AFTER its rows are appended). A group already applied in a prior run is
-      // skipped so the SAME chunk's later, unpersisted groups still append.
-      for (let g = 0; g < groups.length; g++) {
-        const grp = groups[g];
-        const key = groups.length === 1 ? chunkId : `${chunkId}:${g}`;
-        if (deps.spool.isChunkApplied(key)) {
-          openConversationId = grp.id;
-          continue;
-        }
-        if (openConversationId !== null && openConversationId !== grp.id) {
-          finalizeConv(openConversationId);
-        }
-        // Embed now — this is where the audio exists — but do NOT cluster.
-        // Clustering runs at finalize over the segments that SURVIVE
-        // cross-channel dedup (issue #2145), so a mic loopback duplicate that
-        // is later pruned can no longer inflate a centroid or invent a
-        // phantom speaker. The embedding rides along on the segment row.
-        if (deps.embed) {
-          for (const item of grp.items) {
-            item.seg.embedding = await deps.embed(event, item.raw);
-          }
-        }
-        deps.spool.appendAssembledSegments({
-          idempotencyKey: key,
-          chunkId: key,
-          conversationId: grp.id,
-          startedAtUtc: grp.startedAtUtc,
-          state: "capturing",
-          device: event.device,
-          wavPath: event.path,
-          segments: grp.items.map((it) => it.seg),
-        });
-        openConversationId = grp.id;
-      }
+    // Assign conversations over the interleaved stream, then cut it into runs
+    // that each belong to ONE chunk and ONE conversation. The runs are already
+    // in chronological order, so a conversation is only finalized once the
+    // stream has truly moved past it.
+    const runs: Array<{
+      entry: BufferedChunk;
+      id: string;
+      startedAtUtc: string;
+      items: Array<{ seg: AssemblySegment; raw: TranscribedSegment }>;
+    }> = [];
+    for (const { entry, item } of stream) {
+      const conv = deps.assembler.add(item.seg);
+      const last = runs[runs.length - 1];
+      if (last && last.id === conv.id && last.entry === entry) last.items.push(item);
+      else runs.push({ entry, id: conv.id, startedAtUtc: conv.startedAtUtc, items: [item] });
     }
 
-    // Mark the whole chunk complete only when it is safe: either we processed
-    // real segments this run (so every group of this chunk is now applied), or
-    // it is a genuinely fresh silent chunk with no prior partial application. A
-    // zero-segment run over a chunk whose earlier groups were already applied
-    // (a partial crash) must NOT be marked done, or the missing tail groups
-    // would be stranded forever.
-    const chunkFullyProcessed = built.length > 0 || !deps.spool.isChunkApplied(`${chunkId}:0`);
-    processedThisRun.add(chunkId);
-    if (chunkFullyProcessed) {
+    const runsPerChunk = new Map<string, number>();
+    for (const run of runs) {
+      runsPerChunk.set(run.entry.chunkId, (runsPerChunk.get(run.entry.chunkId) ?? 0) + 1);
+    }
+    const emitted = new Map<string, number>();
+    for (const run of runs) {
+      const { chunkId, event } = run.entry;
+      const index = emitted.get(chunkId) ?? 0;
+      emitted.set(chunkId, index + 1);
+      const key = runsPerChunk.get(chunkId) === 1 ? chunkId : `${chunkId}:${index}`;
+      if (deps.spool.isChunkApplied(key)) {
+        openConversationId = run.id;
+        continue;
+      }
+      if (openConversationId !== null && openConversationId !== run.id) {
+        finalizeConv(openConversationId);
+      }
+      // Embed now — this is where the audio exists — but do NOT cluster.
+      // Clustering runs at finalize over the segments that SURVIVE
+      // cross-channel dedup (issue #2145), so a mic loopback duplicate that
+      // is later pruned can no longer inflate a centroid or invent a
+      // phantom speaker. The embedding rides along on the segment row.
+      if (deps.embed) {
+        for (const item of run.items) {
+          item.seg.embedding = await deps.embed(event, item.raw);
+        }
+      }
+      deps.spool.appendAssembledSegments({
+        idempotencyKey: key,
+        chunkId: key,
+        conversationId: run.id,
+        startedAtUtc: run.startedAtUtc,
+        state: "capturing",
+        device: event.device,
+        wavPath: event.path,
+        segments: run.items.map((it) => it.seg),
+      });
+      openConversationId = run.id;
+    }
+
+    for (const entry of batch) {
+      // Mark the whole chunk complete only when it is safe: either we processed
+      // real segments this run (so every run of this chunk is now applied), or
+      // it is a genuinely fresh silent chunk with no prior partial application.
+      // A zero-segment run over a chunk whose earlier groups were already
+      // applied (a partial crash) must NOT be marked done, or the missing tail
+      // groups would be stranded forever.
+      const fullyProcessed =
+        entry.built.length > 0 || !deps.spool.isChunkApplied(`${entry.chunkId}:0`);
+      processedThisRun.add(entry.chunkId);
+      if (!fullyProcessed) continue;
       // The chunk is fully durably transcribed: record completion and reclaim
       // the raw WAV. A partial chunk (earlier groups applied, this run added
-      // nothing) must RETAIN its WAV so a later full replay can still transcribe
-      // the missing tail groups. Cleanup is best-effort; the janitor is the backstop.
-      deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
+      // nothing) must RETAIN its WAV so a later full replay can still
+      // transcribe the missing tail. Cleanup is best-effort; the janitor is
+      // the backstop.
+      deps.spool.markChunkComplete(entry.chunkId, openConversationId ?? "-");
       try {
-        await deps.cleanupRawAudio(event);
+        await deps.cleanupRawAudio(entry.event);
       } catch (err) {
-        report(err, event);
+        report(err, entry.event);
       }
     }
   }
 
   /**
-   * Release every buffered chunk the watermark has passed, oldest first.
+   * Release every buffered chunk the watermark has passed, as one batch.
    *
-   * Release is whole-chunk: a chunk's own segments are already chronological,
-   * and holding until its END clears the watermark is what makes the released
-   * stream chronological ACROSS chunks. Whole-chunk release also keeps the
-   * per-chunk idempotency keys (`chunkId`, `chunkId:g`, `chunkId:done`)
-   * exactly as they were, so replay and crash recovery are unchanged.
+   * A chunk becomes releasable when the newest observed chunk end is
+   * `reorderWindowMs` past its own end. Releasing the whole releasable set
+   * together is what lets `applyBatch` interleave overlapping cross-channel
+   * windows; holding until the END clears the watermark is what bounds how far
+   * out of order an arrival can be.
    *
    * `flushAll` ignores the watermark, for `finalize()`.
    */
   async function releaseReady(flushAll: boolean): Promise<void> {
-    const threshold = flushAll ? Number.POSITIVE_INFINITY : watermarkSourceMs - reorderWindowMs;
     for (;;) {
-      const readyIndex = pickNextReleasable(threshold);
-      if (readyIndex === -1) return;
-      const [entry] = buffer.splice(readyIndex, 1);
-      if (entry === undefined) return;
-      bufferedIds.delete(entry.chunkId);
+      const threshold = flushAll ? Number.POSITIVE_INFINITY : watermarkSourceMs - reorderWindowMs;
+      const batch: BufferedChunk[] = [];
+      for (let i = buffer.length - 1; i >= 0; i--) {
+        const candidate = buffer[i];
+        if (candidate.endMs > threshold) continue;
+        buffer.splice(i, 1);
+        bufferedIds.delete(candidate.chunkId);
+        batch.push(candidate);
+      }
+      if (batch.length === 0) return;
+      // Total order so the same batch always applies the same way (rule 12).
+      batch.sort(
+        (left, right) =>
+          left.startMs - right.startMs ||
+          left.endMs - right.endMs ||
+          (left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0),
+      );
       try {
-        await applyChunk(entry);
+        await applyBatch(batch);
       } catch (error) {
-        report(error, entry.event);
+        report(error, batch[0].event);
       }
     }
-  }
-
-  /**
-   * Index of the oldest releasable chunk, or -1. Ordering is by first
-   * segment start, then chunk end, then id: a total comparator, so the
-   * release order is identical across runs (rule 12).
-   */
-  function pickNextReleasable(threshold: number): number {
-    let best = -1;
-    for (let i = 0; i < buffer.length; i++) {
-      const candidate = buffer[i];
-      if (candidate.endMs > threshold) continue;
-      if (best === -1) {
-        best = i;
-        continue;
-      }
-      const incumbent = buffer[best];
-      if (
-        candidate.startMs < incumbent.startMs ||
-        (candidate.startMs === incumbent.startMs &&
-          (candidate.endMs < incumbent.endMs ||
-            (candidate.endMs === incumbent.endMs && candidate.chunkId < incumbent.chunkId)))
-      ) {
-        best = i;
-      }
-    }
-    return best;
   }
 
   function enqueue(event: ChunkEvent): void {

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -135,6 +135,12 @@ interface BufferedChunk {
   startMs: number;
   /** Latest segment end, never earlier than the chunk's own end. */
   endMs: number;
+  /**
+   * Whether this chunk's transcript manifest is durably recorded. A chunk is
+   * never released without it: the manifest is what stops a later, changed
+   * retranscription from completing a partially applied chunk (issue #2145).
+   */
+  manifestRecorded: boolean;
 }
 
 /**
@@ -333,19 +339,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       built,
       startMs: firstStartMs(event, raw),
       endMs: lastEndMs(event, raw),
+      manifestRecorded: false,
     });
     bufferedIds.add(chunkId);
-    // Recorded AFTER buffering (so a throw here cannot drop the helper's
-    // one-shot event) but BEFORE any append, and only once: this is the fact a
-    // later replay cannot re-derive, so it must survive a failure partway
-    // through appending this chunk (issue #2145).
-    if (built.length > 0 && !deps.spool.hasAppliedChunkPrefix(`${chunkId}:m`)) {
-      try {
-        deps.spool.markApplied(transcriptManifestKey(chunkId, built.map((item) => item.seg)), "-");
-      } catch (err) {
-        report(err, event);
-      }
-    }
     watermarkSourceMs = Math.max(watermarkSourceMs, lastEndMs(event, raw));
     await releaseReady(false);
   }
@@ -556,6 +552,30 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   }
 
   /**
+   * Persist a buffered chunk's transcript manifest, once. Returns whether the
+   * chunk may now be released.
+   */
+  function recordTranscriptManifest(entry: BufferedChunk): boolean {
+    if (entry.built.length === 0) {
+      entry.manifestRecorded = true;
+      return true;
+    }
+    try {
+      if (!deps.spool.hasAppliedChunkPrefix(`${entry.chunkId}:m`)) {
+        deps.spool.markApplied(
+          transcriptManifestKey(entry.chunkId, entry.built.map((item) => item.seg)),
+          "-",
+        );
+      }
+      entry.manifestRecorded = true;
+      return true;
+    } catch (err) {
+      report(err, entry.event);
+      return false;
+    }
+  }
+
+  /**
    * Release every buffered chunk the watermark has passed, as one batch.
    *
    * A chunk becomes releasable when the newest observed chunk end is
@@ -577,6 +597,13 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       for (let i = buffer.length - 1; i >= 0; i--) {
         const candidate = buffer[i];
         if (candidate.endMs > threshold) continue;
+        // Record the transcript manifest BEFORE the chunk can be appended, and
+        // only once. A chunk whose manifest cannot be written stays buffered
+        // with its raw audio: releasing it would let a later, changed
+        // retranscription record the FIRST manifest and complete a partially
+        // applied chunk (issue #2145). The event is not lost — the next pass
+        // retries the write.
+        if (!candidate.manifestRecorded && !recordTranscriptManifest(candidate)) continue;
         buffer.splice(i, 1);
         bufferedIds.delete(candidate.chunkId);
         batch.push(candidate);

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -491,17 +491,19 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       try {
         await applyBatch(batch);
       } catch (error) {
-        report(error, batch[0].event);
-        if (flushAll) finalFailure ??= error;
-        // A throw mid-batch leaves the chunks AFTER the failure point applied
-        // to nothing: they were already spliced out of the buffer, and the
-        // native helper emits each event once. Put every chunk this batch did
-        // not finish back so the next release retries it (issue #2145).
+        // Requeue FIRST: `report` runs an operator callback that may itself
+        // throw, and losing the batch to a broken telemetry sink would turn an
+        // observer failure into data loss. A throw mid-batch leaves the chunks
+        // after the failure point applied to nothing — they were already
+        // spliced out of the buffer, and the native helper emits each event
+        // once (issue #2145).
         for (const entry of batch) {
           if (processedThisRun.has(entry.chunkId) || bufferedIds.has(entry.chunkId)) continue;
           buffer.push(entry);
           bufferedIds.add(entry.chunkId);
         }
+        if (flushAll) finalFailure ??= error;
+        report(error, batch[0].event);
         if (finalFailure !== undefined) throw finalFailure;
         return;
       }
@@ -524,7 +526,15 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // drain/finalize reject with the same stale error (AGENTS.md #28).
     const flush = tail.then(() => releaseReady(true));
     tail = flush.catch(() => undefined);
-    await flush;
+    // A failed flush must NOT skip the sweep: shutdown flips whatever is left
+    // to `final`, and skipping would serve conversations that were never
+    // deduped or diarized. Run the sweep, then report the flush failure.
+    let flushFailure: unknown;
+    try {
+      await flush;
+    } catch (error) {
+      flushFailure = error;
+    }
     deps.assembler.finalize();
     // Dedup then cluster EVERY still-capturing conversation before the bulk
     // flip to final — including one left by a crashed prior run that this
@@ -546,8 +556,13 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
         sweepFailure ??= error;
       }
     }
+    // The bulk flip only catches conversations created after the id snapshot
+    // above. Skipping it when the sweep failed is what keeps the FAILED
+    // conversation `capturing` for the next finalize to retry.
+    const total = sweepFailure === undefined ? closed + deps.spool.finalizeOpenConversations() : closed;
+    if (flushFailure !== undefined) throw flushFailure;
     if (sweepFailure !== undefined) throw sweepFailure;
-    return closed + deps.spool.finalizeOpenConversations();
+    return total;
   }
 
   return { enqueue, drain, finalize };

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -17,6 +17,8 @@
 
 import { createHash } from "node:crypto";
 
+import { log } from "@remnic/core/logger";
+
 import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
 import { dedupeCrossChannel } from "./dedup.js";
 import { CaptureInputError } from "./errors.js";
@@ -225,7 +227,13 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   };
 
   const report = (error: unknown, event: ChunkEvent): void => {
-    deps.onError?.(error instanceof Error ? error : new Error(String(error)), event);
+    // A throwing operator callback must not become a pipeline failure: it would
+    // propagate into the serialized chain and stall every later chunk.
+    try {
+      deps.onError?.(error instanceof Error ? error : new Error(String(error)), event);
+    } catch {
+      // nothing left to report it to
+    }
   };
 
   async function process(event: ChunkEvent): Promise<void> {
@@ -244,13 +252,15 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // would duplicate its segments, which is worse than leaving the tail of
     // one in-flight chunk unsent across the upgrade.
     if (deps.spool.isChunkApplied(chunkId) || deps.spool.isChunkApplied(`${chunkId}:0`)) {
+      // Legacy group keys prove only that SOME group persisted, so this chunk
+      // is left strictly alone: not re-appended (which would duplicate the
+      // stored groups), and not marked done or reclaimed (which would discard
+      // an unpersisted tail). The WAV stays for a rebuild or manual replay,
+      // and the operator is told once.
       processedThisRun.add(chunkId);
-      deps.spool.markChunkComplete(chunkId, openConversationId ?? "-");
-      try {
-        await deps.cleanupRawAudio(event);
-      } catch (err) {
-        report(err, event);
-      }
+      log.warn(
+        `[capture-audio] chunk ${chunkId} was partially applied under the pre-#2145 key scheme; leaving it and its raw audio in place for replay`,
+      );
       return;
     }
     if (deps.spool.isChunkApplied(`${chunkId}:done`)) {
@@ -384,6 +394,13 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // that each belong to ONE chunk and ONE conversation. The runs are already
     // in chronological order, so a conversation is only finalized once the
     // stream has truly moved past it.
+    //
+    // Already-applied segments are dropped BEFORE the assembler sees them.
+    // They live in a durable conversation already, so re-adding them would
+    // either duplicate in-memory state or — if the assembler were rewound to
+    // undo them — mint a second id for a conversation that is already on disk
+    // and split it. Skipping is the only option that keeps the in-memory ids
+    // and the persisted ids identical (issue #2145).
     const runs: Array<{
       entry: BufferedChunk;
       id: string;
@@ -391,6 +408,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       items: Array<{ seg: AssemblySegment; raw: TranscribedSegment; index: number }>;
     }> = [];
     for (const { entry, item, index } of stream) {
+      if (deps.spool.isChunkApplied(`${entry.chunkId}:i${index}`)) continue;
       const conv = deps.assembler.add(item.seg);
       const carried = { ...item, index };
       const last = runs[runs.length - 1];
@@ -408,10 +426,6 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       const { chunkId, event } = run.entry;
       for (const item of run.items) {
         const key = `${chunkId}:i${item.index}`;
-        if (deps.spool.isChunkApplied(key)) {
-          openConversationId = run.id;
-          continue;
-        }
         if (openConversationId !== null && openConversationId !== run.id) {
           finalizeConv(openConversationId);
         }
@@ -488,16 +502,9 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           left.endMs - right.endMs ||
           (left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0),
       );
-      // Rewind point: persistence inside applyBatch is synchronous but can
-      // still throw (a busy/IO error from SQLite) AFTER segments have passed
-      // through the assembler. Without this the retry feeds earlier
-      // timestamps into an advanced assembler and merges spans the first
-      // attempt had split (issue #2145).
-      const assemblerCheckpoint = deps.assembler.checkpoint();
       try {
         await applyBatch(batch);
       } catch (error) {
-        deps.assembler.rewind(assemblerCheckpoint);
         // Requeue FIRST: `report` runs an operator callback that may itself
         // throw, and losing the batch to a broken telemetry sink would turn an
         // observer failure into data loss. A throw mid-batch leaves the chunks

--- a/packages/capture-audio/src/spool.test.ts
+++ b/packages/capture-audio/src/spool.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import { test } from "node:test";
 
+import { SPOOL_SCHEMA_VERSION } from "./constants.js";
 import { CaptureConfigError, CaptureInputError } from "./errors.js";
 import { Spool } from "./spool.js";
 import type { ChunkStatus, ConversationState, SegmentInput } from "./spool.js";
@@ -17,7 +18,7 @@ const seg = (text: string): SegmentInput => ({
 
 test("schema is created with meta schema_version and instance_id", () => {
   const spool = new Spool(":memory:");
-  assert.equal(spool.meta("schema_version"), "1");
+  assert.equal(spool.meta("schema_version"), String(SPOOL_SCHEMA_VERSION));
   assert.ok(spool.meta("instance_id"));
   spool.close();
 });

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -685,6 +685,28 @@ export class Spool {
   }
 
   /**
+   * Chunks whose transcript manifest is recorded but which never completed.
+   *
+   * A restart loses the in-memory record of which chunks are still awaiting a
+   * replay, so it is re-derived from these two durable markers: the manifest is
+   * written before any append, `:done` only after every segment is stored
+   * (issue #2145).
+   */
+  incompleteChunkIds(): string[] {
+    const rows = this.#db
+      .prepare(
+        `SELECT substr(idempotency_key, 1, length(idempotency_key) - 9) AS chunkId
+           FROM applied_chunks
+          WHERE idempotency_key LIKE '%:manifest'
+            AND substr(idempotency_key, 1, length(idempotency_key) - 9) || ':done' NOT IN (
+                  SELECT idempotency_key FROM applied_chunks
+                )`,
+      )
+      .all() as { chunkId: string }[];
+    return rows.map((row) => row.chunkId);
+  }
+
+  /**
    * The value stored alongside an idempotency marker, or `undefined`.
    *
    * `markApplied` uses this column to carry a fact a replay cannot re-derive —

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -670,16 +670,32 @@ export class Spool {
   /**
    * Whether ANY idempotency key for this chunk was applied.
    *
-   * Per-segment keys are content-derived, so they cannot be enumerated from a
-   * chunk id alone; a zero-segment replay still has to know whether the chunk
-   * was partially applied before (issue #2145).
+   * Only a SILENT replay needs this — a chunk partially applied by a binary
+   * predating the transcript manifest has no manifest to compare, and a
+   * zero-segment replay has no per-segment key to look up exactly. Speech
+   * chunks use the indexed manifest lookup below, so continuous capture never
+   * pays for this scan (issue #2145).
    */
-  hasAppliedChunkPrefix(prefix: string): boolean {
-    return (
-      this.#db
-        .prepare("SELECT 1 FROM applied_chunks WHERE idempotency_key LIKE ? ESCAPE '\\' LIMIT 1")
-        .get(`${prefix.replace(/[\\%_]/g, "\\$&")}%`) !== undefined
-    );
+  hasAppliedChunkPrefix(chunkIdPrefix: string): boolean {
+    const escaped = chunkIdPrefix.replace(/[\\%_]/g, "\\$&");
+    const row = this.#db
+      .prepare("SELECT 1 AS present FROM applied_chunks WHERE idempotency_key LIKE ? ESCAPE '\\' LIMIT 1")
+      .get(`${escaped}%`) as { present?: number } | undefined;
+    return row?.present === 1;
+  }
+
+  /**
+   * The value stored alongside an idempotency marker, or `undefined`.
+   *
+   * `markApplied` uses this column to carry a fact a replay cannot re-derive —
+   * the chunk's transcript manifest hash — and this is the exact, primary-key
+   * lookup that reads it back (issue #2145).
+   */
+  appliedChunkValue(idempotencyKey: string): string | undefined {
+    const row = this.#db
+      .prepare("SELECT conversation_id AS conversationId FROM applied_chunks WHERE idempotency_key = ?")
+      .get(idempotencyKey) as { conversationId?: string } | undefined;
+    return row?.conversationId;
   }
 
   /** Whether a chunk with this idempotency key was already durably applied. */

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -595,16 +595,28 @@ export class Spool {
     return out;
   }
 
-  /** Write finalize-time diarization results back onto their segments. */
-  assignSegmentSpeakers(
-    assignments: ReadonlyArray<{ id: string; speakerCluster: string; isWearer: boolean }>,
-  ): number {
-    if (assignments.length === 0) return 0;
+  /**
+   * Commit one conversation's diarization: cluster snapshots and the segment
+   * assignments that produced them, in ONE transaction.
+   *
+   * Splitting the two lets a crash persist an updated `embedding_count` while
+   * its segments stay unassigned; the next finalize would select the same rows
+   * and count the same embeddings again (issue #2145). Atomicity is what makes
+   * the repeated-finalize idempotency claim true.
+   */
+  commitDiarization(input: {
+    clusters: readonly SpeakerInput[];
+    assignments: ReadonlyArray<{ id: string; speakerCluster: string; isWearer: boolean }>;
+  }): number {
+    if (input.assignments.length === 0 && input.clusters.length === 0) return 0;
     const stmt = this.#db.prepare("UPDATE segments SET speaker_cluster = ?, is_wearer = ? WHERE id = ?");
     let updated = 0;
     this.#db.exec("BEGIN");
     try {
-      for (const assignment of assignments) {
+      // Clusters first inside the transaction, so the segments' foreign
+      // reference is already present when they are written.
+      for (const cluster of input.clusters) this.#upsertSpeakerUnlocked(cluster);
+      for (const assignment of input.assignments) {
         updated += Number(stmt.run(assignment.speakerCluster, assignment.isWearer ? 1 : 0, assignment.id).changes);
       }
       this.#db.exec("COMMIT");
@@ -666,6 +678,11 @@ export class Spool {
   }
 
   upsertSpeaker(input: SpeakerInput): void {
+    this.#upsertSpeakerUnlocked(input);
+  }
+
+  /** `upsertSpeaker` without its own transaction, for use inside one. */
+  #upsertSpeakerUnlocked(input: SpeakerInput): void {
     const current = this.#db
       .prepare(
         "SELECT label, embedding_count AS embeddingCount, is_self AS isSelf, centroid, example_embeddings AS examples FROM speaker_clusters WHERE id = ?",

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -275,6 +275,25 @@ export class Spool {
         // filesystem without POSIX perms (e.g. some Windows mounts)
       }
     }
+    // Refuse a spool written by a NEWER binary: migrating it here, and then
+    // stamping our lower version over its higher one, would leave that binary
+    // reading a schema it no longer recognizes (issue #2145).
+    const storedVersion = this.#db
+      .prepare("SELECT value FROM meta WHERE key = 'schema_version'")
+      .get() as { value?: string } | undefined;
+    if (storedVersion?.value !== undefined) {
+      const parsed = Number(storedVersion.value);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new CaptureConfigError(
+          `spool schema_version is malformed: ${JSON.stringify(storedVersion.value)}`,
+        );
+      }
+      if (parsed > SPOOL_SCHEMA_VERSION) {
+        throw new CaptureConfigError(
+          `spool schema_version ${parsed} is newer than this build supports (${SPOOL_SCHEMA_VERSION})`,
+        );
+      }
+    }
     // Additive migration for a spool created before segment embeddings existed
     // (issue #2145). CREATE TABLE IF NOT EXISTS leaves an existing table alone,
     // so the column is added explicitly; ALTER is skipped when it is present.

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -777,6 +777,20 @@ export class Spool {
     return { id: row.id, startedAtUtc: row.startedAtUtc, endedAtUtc: row.endedAtUtc ?? row.startedAtUtc };
   }
 
+  /** One capturing conversation by id, for resuming a specific prefix. */
+  capturingConversationById(
+    id: string,
+  ): { id: string; startedAtUtc: string; endedAtUtc: string } | null {
+    const row = this.#db
+      .prepare(
+        "SELECT id, started_at_utc AS startedAtUtc, ended_at_utc AS endedAtUtc FROM conversations " +
+          "WHERE id = ? AND state = 'capturing'",
+      )
+      .get(id) as { id: string; startedAtUtc: string; endedAtUtc: string | null } | undefined;
+    if (!row) return null;
+    return { id: row.id, startedAtUtc: row.startedAtUtc, endedAtUtc: row.endedAtUtc ?? row.startedAtUtc };
+  }
+
   #segmentCount(conversationId: string): number {
     const row = this.#db
       .prepare("SELECT segment_count AS n FROM conversations WHERE id = ?")

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -33,6 +33,13 @@ export type ChunkStatus = "pending" | "transcribed" | "failed" | "deleted";
 export interface SegmentInput {
   speakerCluster?: string | null;
   isWearer?: boolean;
+  /**
+   * Speaker embedding for this segment, persisted as a JSON BLOB (issue
+   * #2145). Clustering runs at finalize over the segments that SURVIVE
+   * cross-channel dedup, so a pruned loopback duplicate never inflates a
+   * cluster's centroid or count.
+   */
+  embedding?: readonly number[] | null;
   channel: string;
   text: string;
   startUtc: string;
@@ -161,7 +168,8 @@ CREATE TABLE IF NOT EXISTS segments (
   text TEXT NOT NULL,
   start_utc TEXT NOT NULL,
   end_utc TEXT NOT NULL,
-  ordinal INTEGER NOT NULL DEFAULT 0
+  ordinal INTEGER NOT NULL DEFAULT 0,
+  embedding BLOB
 );
 CREATE TABLE IF NOT EXISTS speaker_clusters (
   id TEXT PRIMARY KEY,
@@ -179,6 +187,28 @@ CREATE TABLE IF NOT EXISTS applied_chunks (
 CREATE INDEX IF NOT EXISTS idx_conv_keyset ON conversations(started_at_utc, id);
 CREATE INDEX IF NOT EXISTS idx_seg_conv ON segments(conversation_id, ordinal);
 `;
+
+/**
+ * Encode a speaker embedding for the `segments.embedding` BLOB. `null` and an
+ * empty vector both persist as NULL: an absent embedding must not look like a
+ * zero-length one at finalize.
+ */
+function encodeEmbedding(embedding: readonly number[] | null | undefined): Buffer | null {
+  if (!embedding || embedding.length === 0) return null;
+  return Buffer.from(JSON.stringify(embedding));
+}
+
+/** Decode a JSON-encoded numeric vector BLOB; corrupt rows decode to null. */
+function decodeEmbedding(blob: Buffer | Uint8Array | null): number[] | null {
+  if (!blob || blob.byteLength === 0) return null;
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(blob).toString("utf8"));
+    if (!Array.isArray(parsed)) return null;
+    return parsed.every((n) => typeof n === "number" && Number.isFinite(n)) ? (parsed as number[]) : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Canonical instant required at the Spool boundary: a full date + time with a
@@ -245,8 +275,15 @@ export class Spool {
         // filesystem without POSIX perms (e.g. some Windows mounts)
       }
     }
+    // Additive migration for a spool created before segment embeddings existed
+    // (issue #2145). CREATE TABLE IF NOT EXISTS leaves an existing table alone,
+    // so the column is added explicitly; ALTER is skipped when it is present.
+    const segmentColumns = this.#db.prepare("PRAGMA table_info(segments)").all() as Array<{ name: string }>;
+    if (!segmentColumns.some((column) => column.name === "embedding")) {
+      this.#db.exec("ALTER TABLE segments ADD COLUMN embedding BLOB");
+    }
     this.#db
-      .prepare("INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)")
+      .prepare("INSERT INTO meta(key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
       .run("schema_version", String(SPOOL_SCHEMA_VERSION));
     this.#db.prepare("INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)").run("instance_id", ulid());
   }
@@ -334,7 +371,7 @@ export class Spool {
         "INSERT INTO conversations(id, started_at_utc, ended_at_utc, state, segment_count) VALUES (?,?,?,?,?)",
       ).run(convId, startedAtUtc, endedAtUtc, state, segments.length);
       const segStmt = db.prepare(
-        "INSERT INTO segments(id, chunk_id, conversation_id, speaker_cluster, is_wearer, channel, text, start_utc, end_utc, ordinal) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        "INSERT INTO segments(id, chunk_id, conversation_id, speaker_cluster, is_wearer, channel, text, start_utc, end_utc, ordinal, embedding) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
       );
       for (let i = 0; i < segments.length; i++) {
         const seg = segments[i];
@@ -349,6 +386,7 @@ export class Spool {
           seg.startUtc,
           seg.endUtc,
           i,
+          encodeEmbedding(seg.embedding),
         );
       }
       db.exec("COMMIT");
@@ -430,7 +468,7 @@ export class Spool {
         .get(convId) as { n: number };
       const nextOrdinal = Number(ordinalRow.n);
       const segStmt = db.prepare(
-        "INSERT INTO segments(id, chunk_id, conversation_id, speaker_cluster, is_wearer, channel, text, start_utc, end_utc, ordinal) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        "INSERT INTO segments(id, chunk_id, conversation_id, speaker_cluster, is_wearer, channel, text, start_utc, end_utc, ordinal, embedding) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
       );
       for (let i = 0; i < segments.length; i++) {
         const seg = segments[i];
@@ -445,6 +483,7 @@ export class Spool {
           seg.startUtc,
           seg.endUtc,
           nextOrdinal + i,
+          encodeEmbedding(seg.embedding),
         );
       }
       db.prepare(
@@ -528,6 +567,52 @@ export class Spool {
       throw err;
     }
     return removed;
+  }
+
+  /**
+   * Segments of one conversation that still need a speaker, chronological.
+   *
+   * Only rows with a stored embedding and no cluster yet: clustering runs at
+   * finalize over the segments that SURVIVED dedup (issue #2145), and skipping
+   * already-assigned rows keeps a repeated finalize from double-counting a
+   * centroid.
+   */
+  conversationSegmentsForDiarization(
+    conversationId: string,
+  ): Array<{ id: string; channel: string; embedding: number[] }> {
+    const rows = this.#db
+      .prepare(
+        "SELECT id, channel, embedding FROM segments " +
+          "WHERE conversation_id = ? AND embedding IS NOT NULL AND speaker_cluster IS NULL " +
+          "ORDER BY start_utc ASC, ordinal ASC, id ASC",
+      )
+      .all(conversationId) as Array<{ id: string; channel: string; embedding: Buffer | null }>;
+    const out: Array<{ id: string; channel: string; embedding: number[] }> = [];
+    for (const row of rows) {
+      const embedding = decodeEmbedding(row.embedding);
+      if (embedding !== null) out.push({ id: row.id, channel: row.channel, embedding });
+    }
+    return out;
+  }
+
+  /** Write finalize-time diarization results back onto their segments. */
+  assignSegmentSpeakers(
+    assignments: ReadonlyArray<{ id: string; speakerCluster: string; isWearer: boolean }>,
+  ): number {
+    if (assignments.length === 0) return 0;
+    const stmt = this.#db.prepare("UPDATE segments SET speaker_cluster = ?, is_wearer = ? WHERE id = ?");
+    let updated = 0;
+    this.#db.exec("BEGIN");
+    try {
+      for (const assignment of assignments) {
+        updated += Number(stmt.run(assignment.speakerCluster, assignment.isWearer ? 1 : 0, assignment.id).changes);
+      }
+      this.#db.exec("COMMIT");
+    } catch (err) {
+      this.#db.exec("ROLLBACK");
+      throw err;
+    }
+    return updated;
   }
 
   /** Ids of every still-`capturing` conversation (dedup-before-finalize sweep). */

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -654,6 +654,21 @@ export class Spool {
     return rows.map((r) => r.id);
   }
 
+  /**
+   * Whether ANY idempotency key for this chunk was applied.
+   *
+   * Per-segment keys are content-derived, so they cannot be enumerated from a
+   * chunk id alone; a zero-segment replay still has to know whether the chunk
+   * was partially applied before (issue #2145).
+   */
+  hasAppliedChunkPrefix(prefix: string): boolean {
+    return (
+      this.#db
+        .prepare("SELECT 1 FROM applied_chunks WHERE idempotency_key LIKE ? ESCAPE '\\' LIMIT 1")
+        .get(`${prefix.replace(/[\\%_]/g, "\\$&")}%`) !== undefined
+    );
+  }
+
   /** Whether a chunk with this idempotency key was already durably applied. */
   isChunkApplied(idempotencyKey: string): boolean {
     return (

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -685,6 +685,28 @@ export class Spool {
   }
 
   /**
+   * Conversations a chunk actually contributed stored segments to.
+   *
+   * Used to scope a rebuilt replay hold to the prefix that chunk belongs to,
+   * rather than to every conversation that happens to be capturing (#2145).
+   * Matches the bare chunk id and every per-segment or per-group derivative
+   * (`<chunkId>:h<hash>`, and the pre-manifest `<chunkId>:<n>`).
+   */
+  conversationIdsForChunk(chunkId: string): string[] {
+    const escaped = chunkId.replace(/[\\%_]/g, "\\$&");
+    const rows = this.#db
+      .prepare(
+        `SELECT DISTINCT conversation_id AS conversationId
+           FROM segments
+          WHERE conversation_id IS NOT NULL
+            AND (chunk_id = ? OR chunk_id LIKE ? ESCAPE '\\')
+          ORDER BY conversation_id`,
+      )
+      .all(chunkId, `${escaped}:%`) as { conversationId: string }[];
+    return rows.map((row) => row.conversationId);
+  }
+
+  /**
    * Chunks whose transcript manifest is recorded but which never completed.
    *
    * A restart loses the in-memory record of which chunks are still awaiting a

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -655,6 +655,19 @@ export class Spool {
   }
 
   /**
+   * Record a bare idempotency marker (no segments).
+   *
+   * Used to persist facts a later replay cannot re-derive — such as how many
+   * segments a chunk's transcript produced, which is the only way to tell a
+   * legitimately shorter retranscription from a missing tail (issue #2145).
+   */
+  markApplied(idempotencyKey: string, conversationId: string): void {
+    this.#db
+      .prepare("INSERT OR IGNORE INTO applied_chunks(idempotency_key, conversation_id, applied_at_utc) VALUES (?,?,?)")
+      .run(idempotencyKey, conversationId, new Date().toISOString());
+  }
+
+  /**
    * Whether ANY idempotency key for this chunk was applied.
    *
    * Per-segment keys are content-derived, so they cannot be enumerated from a


### PR DESCRIPTION
Closes #2145.

Both cross-channel ordering concerns from the #2144 review, solved together as
the issue asks.

## 1. Arrival-order grouping (issue body)

With `captureChannel: "both"` the native helper emits one chunk stream per
channel, and the processor fed each chunk's segments to the assembler in
ARRIVAL order — while the assembler documents that segments must arrive
chronologically. A delayed system chunk for an earlier window therefore joined
a conversation that started after it.

The processor now holds each transcribed chunk in a bounded reorder buffer and
releases it only once the newest observed chunk end is `reorderWindowMs` past
its own end, oldest first. Release is whole-chunk, which keeps the per-chunk
idempotency keys (`chunkId`, `chunkId:g`, `chunkId:done`) exactly as they were —
so replay, partial-crash recovery, and the `:done` marker are unchanged. A held
chunk is not marked complete and keeps its WAV, so a crash before release
replays it from the raw audio.

New daemon knob `reorderWindowSeconds` (default 60, `0` restores
release-on-arrival).

## 2. Diarization vs. finalize-time dedup (issue comment)

Segments were embedded and assigned to a speaker cluster at APPEND time, then
some were pruned by the order-independent finalize-time dedup. A pruned mic
loopback had already moved a centroid and bumped `embedding_count`, or created
a phantom cluster.

Implemented recommendation (a): the embedding is persisted with the segment
(`segments.embedding`, additive migration, `SPOOL_SCHEMA_VERSION` 2), and
clustering runs at finalize over each conversation's SURVIVING segments. Only
rows with no cluster yet are assigned, so a repeated finalize is idempotent,
and diarization is now a pure function of the deduped segment set.

## Acceptance

- [x] A delayed cross-channel segment is grouped into the conversation it
      temporally belongs to, at `conversationGapMinutes: 0`.
- [x] No regression in idempotency, crash recovery, dedup, or cluster
      persistence.
- [x] Behavioral tests for out-of-order cross-channel arrival.
- [x] A pruned mic loopback contributes nothing to any speaker cluster.
- [x] Diarization output is independent of cross-channel arrival order.

## Verification

- `pnpm exec tsx --test packages/capture-audio/src/*.test.ts` — 249/249 pass
- `pnpm --filter @remnic/capture-audio check-types` — pass
- `node scripts/check-ratchets.mjs` — OK
- `npm run preflight:quick` — OK

One existing test changed contract deliberately: `kill-9 durability` asserted a
cluster is durable at append time, which is the behavior the issue comment
names as the defect. It now asserts the replacement invariant — the EMBEDDING
is durable, and a restarted finalize derives the same cluster exactly once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to chunk processing, SQLite schema/migrations, and conversation finalization; bugs could mis-group conversations, lose tails on crash, or corrupt speaker clusters.
> 
> **Overview**
> Fixes **cross-channel conversation grouping** and **speaker clustering vs. dedup** for `@remnic/capture-audio` (#2145).
> 
> With `captureChannel: "both"`, mic and system chunks are no longer assembled in **arrival** order. Transcribed chunks sit in a bounded reorder buffer until a watermark passes (`reorderWindowSeconds`, default 60; `0` restores immediate release). Released batches **interleave segments by timestamp** so delayed system audio lands in the right conversation. Held chunks stay incomplete and keep raw WAVs until release.
> 
> **Diarization** moves from append-time to **finalize**, after cross-channel dedup. Segment **embeddings** are stored in the spool (`SPOOL_SCHEMA_VERSION` 2); clustering runs only on surviving segments so pruned loopback copies do not skew centroids or counts. `commitDiarization` and in-memory clusterer **restore** keep retries idempotent.
> 
> The processor gains **content-derived** per-segment idempotency keys, a **transcript manifest** hash for completion, assembler **checkpoint/rewind/prune**, per-chunk **replay retention** (rebuilt from spool on restart), and stricter shutdown error reporting when flush fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3169d2dcb29fad5ce42fb16e90f3debd148922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved cross-channel audio ordering for more chronological conversation assembly.
  - Added configurable buffering for late-arriving audio, including immediate release when set to zero.
  - Enhanced speaker clustering across deduplicated segments.
  - Preserved speaker data and audio state across restarts and crash recovery.
  - Added validation for buffering settings and support for persisted speaker embeddings.

- **Bug Fixes**
  - Prevented duplicate processing during replay or retry scenarios.
  - Improved recovery after processing failures.
  - Added validation for unsupported or malformed stored audio-processing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->