### PR TITLE
fix(plugin-openclaw): recover rotated daemon credentials

### DIFF
--- a/.changeset/quiet-tokens-rotate.md
+++ b/.changeset/quiet-tokens-rotate.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Classify daemon authentication failures correctly and retry one rotated connector token without restarting the session.

--- a/docs/integration/deployment-topologies.md
+++ b/docs/integration/deployment-topologies.md
@@ -142,11 +142,28 @@ volumes:
 
 ## Authentication
 
-All topologies require a bearer token. Set it via:
+All topologies require a bearer token. Standalone server configuration uses
+this precedence:
 
-1. `--token` CLI flag
-2. `OPENCLAW_REMNIC_ACCESS_TOKEN` / `OPENCLAW_ENGRAM_ACCESS_TOKEN` environment variable
-3. `agentAccessHttp.authToken` in `openclaw.json`
+1. The `--token` CLI flag.
+2. The `REMNIC_AUTH_TOKEN` environment variable.
+3. The server `authToken` configuration value.
+
+OpenClaw delegate mode resolves the daemon credential with this precedence:
+
+1. `OPENCLAW_REMNIC_ACCESS_TOKEN`
+2. `REMNIC_AUTH_TOKEN`
+3. `OPENCLAW_ENGRAM_ACCESS_TOKEN` (legacy name)
+4. `ENGRAM_AUTH_TOKEN` (legacy name)
+5. The OpenClaw entry in `~/.remnic/tokens.json`
+6. The OpenClaw entry in `~/.engram/tokens.json` (legacy store)
+7. `server.authToken` in the daemon config file for the selected endpoint
+
+The first non-empty value wins. An environment variable wins over a config
+file, even when the config file has a newer token. After a daemon returns HTTP
+401, delegate mode retries once after it excludes the rejected credential.
+This lets a rotated config token replace a stale exported environment value
+without restarting the session.
 
 Clients must send `Authorization: Bearer <token>` with every request.
 

--- a/packages/plugin-openclaw/src/bridge-auto-mode.test.ts
+++ b/packages/plugin-openclaw/src/bridge-auto-mode.test.ts
@@ -173,17 +173,13 @@ test("readDaemonMemoryDirSync survives a malformed health body", async () => {
 });
 
 test("readDaemonMemoryDirSync reports unhealthy for a non-200 daemon", async () => {
-  // A 401/403 is unhealthy AND flagged as an auth rejection, which is what
-  // licenses the candidate walk to retry a different bound credential. A
-  // readiness stall or a dead socket carries no flag, because no token fixes
-  // those.
   const rejecting = await startHealthStub({ error: "unauthorized" }, 401);
   try {
-    assert.deepEqual(readDaemonMemoryDirSync("127.0.0.1", rejecting.port, 5_000), {
-      healthy: false,
-      memoryDir: undefined,
-      rejectedAuth: true,
-    });
+    const health = readDaemonMemoryDirSync("127.0.0.1", rejecting.port, 5_000);
+    assert.equal(health.healthy, false);
+    assert.equal(health.failure, "auth");
+    assert.equal(health.rejectedAuth, true);
+    assert.equal(typeof health.authSource, "string");
   } finally {
     await rejecting.close();
   }
@@ -192,9 +188,25 @@ test("readDaemonMemoryDirSync reports unhealthy for a non-200 daemon", async () 
     assert.deepEqual(readDaemonMemoryDirSync("127.0.0.1", broken.port, 5_000), {
       healthy: false,
       memoryDir: undefined,
+      failure: "http",
     });
   } finally {
     await broken.close();
+  }
+});
+
+test("auto detection classifies HTTP 401 as an authentication failure", async () => {
+  const rejecting = await startHealthStub({ error: "unauthorized" }, 401);
+  try {
+    const skipped: string[] = [];
+    const result = withDaemonEnv(rejecting.port, () =>
+      detectDaemonBridgeMode({ memoryDir: MEMORY_DIR, onSkip: (reason) => skipped.push(reason) }),
+    );
+    assert.equal(result.mode, "embedded");
+    assert.match(skipped.join("\n"), /authentication/i);
+    assert.doesNotMatch(skipped.join("\n"), /unreachable/i);
+  } finally {
+    await rejecting.close();
   }
 });
 
@@ -202,10 +214,12 @@ test("readDaemonMemoryDirSync rejects an unroutable port without probing", () =>
   assert.deepEqual(readDaemonMemoryDirSync("127.0.0.1", 0, 500), {
     healthy: false,
     memoryDir: undefined,
+    failure: "network",
   });
   assert.deepEqual(readDaemonMemoryDirSync("", 4318, 500), {
     healthy: false,
     memoryDir: undefined,
+    failure: "network",
   });
 });
 
@@ -2217,7 +2231,7 @@ test("a health body that dies after the headers fails fast, not at the deadline"
     const started = Date.now();
     const health = readDaemonMemoryDirSync("127.0.0.1", stub.port, budgetMs);
     const elapsed = Date.now() - started;
-    assert.deepEqual(health, { healthy: false, memoryDir: undefined });
+    assert.deepEqual(health, { healthy: false, memoryDir: undefined, failure: "network" });
     assert.ok(
       elapsed < budgetMs / 2,
       `probe returned in ${elapsed}ms, well inside its ${budgetMs}ms budget`,
@@ -2553,6 +2567,51 @@ test("a removed unit token falls through instead of replaying a dead credential"
     else process.env.HOME = priorHome;
     if (priorToken === undefined) delete process.env.REMNIC_AUTH_TOKEN;
     else process.env.REMNIC_AUTH_TOKEN = priorToken;
+    await rm(home, { recursive: true, force: true });
+  }
+});
+test("a rejected legacy environment token falls back to the daemon config", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-token-rotation-"));
+  const configPath = path.join(home, ".config", "remnic", "config.json");
+  const authNames = [
+    "OPENCLAW_REMNIC_ACCESS_TOKEN",
+    "REMNIC_AUTH_TOKEN",
+    "OPENCLAW_ENGRAM_ACCESS_TOKEN",
+    "ENGRAM_AUTH_TOKEN",
+  ] as const;
+  const previous = new Map(authNames.map((name) => [name, process.env[name]]));
+  try {
+    await mkdir(path.dirname(configPath), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ server: { authToken: "rotated-config-token" } }),
+      "utf8",
+    );
+    for (const name of authNames) delete process.env[name];
+    process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN = "stale-exported-token";
+    const target = daemonTargetFor({
+      mode: "delegate",
+      daemonHost: "127.0.0.1",
+      daemonAuthPrefersConfig: false,
+      daemonPort: 4318,
+      daemonConfigPath: configPath,
+    });
+    const stale = target.resolveAuthToken();
+    assert.deepEqual(stale, {
+      token: "stale-exported-token",
+      source: "OPENCLAW_ENGRAM_ACCESS_TOKEN",
+    });
+    target.invalidateAuthToken?.(stale);
+    assert.deepEqual(target.resolveAuthToken(), {
+      token: "rotated-config-token",
+      source: "daemon configuration",
+    });
+  } finally {
+    for (const name of authNames) {
+      const value = previous.get(name);
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
     await rm(home, { recursive: true, force: true });
   }
 });

--- a/packages/plugin-openclaw/src/bridge-health-worker.ts
+++ b/packages/plugin-openclaw/src/bridge-health-worker.ts
@@ -57,13 +57,12 @@ export function runHealthWorker(request: HealthRequest, data: HealthWorkerData):
   const view = new Int32Array(data.state);
   let completed = false;
 
-  // 1 = healthy, 2 = failed, 3 = failed with an AUTH rejection. The caller
-  // retries a bound credential only for 3: a readiness stall or a dead socket
-  // is not something a different token would fix.
-  function finish(ok: boolean, rejectedAuth = false): void {
+  // 1 = healthy, 2 = network failure, 3 = auth rejection, 4 = HTTP failure.
+  // The caller must not report an HTTP auth response as a network outage.
+  function finish(ok: boolean, rejectedAuth = false, httpFailure = false): void {
     if (completed) return;
     completed = true;
-    Atomics.store(view, 0, ok ? 1 : rejectedAuth ? 3 : 2);
+    Atomics.store(view, 0, ok ? 1 : rejectedAuth ? 3 : httpFailure ? 4 : 2);
     Atomics.notify(view, 0);
   }
 
@@ -151,7 +150,7 @@ export function runHealthWorker(request: HealthRequest, data: HealthWorkerData):
           } else if (statusCode === 401 || statusCode === 403) {
             finish(false, true);
           } else {
-            finish(false);
+            finish(false, false, true);
           }
         },
       );

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -1030,10 +1030,15 @@ function isOpenClawTokenEntry(value: unknown): value is { token: string } {
   );
 }
 
+const daemonAuthKey = (source: DaemonAuthTokenSource, token: string): string =>
+  `${source}\0${token}`;
+
 export function loadDaemonAuth(
   configPath?: string,
-  excludedSources?: ReadonlySet<DaemonAuthTokenSource>,
+  excludedSources?: ReadonlySet<string>,
 ): DaemonAuthToken {
+  const excluded = (source: DaemonAuthTokenSource, token: string): boolean =>
+    excludedSources?.has(source) === true || excludedSources?.has(daemonAuthKey(source, token)) === true;
   const environmentTokens = [
     ["OPENCLAW_REMNIC_ACCESS_TOKEN", readEnv("OPENCLAW_REMNIC_ACCESS_TOKEN")],
     ["REMNIC_AUTH_TOKEN", readEnv("REMNIC_AUTH_TOKEN")],
@@ -1041,7 +1046,7 @@ export function loadDaemonAuth(
     ["ENGRAM_AUTH_TOKEN", readEnv("ENGRAM_AUTH_TOKEN")],
   ] as const;
   for (const [source, token] of environmentTokens) {
-    if (token && !excludedSources?.has(source)) return { token, source };
+    if (token && !excluded(source, token)) return { token, source };
   }
 
   const tokenStores = [
@@ -1057,7 +1062,7 @@ export function loadDaemonAuth(
       if (
         typeof openClawToken === "string" &&
         openClawToken.length > 0 &&
-        !excludedSources?.has(tokenStore.source)
+        !excluded(tokenStore.source, openClawToken)
       ) {
         return { token: openClawToken, source: tokenStore.source };
       }
@@ -1068,7 +1073,7 @@ export function loadDaemonAuth(
         typeof store.openclaw === "string" &&
         store.openclaw.length > 0 &&
         (store.openclaw.startsWith("remnic_") || store.openclaw.startsWith("engram_")) &&
-        !excludedSources?.has(tokenStore.source)
+        !excluded(tokenStore.source, store.openclaw)
       ) {
         return { token: store.openclaw, source: tokenStore.source };
       }
@@ -1087,7 +1092,7 @@ export function loadDaemonAuth(
       if (
         typeof token === "string" &&
         token.length > 0 &&
-        !excludedSources?.has("daemon configuration")
+        !excluded("daemon configuration", token)
       ) {
         return { token, source: "daemon configuration" };
       }
@@ -1162,16 +1167,21 @@ export async function checkDaemonHealthDetailed(
         req.end();
       });
 
-    let livenessStatus = await probe(LIVENESS_PATH, auth.token);
-    if (livenessStatus === 401 || livenessStatus === 403) {
-      if (fallbackAuth?.token && fallbackAuth.token !== auth.token) {
+    const probeWithFallback = async (requestPath: string): Promise<number | undefined> => {
+      let status = await probe(requestPath, auth.token);
+      if ((status === 401 || status === 403) && fallbackAuth?.token && fallbackAuth.token !== auth.token) {
         auth = fallbackAuth;
-        livenessStatus = await probe(LIVENESS_PATH, auth.token);
+        status = await probe(requestPath, auth.token);
       }
-    }
+      return status;
+    };
+    const livenessStatus = await probeWithFallback(LIVENESS_PATH);
     if (livenessStatus === 200) return { ok: true };
     if (livenessStatus !== 404) return classifyDaemonHealthStatus(livenessStatus, auth.source);
-    return classifyDaemonHealthStatus(await probe(LEGACY_HEALTH_PATH, auth.token), auth.source);
+    return classifyDaemonHealthStatus(
+      await probeWithFallback(LEGACY_HEALTH_PATH),
+      auth.source,
+    );
   } catch {
     return { ok: false, failure: "network" };
   }

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -139,6 +139,8 @@ export interface DelegateDaemonTarget {
   host: string;
   port: number;
   resolveAuthToken: () => DaemonAuthToken;
+  /** Drop a credential after a 401 so the next resolver call can fall back. */
+  invalidateAuthToken?: (auth: DaemonAuthToken) => void;
 }
 
 /** Base URL for a daemon route, bracketing a bare IPv6 literal host. */
@@ -159,6 +161,15 @@ const DEFAULT_PORT = 4318;
 const LIVENESS_PATH = "/engram/v1/live";
 const LEGACY_HEALTH_PATH = "/engram/v1/health";
 export const DEFAULT_DAEMON_HEALTH_TIMEOUT_MS = 10_000;
+
+export type DaemonHealthFailure = "auth" | "network" | "http";
+
+export interface DaemonHealthResult {
+  readonly ok: boolean;
+  readonly failure?: DaemonHealthFailure;
+  readonly status?: number;
+  readonly tokenSource?: DaemonAuthTokenSource;
+}
 
 /**
  * Validate a caller-supplied probe budget, in the same range the config
@@ -356,12 +367,6 @@ function coerceDaemonPort(value: unknown): number | undefined {
 
 const DAEMON_CAPTURE_BYTES = 1_024;
 
-/**
- * Run one blocking daemon probe on a worker thread. `register()` is
- * synchronous, so this is the only way to consult the daemon before deciding
- * how to register. When `captureField` is set, the probe targets the detailed
- * health route and returns that field's string value from the response body.
- */
 function probeDaemonSync(options: {
   host: string;
   port: number;
@@ -373,9 +378,21 @@ function probeDaemonSync(options: {
   configPath?: string;
   /** A unit-supplied credential, which outranks the config's. */
   authToken?: string;
-}): { ok: boolean; captured?: string; rejectedAuth?: boolean } {
+}): {
+  ok: boolean;
+  captured?: string;
+  rejectedAuth?: boolean;
+  failure?: "auth" | "network" | "http";
+  authSource?: DaemonAuthTokenSource;
+} {
+  const auth =
+    options.authToken === undefined
+      ? loadDaemonAuth(options.configPath)
+      : { token: options.authToken, source: "daemon configuration" as const };
   const { host, port, timeoutMs } = options;
-  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) return { ok: false };
+  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) {
+    return { ok: false, failure: "network" };
+  }
   const deadline = Date.now() + timeoutMs;
 
   let worker: Worker | undefined;
@@ -393,7 +410,7 @@ function probeDaemonSync(options: {
         port,
         path: options.path,
         fallbackPath: options.fallbackPath,
-        token: options.authToken ?? loadDaemonAuth(options.configPath).token,
+        token: auth.token,
         deadline,
         state,
         ...(capture ? { capture, captureField: options.captureField } : {}),
@@ -404,13 +421,17 @@ function probeDaemonSync(options: {
     Atomics.wait(view, 0, 0, Math.max(0, deadline - Date.now()));
     const status = Atomics.load(view, 0);
     if (status === 0) void worker.terminate();
-    if (status !== 1) return { ok: false, ...(status === 3 ? { rejectedAuth: true } : {}) };
+    if (status !== 1) {
+      const failure = status === 3 ? "auth" : status === 4 ? "http" : "network";
+      return {
+        ok: false,
+        failure,
+        ...(status === 3 ? { rejectedAuth: true, authSource: auth.source } : {}),
+      };
+    }
     if (!capture) return { ok: true };
     const length = new DataView(capture).getUint32(0);
     if (length === 0) return { ok: true };
-    // A value that did not fit is UNKNOWN, never a truncated path: a shortened
-    // memoryDir would read as a different corpus and start a second
-    // orchestrator beside the daemon on the very same files.
     if (length > capture.byteLength - 4) return { ok: true };
     return { ok: true, captured: new TextDecoder().decode(new Uint8Array(capture, 4, length)) };
   } catch {
@@ -436,22 +457,19 @@ export function checkDaemonHealthSync(
   }).ok;
 }
 
-/**
- * Read the memoryDir a healthy daemon is serving. Returns `undefined` for the
- * directory when the daemon answers but does not report one (an older build,
- * or a token without health access), which callers must treat as "unknown" —
- * never as a match.
- */
 export function readDaemonMemoryDirSync(
   host: string,
   port: number,
   timeoutMs = DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
   configPath?: string,
   authToken?: string,
-): { healthy: boolean; memoryDir?: string; rejectedAuth?: boolean } {
-  // A non-finite budget survives `Math.max(0, deadline - Date.now())` and
-  // reaches `Atomics.wait` as an UNBOUNDED wait, hanging the caller's main
-  // thread instead of failing the probe.
+): {
+  healthy: boolean;
+  memoryDir?: string;
+  rejectedAuth?: boolean;
+  failure?: "auth" | "network" | "http";
+  authSource?: DaemonAuthTokenSource;
+} {
   assertProbeBudget(timeoutMs);
   const probe = probeDaemonSync({
     host,
@@ -466,9 +484,9 @@ export function readDaemonMemoryDirSync(
   return {
     healthy: probe.ok,
     memoryDir: probe.captured,
-    // Present only when true, so the result shape is unchanged for callers
-    // that compare it structurally.
+    ...(probe.failure === undefined ? {} : { failure: probe.failure }),
     ...(probe.rejectedAuth === true ? { rejectedAuth: true } : {}),
+    ...(probe.authSource === undefined ? {} : { authSource: probe.authSource }),
   };
 }
 
@@ -835,7 +853,13 @@ export function detectDaemonBridgeMode(options: {
       }
     }
     if (!health.healthy) {
-      options.onSkip?.(`no healthy daemon at ${daemonHost}:${daemonPort}`);
+      const reason =
+        health.failure === "auth"
+          ? `daemon authentication failed at ${daemonHost}:${daemonPort} using ${health.authSource ?? "the configured credential"}`
+          : health.failure === "http"
+            ? `daemon health at ${daemonHost}:${daemonPort} returned an HTTP error; no healthy daemon`
+            : `daemon network probe failed at ${daemonHost}:${daemonPort}; no healthy daemon`;
+      options.onSkip?.(reason);
       continue;
     }
     if (health.memoryDir === undefined) {
@@ -988,11 +1012,7 @@ export function readDaemonConfigAuthToken(configPath: string): string | undefine
   return readServerBlock(configPath)?.authToken;
 }
 
-/** The one config file explicit resolution took host and port from. */
 function selectedDaemonConfigPath(): string | undefined {
-  // The SAME file `readDaemonServerConfig` resolves the endpoint from, which
-  // is the one the daemon itself selected — so the credential is always bound
-  // to the config that describes the endpoint being dialed.
   for (const candidate of configPathCandidates()) {
     if (readServerBlock(candidate) !== undefined) return candidate;
   }
@@ -1010,25 +1030,10 @@ function isOpenClawTokenEntry(value: unknown): value is { token: string } {
   );
 }
 
-/**
- * Load daemon credentials from the environment, standard token stores, or
- * daemon configuration. Shared by health and delegate requests.
- *
- * Environment precedence is primary-before-legacy (AGENTS.md §9): both current
- * names outrank both pre-rename aliases. A migrated deployment commonly still
- * exports `OPENCLAW_ENGRAM_ACCESS_TOKEN` from an old shell profile or unit
- * file; if that stale value outranked the `REMNIC_AUTH_TOKEN` the daemon is
- * actually running with, every request would 401 and the reported `source`
- * would point the operator at the wrong variable (issue #2286).
- *
- * `configPath` binds the config-file tier to ONE file. Candidate endpoints are
- * discovered per config, and two configs can carry different
- * `server.authToken` values — resolving credentials independently would send
- * the first config's token to a daemon that came from the second, which
- * answers 401 and leaves `auto` embedded beside it. Env and token stores are
- * daemon-independent and keep their precedence.
- */
-export function loadDaemonAuth(configPath?: string): DaemonAuthToken {
+export function loadDaemonAuth(
+  configPath?: string,
+  excludedSources?: ReadonlySet<DaemonAuthTokenSource>,
+): DaemonAuthToken {
   const environmentTokens = [
     ["OPENCLAW_REMNIC_ACCESS_TOKEN", readEnv("OPENCLAW_REMNIC_ACCESS_TOKEN")],
     ["REMNIC_AUTH_TOKEN", readEnv("REMNIC_AUTH_TOKEN")],
@@ -1036,7 +1041,7 @@ export function loadDaemonAuth(configPath?: string): DaemonAuthToken {
     ["ENGRAM_AUTH_TOKEN", readEnv("ENGRAM_AUTH_TOKEN")],
   ] as const;
   for (const [source, token] of environmentTokens) {
-    if (token) return { token, source };
+    if (token && !excludedSources?.has(source)) return { token, source };
   }
 
   const tokenStores = [
@@ -1049,7 +1054,11 @@ export function loadDaemonAuth(configPath?: string): DaemonAuthToken {
       const store = JSON.parse(fs.readFileSync(tokenStore.path, "utf8"));
       const tokens = Array.isArray(store.tokens) ? store.tokens : [];
       const openClawToken = tokens.find(isOpenClawTokenEntry)?.token;
-      if (typeof openClawToken === "string" && openClawToken.length > 0) {
+      if (
+        typeof openClawToken === "string" &&
+        openClawToken.length > 0 &&
+        !excludedSources?.has(tokenStore.source)
+      ) {
         return { token: openClawToken, source: tokenStore.source };
       }
       if (
@@ -1058,7 +1067,8 @@ export function loadDaemonAuth(configPath?: string): DaemonAuthToken {
         "openclaw" in store &&
         typeof store.openclaw === "string" &&
         store.openclaw.length > 0 &&
-        (store.openclaw.startsWith("remnic_") || store.openclaw.startsWith("engram_"))
+        (store.openclaw.startsWith("remnic_") || store.openclaw.startsWith("engram_")) &&
+        !excludedSources?.has(tokenStore.source)
       ) {
         return { token: store.openclaw, source: tokenStore.source };
       }
@@ -1074,7 +1084,11 @@ export function loadDaemonAuth(configPath?: string): DaemonAuthToken {
       const raw: unknown = JSON.parse(fs.readFileSync(candidate, "utf8"));
       const server = (raw as { server?: { authToken?: unknown } } | null)?.server;
       const token = server?.authToken;
-      if (typeof token === "string" && token.length > 0) {
+      if (
+        typeof token === "string" &&
+        token.length > 0 &&
+        !excludedSources?.has("daemon configuration")
+      ) {
         return { token, source: "daemon configuration" };
       }
     } catch {
@@ -1089,24 +1103,36 @@ export function loadDaemonAuth(configPath?: string): DaemonAuthToken {
   return { token: "", source: "no configured token" };
 }
 
-/**
- * Check whether the standalone daemon is available for delegated requests.
- * Falls back to detailed health when the daemon predates the liveness route.
- */
-export async function checkDaemonHealth(
+function classifyDaemonHealthStatus(
+  status: number | undefined,
+  tokenSource: DaemonAuthTokenSource,
+): DaemonHealthResult {
+  if (status === 200) return { ok: true };
+  if (status === 401 || status === 403) {
+    return { ok: false, failure: "auth", status, tokenSource };
+  }
+  if (status === undefined) return { ok: false, failure: "network" };
+  return { ok: false, failure: "http", status };
+}
+
+export async function checkDaemonHealthDetailed(
   host: string,
   port: number,
   timeoutMs = DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
-): Promise<boolean> {
-  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) return false;
+): Promise<DaemonHealthResult> {
+  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) {
+    return { ok: false, failure: "network" };
+  }
   const deadline = Date.now() + timeoutMs;
   try {
     const { request } = await import("node:http");
-    const token = loadDaemonAuth().token;
-    const headers: Record<string, string> = {};
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+    let auth = loadDaemonAuth();
+    const fallbackAuth =
+      auth.token === ""
+        ? undefined
+        : loadDaemonAuth(undefined, new Set<DaemonAuthTokenSource>([auth.source]));
 
-    const probe = (requestPath: string): Promise<number | undefined> =>
+    const probe = (requestPath: string, token: string): Promise<number | undefined> =>
       new Promise((resolve) => {
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {
@@ -1119,6 +1145,8 @@ export async function checkDaemonHealth(
           settled = true;
           resolve(statusCode);
         };
+        const headers: Record<string, string> = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
         const req = request(
           { hostname: host, port, path: requestPath, method: "GET", timeout: remainingMs, headers },
           (res) => {
@@ -1134,11 +1162,29 @@ export async function checkDaemonHealth(
         req.end();
       });
 
-    const livenessStatus = await probe(LIVENESS_PATH);
-    if (livenessStatus === 200) return true;
-    if (livenessStatus !== 404) return false;
-    return await probe(LEGACY_HEALTH_PATH) === 200;
+    let livenessStatus = await probe(LIVENESS_PATH, auth.token);
+    if (livenessStatus === 401 || livenessStatus === 403) {
+      if (fallbackAuth?.token && fallbackAuth.token !== auth.token) {
+        auth = fallbackAuth;
+        livenessStatus = await probe(LIVENESS_PATH, auth.token);
+      }
+    }
+    if (livenessStatus === 200) return { ok: true };
+    if (livenessStatus !== 404) return classifyDaemonHealthStatus(livenessStatus, auth.source);
+    return classifyDaemonHealthStatus(await probe(LEGACY_HEALTH_PATH, auth.token), auth.source);
   } catch {
-    return false;
+    return { ok: false, failure: "network" };
   }
+}
+
+/**
+ * Check whether the standalone daemon is available for delegated requests.
+ * Falls back to detailed health when the daemon predates the liveness route.
+ */
+export async function checkDaemonHealth(
+  host: string,
+  port: number,
+  timeoutMs = DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
+): Promise<boolean> {
+  return (await checkDaemonHealthDetailed(host, port, timeoutMs)).ok;
 }

--- a/packages/plugin-openclaw/src/delegate-daemon-target.ts
+++ b/packages/plugin-openclaw/src/delegate-daemon-target.ts
@@ -12,7 +12,6 @@ import {
   readUnitAuthToken,
   type BridgeConfig,
   type DaemonAuthToken,
-  type DaemonAuthTokenSource,
   type DelegateDaemonTarget,
 } from "./bridge.js";
 
@@ -26,28 +25,32 @@ import {
  * not 401 every delegated route until the gateway restarts too.
  */
 export function daemonTargetFor(bridge: BridgeConfig): DelegateDaemonTarget {
-  const invalidatedSources = new Set<DaemonAuthTokenSource>();
+  const invalidatedCredentials = new Set<string>();
+  const invalidated = (token: string): boolean =>
+    invalidatedCredentials.has(`daemon configuration\0${token}`);
   return {
     host: bridge.daemonHost,
     port: bridge.daemonPort,
     invalidateAuthToken: (auth: DaemonAuthToken) => {
-      invalidatedSources.add(auth.source);
+      invalidatedCredentials.add(`${auth.source}\0${auth.token}`);
     },
     resolveAuthToken: () => {
       if (
         bridge.daemonAuthTokenOverride !== undefined &&
-        !invalidatedSources.has("daemon configuration")
+        !invalidated(bridge.daemonAuthTokenOverride)
       ) {
         // A unit-supplied credential is re-read from its unit — including its
         // drop-ins and `EnvironmentFile=`.
         const unit =
           bridge.daemonAuthUnit === undefined ? undefined : readUnitAuthToken(bridge.daemonAuthUnit);
-        if (unit?.readable === true && unit.token !== undefined) {
+        if (unit?.readable === true && unit.token !== undefined && !invalidated(unit.token)) {
           return { token: unit.token, source: "daemon configuration" };
         }
         // A unit that is no longer READABLE proves nothing, so the value the
-        // probe authenticated with is still the best guess.
-        if (unit === undefined || unit.readable === false) {
+        if (
+          (unit === undefined || unit.readable === false) &&
+          !invalidated(bridge.daemonAuthTokenOverride)
+        ) {
           return { token: bridge.daemonAuthTokenOverride, source: "daemon configuration" };
         }
         // Readable and deliberately carrying no token: the daemon has fallen
@@ -58,22 +61,21 @@ export function daemonTargetFor(bridge: BridgeConfig): DelegateDaemonTarget {
         // under another account and would keep 401ing after the restart.
         if (bridge.daemonConfigPath !== undefined) {
           const configToken = readDaemonConfigAuthToken(bridge.daemonConfigPath);
-          if (configToken !== undefined) {
+          if (configToken !== undefined && !invalidated(configToken)) {
             return { token: configToken, source: "daemon configuration" };
           }
         }
       }
       if (
         bridge.daemonAuthPrefersConfig &&
-        bridge.daemonConfigPath !== undefined &&
-        !invalidatedSources.has("daemon configuration")
+        bridge.daemonConfigPath !== undefined
       ) {
         const configToken = readDaemonConfigAuthToken(bridge.daemonConfigPath);
-        if (configToken !== undefined) {
+        if (configToken !== undefined && !invalidated(configToken)) {
           return { token: configToken, source: "daemon configuration" };
         }
       }
-      return loadDaemonAuth(bridge.daemonConfigPath, invalidatedSources);
+      return loadDaemonAuth(bridge.daemonConfigPath, invalidatedCredentials);
     },
   };
 }

--- a/packages/plugin-openclaw/src/delegate-daemon-target.ts
+++ b/packages/plugin-openclaw/src/delegate-daemon-target.ts
@@ -11,6 +11,8 @@ import {
   readDaemonConfigAuthToken,
   readUnitAuthToken,
   type BridgeConfig,
+  type DaemonAuthToken,
+  type DaemonAuthTokenSource,
   type DelegateDaemonTarget,
 } from "./bridge.js";
 
@@ -24,11 +26,18 @@ import {
  * not 401 every delegated route until the gateway restarts too.
  */
 export function daemonTargetFor(bridge: BridgeConfig): DelegateDaemonTarget {
+  const invalidatedSources = new Set<DaemonAuthTokenSource>();
   return {
     host: bridge.daemonHost,
     port: bridge.daemonPort,
+    invalidateAuthToken: (auth: DaemonAuthToken) => {
+      invalidatedSources.add(auth.source);
+    },
     resolveAuthToken: () => {
-      if (bridge.daemonAuthTokenOverride !== undefined) {
+      if (
+        bridge.daemonAuthTokenOverride !== undefined &&
+        !invalidatedSources.has("daemon configuration")
+      ) {
         // A unit-supplied credential is re-read from its unit — including its
         // drop-ins and `EnvironmentFile=`.
         const unit =
@@ -54,13 +63,17 @@ export function daemonTargetFor(bridge: BridgeConfig): DelegateDaemonTarget {
           }
         }
       }
-      if (bridge.daemonAuthPrefersConfig && bridge.daemonConfigPath !== undefined) {
+      if (
+        bridge.daemonAuthPrefersConfig &&
+        bridge.daemonConfigPath !== undefined &&
+        !invalidatedSources.has("daemon configuration")
+      ) {
         const configToken = readDaemonConfigAuthToken(bridge.daemonConfigPath);
         if (configToken !== undefined) {
           return { token: configToken, source: "daemon configuration" };
         }
       }
-      return loadDaemonAuth(bridge.daemonConfigPath);
+      return loadDaemonAuth(bridge.daemonConfigPath, invalidatedSources);
     },
   };
 }

--- a/packages/plugin-openclaw/src/delegate-http.ts
+++ b/packages/plugin-openclaw/src/delegate-http.ts
@@ -58,13 +58,16 @@ async function fetchWithAuthRetry(
   timeoutMs: number,
   init: RequestInit = {},
 ): Promise<{ response: Response; auth: DaemonAuthToken }> {
+  const deadline = Date.now() + timeoutMs;
   const request = async (auth: DaemonAuthToken): Promise<Response> => {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw new Error("daemon request deadline exceeded");
     const headers = new Headers(init.headers);
     if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
     return fetch(daemonUrl(target, pathname), {
       ...init,
       headers,
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: AbortSignal.timeout(remainingMs),
     });
   };
   const auth = target.resolveAuthToken();

--- a/packages/plugin-openclaw/src/delegate-http.ts
+++ b/packages/plugin-openclaw/src/delegate-http.ts
@@ -8,6 +8,7 @@
 
 import {
   daemonUrl,
+  type DaemonAuthToken,
   type DaemonAuthTokenSource,
   type DelegateDaemonTarget,
 } from "./bridge.js";
@@ -44,14 +45,47 @@ async function noteRefusal(
 }
 
 /**
+ * Retry one unauthorized request after resolving the credential again.
+ *
+ * OpenClaw can rotate a connector token while a session remains active. A
+ * single retry lets a resolver that observed that rotation recover the
+ * current request, including `TRIGGER_REAUTHENTICATION`, without re-registering
+ * the session hooks. A network failure still rejects from `fetch`.
+ */
+async function fetchWithAuthRetry(
+  target: DelegateDaemonTarget,
+  pathname: string,
+  timeoutMs: number,
+  init: RequestInit = {},
+): Promise<{ response: Response; auth: DaemonAuthToken }> {
+  const request = async (auth: DaemonAuthToken): Promise<Response> => {
+    const headers = new Headers(init.headers);
+    if (auth.token) headers.set("Authorization", `Bearer ${auth.token}`);
+    return fetch(daemonUrl(target, pathname), {
+      ...init,
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  };
+  const auth = target.resolveAuthToken();
+  const response = await request(auth);
+  if (response.status !== 401) return { response, auth };
+
+  await response.body?.cancel();
+  target.invalidateAuthToken?.(auth);
+  const refreshedAuth = target.resolveAuthToken();
+  if (refreshedAuth.token === auth.token) return { response, auth };
+  return { response: await request(refreshedAuth), auth: refreshedAuth };
+}
+
+/**
  * POST that reports the daemon's status instead of collapsing it.
  *
  * `postJson` below cannot tell a caller WHY a request failed: 401/403
- * become `null` and every other non-2xx throws. A client that adapts to
- * the daemon's body limit needs the difference, because halving the
- * payload fixes a 413 and does nothing for a refused credential
- * (issue #2303). Transport failures still reject — only HTTP responses
- * are reported.
+ * become `null` and every other non-2xx throws. A client that adapts to the
+ * daemon's body limit needs the difference, because halving the payload fixes
+ * a 413 and does nothing for a refused credential (issue #2303). Transport
+ * failures still reject — only HTTP responses are reported.
  */
 export async function postJsonWithStatus(
   target: DelegateDaemonTarget,
@@ -60,18 +94,15 @@ export async function postJsonWithStatus(
   body: Record<string, unknown>,
   timeoutMs: number,
 ): Promise<DelegateJsonResponse> {
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  const auth = target.resolveAuthToken();
-  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
-  const res = await fetch(daemonUrl(target, pathname), {
+  const { response: res, auth } = await fetchWithAuthRetry(target, pathname, timeoutMs, {
     method: "POST",
-    headers,
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) return noteRefusal(res, serviceId, pathname, auth.source);
   return { status: res.status, body: await readJsonObject(res) };
 }
+
 
 /**
  * Legacy contract kept for every existing delegate route: `null` on an
@@ -91,20 +122,13 @@ export async function postJson(
   }
   return response.body;
 }
-
 export async function getJson(
   target: DelegateDaemonTarget,
   serviceId: string,
   pathname: string,
   timeoutMs: number,
 ): Promise<DelegateJsonResponse> {
-  const headers: Record<string, string> = {};
-  const auth = target.resolveAuthToken();
-  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
-  const res = await fetch(daemonUrl(target, pathname), {
-    headers,
-    signal: AbortSignal.timeout(timeoutMs),
-  });
+  const { response: res, auth } = await fetchWithAuthRetry(target, pathname, timeoutMs);
   if (!res.ok) return noteRefusal(res, serviceId, pathname, auth.source);
   return { status: res.status, body: await readJsonObject(res) };
 }

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -16,6 +16,7 @@ import {
   type MaybeRegisterDelegateDeps,
 } from "./delegate-runtime.js";
 import { loadDaemonAuth, resolveBridgeMode } from "./bridge.js";
+import { getJson } from "./delegate-http.js";
 import { ingestFlushPlanNotes } from "./delegate-flush-plan-ingest.js";
 import {
   SESSION_NAMESPACE_BINDING_MAX_ENTRIES,
@@ -2565,6 +2566,54 @@ test("delegate runtime reloads a rotated daemon token without re-registering hoo
     );
   }
 });
+test("delegate retries a TRIGGER_REAUTHENTICATION response after token rotation", async () => {
+  let currentToken = "stale-token";
+  let attempts = 0;
+  const server = http.createServer((req, res) => {
+    attempts += 1;
+    res.setHeader("content-type", "application/json");
+    if (req.headers.authorization !== "Bearer fresh-token") {
+      currentToken = "fresh-token";
+      res.writeHead(401);
+      res.end(
+        JSON.stringify({
+          error_code: "UNAUTHORIZED",
+          action: "TRIGGER_REAUTHENTICATION",
+        }),
+      );
+      return;
+    }
+    res.end(JSON.stringify({ context: "same-session recovery" }));
+  });
+  const listening = Promise.withResolvers<void>();
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    const response = await getJson(
+      {
+        host: "127.0.0.1",
+        port: address.port,
+        resolveAuthToken: () => ({
+          token: currentToken,
+          source: "OPENCLAW_REMNIC_ACCESS_TOKEN",
+        }),
+      },
+      "reauth-test",
+      "/engram/v1/recall",
+      1_000,
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.body?.context, "same-session recovery");
+    assert.equal(attempts, 2);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
 
 test("delegate daemon auth failures log one sanitized error per route and status", async (t) => {
   const errors: string[] = [];

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -190,6 +190,40 @@ test("checkDaemonHealth returns false when nothing is listening", async () => {
   assert.equal(healthy, false);
 });
 
+test("checkDaemonHealthDetailed classifies auth and network failures separately", async () => {
+  const { checkDaemonHealthDetailed } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
+  const authNames = ["OPENCLAW_REMNIC_ACCESS_TOKEN", "REMNIC_AUTH_TOKEN", "OPENCLAW_ENGRAM_ACCESS_TOKEN", "ENGRAM_AUTH_TOKEN"];
+  const previousAuth = new Map(authNames.map((name) => [name, process.env[name]]));
+  for (const name of authNames) delete process.env[name];
+  process.env.REMNIC_AUTH_TOKEN = "health-test-token";
+  const server = createServer((_req, res) => {
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    assert.deepEqual(await checkDaemonHealthDetailed("127.0.0.1", address.port, PROBE_BUDGET_MS), {
+      ok: false,
+      failure: "auth",
+      status: 401,
+      tokenSource: "REMNIC_AUTH_TOKEN",
+    });
+    assert.deepEqual(await checkDaemonHealthDetailed("127.0.0.1", 49999, PROBE_BUDGET_MS), {
+      ok: false,
+      failure: "network",
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    for (const name of authNames) {
+      const previous = previousAuth.get(name);
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    }
+  }
+});
+
 test("daemon health timeout default exceeds the server diagnostic deadline", async () => {
   const { DEFAULT_DAEMON_HEALTH_TIMEOUT_MS } = await import(
     path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts")


### PR DESCRIPTION
Fixes #2391

## Behavior
- Classify daemon HTTP 401 and 403 responses as authentication failures with the credential source.
- Keep transport failures and other HTTP failures distinct.
- Retry one unauthorized delegate request after excluding the rejected credential, so token rotation does not restart the session.
- Document current and legacy environment variable precedence over token stores and daemon config.

## Verification
- `npm exec --yes pnpm@10.32.1 -- run preflight:quick`
- `npm exec --yes pnpm@10.32.1 -- run test:entity-hardening`
- Focused OpenClaw authentication, health, and token-rotation tests pass.

## Notes
- Added a patch changeset for `@remnic/plugin-openclaw`.
- No production or operator-specific data is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication resolution and delegate HTTP retry behavior for the OpenClaw bridge; scope is limited to credential fallback paths and is covered by new tests, but misclassification could still affect auto/delegate mode selection.
> 
> **Overview**
> OpenClaw delegate mode now **treats daemon 401/403 as auth failures** (with credential source) instead of lumping them with network outages. Sync health probes and `auto` detection surface `failure: "auth" | "http" | "network"` and clearer skip reasons so operators see authentication vs reachability problems.
> 
> **Token rotation without restart:** `DelegateDaemonTarget` gains optional `invalidateAuthToken`; `daemonTargetFor` tracks rejected credentials and `loadDaemonAuth` skips excluded sources so the next resolution can pick a fresher token (e.g. stale env var → `server.authToken` in config). Delegate `getJson`/`postJson` paths retry **once** after HTTP 401 by invalidating and re-resolving. Async `checkDaemonHealthDetailed` mirrors that with a single fallback credential probe.
> 
> Deployment docs now spell out standalone vs OpenClaw delegate token precedence and the post-401 retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a8d4002b8c3a8138e59948915ebe6c5d47a907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->