### PR TITLE
docs(readme): link remnic.ai, add comparison table and site docs pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Open-source, local-first memory and context for AI agents. One memory store, every agent.
 
+Website: **[remnic.ai](https://remnic.ai)** - guide library, comparisons, benchmarks, and changelog.
+
 - **Your files, your machine.** Every memory is a plain markdown file with YAML frontmatter on your disk. No database, no cloud dependency, no subscription. `cat`, `grep`, edit, and version-control your memory with the tools you already use.
 - **One memory across every tool.** OpenClaw, Claude Code, Codex CLI, Cursor, ChatGPT (developer mode), Hermes, Replit, Pi, omp, and any MCP client read and write the same store. Tell one agent a preference; every agent knows it.
 - **Automatic extraction and recall.** Remnic watches conversations, distills durable knowledge, and injects the right context back when it is needed.
@@ -241,6 +243,23 @@ There is a useful split in AI memory between **memory backends** (extract facts,
 | Built-in agent memory that does not scale | Hybrid search, lifecycle management, namespaces, and governance |
 | Third-party memory services that cost money and hold your data | Everything stays local: your filesystem, your rules |
 
+
+## How Remnic compares
+
+Remnic is the only option that is local-first, free, and multi-host at the same time.
+
+| Option | Local-first | Free / open source | Multi-host | Storage |
+|---|---|---|---|---|
+| Remnic | Yes - plain markdown on your disk | MIT, free forever | 10+ native integrations plus any MCP client | Markdown + YAML, rebuildable index |
+| mem0 | Cloud-biased (self-host possible) | Paid cloud; OSS core | SDK / API | Vectors / database |
+| Zep (Graphiti) | Cloud + self-host graph database | Paid cloud | SDK / API | Graph database |
+| Letta (MemGPT) | Self-host server | OSS | API | Database-backed |
+| Supermemory | Hosted | Paid | API | Hosted |
+| MemPalace | Yes | Yes | Single host | Local |
+| ChatGPT memory | No - cloud | Subscription | Single tool | Opaque |
+
+Per-competitor teardowns and import paths: [remnic.ai/compare](https://remnic.ai/compare). One-command migration from mem0, Supermemory, ChatGPT, Claude, and Gemini: [remnic.ai/import](https://remnic.ai/import).
+
 ## Quick start
 
 ### Prerequisites
@@ -471,6 +490,8 @@ The complete, organized docs hub lives at **[docs/README.md](docs/README.md)**. 
 - **Configure:** [Config reference](docs/config-reference.md) - [Search backends](docs/search-backends.md) - [Local LLM](docs/guides/local-llm.md) - [Cost control](docs/guides/cost-control.md)
 - **Operate:** [Operations](docs/operations.md) - [Retention policy](docs/retention-policy.md) - [Import / export](docs/import-export.md) - [Standalone server](docs/guides/standalone-server.md)
 - **Internals:** [Architecture overview](docs/architecture/overview.md) - [Retrieval pipeline](docs/architecture/retrieval-pipeline.md) - [Memory lifecycle](docs/architecture/memory-lifecycle.md) - [HTTP + MCP API](docs/api.md)
+
+The website publishes the [guide library](https://remnic.ai/guides) (what is AI agent memory, MCP memory servers, Claude Code memory), the [comparison pages](https://remnic.ai/compare), the [benchmarks report](https://remnic.ai/benchmarks), and the [changelog](https://remnic.ai/changelog).
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ There is a useful split in AI memory between **memory backends** (extract facts,
 
 ## How Remnic compares
 
-Remnic is the only option that is local-first, free, and multi-host at the same time.
+Most alternatives trade away at least one of local-first storage, a free license, or multi-host support; Remnic combines all three in one package.
 
 | Option | Hosting | Price | Agent coverage | Storage |
 |---|---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -248,17 +248,17 @@ There is a useful split in AI memory between **memory backends** (extract facts,
 
 Remnic is the only option that is local-first, free, and multi-host at the same time.
 
-| Option | Local-first | Free / open source | Multi-host | Storage |
+| Option | Hosting | Price | Agent coverage | Storage |
 |---|---|---|---|---|
-| Remnic | Yes - plain markdown on your disk | MIT, free forever | 10+ native integrations plus any MCP client | Markdown + YAML, rebuildable index |
-| mem0 | Cloud-biased (self-host possible) | Paid cloud; OSS core | SDK / API | Vectors / database |
-| Zep (Graphiti) | Cloud + self-host graph database | Paid cloud | SDK / API | Graph database |
-| Letta (MemGPT) | Self-host server | OSS | API | Database-backed |
-| Supermemory | Hosted | Paid | API | Hosted |
-| MemPalace | Yes | Yes | Single host | Local |
-| ChatGPT memory | No - cloud | Subscription | Single tool | Opaque |
+| Remnic | Local-first | Free (MIT) | Native plugins for Claude Code, Codex CLI, Pi, OpenClaw, Hermes, plus any MCP client | Markdown + YAML, rebuildable index |
+| mem0 | Cloud / self-host | Freemium | SDK / API | Vectors / database |
+| Letta (MemGPT) | Cloud / self-host | Freemium | API | Database-backed |
+| Zep (Graphiti) | Cloud / self-host | Freemium | SDK / API | Graph database |
+| Supermemory | Cloud | Paid | API | Hosting handled by the service |
+| MemPalace | Local | Free | Single host | Local |
+| ChatGPT memory | Cloud | Bundled | Single tool | Opaque |
 
-Per-competitor teardowns and import paths: [remnic.ai/compare](https://remnic.ai/compare). One-command migration from mem0, Supermemory, ChatGPT, Claude, and Gemini: [remnic.ai/import](https://remnic.ai/import).
+Hosting and price labels mirror the canonical matrix at [remnic.ai/compare](https://remnic.ai/compare), which also carries the per-competitor teardowns. Importers for mem0, Supermemory, ChatGPT, Claude, and Gemini: [remnic.ai/import](https://remnic.ai/import).
 
 ## Quick start
 


### PR DESCRIPTION
SEO/GEO pass grounded in an August 2026 generative-engine-optimization research run (plan: remnic-site`SEO-GEO-PLAN.md`).

- The README never linked remnic.ai; GitHub is the brand's strongest entity, so the missing repo-to-site link was the top gap.
- Comparison content is the most-cited format in AI answers (~33%); this adds the local-first / free / multi-host / storage table vs mem0, Zep, Letta, Supermemory, MemPalace, and ChatGPT memory, linking the per-competitor pages on remnic.ai.
- Documentation section now points at the site guide library, comparison pages, benchmarks report, and changelog.

Docs-only; no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, API, or security impact.
> 
> **Overview**
> **README-only SEO/GEO update** that ties the GitHub repo to [remnic.ai](https://remnic.ai) and surfaces competitive positioning on the main landing page.
> 
> Adds a **remnic.ai** link under the tagline (guides, comparisons, benchmarks, changelog). Inserts a new **How Remnic compares** section with a matrix vs mem0, Letta, Zep, Supermemory, MemPalace, and ChatGPT memory on hosting, price, agent coverage, and storage, plus pointers to [remnic.ai/compare](https://remnic.ai/compare) and [remnic.ai/import](https://remnic.ai/import). The **Documentation** section now also links to the site guide library, comparison pages, benchmarks report, and changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3538a41486184d082204b39257cf08eeed9a7fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added links to the Remnic website in key README sections.
  * Added a comparison of Remnic with competing memory solutions, including hosting, licensing, storage, and local-first capabilities.
  * Added links to comparison and migration resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->