### PR TITLE
agent-notes: document gh PR review-comment API routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2114,6 +2114,7 @@ grep "\[engram\]" ~/.openclaw/logs/gateway.log
 50. **Use canonical validation script names** — the root package exposes `check:ratchets` (plural) and `check-types`; `@remnic/core` exposes only `check-types`. Neither defines a `typecheck` script. Verify `package.json` before invoking scripts. Twenty fleet notes in one week came from guessed names.
 51. **Use Biome for formatting** — the root package pins `@biomejs/biome` 1.9.4. Prettier is not installed anywhere in the workspace: `pnpm exec prettier` fails, and `npx prettier` may download Prettier and prompt for confirmation — use the pinned Biome binary instead. Do not run whole-file formatting on baseline-unformatted legacy files; format changed lines only. Six incidents caused whole-file churn.
 52. **Keep napkins per worktree** — copy or create `.claude/napkin.md` in every worktree. Per-worktree napkins prevent concurrent writer clobbering.
+- **GitHub PR review-comment API routes (agent-notes: 2026-08-14):** read a review comment with `repos/{owner}/{repo}/pulls/comments/{comment_id}` (no PR number in the path); reply with `repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies` (PR number required). The owner is `joshuaswarren` — read it from `git remote -v`, never guess. Five route-guessing failures on 2026-08-13/14.
 
 ## Sealed memory-write envelope (issue #1989)
 


### PR DESCRIPTION
Evidence: 5 fleet agent-notes in 24h hit 404s on guessed review-comment routes or owners. This report is privacy-scrubbed and contains no local paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime, CI, or security behavior impact.
> 
> **Overview**
> Adds a single **agent-notes** bullet to `AGENTS.md` so agents stop guessing GitHub REST paths when reading or replying to PR review comments.
> 
> It documents that **reads** use `repos/{owner}/{repo}/pulls/comments/{comment_id}` (no PR number), **replies** use `repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies` (PR number required), and that **owner** must come from `git remote -v` rather than assumptions. The note cites five fleet 404s from route/owner guessing on 2026-08-13/14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74fc2cfbe24733437c85b45f3446c34413e211c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using GitHub pull request review-comment API routes.
  * Clarified how to identify the repository owner when working with these endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->