### PR TITLE
test(bridge-mode): make unit discovery injectable so tests are host-independent

### DIFF
--- a/.changeset/bridge-mode-unit-isolation.md
+++ b/.changeset/bridge-mode-unit-isolation.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Make daemon-unit discovery injectable so bridge-mode tests do not depend on whether the host has Remnic installed.

--- a/packages/plugin-openclaw/src/bridge-unit-discovery.ts
+++ b/packages/plugin-openclaw/src/bridge-unit-discovery.ts
@@ -201,8 +201,17 @@ export function readUnitAuthToken(
   };
 }
 
-/** Every installed unit's endpoint hints, in discovery order. */
-export function readServiceEndpoints(): Array<{
+/**
+ * Every installed unit's endpoint hints, in discovery order.
+ *
+ * `exists` is injectable for the same reason `resolveSystemUnitSources` takes
+ * it: the SYSTEM unit directories are absolute, so a test that redirects `HOME`
+ * still sees the real host's installed daemon and cannot exercise the
+ * lower-precedence config candidates at all.
+ */
+export function readServiceEndpoints(
+  exists: (candidate: string) => boolean = fileExists,
+): Array<{
   configPath?: string;
   host?: string;
   port?: number;
@@ -224,12 +233,12 @@ export function readServiceEndpoints(): Array<{
     ...resolveSystemUnitSources(
       systemdUserUnitDirs(homeDir),
       SYSTEMD_UNIT_NAMES,
-      fileExists,
+      exists,
     ).map((source) => ({ ...source, userScoped: true })),
     // For a SYSTEM unit the base file and its overrides can live in different
     // load-path directories: a packaged unit under `/usr/lib` customized by
     // `systemctl edit`, which writes `/etc/systemd/system/<unit>.d/*.conf`.
-    ...resolveSystemUnitSources(SYSTEMD_SYSTEM_UNIT_DIRS, SYSTEMD_SYSTEM_UNIT_NAMES, fileExists).map(
+    ...resolveSystemUnitSources(SYSTEMD_SYSTEM_UNIT_DIRS, SYSTEMD_SYSTEM_UNIT_NAMES, exists).map(
       (source) => ({ ...source, userScoped: false }),
     ),
   ];

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -560,7 +560,9 @@ function readServerBlock(
  * Explicit `delegate` still resolves exactly one endpoint: the operator named
  * a daemon, so guessing among candidates would be the wrong behavior.
  */
-function daemonEndpointCandidates(): DaemonEndpointCandidate[] {
+function daemonEndpointCandidates(
+  unitExists?: (candidate: string) => boolean,
+): DaemonEndpointCandidate[] {
   const envHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
   const envPort = coerceDaemonPort(readCompatEnv("REMNIC_PORT", "ENGRAM_PORT"));
   const candidates: DaemonEndpointCandidate[] = [];
@@ -644,7 +646,7 @@ function daemonEndpointCandidates(): DaemonEndpointCandidate[] {
   // merges its environment over its config file. They rank ahead of cwd/home
   // because they name what the daemon was actually launched with - and every
   // candidate is probed, so a stale one costs one failed probe.
-  for (const unit of readServiceEndpoints()) {
+  for (const unit of readServiceEndpoints(unitExists)) {
     const server = unit.configPath === undefined ? {} : (readServerBlock(unit.configPath) ?? {});
     add(
       unit.host ?? server.host,
@@ -704,8 +706,15 @@ export function detectDaemonBridgeMode(options: {
   memoryDir: string;
   timeoutMs?: number;
   onSkip?: (reason: string) => void;
+  /**
+   * Injectable unit-file probe. The SYSTEM unit directories are absolute, so a
+   * caller that redirects `HOME` still discovers the real host's installed
+   * daemon; tests for the lower-precedence config candidates pass a probe that
+   * reports no installed unit.
+   */
+  unitExists?: (candidate: string) => boolean;
 }): BridgeConfig {
-  const endpoints = daemonEndpointCandidates();
+  const endpoints = daemonEndpointCandidates(options.unitExists);
   // The first candidate is what an explicit `delegate` would dial, so it is
   // also what an embedded result reports.
   const primary =

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -477,7 +477,13 @@ test("detectDaemonBridgeMode reads legacy config port when remnic config is malf
     delete process.env.ENGRAM_BRIDGE_MODE;
 
     const { detectDaemonBridgeMode } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
-    const config = detectDaemonBridgeMode({ memoryDir: DETECT_MEMORY_DIR });
+    // An installed daemon unit legitimately outranks the home-config candidates,
+    // and the SYSTEM unit directories are absolute — so without this probe the
+    // assertion below only holds on hosts that have no daemon installed.
+    const config = detectDaemonBridgeMode({
+      memoryDir: DETECT_MEMORY_DIR,
+      unitExists: () => false,
+    });
     assert.equal(config.daemonPort, 4815);
   } finally {
     if (previousHome === undefined) delete process.env.HOME;


### PR DESCRIPTION
## Problem

`detectDaemonBridgeMode reads legacy config port when remnic config is malformed` fails on any host with Remnic installed as a service, and passes everywhere else.

The test redirects `HOME` and writes a malformed `~/.config/remnic/config.json` plus a legacy `~/.config/engram/config.json` on port 4815. But installed daemon units deliberately outrank the home-config candidates, and the SYSTEM unit directories are absolute paths — so on a host with an installed unit, discovery correctly returns the real daemon's port and the assertion cannot hold.

This was found while verifying a release on the two hosts that actually run the daemon: 22/23 there, 23/23 in CI. A suite that always fails one case on the deployment hosts is not usable as a deploy gate.

## Change

`readServiceEndpoints(exists = fileExists)` takes an injectable unit-file probe — the same seam `resolveSystemUnitSources` already exposes for the same reason — threaded through `daemonEndpointCandidates` and an optional `detectDaemonBridgeMode({ unitExists })`. Production callers pass nothing and behave exactly as before; the one test that asserts the lower-precedence config candidates passes a probe reporting no installed unit.

No precedence change: an installed unit still outranks cwd/home config.

## Verification

- `pnpm exec tsx --test tests/integration/bridge-mode.test.ts` — 23/23 on this checkout.
- Same suite on a host with an installed `remnic.service`: 23/23 (was 22/23 with one failure on this exact test).
- `npm run preflight:quick` and `node scripts/check-ratchets.mjs` both exit 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only seam with default production behavior preserved; no auth or runtime precedence changes.
> 
> **Overview**
> Adds an optional **`unitExists`** probe through daemon endpoint discovery so bridge-mode integration tests can pretend no systemd/LaunchAgent unit is installed.
> 
> **`readServiceEndpoints(exists?)`** now accepts an injectable file-existence check (defaulting to real `fileExists`), threaded via **`daemonEndpointCandidates`** into **`detectDaemonBridgeMode({ unitExists })`**. Production callers omit it and behavior is unchanged—installed units still outrank home/cwd config.
> 
> The malformed-remnic / legacy-engram port test passes **`unitExists: () => false`** so redirecting `HOME` is not overridden by absolute system unit paths on machines that actually have Remnic installed. Includes a patch changeset for `@remnic/plugin-openclaw`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dad358ce357aaa31493ff5295b3febcbd49fab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge-mode endpoint detection to reliably resolve service locations across user and system installations.
  * Preserved existing behavior while allowing controlled detection when installed service units cannot be accessed.

* **Tests**
  * Improved test isolation for legacy configuration handling, preventing results from depending on the host machine’s installed daemon services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->