### PR TITLE
docs(npm): link website, source, and docs from package READMEs

### DIFF
--- a/packages/plugin-claude-code/README.md
+++ b/packages/plugin-claude-code/README.md
@@ -2,6 +2,8 @@
 
 Native [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin for [Remnic](https://github.com/joshuaswarren/remnic) memory. Wires Claude Code's session hooks, MCP server, skills, and the `memory-review` agent into a running Remnic daemon so every Claude Code session gets persistent long-term memory automatically.
 
+Website: <https://remnic.ai> - Source: <https://github.com/joshuaswarren/remnic> - Docs: <https://remnic.ai/guides/>
+
 ## Install
 
 Three discrete steps. None is automated for you end-to-end today; each writes to a different place.
@@ -120,3 +122,4 @@ The plugin is intentionally data-only so Claude Code's plugin loader can manage 
 ## License
 
 MIT. See the root [LICENSE](https://github.com/joshuaswarren/remnic/blob/main/LICENSE) file.
+

--- a/packages/plugin-codex/README.md
+++ b/packages/plugin-codex/README.md
@@ -2,6 +2,8 @@
 
 Native [OpenAI Codex CLI](https://github.com/openai/codex) plugin for [Remnic](https://github.com/joshuaswarren/remnic) memory. Wires Codex's session hooks, MCP server, skills, and memory-extension into a running Remnic daemon so every Codex session gets persistent long-term memory automatically.
 
+Website: <https://remnic.ai> - Source: <https://github.com/joshuaswarren/remnic> - Docs: <https://remnic.ai/guides/>
+
 ## Install
 
 Three discrete steps. None is automated end-to-end today; each writes to a different place.
@@ -171,3 +173,4 @@ If you're an AI agent scaffolding a Codex integration: **do not** hand-edit `~/.
 ## License
 
 MIT. See the root [LICENSE](https://github.com/joshuaswarren/remnic/blob/main/LICENSE) file.
+

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -2,6 +2,8 @@
 
 OpenClaw plugin for Remnic memory and context. The package bundles the OpenClaw adapter plus the Remnic core runtime so it can run without a separate Remnic service; the adapter registers OpenClaw hooks/tools and delegates memory behavior to [`@remnic/core`](https://www.npmjs.com/package/@remnic/core).
 
+Website: <https://remnic.ai> - Source: <https://github.com/joshuaswarren/remnic> - Docs: <https://remnic.ai/guides/>
+
 Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
@@ -538,3 +540,4 @@ If you're not using OpenClaw, use [`@remnic/cli`](https://www.npmjs.com/package/
 ## License
 
 MIT
+

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -2,6 +2,8 @@
 
 CLI for Remnic memory and context -- init, query, daemon management, connectors, curation, and more.
 
+Website: <https://remnic.ai> - Source: <https://github.com/joshuaswarren/remnic> - Docs: <https://remnic.ai/guides/>
+
 Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
@@ -117,3 +119,4 @@ All agents share the same memory store.
 ## License
 
 MIT
+

--- a/packages/remnic-core/README.md
+++ b/packages/remnic-core/README.md
@@ -2,6 +2,8 @@
 
 Framework-agnostic memory and context engine for user-aware agents. Orchestration, storage, extraction, search, and trust zones -- inspectable and local by default.
 
+Website: <https://remnic.ai> - Source: <https://github.com/joshuaswarren/remnic> - Docs: <https://remnic.ai/guides/>
+
 Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
@@ -46,3 +48,4 @@ The core includes a fallback LLM client that resolves providers from your gatewa
 ## License
 
 MIT
+

--- a/packages/remnic-server/README.md
+++ b/packages/remnic-server/README.md
@@ -2,6 +2,8 @@
 
 Standalone Remnic memory and context server -- HTTP and MCP interfaces without requiring OpenClaw.
 
+Website: <https://remnic.ai> - Source: <https://github.com/joshuaswarren/remnic> - Docs: <https://remnic.ai/guides/>
+
 Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
@@ -71,3 +73,4 @@ await server.stop();
 ## License
 
 MIT
+


### PR DESCRIPTION
The npm package pages for @remnic/cli, @remnic/core, @remnic/server, @remnic/plugin-openclaw, @remnic/plugin-claude-code, and @remnic/plugin-codex rendered with no link to remnic.ai or the GitHub repo. npm pages are crawled and cited by AI engines; this adds one Website / Source / Docs line under each package description. Docs-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no code or configuration impact.
> 
> **Overview**
> Adds a single **Website / Source / Docs** line near the top of the npm package READMEs for `@remnic/cli`, `@remnic/core`, `@remnic/server`, `@remnic/plugin-openclaw`, `@remnic/plugin-claude-code`, and `@remnic/plugin-codex`, pointing to remnic.ai, the GitHub repo, and the guides index.
> 
> Each affected README also gets a trailing blank line after the License section. No runtime, API, or install behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd253d9ab7fe3a1c3bd387f36cb216ec8a1390e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added website, source repository, and documentation links to package README files.
  * Improved README spacing and formatting around headers and license sections.
  * No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->