### PR TITLE
fix(core): allow Unicode route namespaces

### DIFF
--- a/.changeset/unicode-route-namespaces.md
+++ b/.changeset/unicode-route-namespaces.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Allow Unicode letters, marks, and numbers in route namespaces while preserving traversal and filesystem safety checks.

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -19,12 +19,7 @@ import {
   withHeldFileLock,
 } from "../utils/serialize-mutations.js";
 import { isSafeRouteNamespace } from "../routing/engine.js";
-import {
-  namespaceIdentityFromToken,
-  namespaceIdentityLegacyToken,
-  namespaceIdentityToken,
-  normalizeNamespaceIdentity,
-} from "./identity.js";
+import { namespaceIdentityFromToken, namespaceIdentityLegacyToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
 import { resolveDefaultNamespaceRoot, resolveNamespaceStorageRoot } from "./storage.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
@@ -1803,10 +1798,7 @@ export class NamespaceCatalog {
       const tokenDecoded = literalOwnsRoot ? null : namespaceIdentityFromToken(token);
       const rawDecoded = tokenDecoded && tokenDecoded.length > 0 ? tokenDecoded : token;
       const decoded = normalizeNamespaceIdentity(rawDecoded);
-      if (
-        decoded.length === 0 ||
-        (rawDecoded !== decoded && rawDecoded.normalize("NFC") !== decoded)
-      ) {
+      if (decoded.length === 0 || (rawDecoded !== decoded && rawDecoded.normalize("NFC") !== decoded)) {
         skipped.push({ token, reason: "unsafe", detail: rawDecoded });
         continue;
       }
@@ -1849,9 +1841,7 @@ export class NamespaceCatalog {
       // is the on-disk dir name; it is the tokenized dir iff it equals the
       // namespace's identity token. If we already recorded this namespace from
       // its tokenized dir, a later legacy-named entry must not clobber it.
-      const isTokenizedEntry =
-        token === namespaceIdentityToken(decoded) ||
-        token === namespaceIdentityLegacyToken(decoded.normalize("NFD"));
+      const isTokenizedEntry = token === namespaceIdentityToken(decoded) || token === namespaceIdentityLegacyToken(decoded.normalize("NFD"));
       if (rebuilt.has(decoded) && scannedFromTokenized.has(decoded) && !isTokenizedEntry) {
         continue;
       }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -19,7 +19,12 @@ import {
   withHeldFileLock,
 } from "../utils/serialize-mutations.js";
 import { isSafeRouteNamespace } from "../routing/engine.js";
-import { namespaceIdentityFromToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
+import {
+  namespaceIdentityFromToken,
+  namespaceIdentityLegacyToken,
+  namespaceIdentityToken,
+  normalizeNamespaceIdentity,
+} from "./identity.js";
 import { resolveDefaultNamespaceRoot, resolveNamespaceStorageRoot } from "./storage.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
@@ -1798,7 +1803,10 @@ export class NamespaceCatalog {
       const tokenDecoded = literalOwnsRoot ? null : namespaceIdentityFromToken(token);
       const rawDecoded = tokenDecoded && tokenDecoded.length > 0 ? tokenDecoded : token;
       const decoded = normalizeNamespaceIdentity(rawDecoded);
-      if (decoded.length === 0 || rawDecoded !== decoded) {
+      if (
+        decoded.length === 0 ||
+        (rawDecoded !== decoded && rawDecoded.normalize("NFC") !== decoded)
+      ) {
         skipped.push({ token, reason: "unsafe", detail: rawDecoded });
         continue;
       }
@@ -1841,7 +1849,9 @@ export class NamespaceCatalog {
       // is the on-disk dir name; it is the tokenized dir iff it equals the
       // namespace's identity token. If we already recorded this namespace from
       // its tokenized dir, a later legacy-named entry must not clobber it.
-      const isTokenizedEntry = token === namespaceIdentityToken(decoded);
+      const isTokenizedEntry =
+        token === namespaceIdentityToken(decoded) ||
+        token === namespaceIdentityLegacyToken(decoded.normalize("NFD"));
       if (rebuilt.has(decoded) && scannedFromTokenized.has(decoded) && !isTokenizedEntry) {
         continue;
       }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1721,7 +1721,7 @@ export class NamespaceCatalog {
     // sourced from their tokenized dir so a later legacy-named `readdir` entry
     // cannot overwrite the tokenized record (and vice-versa: a tokenized entry
     // always wins over a previously-set legacy one).
-    const scannedFromTokenized = new Set<string>();
+    const scannedFromTokenized = new Map<string, number>();
 
     for (const entry of entries) {
       const token = entry.name;
@@ -1841,11 +1841,12 @@ export class NamespaceCatalog {
       // is the on-disk dir name; it is the tokenized dir iff it equals the
       // namespace's identity token. If we already recorded this namespace from
       // its tokenized dir, a later legacy-named entry must not clobber it.
-      const isTokenizedEntry = token === namespaceIdentityToken(decoded) || token === namespaceIdentityLegacyToken(decoded.normalize("NFD"));
-      if (rebuilt.has(decoded) && scannedFromTokenized.has(decoded) && !isTokenizedEntry) {
-        continue;
-      }
-      if (isTokenizedEntry) scannedFromTokenized.add(decoded);
+      const canonicalToken = namespaceIdentityToken(decoded);
+      const legacyToken = namespaceIdentityLegacyToken(decoded.normalize("NFD"));
+      const tokenKind = token === canonicalToken ? 2 : token === legacyToken ? 1 : 0;
+      const priorTokenKind = scannedFromTokenized.get(decoded) ?? 0;
+      if (rebuilt.has(decoded) && priorTokenKind > tokenKind) continue;
+      if (tokenKind > 0) scannedFromTokenized.set(decoded, tokenKind);
 
       const prior = existing.get(decoded);
       rebuilt.set(

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1722,7 +1722,6 @@ export class NamespaceCatalog {
     // cannot overwrite the tokenized record (and vice-versa: a tokenized entry
     // always wins over a previously-set legacy one).
     const scannedFromTokenized = new Map<string, number>();
-
     for (const entry of entries) {
       const token = entry.name;
       const fullPath = path.join(namespacesDir, token);

--- a/packages/remnic-core/src/namespaces/identity.ts
+++ b/packages/remnic-core/src/namespaces/identity.ts
@@ -1,5 +1,5 @@
 export function normalizeNamespaceIdentity(namespace: string | null | undefined): string {
-  return namespace?.trim() ?? "";
+  return namespace?.trim().normalize("NFC") ?? "";
 }
 
 export function namespaceIdentityToken(namespace: string): string {

--- a/packages/remnic-core/src/namespaces/identity.ts
+++ b/packages/remnic-core/src/namespaces/identity.ts
@@ -2,11 +2,18 @@ export function normalizeNamespaceIdentity(namespace: string | null | undefined)
   return namespace?.trim().normalize("NFC") ?? "";
 }
 
-export function namespaceIdentityToken(namespace: string): string {
-  const normalized = normalizeNamespaceIdentity(namespace);
-  const bytes = new TextEncoder().encode(normalized);
+function encodeNamespaceIdentityToken(namespace: string): string {
+  const bytes = new TextEncoder().encode(namespace);
   const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
   return `ns-${hex || "default"}`;
+}
+
+export function namespaceIdentityToken(namespace: string): string {
+  return encodeNamespaceIdentityToken(normalizeNamespaceIdentity(namespace));
+}
+
+export function namespaceIdentityLegacyToken(namespace: string): string {
+  return encodeNamespaceIdentityToken(namespace.trim());
 }
 
 export function namespaceIdentityFromToken(token: string): string | null {
@@ -17,7 +24,9 @@ export function namespaceIdentityFromToken(token: string): string | null {
     return null;
   }
   const decoded = Buffer.from(hex, "hex").toString("utf8");
-  return namespaceIdentityToken(decoded).toLowerCase() === token.toLowerCase()
-    ? decoded
+  const normalized = normalizeNamespaceIdentity(decoded);
+  return namespaceIdentityToken(decoded).toLowerCase() === token.toLowerCase() ||
+    namespaceIdentityLegacyToken(decoded).toLowerCase() === token.toLowerCase()
+    ? normalized
     : null;
 }

--- a/packages/remnic-core/src/namespaces/principal.test.ts
+++ b/packages/remnic-core/src/namespaces/principal.test.ts
@@ -12,8 +12,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { canReadNamespace, isNamespacePolicyCovered, resolvePrincipal } from "./principal.js";
 import type { PluginConfig } from "../types.js";
+import { canReadNamespace, canWriteNamespace, isNamespacePolicyCovered, resolvePrincipal } from "./principal.js";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -284,4 +284,13 @@ test("isNamespacePolicyCovered: an explicit default-namespace policy overrides t
   assert.equal(isNamespacePolicyCovered("default", blankDefault), false);
   const grantedDefault = makeConfig(true, [{ name: "default", readPrincipals: [], writePrincipals: ["alice"] }]);
   assert.equal(isNamespacePolicyCovered("default", grantedDefault), true);
+});
+
+test("namespace ACL matches canonically equivalent Unicode identities", () => {
+  const config = makeConfig(true, [
+    { name: "Cafe\u0301", readPrincipals: ["reader"], writePrincipals: ["writer"] },
+  ]);
+
+  assert.equal(canReadNamespace("reader", "Café", config), true);
+  assert.equal(canWriteNamespace("writer", "Café", config), true);
 });

--- a/packages/remnic-core/src/namespaces/principal.ts
+++ b/packages/remnic-core/src/namespaces/principal.ts
@@ -1,7 +1,7 @@
 import { resolveNamespaceCapabilities } from "../capabilities.js";
 import type { PluginConfig } from "../types.js";
 import { isLikelyUnsafeRegex } from "../routing/engine.js";
-
+import { normalizeNamespaceIdentity } from "./identity.js";
 const MAX_REGEX_SESSION_KEY_LENGTH = 512;
 
 function compileSafePrincipalRegex(pattern: string): RegExp | null {
@@ -54,16 +54,21 @@ export function resolvePrincipal(sessionKey: string | undefined, config: PluginC
 export function canReadNamespace(principal: string | undefined, namespace: string, config: PluginConfig): boolean {
   if (!resolveNamespaceCapabilities(config).namespaces) return true;
   if (!principal) return false;
-  const policy = config.namespacePolicies.find((p) => p.name === namespace);
-  if (!policy) return namespace === config.defaultNamespace || namespace === config.sharedNamespace;
+  const identity = normalizeNamespaceIdentity(namespace);
+  const policy = config.namespacePolicies.find((p) => normalizeNamespaceIdentity(p.name) === identity);
+  if (!policy) {
+    return identity === normalizeNamespaceIdentity(config.defaultNamespace) ||
+      identity === normalizeNamespaceIdentity(config.sharedNamespace);
+  }
   return policy.readPrincipals.includes(principal) || policy.readPrincipals.includes("*");
 }
 
 export function canWriteNamespace(principal: string | undefined, namespace: string, config: PluginConfig): boolean {
   if (!resolveNamespaceCapabilities(config).namespaces) return true;
   if (!principal) return false;
-  const policy = config.namespacePolicies.find((p) => p.name === namespace);
-  if (!policy) return namespace === config.defaultNamespace;
+  const identity = normalizeNamespaceIdentity(namespace);
+  const policy = config.namespacePolicies.find((p) => normalizeNamespaceIdentity(p.name) === identity);
+  if (!policy) return identity === normalizeNamespaceIdentity(config.defaultNamespace);
   return policy.writePrincipals.includes(principal) || policy.writePrincipals.includes("*");
 }
 
@@ -87,8 +92,9 @@ export function isNamespacePolicyCovered(namespace: string, config: PluginConfig
   // An explicit policy wins over the default fallback (exactly as
   // canWriteNamespace), so a policy naming the default with no writers is NOT
   // covered. Only fall back to defaultNamespace when no policy matches.
-  const policy = config.namespacePolicies.find((p) => p.name === namespace);
-  if (!policy) return namespace === config.defaultNamespace;
+  const identity = normalizeNamespaceIdentity(namespace);
+  const policy = config.namespacePolicies.find((p) => normalizeNamespaceIdentity(p.name) === identity);
+  if (!policy) return identity === normalizeNamespaceIdentity(config.defaultNamespace);
   return policy.writePrincipals.some((w) => w.trim().length > 0);
 }
 
@@ -102,10 +108,11 @@ export function isNamespacePolicyCovered(namespace: string, config: PluginConfig
 export function defaultNamespaceForPrincipal(principal: string | undefined, config: PluginConfig): string {
   if (!resolveNamespaceCapabilities(config).namespaces) return config.defaultNamespace;
   if (!principal) return config.defaultNamespace;
-  const exists = config.namespacePolicies.some((p) => p.name === principal);
+  const exists = config.namespacePolicies.some(
+    (p) => normalizeNamespaceIdentity(p.name) === normalizeNamespaceIdentity(principal),
+  );
   return exists ? principal : config.defaultNamespace;
 }
-
 export function recallNamespacesForPrincipal(principal: string | undefined, config: PluginConfig): string[] {
   const out: string[] = [];
   if (!resolveNamespaceCapabilities(config).namespaces) return [config.defaultNamespace];

--- a/packages/remnic-core/src/namespaces/principal.ts
+++ b/packages/remnic-core/src/namespaces/principal.ts
@@ -108,11 +108,12 @@ export function isNamespacePolicyCovered(namespace: string, config: PluginConfig
 export function defaultNamespaceForPrincipal(principal: string | undefined, config: PluginConfig): string {
   if (!resolveNamespaceCapabilities(config).namespaces) return config.defaultNamespace;
   if (!principal) return config.defaultNamespace;
-  const exists = config.namespacePolicies.some(
+  const policy = config.namespacePolicies.find(
     (p) => normalizeNamespaceIdentity(p.name) === normalizeNamespaceIdentity(principal),
   );
-  return exists ? principal : config.defaultNamespace;
+  return policy ? normalizeNamespaceIdentity(policy.name) : config.defaultNamespace;
 }
+
 export function recallNamespacesForPrincipal(principal: string | undefined, config: PluginConfig): string[] {
   const out: string[] = [];
   if (!resolveNamespaceCapabilities(config).namespaces) return [config.defaultNamespace];

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -12,7 +12,12 @@ import type {
   ScopeProfilePromotionTarget,
   ScopeTeamConfig,
 } from "../types.js";
-import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal } from "./principal.js";
+import {
+  canReadNamespace,
+  canWriteNamespace,
+  defaultNamespaceForPrincipal,
+} from "./principal.js";
+import { normalizeNamespaceIdentity } from "./identity.js";
 
 type ScopeProfileCodingOverlay = Pick<CodingNamespaceOverlay, "namespace" | "readFallbacks">;
 
@@ -65,19 +70,28 @@ function principalListed(list: string[], principal: string | undefined): boolean
 }
 
 function derivedScopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string | null {
-  if (!principal || principal === config.defaultNamespace || principal === config.sharedNamespace) return null;
+  if (
+    !principal ||
+    normalizeNamespaceIdentity(principal) === normalizeNamespaceIdentity(config.defaultNamespace) ||
+    normalizeNamespaceIdentity(principal) === normalizeNamespaceIdentity(config.sharedNamespace)
+  ) {
+    return null;
+  }
   if (isSafeRouteNamespace(principal)) return principal;
   return "principal-" + createHash("sha256").update(principal).digest("hex").slice(0, 54);
 }
 
 function scopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string {
   const existing = defaultNamespaceForPrincipal(principal, config);
-  if (existing !== config.defaultNamespace) return existing;
+  if (normalizeNamespaceIdentity(existing) !== normalizeNamespaceIdentity(config.defaultNamespace)) return existing;
   return derivedScopeProfileSelfNamespace(principal, config) ?? existing;
 }
 
 function hasExplicitNamespacePolicy(namespace: string, config: PluginConfig): boolean {
-  return (config.namespacePolicies ?? []).some((policy) => policy.name === namespace);
+  const identity = normalizeNamespaceIdentity(namespace);
+  return (config.namespacePolicies ?? []).some(
+    (policy) => normalizeNamespaceIdentity(policy.name) === identity,
+  );
 }
 
 function isScopeProfileImplicitSelfNamespace(
@@ -88,9 +102,9 @@ function isScopeProfileImplicitSelfNamespace(
   const derived = derivedScopeProfileSelfNamespace(principal, config);
   return Boolean(
     derived &&
-      namespace === derived &&
-      namespace !== config.defaultNamespace &&
-      namespace !== config.sharedNamespace &&
+      normalizeNamespaceIdentity(namespace) === normalizeNamespaceIdentity(derived) &&
+      normalizeNamespaceIdentity(namespace) !== normalizeNamespaceIdentity(config.defaultNamespace) &&
+      normalizeNamespaceIdentity(namespace) !== normalizeNamespaceIdentity(config.sharedNamespace) &&
       isSafeRouteNamespace(namespace) &&
       !hasExplicitNamespacePolicy(namespace, config),
   );
@@ -297,16 +311,24 @@ function resolveLayer(params: {
   const userProjectBase = namespace.endsWith(userProjectSuffix)
     ? namespace.slice(0, -userProjectSuffix.length)
     : "";
+  const userProjectBaseIdentity = normalizeNamespaceIdentity(userProjectBase);
+  const defaultIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
+  const sharedIdentity = normalizeNamespaceIdentity(config.sharedNamespace);
+  const namespaceIdentity = normalizeNamespaceIdentity(namespace);
   const dynamicUserProjectCollision =
     userProjectBase.length > 0 &&
-    (userProjectBase === config.defaultNamespace ||
-      userProjectBase === config.sharedNamespace ||
-      (config.namespacePolicies ?? []).some((policy) => policy.name === userProjectBase));
+    (userProjectBaseIdentity === defaultIdentity ||
+      userProjectBaseIdentity === sharedIdentity ||
+      (config.namespacePolicies ?? []).some(
+        (policy) => normalizeNamespaceIdentity(policy.name) === userProjectBaseIdentity,
+      ));
   const protectedNamespace =
-    namespace === config.defaultNamespace ||
-    namespace === config.sharedNamespace ||
+    namespaceIdentity === defaultIdentity ||
+    namespaceIdentity === sharedIdentity ||
     dynamicUserProjectCollision ||
-    (config.namespacePolicies ?? []).some((policy) => policy.name === namespace);
+    (config.namespacePolicies ?? []).some(
+      (policy) => normalizeNamespaceIdentity(policy.name) === namespaceIdentity,
+    );
   const policyReadable = !protectedNamespace || canReadNamespace(principal, namespace, config);
   const policyWritable = !protectedNamespace || canWriteNamespace(principal, namespace, config);
   const policyBlocked = protectedNamespace && (!policyReadable || !policyWritable);

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -6,7 +6,11 @@ import { StorageManager } from "../storage.js";
 import { keyring, secureStoreDir } from "../secure-store/index.js";
 import type { PluginConfig } from "../types.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
-import { namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
+import {
+  namespaceIdentityLegacyToken,
+  namespaceIdentityToken,
+  normalizeNamespaceIdentity,
+} from "./identity.js";
 import type { NamespaceCatalog } from "./catalog.js";
 import { MutationSerializer } from "../utils/serialize-mutations.js";
 
@@ -192,15 +196,28 @@ export async function resolveNamespaceStorageRoot(
   if (normalizeNamespaceIdentity(namespace) === normalizeNamespaceIdentity(config.defaultNamespace)) {
     return resolveDefaultNamespaceRoot(config);
   }
-  const legacyRoot = resolveNamespaceDir(config.memoryDir, namespace);
-  const tokenizedRoot = resolveNamespaceDir(config.memoryDir, namespaceIdentityToken(namespace));
-  if (
-    (await exists(tokenizedRoot)) &&
-    (await hasAnyNamespaceStorageMarker(tokenizedRoot, { includeRuntimeState: true }))
-  ) {
-    return tokenizedRoot;
+  const normalized = normalizeNamespaceIdentity(namespace);
+  const legacyRoot = resolveNamespaceDir(config.memoryDir, normalized);
+  const legacyNfdNamespace = normalized.normalize("NFD");
+  const legacyNfdRoot = legacyNfdNamespace === normalized
+    ? null
+    : resolveNamespaceDir(config.memoryDir, legacyNfdNamespace);
+  const tokenizedRoot = resolveNamespaceDir(config.memoryDir, namespaceIdentityToken(normalized));
+  const legacyTokenRoot = resolveNamespaceDir(
+    config.memoryDir,
+    namespaceIdentityLegacyToken(legacyNfdNamespace),
+  );
+  for (const candidate of [tokenizedRoot, legacyTokenRoot]) {
+    if (
+      (await exists(candidate)) &&
+      (await hasAnyNamespaceStorageMarker(candidate, { includeRuntimeState: true }))
+    ) {
+      return candidate;
+    }
   }
-  return (await exists(legacyRoot)) ? legacyRoot : tokenizedRoot;
+  if (await exists(legacyRoot)) return legacyRoot;
+  if (legacyNfdRoot && (await exists(legacyNfdRoot))) return legacyNfdRoot;
+  return tokenizedRoot;
 }
 
 export class NamespaceStorageRouter {

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -174,15 +174,26 @@ export async function resolveDefaultNamespaceRoot(config: PluginConfig): Promise
   const legacyTokenHasData =
     (await exists(legacyTokenNsDir)) &&
     (await hasAnyNamespaceStorageMarker(legacyTokenNsDir, { includeRuntimeState: true }));
+  const legacyHasData =
+    (await exists(legacyNsDir)) &&
+    (await hasAnyNamespaceStorageMarker(legacyNsDir, { includeRuntimeState: true }));
+  const legacyNfdHasData =
+    legacyNfdNsDir !== legacyNsDir &&
+    (await exists(legacyNfdNsDir)) &&
+    (await hasAnyNamespaceStorageMarker(legacyNfdNsDir, { includeRuntimeState: true }));
   const nsDir = tokenizedHasData
     ? tokenizedNsDir
     : legacyTokenHasData
       ? legacyTokenNsDir
-      : (await exists(legacyNsDir))
+      : legacyHasData
         ? legacyNsDir
-        : legacyNfdNsDir !== legacyNsDir && (await exists(legacyNfdNsDir))
+        : legacyNfdHasData
           ? legacyNfdNsDir
-          : tokenizedNsDir;
+          : (await exists(legacyNsDir))
+            ? legacyNsDir
+            : legacyNfdNsDir !== legacyNsDir && (await exists(legacyNfdNsDir))
+              ? legacyNfdNsDir
+              : tokenizedNsDir;
   return (await exists(nsDir)) && !(await hasAnyLegacyData(config.memoryDir))
     ? nsDir
     : config.memoryDir;
@@ -210,17 +221,25 @@ export async function resolveNamespaceStorageRoot(
     return resolveDefaultNamespaceRoot(config);
   }
   const normalized = normalizeNamespaceIdentity(namespace);
-  const legacyRoot = resolveNamespaceDir(config.memoryDir, normalized);
+  const legacyExactNamespace = namespace.trim();
   const legacyNfdNamespace = normalized.normalize("NFD");
-  const legacyNfdRoot = legacyNfdNamespace === normalized
-    ? null
-    : resolveNamespaceDir(config.memoryDir, legacyNfdNamespace);
+  const legacyRoot = resolveNamespaceDir(config.memoryDir, normalized);
+  const legacyExactRoot =
+    legacyExactNamespace !== normalized && isSafeRouteNamespace(legacyExactNamespace)
+      ? resolveNamespaceDir(config.memoryDir, legacyExactNamespace)
+      : null;
+  const legacyNfdRoot =
+    legacyNfdNamespace !== normalized
+      ? resolveNamespaceDir(config.memoryDir, legacyNfdNamespace)
+      : null;
   const tokenizedRoot = resolveNamespaceDir(config.memoryDir, namespaceIdentityToken(normalized));
-  const legacyTokenRoot = resolveNamespaceDir(
-    config.memoryDir,
+  const legacyTokenRoots = [
+    namespaceIdentityLegacyToken(legacyExactNamespace),
     namespaceIdentityLegacyToken(legacyNfdNamespace),
-  );
-  for (const candidate of [tokenizedRoot, legacyTokenRoot]) {
+  ]
+    .filter((token, index, tokens) => tokens.indexOf(token) === index)
+    .map((token) => resolveNamespaceDir(config.memoryDir, token));
+  for (const candidate of [tokenizedRoot, ...legacyTokenRoots]) {
     if (
       (await exists(candidate)) &&
       (await hasAnyNamespaceStorageMarker(candidate, { includeRuntimeState: true }))
@@ -228,8 +247,9 @@ export async function resolveNamespaceStorageRoot(
       return candidate;
     }
   }
-  if (await exists(legacyRoot)) return legacyRoot;
-  if (legacyNfdRoot && (await exists(legacyNfdRoot))) return legacyNfdRoot;
+  for (const candidate of [legacyRoot, legacyExactRoot, legacyNfdRoot]) {
+    if (candidate && (await exists(candidate))) return candidate;
+  }
   return tokenizedRoot;
 }
 

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -157,19 +157,32 @@ export async function resolveDefaultNamespaceRoot(config: PluginConfig): Promise
   // back to memoryDir/tokenized. `namespaceIdentityToken` already normalizes
   // internally, so the tokenized path is unaffected.
   const defaultIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
+  const defaultNfdIdentity = defaultIdentity.normalize("NFD");
   const legacyNsDir = resolveNamespaceDir(config.memoryDir, defaultIdentity);
+  const legacyNfdNsDir = resolveNamespaceDir(config.memoryDir, defaultNfdIdentity);
   const tokenizedNsDir = resolveNamespaceDir(
     config.memoryDir,
-    namespaceIdentityToken(config.defaultNamespace),
+    namespaceIdentityToken(defaultIdentity),
+  );
+  const legacyTokenNsDir = resolveNamespaceDir(
+    config.memoryDir,
+    namespaceIdentityLegacyToken(defaultNfdIdentity),
   );
   const tokenizedHasData =
     (await exists(tokenizedNsDir)) &&
     (await hasAnyNamespaceStorageMarker(tokenizedNsDir, { includeRuntimeState: true }));
+  const legacyTokenHasData =
+    (await exists(legacyTokenNsDir)) &&
+    (await hasAnyNamespaceStorageMarker(legacyTokenNsDir, { includeRuntimeState: true }));
   const nsDir = tokenizedHasData
     ? tokenizedNsDir
-    : (await exists(legacyNsDir))
-      ? legacyNsDir
-      : tokenizedNsDir;
+    : legacyTokenHasData
+      ? legacyTokenNsDir
+      : (await exists(legacyNsDir))
+        ? legacyNsDir
+        : legacyNfdNsDir !== legacyNsDir && (await exists(legacyNfdNsDir))
+          ? legacyNfdNsDir
+          : tokenizedNsDir;
   return (await exists(nsDir)) && !(await hasAnyLegacyData(config.memoryDir))
     ? nsDir
     : config.memoryDir;

--- a/packages/remnic-core/src/namespaces/unicode-routing.test.ts
+++ b/packages/remnic-core/src/namespaces/unicode-routing.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 import type { PluginConfig } from "../types.js";
 import { NamespaceCatalog } from "./catalog.js";
 import { namespaceIdentityFromToken, namespaceIdentityLegacyToken, namespaceIdentityToken } from "./identity.js";
-import { resolveNamespaceStorageRoot } from "./storage.js";
+import { resolveDefaultNamespaceRoot, resolveNamespaceStorageRoot } from "./storage.js";
 
 function makeConfig(memoryDir: string): PluginConfig {
   return {
@@ -35,7 +35,13 @@ test("Unicode namespaces decode from disk and list in stable order", async () =>
     const legacyToken = namespaceIdentityLegacyToken(nfd);
     assert.equal(namespaceIdentityFromToken(legacyToken), "Café");
     await mkdir(path.join(memoryDir, "namespaces", legacyToken, "facts"), { recursive: true });
-    assert.equal(await resolveNamespaceStorageRoot(config, "Café"), path.join(memoryDir, "namespaces", legacyToken));
+    assert.equal(
+      await resolveNamespaceStorageRoot(config, "Café"),
+      path.join(memoryDir, "namespaces", legacyToken),
+    );
+    const rebuilt = await catalog.rebuildFromDisk({ dryRun: true });
+    const legacyRecord = rebuilt.records.find((record) => record.namespace === "Café");
+    assert.equal(legacyRecord?.storageDir, path.join(memoryDir, "namespaces", legacyToken));
     await catalog.markWrite(cjk, { discoveredBy: "write" });
     await catalog.markWrite(ascii, { discoveredBy: "write" });
 
@@ -46,6 +52,19 @@ test("Unicode namespaces decode from disk and list in stable order", async () =>
       second.map((record) => record.namespace)
     );
     assert.ok(first.some((record) => record.namespace === cjk));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("default Unicode namespace resolves legacy NFD roots", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-unicode-default-"));
+  try {
+    const config = { ...makeConfig(memoryDir), defaultNamespace: "Café" };
+    const nfd = config.defaultNamespace.normalize("NFD");
+    const nfdRoot = path.join(memoryDir, "namespaces", nfd);
+    await mkdir(path.join(nfdRoot, "facts"), { recursive: true });
+    assert.equal(await resolveDefaultNamespaceRoot(config), nfdRoot);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/unicode-routing.test.ts
+++ b/packages/remnic-core/src/namespaces/unicode-routing.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { PluginConfig } from "../types.js";
+import { NamespaceCatalog } from "./catalog.js";
+import { namespaceIdentityFromToken, namespaceIdentityToken } from "./identity.js";
+
+function makeConfig(memoryDir: string): PluginConfig {
+  return {
+    memoryDir,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    entitySchemas: {},
+  } as unknown as PluginConfig;
+}
+
+test("Unicode namespaces decode from disk and list in stable order", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-unicode-routing-"));
+  try {
+    const config = makeConfig(memoryDir);
+    const catalog = new NamespaceCatalog(config);
+    const cjk = "项目";
+    const ascii = "alpha";
+
+    assert.equal(namespaceIdentityFromToken(namespaceIdentityToken(cjk)), cjk);
+    assert.equal(namespaceIdentityToken("Cafe\u0301"), namespaceIdentityToken("Café"));
+    await catalog.markWrite(cjk, { discoveredBy: "write" });
+    await catalog.markWrite(ascii, { discoveredBy: "write" });
+
+    const first = await catalog.listNamespaces();
+    const second = await catalog.listNamespaces();
+    assert.deepEqual(first.map((record) => record.namespace), second.map((record) => record.namespace));
+    assert.ok(first.some((record) => record.namespace === cjk));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/unicode-routing.test.ts
+++ b/packages/remnic-core/src/namespaces/unicode-routing.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import type { PluginConfig } from "../types.js";
 import { NamespaceCatalog } from "./catalog.js";
-import { namespaceIdentityFromToken, namespaceIdentityToken } from "./identity.js";
+import { namespaceIdentityFromToken, namespaceIdentityLegacyToken, namespaceIdentityToken } from "./identity.js";
+import { resolveNamespaceStorageRoot } from "./storage.js";
 
 function makeConfig(memoryDir: string): PluginConfig {
   return {
@@ -30,12 +31,20 @@ test("Unicode namespaces decode from disk and list in stable order", async () =>
 
     assert.equal(namespaceIdentityFromToken(namespaceIdentityToken(cjk)), cjk);
     assert.equal(namespaceIdentityToken("Cafe\u0301"), namespaceIdentityToken("Café"));
+    const nfd = "Café".normalize("NFD");
+    const legacyToken = namespaceIdentityLegacyToken(nfd);
+    assert.equal(namespaceIdentityFromToken(legacyToken), "Café");
+    await mkdir(path.join(memoryDir, "namespaces", legacyToken, "facts"), { recursive: true });
+    assert.equal(await resolveNamespaceStorageRoot(config, "Café"), path.join(memoryDir, "namespaces", legacyToken));
     await catalog.markWrite(cjk, { discoveredBy: "write" });
     await catalog.markWrite(ascii, { discoveredBy: "write" });
 
     const first = await catalog.listNamespaces();
     const second = await catalog.listNamespaces();
-    assert.deepEqual(first.map((record) => record.namespace), second.map((record) => record.namespace));
+    assert.deepEqual(
+      first.map((record) => record.namespace),
+      second.map((record) => record.namespace)
+    );
     assert.ok(first.some((record) => record.namespace === cjk));
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/routing/engine.test.ts
+++ b/packages/remnic-core/src/routing/engine.test.ts
@@ -17,6 +17,10 @@ test("isSafeRouteNamespace accepts Unicode letters and NFC-normalizes before val
     ok: true,
     target: { namespace: "Café" },
   });
+  assert.equal(
+    validateRouteTarget({ namespace: "Café" }, { allowedNamespaces: [" Café "] }).ok,
+    true,
+  );
 });
 
 test("isSafeRouteNamespace rejects traversal, controls, bidi overrides, and edge whitespace", () => {

--- a/packages/remnic-core/src/routing/engine.test.ts
+++ b/packages/remnic-core/src/routing/engine.test.ts
@@ -12,10 +12,7 @@ test("isSafeRouteNamespace accepts Unicode letters and NFC-normalizes before val
   assert.equal(isSafeRouteNamespace("界".repeat(42)), true);
   assert.equal(isSafeRouteNamespace("界".repeat(43)), false);
 
-  const target = validateRouteTarget(
-    { namespace: "Cafe\u0301" },
-    { allowedNamespaces: ["Café"] },
-  );
+  const target = validateRouteTarget({ namespace: "Cafe\u0301" }, { allowedNamespaces: ["Café"] });
   assert.deepEqual(target, {
     ok: true,
     target: { namespace: "Café" },
@@ -23,16 +20,7 @@ test("isSafeRouteNamespace accepts Unicode letters and NFC-normalizes before val
 });
 
 test("isSafeRouteNamespace rejects traversal, controls, bidi overrides, and edge whitespace", () => {
-  for (const unsafe of [
-    "../escape",
-    "a/b",
-    "a\\b",
-    "a\u0000b",
-    "a\u202Eb",
-    " name",
-    "name ",
-    "..",
-  ]) {
+  for (const unsafe of ["../escape", "a/b", "a\\b", "a\u0000b", "a\u202Eb", " name", "name ", ".."]) {
     assert.equal(isSafeRouteNamespace(unsafe), false, JSON.stringify(unsafe));
   }
 });

--- a/packages/remnic-core/src/routing/engine.test.ts
+++ b/packages/remnic-core/src/routing/engine.test.ts
@@ -7,10 +7,15 @@ test("isSafeRouteNamespace accepts Unicode letters and NFC-normalizes before val
   assert.equal(isSafeRouteNamespace("项目"), true);
   assert.equal(isSafeRouteNamespace("Cafe\u0301"), true);
   assert.equal(isSafeRouteNamespace("a1._-"), true);
-  assert.equal(isSafeRouteNamespace("界".repeat(64)), true);
-  assert.equal(isSafeRouteNamespace("界".repeat(65)), false);
+  assert.equal(isSafeRouteNamespace("a".repeat(64)), true);
+  assert.equal(isSafeRouteNamespace("a".repeat(65)), false);
+  assert.equal(isSafeRouteNamespace("界".repeat(42)), true);
+  assert.equal(isSafeRouteNamespace("界".repeat(43)), false);
 
-  const target = validateRouteTarget({ namespace: "Cafe\u0301" });
+  const target = validateRouteTarget(
+    { namespace: "Cafe\u0301" },
+    { allowedNamespaces: ["Café"] },
+  );
   assert.deepEqual(target, {
     ok: true,
     target: { namespace: "Café" },

--- a/packages/remnic-core/src/routing/engine.test.ts
+++ b/packages/remnic-core/src/routing/engine.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSafeRouteNamespace, validateRouteTarget } from "./engine.js";
+
+test("isSafeRouteNamespace accepts Unicode letters and NFC-normalizes before validation", () => {
+  assert.equal(isSafeRouteNamespace("项目"), true);
+  assert.equal(isSafeRouteNamespace("Cafe\u0301"), true);
+  assert.equal(isSafeRouteNamespace("a1._-"), true);
+  assert.equal(isSafeRouteNamespace("界".repeat(64)), true);
+  assert.equal(isSafeRouteNamespace("界".repeat(65)), false);
+
+  const target = validateRouteTarget({ namespace: "Cafe\u0301" });
+  assert.deepEqual(target, {
+    ok: true,
+    target: { namespace: "Café" },
+  });
+});
+
+test("isSafeRouteNamespace rejects traversal, controls, bidi overrides, and edge whitespace", () => {
+  for (const unsafe of [
+    "../escape",
+    "a/b",
+    "a\\b",
+    "a\u0000b",
+    "a\u202Eb",
+    " name",
+    "name ",
+    "..",
+  ]) {
+    assert.equal(isSafeRouteNamespace(unsafe), false, JSON.stringify(unsafe));
+  }
+});

--- a/packages/remnic-core/src/routing/engine.ts
+++ b/packages/remnic-core/src/routing/engine.ts
@@ -1,3 +1,4 @@
+import { namespaceIdentityToken } from "../namespaces/identity.js";
 import type { MemoryCategory } from "../types.js";
 
 export type RoutePatternType = "regex" | "keyword";
@@ -48,7 +49,6 @@ function normalizeNamespace(namespace: string): string {
 
 const SAFE_ROUTE_NAMESPACE_CHARS = /^[\p{L}\p{M}\p{N}._-]+$/u;
 
-
 export function isLikelyUnsafeRegex(pattern: string): boolean {
   const value = pattern.trim();
   if (value.length === 0) return true;
@@ -70,8 +70,11 @@ export function isSafeRouteNamespace(namespace: string): boolean {
   const value = normalizeNamespace(namespace);
   // The route limit is 64 Unicode code points. On-disk identity tokens may
   // exceed 64 characters because namespaceIdentityToken hex-encodes UTF-8.
+  // A route can use at most 64 code points, but the reversible on-disk token
+  // must also fit one filesystem component (255 characters).
   if (value.length === 0) return false;
   if (Array.from(value).length > 64) return false;
+  if (namespaceIdentityToken(value).length > 255) return false;
   if (value === ".") return false;
   if (value.includes("/") || value.includes("\\")) return false;
   if (value.includes("..")) return false;
@@ -89,7 +92,7 @@ export function validateRouteTarget(target: RouteTarget | null | undefined, opti
 
   const allowedCategories = new Set(options?.allowedCategories ?? DEFAULT_CATEGORIES);
   const allowedNamespaces = options?.allowedNamespaces
-    ? new Set(options.allowedNamespaces.map((v) => v.trim()).filter((v) => v.length > 0))
+    ? new Set(options.allowedNamespaces.map((v) => normalizeNamespace(v)).filter((v) => v.length > 0))
     : null;
 
   const normalized: RouteTarget = {};

--- a/packages/remnic-core/src/routing/engine.ts
+++ b/packages/remnic-core/src/routing/engine.ts
@@ -43,8 +43,11 @@ const DEFAULT_CATEGORIES: readonly MemoryCategory[] = [
 ] as const;
 
 function normalizeNamespace(namespace: string): string {
-  return namespace.trim();
+  return namespace.normalize("NFC");
 }
+
+const SAFE_ROUTE_NAMESPACE_CHARS = /^[\p{L}\p{M}\p{N}._-]+$/u;
+
 
 export function isLikelyUnsafeRegex(pattern: string): boolean {
   const value = pattern.trim();
@@ -65,11 +68,14 @@ export function isLikelyUnsafeRegex(pattern: string): boolean {
 
 export function isSafeRouteNamespace(namespace: string): boolean {
   const value = normalizeNamespace(namespace);
+  // The route limit is 64 Unicode code points. On-disk identity tokens may
+  // exceed 64 characters because namespaceIdentityToken hex-encodes UTF-8.
   if (value.length === 0) return false;
+  if (Array.from(value).length > 64) return false;
   if (value === ".") return false;
   if (value.includes("/") || value.includes("\\")) return false;
   if (value.includes("..")) return false;
-  return /^[A-Za-z0-9._-]{1,64}$/.test(value);
+  return SAFE_ROUTE_NAMESPACE_CHARS.test(value);
 }
 
 export function validateRouteTarget(target: RouteTarget | null | undefined, options?: RoutingEngineOptions): {

--- a/packages/remnic-core/src/routing/engine.ts
+++ b/packages/remnic-core/src/routing/engine.ts
@@ -92,7 +92,7 @@ export function validateRouteTarget(target: RouteTarget | null | undefined, opti
 
   const allowedCategories = new Set(options?.allowedCategories ?? DEFAULT_CATEGORIES);
   const allowedNamespaces = options?.allowedNamespaces
-    ? new Set(options.allowedNamespaces.map((v) => normalizeNamespace(v)).filter((v) => v.length > 0))
+    ? new Set(options.allowedNamespaces.map((v) => normalizeNamespace(v.trim())).filter((v) => v.length > 0))
     : null;
 
   const normalized: RouteTarget = {};

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -41,7 +41,9 @@ import {
 } from "../namespaces/principal.js";
 import {
   namespaceIdentityFromToken,
+  namespaceIdentityLegacyToken,
   namespaceIdentityToken,
+  normalizeNamespaceIdentity,
 } from "../namespaces/identity.js";
 import path from "node:path";
 import {
@@ -359,7 +361,7 @@ export function getConfiguredNamespaces(config: PluginConfig): string[] {
         config.sharedNamespace,
         ...config.namespacePolicies.map((policy) => policy.name),
       ]
-        .map((value) => value.trim())
+        .map((value) => normalizeNamespaceIdentity(value))
         .filter(Boolean),
     ),
   );
@@ -430,7 +432,11 @@ export function resolveNamespaceFromStorageDir(
     if (hintedNamespace) return hintedNamespace;
   }
   const decoded = namespaceIdentityFromToken(dirName);
-  if (decoded && namespaceIdentityToken(decoded) === dirName) {
+  if (
+    decoded &&
+    (namespaceIdentityToken(decoded) === dirName ||
+      namespaceIdentityLegacyToken(decoded.normalize("NFD")) === dirName)
+  ) {
     return decoded;
   }
   return dirName;

--- a/packages/remnic-core/src/storage-contract/namespace-routing.test.ts
+++ b/packages/remnic-core/src/storage-contract/namespace-routing.test.ts
@@ -19,7 +19,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { makeStorage, makeNamespaceRouter, resetStaticCaches } from "./harness.js";
-import { resolveNamespaceStorageRoot } from "../namespaces/storage.js";
+import { NamespaceStorageRouter, resolveNamespaceStorageRoot } from "../namespaces/storage.js";
 import { namespaceIdentityToken } from "../namespaces/identity.js";
 import { getCachedMemories } from "../memory-cache.js";
 
@@ -154,6 +154,23 @@ test("namespace-routing: hotMemoriesCacheEnabled=false propagates to namespace c
       null,
       "namespace child honors the disabled gate and never caches the corpus",
     );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: CJK namespace round-trips through storage", async () => {
+  const { router, memoryDir, config, cleanup } = await makeNamespaceRouter();
+  try {
+    const namespace = "项目";
+    const token = namespaceIdentityToken(namespace);
+    const writer = await router.storageFor(namespace);
+    const written = await writer.writeMemory("fact", "CJK namespace fact");
+    assert.equal(writer.dir, path.join(memoryDir, "namespaces", token));
+
+    const reader = await new NamespaceStorageRouter(config).storageFor(namespace);
+    assert.equal(reader.dir, writer.dir);
+    assert.equal((await reader.getMemoryById(written.id))?.content, "CJK namespace fact");
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
Fixes #2194

## Behavior
- NFC-normalize route namespaces before validation.
- Accept Unicode letters, marks, and numbers plus `.`, `_`, and `-`.
- Enforce a 64-code-point route limit while retaining encoded on-disk identity tokens.
- Keep traversal, separator, control, bidi, and edge-whitespace rejection.
- Canonicalize namespace identity tokens with NFC so composed and decomposed forms share storage.

## Verification
- Focused Unicode, routing, catalog, identity, coding, and offline-sync tests: 164 passed.
- `@remnic/core` typecheck passed.
- `preflight:quick` passed with existing repository warnings.

## Notes
- Added explicit CJK storage round-trip and catalog ordering coverage.
- Full core test command exceeded the 900-second tool limit after producing passing test output; focused tests and preflight completed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace validation, on-disk root resolution, and ACL matching—areas that affect isolation and data location—but keeps fail-closed safety checks and adds regression tests for Unicode and legacy layouts.
> 
> **Overview**
> **Route validation** now NFC-normalizes namespace strings and allows Unicode letters, marks, and numbers (plus `.`, `_`, `-`) with a **64 code-point** cap and a check that the encoded on-disk token fits a single filesystem component. Existing traversal, separator, control, bidi, and edge-whitespace rules stay in place.
> 
> **Identity and storage** canonicalize with **NFC** in `normalizeNamespaceIdentity` and `namespaceIdentityToken`, add **`namespaceIdentityLegacyToken`** for pre-NFC on-disk dirs (e.g. NFD), and teach **`namespaceIdentityFromToken`** to decode either form. **`resolveNamespaceStorageRoot`** / **`resolveDefaultNamespaceRoot`** prefer tokenized roots but also discover legacy raw and legacy-token paths so composed vs decomposed spellings share one logical namespace.
> 
> **ACL and scope** compare policies and configured names via normalized identity so NFC-equivalent names match (e.g. `Cafe\u0301` vs `Café`). The catalog rebuild scan ranks canonical vs legacy token dirs when both exist for the same namespace.
> 
> New focused tests cover routing safety, Unicode catalog/list ordering, default NFD legacy roots, principal ACL equivalence, and CJK storage round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb5fabd390f75f06e662f9d1ffcd0ff71954994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->