### PR TITLE
fix(hermes): publish memory store category enum

### DIFF
--- a/.changeset/memory-store-category-enum.md
+++ b/.changeset/memory-store-category-enum.md
@@ -1,5 +1,5 @@
 ---
-"@remnic/hermes-provider": patch
 ---
 
-Publish the valid memory category enum in the Hermes memory store tool schema (#2392). The Python package version is 1.0.8.
+
+Publish the valid memory category enum in the Python Hermes plugin schema (#2392). The Python package and bundled plugin manifest use version 1.0.8; no pnpm package changes.

--- a/.changeset/memory-store-category-enum.md
+++ b/.changeset/memory-store-category-enum.md
@@ -2,4 +2,4 @@
 "@remnic/hermes-provider": patch
 ---
 
-Publish the valid memory category enum in the Hermes memory store tool schema (#2392).
+Publish the valid memory category enum in the Hermes memory store tool schema (#2392). The Python package version is 1.0.8.

--- a/.changeset/memory-store-category-enum.md
+++ b/.changeset/memory-store-category-enum.md
@@ -1,0 +1,5 @@
+---
+"@remnic/hermes-provider": patch
+---
+
+Publish the valid memory category enum in the Hermes memory store tool schema (#2392).

--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: remnic
-version: 1.0.7
+version: 1.0.8
 description: Universal memory for AI agents — Remnic MemoryProvider integration for Hermes
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic

--- a/packages/plugin-hermes/pyproject.toml
+++ b/packages/plugin-hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "remnic-hermes"
-version = "1.0.7"
+version = "1.0.8"
 description = "Remnic MemoryProvider plugin for Hermes Agent"
 readme = "README.md"
 license = "MIT"

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -718,7 +718,7 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
             "dryRun": {"type": "boolean"},
             "sessionKey": {"type": "string"},
             "content": {"type": "string"},
-            "category": {"type": "string"},
+            "category": _MEMORY_CATEGORY,
             "confidence": {"type": "number"},
             "namespace": _NAMESPACE,
             "tags": _STRING_ARRAY,

--- a/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
@@ -105,16 +105,13 @@ class FakeContext:
         self.tools[name] = {"schema": schema, "handler": handler}
 
 
-def _runtime_memory_store_categories() -> list[str]:
-    tools_source = (
-        Path(__file__).resolve().parents[3] / "src" / "tools.ts"
+def _canonical_memory_categories() -> list[str]:
+    config_source = (
+        Path(__file__).resolve().parents[3] / "packages" / "remnic-core" / "src" / "config.ts"
     ).read_text(encoding="utf-8")
-    memory_store_source = tools_source.split('name: "memory_store"', 1)[1].split(
-        'name: "memory_capture"', 1
-    )[0]
     match = re.search(
-        r"category:\s+Type\.Optional\(.*?enum:\s*\[(.*?)\]",
-        memory_store_source,
+        r"export const VALID_MEMORY_CATEGORIES = new Set\(\[(.*?)\]\);",
+        config_source,
         re.DOTALL,
     )
     assert match is not None
@@ -180,4 +177,4 @@ def test_issue_2392_memory_store_category_schema_matches_runtime_enum() -> None:
 
     category_schema = ctx.tools["remnic_memory_store"]["schema"]["parameters"]["properties"]["category"]
 
-    assert category_schema["enum"] == _runtime_memory_store_categories()
+    assert category_schema["enum"] == _canonical_memory_categories()

--- a/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -103,6 +105,22 @@ class FakeContext:
         self.tools[name] = {"schema": schema, "handler": handler}
 
 
+def _runtime_memory_store_categories() -> list[str]:
+    tools_source = (
+        Path(__file__).resolve().parents[3] / "src" / "tools.ts"
+    ).read_text(encoding="utf-8")
+    memory_store_source = tools_source.split('name: "memory_store"', 1)[1].split(
+        'name: "memory_capture"', 1
+    )[0]
+    match = re.search(
+        r"category:\s+Type\.Optional\(.*?enum:\s*\[(.*?)\]",
+        memory_store_source,
+        re.DOTALL,
+    )
+    assert match is not None
+    return re.findall(r"""["']([^"']+)["']""", match.group(1))
+
+
 def test_issue_805_tools_are_registered_with_primary_and_legacy_names() -> None:
     ctx = FakeContext()
 
@@ -131,10 +149,35 @@ def test_issue_805_tools_are_registered_with_primary_and_legacy_names() -> None:
     assert ctx.tools["engram_memory_store"]["schema"]["name"] == "engram_memory_store"
     assert ctx.tools["remnic_store"]["handler"] is not ctx.tools["remnic_memory_store"]["handler"]
     assert ctx.tools["remnic_memory_store"]["schema"]["parameters"]["properties"]["category"] == {
-        "type": "string"
+        "type": "string",
+        "enum": [
+            "fact",
+            "preference",
+            "correction",
+            "entity",
+            "decision",
+            "relationship",
+            "principle",
+            "commitment",
+            "moment",
+            "skill",
+            "rule",
+            "procedure",
+            "reasoning_trace",
+        ],
     }
     assert ctx.tools["remnic_memory_promote"]["schema"]["parameters"]["required"] == ["memoryId"]
     assert ctx.tools["remnic_memory_outcome"]["schema"]["parameters"]["required"] == [
         "memoryId",
         "outcome",
     ]
+
+
+def test_issue_2392_memory_store_category_schema_matches_runtime_enum() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    category_schema = ctx.tools["remnic_memory_store"]["schema"]["parameters"]["properties"]["category"]
+
+    assert category_schema["enum"] == _runtime_memory_store_categories()


### PR DESCRIPTION
Fixes #2392

## Behavior
- Advertise the exact 13-value memory category enum in the Hermes `memory_store` schema.
- Keep the legacy `engram_memory_store` schema aligned through the shared schema object.

## Verification
- `uv run --with pytest --with pytest-asyncio --with httpx python -m pytest`
- Result: 152 passed.
- `npm exec --yes pnpm@10.32.1 -- run preflight:quick`
- Result: OK (quick).
- Added a parity test that reads the TypeScript `memory_store` enum and compares it with the mounted Python schema.

## Notes
- Added a patch changeset for `@remnic/hermes-provider`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only tightening for tool metadata and version bump; no runtime auth or storage logic changes.
> 
> **Overview**
> The Hermes **`remnic_memory_store`** tool schema now exposes **`category`** as a string with a fixed **13-value enum** (via shared `_MEMORY_CATEGORY`) instead of an unconstrained string, so agents and validators see the same categories the daemon accepts. **`engram_memory_store`** stays aligned because it reuses the same schema object.
> 
> **`remnic-hermes`** is bumped to **1.0.8** in `plugin.yaml` and `pyproject.toml`, with a patch changeset for the Hermes provider package.
> 
> Tests assert the mounted enum matches **`VALID_MEMORY_CATEGORIES`** in `remnic-core` `config.ts`, including a dedicated parity test for #2392.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bba468e43791773b4d4d0bfd4469b62f86732c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory storage validation by restricting categories to supported values.
  - Updated the published tool schema to accurately reflect available memory categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->