### PR TITLE
fix(core): split chunks at Unicode sentence boundaries

### DIFF
--- a/.changeset/cjk-sentence-boundaries.md
+++ b/.changeset/cjk-sentence-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Split CJK, Arabic, Indic, and English content at sentence boundaries during chunking (#2189).

--- a/packages/remnic-core/src/chunking.ts
+++ b/packages/remnic-core/src/chunking.ts
@@ -47,51 +47,136 @@ function estimateTokens(text: string): number {
 
 /**
  * Split text into sentences.
- * Handles common abbreviations and edge cases.
+ *
+ * The scan stays linear and does not use a backtracking regular expression.
+ * ASCII punctuation keeps its old whitespace rule. Unicode terminators also
+ * split when the next sentence starts immediately, as in CJK text.
  */
-function splitSentences(text: string): string[] {
-  // Split on sentence-ending punctuation (. ! ?) that is followed by whitespace
-  // or end of string; the punctuation stays with the sentence.
-  //
-  // Implemented as a single linear scan rather than a regex. Every regex form of
-  // this split is either polynomial (CodeQL js/polynomial-redos) or — once
-  // bounded/anchored to satisfy CodeQL — mishandles long runs or non-boundary
-  // punctuation (a global match silently drops a skipped prefix; a sticky match
-  // stops at the first interior `.` that is not a real boundary, e.g. "v1.2.3"
-  // or "example.com", emitting the whole document as one chunk). A character
-  // scan is O(n), allocation-free, drops nothing, and treats interior
-  // punctuation correctly. Normal prose splits identically to the previous
-  // /[^.!?]*[.!?]+(?:\s+|$)/g form.
-  const sentences: string[] = [];
+const UNICODE_SENTENCE_TERMINATORS = "。．！？؟۔।॥｡…";
+const ASCII_SENTENCE_TERMINATORS = ".!?";
+const CJK_NO_SPACE_TERMINATORS = "。．！？｡";
+const CLOSING_PUNCTUATION = "\"'”’»」』）］】〉》)]}";
+const DIGITS = "0123456789０１２３４５６７８９";
+const SENTENCE_SEGMENTER =
+  typeof Intl.Segmenter === "function"
+    ? new Intl.Segmenter(undefined, { granularity: "sentence" })
+    : undefined;
+
+function isSentenceTerminator(character: string): boolean {
+  return (
+    ASCII_SENTENCE_TERMINATORS.includes(character) ||
+    UNICODE_SENTENCE_TERMINATORS.includes(character)
+  );
+}
+
+function isCjk(character: string): boolean {
+  return /[\u3000-\u9fff\uf900-\ufaff\uac00-\ud7af]/u.test(character);
+}
+
+type SentenceList = string[] & { separators: string[] };
+
+function splitSentencesFallback(text: string): SentenceList {
+  const sentences = [] as unknown as SentenceList;
+  Object.defineProperty(sentences, "separators", {
+    value: [],
+    writable: true,
+  });
   let start = 0;
+  let separator = "";
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
-    if (ch !== "." && ch !== "!" && ch !== "?") continue;
-    // Consume a run of terminators (e.g. "?!", "...").
+    if (!isSentenceTerminator(ch)) continue;
+
     let end = i;
-    while (end + 1 < text.length) {
-      const n = text[end + 1];
-      if (n !== "." && n !== "!" && n !== "?") break;
+    let hasUnicodeTerminator = UNICODE_SENTENCE_TERMINATORS.includes(ch);
+    while (end + 1 < text.length && isSentenceTerminator(text[end + 1])) {
+      end++;
+      hasUnicodeTerminator ||= UNICODE_SENTENCE_TERMINATORS.includes(text[end]);
+    }
+
+    const isFullwidthDecimal =
+      ch === "．" &&
+      DIGITS.includes(text[i - 1] ?? "") &&
+      DIGITS.includes(text[end + 1] ?? "");
+    while (end + 1 < text.length && CLOSING_PUNCTUATION.includes(text[end + 1])) {
       end++;
     }
+
     const after = text[end + 1];
-    // A real boundary only if the terminator run ends the string or is followed
-    // by whitespace. Interior punctuation (no following whitespace) is left in
-    // place and the scan continues.
-    if (after === undefined || /\s/.test(after)) {
+    const boundary =
+      !isFullwidthDecimal &&
+      (hasUnicodeTerminator || after === undefined || /\s/u.test(after));
+    if (boundary) {
       const sentence = text.slice(start, end + 1).trim();
-      if (sentence.length > 0) sentences.push(sentence);
-      start = end + 1;
+      if (sentence.length > 0) {
+        sentences.push(sentence);
+        if (sentences.length > 1) sentences.separators.push(separator);
+      }
+      let nextStart = end + 1;
+      while (nextStart < text.length && /\s/u.test(text[nextStart])) nextStart++;
+      separator = text.slice(end + 1, nextStart);
+      start = nextStart;
     }
     i = end;
   }
-  // Trailing text without a closing terminator.
-  if (start < text.length) {
-    const remaining = text.slice(start).trim();
-    if (remaining.length > 0) sentences.push(remaining);
+
+  const remaining = text.slice(start).trim();
+  if (remaining.length > 0) {
+    sentences.push(remaining);
+    if (sentences.length > 1) sentences.separators.push(separator);
   }
   return sentences;
 }
+export function splitSentences(text: string): string[] {
+  const canUseSegmenter =
+    SENTENCE_SEGMENTER !== undefined &&
+    !/\s/u.test(text) &&
+    [...text].some((character) => UNICODE_SENTENCE_TERMINATORS.includes(character));
+  if (canUseSegmenter) {
+    const segments = Array.from(SENTENCE_SEGMENTER.segment(text), ({ segment }) =>
+      segment.trim(),
+    ).filter((segment) => segment.length > 0) as SentenceList;
+    if (
+      segments.length > 1 &&
+      segments.slice(0, -1).every((segment) =>
+        [...segment].some((character) =>
+          UNICODE_SENTENCE_TERMINATORS.includes(character),
+        ),
+      )
+    ) {
+      Object.defineProperty(segments, "separators", {
+        value: Array(segments.length - 1).fill(""),
+        writable: true,
+      });
+      return segments;
+    }
+  }
+  return splitSentencesFallback(text);
+}
+
+function endsWithoutSpace(text: string): boolean {
+  let index = text.length - 1;
+  while (index >= 0 && CLOSING_PUNCTUATION.includes(text[index])) index--;
+  const terminator = text[index] ?? "";
+  if (CJK_NO_SPACE_TERMINATORS.includes(terminator)) {
+    return isCjk(text[index - 1] ?? "");
+  }
+  return terminator === "…" && isCjk(text[index - 1] ?? "");
+}
+export function joinSentences(sentences: string[]): string {
+  let result = "";
+  const separators = (sentences as Partial<SentenceList>).separators;
+  for (let i = 0; i < sentences.length; i++) {
+    const sentence = sentences[i];
+    if (result.length > 0) {
+      const separator = separators?.[i - 1];
+      result += separator ?? (endsWithoutSpace(result) ? "" : " ");
+    }
+    result += sentence;
+  }
+  return result;
+}
+
 
 /**
  * Chunk content into overlapping segments at sentence boundaries.
@@ -152,7 +237,7 @@ export function chunkContent(
 
     if (atTarget || isLastSentence) {
       // Create chunk from accumulated sentences
-      const chunkContent = currentChunkSentences.join(" ");
+      const chunkContent = joinSentences(currentChunkSentences);
       chunks.push({
         content: chunkContent,
         index: chunkIndex,
@@ -216,14 +301,14 @@ export function reassembleChunks(chunks: string[]): string {
       const prevEnd = prevSentences.slice(-(j + 1));
       const currStart = currSentences.slice(0, j + 1);
 
-      if (prevEnd.join(" ") === currStart.join(" ")) {
+      if (joinSentences(prevEnd) === joinSentences(currStart)) {
         overlapCount = j + 1;
       }
     }
 
     // Add non-overlapping portion
     if (overlapCount > 0 && overlapCount < currSentences.length) {
-      result.push(currSentences.slice(overlapCount).join(" "));
+      result.push(joinSentences(currSentences.slice(overlapCount)));
     } else if (overlapCount === 0) {
       // No detected overlap, add full chunk
       result.push(currChunk);
@@ -231,5 +316,5 @@ export function reassembleChunks(chunks: string[]): string {
     // If overlapCount === currSentences.length, skip (fully contained)
   }
 
-  return result.join(" ");
+  return joinSentences(result);
 }

--- a/packages/remnic-core/src/semantic-chunking.ts
+++ b/packages/remnic-core/src/semantic-chunking.ts
@@ -6,7 +6,13 @@
  * natural topic boundaries, producing more coherent chunks.
  */
 
-import { chunkContent, type Chunk, type ChunkResult } from "./chunking.js";
+import {
+  chunkContent,
+  joinSentences,
+  splitSentences,
+  type Chunk,
+  type ChunkResult,
+} from "./chunking.js";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -177,50 +183,6 @@ export function findLocalMinima(
 }
 
 // ---------------------------------------------------------------------------
-// Sentence tokenizer
-// ---------------------------------------------------------------------------
-
-/**
- * Split text into sentences at punctuation boundaries.
- * Preserves punctuation with the preceding sentence.
- */
-function splitSentences(text: string): string[] {
-  // Linear character scan instead of a regex. Every regex form of this split is
-  // either polynomial (CodeQL js/polynomial-redos) or — once bounded/anchored to
-  // satisfy CodeQL — mishandles long runs or interior punctuation (a global
-  // match drops a skipped prefix; a sticky match stops at the first non-boundary
-  // `.`, e.g. "v1.2.3" / "example.com", returning the whole document as one
-  // sentence and bypassing chunking). The scan is O(n), drops nothing, and
-  // handles interior punctuation correctly; normal prose splits identically to
-  // the previous /[^.!?]*[.!?]+(?:\s+|$)/g form.
-  const sentences: string[] = [];
-  let start = 0;
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    if (ch !== "." && ch !== "!" && ch !== "?") continue;
-    let end = i;
-    while (end + 1 < text.length) {
-      const n = text[end + 1];
-      if (n !== "." && n !== "!" && n !== "?") break;
-      end++;
-    }
-    const after = text[end + 1];
-    // A real boundary only if the terminator run ends the string or is followed
-    // by whitespace. Interior punctuation (no following whitespace) is left in
-    // place and the scan continues.
-    if (after === undefined || /\s/.test(after)) {
-      const sentence = text.slice(start, end + 1).trim();
-      if (sentence.length > 0) sentences.push(sentence);
-      start = end + 1;
-    }
-    i = end;
-  }
-  if (start < text.length) {
-    const remaining = text.slice(start).trim();
-    if (remaining.length > 0) sentences.push(remaining);
-  }
-  return sentences;
-}
 
 // ---------------------------------------------------------------------------
 // Token estimation
@@ -316,7 +278,7 @@ function mergeShortSegments(
 
   for (let i = 0; i < segments.length; i++) {
     buffer = [...buffer, ...segments[i]];
-    const tokenCount = estimateTokens(buffer.join(" "));
+    const tokenCount = estimateTokens(joinSentences(buffer));
 
     if (tokenCount >= minTokens || i === segments.length - 1) {
       merged.push(buffer);
@@ -344,7 +306,7 @@ function splitLongSegment(
   maxTokens: number,
   targetTokens: number,
 ): SemanticChunk[] {
-  const text = segment.join(" ");
+  const text = joinSentences(segment);
   // Cap targetTokens to maxTokens so recursive splitting never produces
   // segments larger than the configured maximum (Finding 2, PR #420).
   const cappedTarget = Math.min(targetTokens, maxTokens);
@@ -511,7 +473,7 @@ export async function semanticChunkContent(
 
   for (let segIdx = 0; segIdx < segments.length; segIdx++) {
     const segment = segments[segIdx];
-    const segText = segment.join(" ");
+    const segText = joinSentences(segment);
     const segTokens = estimateTokens(segText);
 
     if (segTokens > cfg.maxTokens) {

--- a/tests/chunking.test.ts
+++ b/tests/chunking.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  chunkContent,
+  joinSentences,
+  reassembleChunks,
+  splitSentences,
+} from "../packages/remnic-core/src/chunking.js";
+
+test("splitSentences handles CJK terminators without ASCII spaces", () => {
+  const text = "第一文です。第二文です！第三文です？";
+
+  assert.deepEqual(splitSentences(text), [
+    "第一文です。",
+    "第二文です！",
+    "第三文です？",
+  ]);
+});
+
+test("splitSentences handles Arabic and Indic terminators", () => {
+  const text = "مرحبا بالعالم؟كيف حالك؟यह पहला वाक्य है।यह दूसरा वाक्य है।";
+
+  assert.deepEqual(splitSentences(text), [
+    "مرحبا بالعالم؟",
+    "كيف حالك؟",
+    "यह पहला वाक्य है।",
+    "यह दूसरा वाक्य है।",
+  ]);
+});
+
+test("splitSentences handles ellipses and mixed ASCII content", () => {
+  assert.deepEqual(splitSentences("甲…乙…"), ["甲…", "乙…"]);
+  assert.deepEqual(splitSentences("word0_0. word1_0. 日本語。"), [
+    "word0_0.",
+    "word1_0.",
+    "日本語。",
+  ]);
+});
+
+test("chunkContent does not add spaces between CJK sentences", () => {
+  const content = "第一文です。第二文です！第三文です？";
+  const result = chunkContent(content, {
+    targetTokens: 1,
+    minTokens: 1,
+    overlapSentences: 0,
+  });
+
+  assert.equal(reassembleChunks(result.chunks.map((chunk) => chunk.content)), content);
+  assert.ok(result.chunks.every((chunk) => !chunk.content.includes("。 ")));
+});
+
+test("splitSentences preserves Arabic spaces and quoted CJK boundaries", () => {
+  assert.deepEqual(splitSentences("مرحبا؟ كيف حالك؟"), ["مرحبا؟", "كيف حالك؟"]);
+  assert.deepEqual(splitSentences("「第一文です。」第二文です。"), [
+    "「第一文です。」",
+    "第二文です。",
+  ]);
+  assert.deepEqual(splitSentences("値は３．１４です。次です。"), [
+    "値は３．１４です。",
+    "次です。",
+  ]);
+});
+
+test("splitSentences handles additional Unicode sentence marks", () => {
+  assert.deepEqual(splitSentences("第一文｡第二文｡"), ["第一文｡", "第二文｡"]);
+  assert.deepEqual(splitSentences("पहला वाक्य॥दूसरा वाक्य॥"), [
+    "पहला वाक्य॥",
+    "दूसरा वाक्य॥",
+  ]);
+  assert.deepEqual(splitSentences("Wait… Next sentence."), [
+    "Wait…",
+    "Next sentence.",
+  ]);
+  assert.deepEqual(splitSentences("(第一文です。)第二文です。"), [
+    "(第一文です。)",
+    "第二文です。",
+  ]);
+});
+
+test("joinSentences preserves Unicode boundary spacing", () => {
+  assert.equal(
+    joinSentences(splitSentences("第一文です．第二文です．")),
+    "第一文です．第二文です．",
+  );
+  assert.equal(
+    joinSentences(splitSentences("مرحبا؟كيف حالك؟")),
+    "مرحبا؟كيف حالك؟",
+  );
+  assert.equal(
+    joinSentences(splitSentences("مرحبا؟ كيف حالك؟")),
+    "مرحبا؟ كيف حالك؟",
+  );
+  assert.equal(
+    joinSentences(splitSentences("Wait… Next sentence.")),
+    "Wait… Next sentence.",
+  );
+});
+
+test("chunkContent splits long Japanese and Arabic documents", () => {
+  const japanese = Array.from({ length: 12 }, () => "これは日本語の文です。").join("");
+  const arabic = Array.from({ length: 12 }, () => "هذه جملة عربية طويلة؟").join("");
+  const config = { targetTokens: 8, minTokens: 1, overlapSentences: 0 };
+
+  assert.ok(chunkContent(japanese, config).chunks.length > 1);
+  assert.ok(chunkContent(arabic, config).chunks.length > 1);
+});
+
+test("splitSentences preserves English punctuation behavior", () => {
+  assert.deepEqual(splitSentences("Version v1.2.3 stays intact. Next sentence!"), [
+    "Version v1.2.3 stays intact.",
+    "Next sentence!",
+  ]);
+});


### PR DESCRIPTION
Fixes #2189

## Behavior
- Share one sentence splitter between recursive and semantic chunking.
- Use Intl.Segmenter when available.
- Fall back to a ReDoS-safe linear scan with CJK, Arabic, Indic, and ellipsis terminators.
- Keep ASCII interior punctuation behavior unchanged.

## Verification
- `npm exec --yes pnpm@10.32.1 -- exec tsx --test tests/chunking.test.ts tests/semantic-chunking.test.ts`
- `npm exec --yes pnpm@10.32.1 -- run preflight:quick`

## Notes
- Added regression coverage for Japanese, Arabic, Indic, and English sentence boundaries.
- Added a patch changeset for `@remnic/core`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core text chunking for all languages; English behavior is explicitly preserved and regression tests are added, but chunk boundaries and stored chunk text can differ for non-ASCII content.
> 
> **Overview**
> Improves **sentence-boundary chunking** for CJK, Arabic, Indic, and mixed scripts by replacing ASCII-only splitting and always joining with a space.
> 
> **`splitSentences`** now recognizes Unicode terminators (e.g. `。！？؟।॥｡…`), can use **`Intl.Segmenter`** for spaceless Unicode prose when validation passes, and falls back to a linear scan that keeps English rules (interior `.` in `v1.2.3`, whitespace after `.!?`) while avoiding fullwidth decimals like `３．１４`. Split results can carry **original inter-sentence separators** via an internal `separators` list.
> 
> New **`joinSentences`** reassembles sentences using those separators or CJK-aware spacing so chunks and **`reassembleChunks`** no longer insert spurious spaces (e.g. `。 `). **Semantic chunking** drops its duplicate tokenizer and uses the same **`splitSentences` / `joinSentences`** from `chunking.ts`.
> 
> Adds **`tests/chunking.test.ts`** coverage and a **`@remnic/core` patch** changeset (#2189).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798e98e760b50115051d3ceb98fccc6dfe0c5154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text chunking for Chinese, Japanese, Korean, Arabic, Indic, and English content.
  * Recognizes Unicode punctuation, ellipses, quoted sentences, decimal numbers, and sentence boundaries without spaces.
  * Preserves natural spacing when reassembling chunks, including for CJK text.
  * Better handles long multilingual documents by splitting them into appropriate chunks.

* **Bug Fixes**
  * Prevented incorrect spaces from being inserted between sentences during chunk creation and reassembly.
  * Improved sentence-boundary detection across mixed-language content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->