### PR TITLE
test(bridge-mode): await worker startup instead of budgeting it

### DIFF
--- a/.changeset/bridge-mode-worker-handshake.md
+++ b/.changeset/bridge-mode-worker-handshake.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Await the real worker-startup event in bridge-mode tests instead of budgeting wall clock.

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -107,7 +107,9 @@ async function startServerWorker(
     const port = await new Promise<number>((resolve, reject) => {
       worker.once("message", (message: { port?: unknown }) => {
         const value = message?.port;
-        if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+        // A TCP port is 1..65535. Accepting any positive integer would let a
+        // worker pass the handshake without a bindable port.
+        if (typeof value !== "number" || !Number.isInteger(value) || value <= 0 || value > 65_535) {
           reject(new Error(`worker announced an unusable port: ${JSON.stringify(value)}`));
           return;
         }
@@ -277,6 +279,39 @@ throw new Error("worker exploded before listen");
   await assert.rejects(
     () => startServerWorker(DYING_WORKER_SOURCE, {}),
     /worker exploded before listen/,
+  );
+});
+
+test("a worker that exits cleanly before listening fails with the early-exit error", async () => {
+  // The `exit` path is distinct from `error`: a worker can return without
+  // throwing and without ever announcing a port (issue #2293).
+  const SILENT_EXIT_WORKER_SOURCE = `
+// exits with code 0 without posting a message
+`;
+  await assert.rejects(
+    () => startServerWorker(SILENT_EXIT_WORKER_SOURCE, {}),
+    /exited with code 0 before it started listening/,
+  );
+});
+
+test("an out-of-range port is rejected rather than accepted as a handshake", async () => {
+  const BAD_PORT_WORKER_SOURCE = `
+import { parentPort } from "node:worker_threads";
+parentPort.postMessage({ port: 65536 });
+setInterval(() => {}, 1000);
+`;
+  await assert.rejects(
+    () => startServerWorker(BAD_PORT_WORKER_SOURCE, {}),
+    /announced an unusable port: 65536/,
+  );
+  const ZERO_PORT_WORKER_SOURCE = `
+import { parentPort } from "node:worker_threads";
+parentPort.postMessage({ port: 0 });
+setInterval(() => {}, 1000);
+`;
+  await assert.rejects(
+    () => startServerWorker(ZERO_PORT_WORKER_SOURCE, {}),
+    /announced an unusable port: 0/,
   );
 });
 

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -39,29 +39,29 @@ const DETECT_MEMORY_DIR = await realpath(
 );
 const HEALTH_SERVER_WORKER_SOURCE = `
 import { createServer } from "node:http";
-import { workerData } from "node:worker_threads";
+import { parentPort, workerData } from "node:worker_threads";
 
-const view = new Int32Array(workerData.state);
 const server = createServer((_req, res) => {
   res.writeHead(200, { "content-type": "application/json" });
   res.end(JSON.stringify({ ok: true, memoryDir: workerData.memoryDir }));
 });
 
 server.listen(0, "127.0.0.1", () => {
-  Atomics.store(view, 1, server.address().port);
-  Atomics.store(view, 0, 1);
-  Atomics.notify(view, 0);
+  parentPort.postMessage({ port: server.address().port });
 });
 
 setInterval(() => {}, 1000);
 `;
 const LIVENESS_SERVER_WORKER_SOURCE = `
 import { createServer } from "node:http";
-import { workerData } from "node:worker_threads";
+import { parentPort, workerData } from "node:worker_threads";
 
+// One shared slot records which route was served. It is genuinely shared
+// state: checkDaemonHealthSync BLOCKS the main thread, so the assertion
+// cannot read it over a message channel.
 const view = new Int32Array(workerData.state);
 const server = createServer((req, res) => {
-  Atomics.store(view, 2, req.url === "/engram/v1/live" ? 1 : 2);
+  Atomics.store(view, 0, req.url === "/engram/v1/live" ? 1 : 2);
   if (workerData.legacy) {
     res.writeHead(req.url === "/engram/v1/health" ? 200 : 404);
     res.end();
@@ -79,13 +79,51 @@ const server = createServer((req, res) => {
 });
 
 server.listen(0, "127.0.0.1", () => {
-  Atomics.store(view, 1, server.address().port);
-  Atomics.store(view, 0, 1);
-  Atomics.notify(view, 0);
+  parentPort.postMessage({ port: server.address().port });
 });
 
 setInterval(() => {}, 1000);
 `;
+
+/**
+ * Start a worker-thread HTTP server and resolve once it is actually
+ * listening.
+ *
+ * The startup handshake used to budget 1000 ms of wall clock for a worker to
+ * boot a JS realm, load `node:http`, and bind a socket (issue #2293). A slow
+ * runner blew that budget and the test failed on `port > 0`, which says
+ * nothing about the real cause. Awaiting the worker's own `message` event
+ * removes the guess; an `error` or an early `exit` rejects with the worker's
+ * exception instead of a misleading assertion.
+ */
+async function startServerWorker(
+  source: string,
+  workerData: Record<string, unknown>,
+): Promise<{ worker: Worker; port: number }> {
+  const worker = new Worker(new URL(`data:text/javascript,${encodeURIComponent(source)}`), {
+    workerData,
+  });
+  try {
+    const port = await new Promise<number>((resolve, reject) => {
+      worker.once("message", (message: { port?: unknown }) => {
+        const value = message?.port;
+        if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+          reject(new Error(`worker announced an unusable port: ${JSON.stringify(value)}`));
+          return;
+        }
+        resolve(value);
+      });
+      worker.once("error", reject);
+      worker.once("exit", (code) => {
+        reject(new Error(`worker exited with code ${code} before it started listening`));
+      });
+    });
+    return { worker, port };
+  } catch (error) {
+    await worker.terminate();
+    throw error;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Bridge mode detection — packages/plugin-openclaw/src/bridge.ts
@@ -229,41 +267,45 @@ test("checkDaemonHealth uses liveness without waiting for detailed health", asyn
   }
 });
 
-test("checkDaemonHealthSync uses liveness without waiting for detailed health", async () => {
-  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 3);
-  const view = new Int32Array(state);
-  const serverWorker = new Worker(
-    new URL(`data:text/javascript,${encodeURIComponent(LIVENESS_SERVER_WORKER_SOURCE)}`),
-    { workerData: { state } },
+test("a worker that dies during startup fails with its own error", async () => {
+  // The old handshake waited a fixed 1000 ms and then asserted `port > 0`, so
+  // a worker that threw reported "port was not greater than 0" instead of the
+  // exception (issue #2293).
+  const DYING_WORKER_SOURCE = `
+throw new Error("worker exploded before listen");
+`;
+  await assert.rejects(
+    () => startServerWorker(DYING_WORKER_SOURCE, {}),
+    /worker exploded before listen/,
   );
-  Atomics.wait(view, 0, 0, 1_000);
-  const port = Atomics.load(view, 1);
-  assert.ok(port > 0);
+});
+
+test("checkDaemonHealthSync uses liveness without waiting for detailed health", async () => {
+  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+  const view = new Int32Array(state);
+  const { worker: serverWorker, port } = await startServerWorker(LIVENESS_SERVER_WORKER_SOURCE, { state });
 
   try {
     const { checkDaemonHealthSync } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
     assert.equal(checkDaemonHealthSync("127.0.0.1", port, PROBE_BUDGET_MS), true);
-    assert.equal(Atomics.load(view, 2), 1);
+    assert.equal(Atomics.load(view, 0), 1);
   } finally {
     await serverWorker.terminate();
   }
 });
 
 test("checkDaemonHealthSync falls back to detailed health for older daemons", async () => {
-  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 3);
+  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
   const view = new Int32Array(state);
-  const serverWorker = new Worker(
-    new URL(`data:text/javascript,${encodeURIComponent(LIVENESS_SERVER_WORKER_SOURCE)}`),
-    { workerData: { state, legacy: true } },
-  );
-  Atomics.wait(view, 0, 0, 1_000);
-  const port = Atomics.load(view, 1);
-  assert.ok(port > 0);
+  const { worker: serverWorker, port } = await startServerWorker(LIVENESS_SERVER_WORKER_SOURCE, {
+    state,
+    legacy: true,
+  });
 
   try {
     const { checkDaemonHealthSync } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
     assert.equal(checkDaemonHealthSync("127.0.0.1", port, PROBE_BUDGET_MS), true);
-    assert.equal(Atomics.load(view, 2), 2);
+    assert.equal(Atomics.load(view, 0), 2);
   } finally {
     await serverWorker.terminate();
   }
@@ -461,15 +503,9 @@ test("detectDaemonBridgeMode delegates when daemon service is installed and heal
   await mkdir(launchAgentsDir, { recursive: true });
   await writeFile(path.join(launchAgentsDir, "ai.remnic.daemon.plist"), "<plist />\n", "utf8");
 
-  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
-  const view = new Int32Array(state);
-  const serverWorker = new Worker(
-    new URL(`data:text/javascript,${encodeURIComponent(HEALTH_SERVER_WORKER_SOURCE)}`),
-    { workerData: { state, memoryDir: DETECT_MEMORY_DIR } },
-  );
-  Atomics.wait(view, 0, 0, 1000);
-  const port = Atomics.load(view, 1);
-  assert.ok(port > 0);
+  const { worker: serverWorker, port } = await startServerWorker(HEALTH_SERVER_WORKER_SOURCE, {
+    memoryDir: DETECT_MEMORY_DIR,
+  });
 
   try {
     process.env.HOME = homeDir;
@@ -504,15 +540,9 @@ test("detectDaemonBridgeMode delegates when legacy ai.remnic.server launchd serv
   await mkdir(launchAgentsDir, { recursive: true });
   await writeFile(path.join(launchAgentsDir, "ai.remnic.server.plist"), "<plist />\n", "utf8");
 
-  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
-  const view = new Int32Array(state);
-  const serverWorker = new Worker(
-    new URL(`data:text/javascript,${encodeURIComponent(HEALTH_SERVER_WORKER_SOURCE)}`),
-    { workerData: { state, memoryDir: DETECT_MEMORY_DIR } },
-  );
-  Atomics.wait(view, 0, 0, 1000);
-  const port = Atomics.load(view, 1);
-  assert.ok(port > 0);
+  const { worker: serverWorker, port } = await startServerWorker(HEALTH_SERVER_WORKER_SOURCE, {
+    memoryDir: DETECT_MEMORY_DIR,
+  });
 
   try {
     process.env.HOME = homeDir;
@@ -543,15 +573,9 @@ test("detectDaemonBridgeMode delegates to a reachable local daemon without servi
   const previousLegacyMode = process.env.ENGRAM_BRIDGE_MODE;
   const homeDir = await mkdtemp(path.join(os.tmpdir(), "bridge-local-health-probe-"));
 
-  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
-  const view = new Int32Array(state);
-  const serverWorker = new Worker(
-    new URL(`data:text/javascript,${encodeURIComponent(HEALTH_SERVER_WORKER_SOURCE)}`),
-    { workerData: { state, memoryDir: DETECT_MEMORY_DIR } },
-  );
-  Atomics.wait(view, 0, 0, 1000);
-  const port = Atomics.load(view, 1);
-  assert.ok(port > 0);
+  const { worker: serverWorker, port } = await startServerWorker(HEALTH_SERVER_WORKER_SOURCE, {
+    memoryDir: DETECT_MEMORY_DIR,
+  });
 
   try {
     process.env.HOME = homeDir;
@@ -588,15 +612,9 @@ test("detectDaemonBridgeMode coerces string config port before service health pr
   await mkdir(remnicConfigDir, { recursive: true });
   await writeFile(path.join(launchAgentsDir, "ai.remnic.daemon.plist"), "<plist />\n", "utf8");
 
-  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
-  const view = new Int32Array(state);
-  const serverWorker = new Worker(
-    new URL(`data:text/javascript,${encodeURIComponent(HEALTH_SERVER_WORKER_SOURCE)}`),
-    { workerData: { state, memoryDir: DETECT_MEMORY_DIR } },
-  );
-  Atomics.wait(view, 0, 0, 1000);
-  const port = Atomics.load(view, 1);
-  assert.ok(port > 0);
+  const { worker: serverWorker, port } = await startServerWorker(HEALTH_SERVER_WORKER_SOURCE, {
+    memoryDir: DETECT_MEMORY_DIR,
+  });
 
   await writeFile(
     path.join(remnicConfigDir, "config.json"),

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -29,6 +29,12 @@ const ROOT = path.resolve(__dirname, "../..");
 // thread with Atomics.wait. Fake timers can drive neither side, so the only
 // lever available is a wide margin between the two constants below.
 const PROBE_BUDGET_MS = 2_500;
+/**
+ * Watchdog for the worker startup handshake. Not a boot-time budget: it only
+ * converts a worker that never settles into a named failure instead of a hung
+ * shard (issue #2293).
+ */
+const WORKER_START_WATCHDOG_MS = 30_000;
 const STALLED_DETAILED_HEALTH_MS = 3_000;
 // The auto detector requires the daemon to report the SAME memoryDir, so the
 // stubs below and every detect call agree on one corpus path. It must EXIST:
@@ -99,13 +105,28 @@ setInterval(() => {}, 1000);
 async function startServerWorker(
   source: string,
   workerData: Record<string, unknown>,
+  watchdogMs: number = WORKER_START_WATCHDOG_MS,
 ): Promise<{ worker: Worker; port: number }> {
   const worker = new Worker(new URL(`data:text/javascript,${encodeURIComponent(source)}`), {
     workerData,
   });
   try {
     const port = await new Promise<number>((resolve, reject) => {
-      worker.once("message", (message: { port?: unknown }) => {
+      // A watchdog, not a budget. The 1000 ms handshake this replaced was a
+      // guess at how long a worker needs to boot, and a slow runner blew it
+      // (issue #2293). This bound exists only so a worker that hangs without
+      // posting, erroring, or exiting fails with a clear message instead of
+      // occupying the shard until the CI job timeout — it is orders of
+      // magnitude above any real boot, so it can never decide a healthy run.
+      const watchdog = setTimeout(() => {
+        reject(new Error(`worker never announced a port within ${watchdogMs} ms`));
+      }, watchdogMs);
+      watchdog.unref();
+      const settle = <T>(fn: (value: T) => void) => (value: T) => {
+        clearTimeout(watchdog);
+        fn(value);
+      };
+      worker.once("message", settle((message: { port?: unknown }) => {
         const value = message?.port;
         // A TCP port is 1..65535. Accepting any positive integer would let a
         // worker pass the handshake without a bindable port.
@@ -114,11 +135,14 @@ async function startServerWorker(
           return;
         }
         resolve(value);
-      });
-      worker.once("error", reject);
-      worker.once("exit", (code) => {
-        reject(new Error(`worker exited with code ${code} before it started listening`));
-      });
+      }));
+      worker.once("error", settle(reject));
+      worker.once(
+        "exit",
+        settle((code: number) => {
+          reject(new Error(`worker exited with code ${code} before it started listening`));
+        }),
+      );
     });
     return { worker, port };
   } catch (error) {
@@ -280,6 +304,20 @@ throw new Error("worker exploded before listen");
     () => startServerWorker(DYING_WORKER_SOURCE, {}),
     /worker exploded before listen/,
   );
+});
+
+test("a worker that never settles fails with a named watchdog error, not a hang", async () => {
+  const STALLED_WORKER_SOURCE = `
+import { parentPort } from "node:worker_threads";
+// never posts, never exits
+setInterval(() => {}, 1000);
+`;
+  const started = Date.now();
+  await assert.rejects(
+    () => startServerWorker(STALLED_WORKER_SOURCE, {}, 50),
+    /never announced a port within 50 ms/,
+  );
+  assert.ok(Date.now() - started < 5_000, "the watchdog fired instead of hanging the shard");
 });
 
 test("a worker that exits cleanly before listening fails with the early-exit error", async () => {


### PR DESCRIPTION
Closes #2293.

## Problem

Six worker-startup handshakes in `tests/integration/bridge-mode.test.ts`
budgeted 1000 ms of wall clock for a worker thread to boot a JS realm, load
`node:http`, create a server, and bind a socket:

```js
Atomics.wait(view, 0, 0, 1_000);
const port = Atomics.load(view, 1);
assert.ok(port > 0);
```

A slow runner blows that budget, `port` stays `0`, and the test fails on an
assertion that says nothing about the cause. `tests (root)` feeds the required
`quality` gate, so the flake lands as a red required check on unrelated PRs.

## Fix

The budget is removed, not raised — exactly as the issue specifies.

- Both worker sources `postMessage({ port })` once they are listening.
- One `startServerWorker(source, workerData)` helper resolves on that message
  and rejects on `error` or an early `exit`, so a worker that dies during
  startup surfaces its own exception.
- The six copied handshakes collapse into one call each.

Shared memory that existed only to carry the timed handshake is gone. The four
`HEALTH_SERVER_WORKER_SOURCE` sites no longer allocate a `SharedArrayBuffer` at
all. The two liveness sites keep a single slot, which is genuinely required:
the worker records which route it served while `checkDaemonHealthSync` blocks
the main thread, so a message channel cannot carry it.

## Acceptance

- [x] No wall-clock budget remains in the worker startup path — the only
      surviving `Atomics.wait` mention is a comment describing the code under
      test.
- [x] A worker that dies during startup fails with its own error, with a
      regression test that asserts the thrown message reaches the caller.
- [x] `bridge-mode.test.ts` stays green across repeated runs.

## Verification

- `pnpm exec tsx --test tests/integration/bridge-mode.test.ts` — 20/20 pass,
  five consecutive runs, all green
- `node scripts/check-test-types.mjs` — bridge-mode contributes zero type
  errors
- `npm run preflight:quick` — OK
- `node scripts/check-ratchets.mjs` — OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and changeset changes; no production bridge runtime behavior is modified.
> 
> **Overview**
> Bridge-mode integration tests no longer use a **1s `Atomics.wait` handshake** to guess when worker HTTP servers are listening (#2293). Workers announce readiness with **`parentPort.postMessage({ port })`**, and a shared **`startServerWorker`** helper resolves on that message and rejects on worker **`error`**, early **`exit`**, invalid ports, or a **30s watchdog** (not a boot budget).
> 
> Six duplicated startup blocks are replaced by one helper call; health stub workers drop shared memory for the port, while liveness stubs keep a **single `SharedArrayBuffer` slot** for route assertions under blocking sync health checks. **Four regression tests** cover crash, hang, silent exit, and bad port announcements. A patch **changeset** is added for `@remnic/plugin-openclaw`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47801e49641c1f57fd19b385ba92b99b276fbd8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge-mode test server startup reliability by waiting for confirmed readiness instead of relying on timing.
  * Enhanced startup error reporting to preserve and expose the original worker error.

* **Tests**
  * Expanded coverage for worker startup failures.
  * Updated bridge-mode tests to use consistent, reliable server initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->