### PR TITLE
feat(devx): add worktree quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,43 @@ These rules are the default workflow for all agents and contributors.
 
 Reference workflow:
 `docs/ops/pr-review-hardening-playbook.md`
+## Agent / automation contributors
+
+Use `scripts/dev-worktree.sh <worktree-path> <branch> [base]` to create an
+isolated, installed worktree with a core type-check smoke check.
+
+Run pnpm through the pinned package manager:
+
+```bash
+npm exec --yes pnpm@10.32.1 -- <command>
+```
+
+Set command deadlines before you start long checks:
+
+| Command | Timeout |
+| --- | ---: |
+| `npm run preflight:quick` | 900s |
+| `npm run test:entity-hardening` | 900s |
+| Full test suites | 1800s |
+| Builds | 1800s |
+
+Merge with `gh pr merge <number> --squash`. Do not add `--delete-branch` when
+`main` is checked out in another worktree. Delete the remote branch explicitly:
+
+```bash
+git push origin --delete <branch>
+```
+
+When review threads remain, resolve every thread, including outdated threads.
+If `unresolved-review-threads` stays red, dispatch the check-unsticker workflow:
+
+```bash
+gh workflow run check-unsticker.yml
+```
+
+Wait for the guard to run again, then confirm that the current pull request has
+no unresolved threads and all required checks pass.
+
 
 ## CI Review-Gate Scheduling (Read Before Iterating on a PR)
 

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -21,8 +21,14 @@ if [[ $worktree_arg = /* ]]; then
 else
   worktree_path=$PWD/$worktree_arg
 fi
-worktree_path=$(realpath -m -- "$worktree_path")
-
+worktree_parent=$(dirname -- "$worktree_path")
+worktree_name=$(basename -- "$worktree_path")
+if [[ -e $worktree_path || -L $worktree_path ]]; then
+  printf 'Refusing to clobber existing path: %s\n' "$worktree_path" >&2
+  exit 1
+fi
+mkdir -p -- "$worktree_parent"
+worktree_path="$(cd -- "$worktree_parent" && pwd -P)/$worktree_name"
 if [[ -e $worktree_path || -L $worktree_path ]]; then
   printf 'Refusing to clobber existing path: %s\n' "$worktree_path" >&2
   exit 1
@@ -37,11 +43,10 @@ if [[ $base == -* ]] || ! git -C "$repo_root" rev-parse --verify --quiet "$base^
   printf 'Base ref not found: %s\n' "$base" >&2
   exit 1
 fi
-mkdir -p -- "$(dirname -- "$worktree_path")"
 worktree_added=0
 cleanup() {
-  if (( worktree_added )); then
-    git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+  if (( worktree_added )) && git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1; then
+    git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s <worktree-path> <branch> [base]\n' "$(basename "$0")" >&2
+  exit 2
+}
+
+if (( $# < 2 || $# > 3 )); then
+  usage
+fi
+
+worktree_arg=$1
+branch=$2
+base=${3:-HEAD}
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+
+if [[ $worktree_arg = /* ]]; then
+  worktree_path=$worktree_arg
+else
+  worktree_path=$PWD/$worktree_arg
+fi
+worktree_path=$(realpath -m -- "$worktree_path")
+
+if [[ -e $worktree_path || -L $worktree_path ]]; then
+  printf 'Refusing to clobber existing path: %s\n' "$worktree_path" >&2
+  exit 1
+fi
+
+if [[ $branch == -* ]] || ! git -C "$repo_root" check-ref-format --branch "$branch" >/dev/null 2>&1; then
+  printf 'Invalid branch name: %s\n' "$branch" >&2
+  exit 1
+fi
+
+if [[ $base == -* ]] || ! git -C "$repo_root" rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+  printf 'Base ref not found: %s\n' "$base" >&2
+  exit 1
+fi
+mkdir -p -- "$(dirname -- "$worktree_path")"
+worktree_added=0
+cleanup() {
+  if (( worktree_added )); then
+    git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base" "$branch"
+git -C "$repo_root" worktree add -b "$branch" "$worktree_path" "$base"
+worktree_added=1
+
+printf 'Installing packages with pnpm@10.32.1\n'
+if ! (
+  cd -- "$worktree_path"
+  npm exec --yes pnpm@10.32.1 -- install --frozen-lockfile
+); then
+  printf 'Package install failed; removed worktree: %s\n' "$worktree_path" >&2
+  exit 1
+fi
+
+printf 'Running core type-check smoke check\n'
+if ! (
+  cd -- "$worktree_path"
+  npm exec --yes pnpm@10.32.1 -- --filter @remnic/core run check-types
+); then
+  printf 'Smoke check failed; removed worktree: %s\n' "$worktree_path" >&2
+  exit 1
+fi
+
+trap - EXIT
+printf '\nWorktree ready: %s\n' "$worktree_path"
+printf 'Next steps:\n'
+printf '  cd %q\n' "$worktree_path"
+printf '  git status\n'
+printf '  git push -u origin %q\n' "$branch"

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -15,6 +15,21 @@ branch=$2
 base=${3:-HEAD}
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+git_common_dir=$(git -C "$repo_root" rev-parse --git-common-dir)
+if [[ $git_common_dir != /* ]]; then
+  git_common_dir=$repo_root/$git_common_dir
+fi
+git_common_dir=$(cd -- "$git_common_dir" && pwd -P)
+# Serialize helper invocations so ownership checks cannot race another helper.
+lock_path=$git_common_dir/dev-worktree.lock
+if ! mkdir -- "$lock_path" 2>/dev/null; then
+  printf 'Another worktree quickstart is already running for this repository.\n' >&2
+  exit 1
+fi
+release_lock() {
+  rmdir -- "$lock_path" >/dev/null 2>&1 || true
+}
+trap release_lock EXIT
 
 if [[ $worktree_arg = /* ]]; then
   worktree_path=$worktree_arg
@@ -52,6 +67,10 @@ worktree_registered() {
   done < <(git -C "$repo_root" worktree list --porcelain)
   return 1
 }
+if worktree_registered; then
+  printf 'Refusing to clobber registered worktree path: %s\n' "$worktree_path" >&2
+  exit 1
+fi
 
 worktree_owned() {
   local line current_path=
@@ -64,16 +83,35 @@ worktree_owned() {
   return 1
 }
 
+branch_has_worktree() {
+  local line
+  while IFS= read -r line; do
+    if [[ $line == "branch refs/heads/$branch" ]]; then
+      return 0
+    fi
+  done < <(git -C "$repo_root" worktree list --porcelain)
+  return 1
+}
+
 worktree_registered_before=0
 if worktree_registered; then
   worktree_registered_before=1
 fi
-cleanup_armed=1
+branch_existed_before=0
+if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
+  branch_existed_before=1
+fi
 cleanup() {
-  if (( cleanup_armed && ! worktree_registered_before )) && worktree_owned; then
-    git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
-    git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+  if (( ! worktree_registered_before )); then
+    if worktree_owned; then
+      if git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1; then
+        git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+      fi
+    elif (( ! branch_existed_before )) && ! branch_has_worktree; then
+      git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+    fi
   fi
+  release_lock
 }
 trap cleanup EXIT
 
@@ -98,6 +136,7 @@ if ! (
   exit 1
 fi
 
+release_lock
 trap - EXIT
 printf '\nWorktree ready: %s\n' "$worktree_path"
 printf 'Next steps:\n'

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -61,6 +61,11 @@ if [[ -e $worktree_path || -L $worktree_path ]]; then
   printf 'Refusing to clobber existing path: %s\n' "$worktree_path" >&2
   exit 1
 fi
+staging_path=$worktree_path.remnic-setup-$$
+if [[ -e $staging_path || -L $staging_path ]]; then
+  printf 'Temporary setup path already exists: %s\n' "$staging_path" >&2
+  exit 1
+fi
 
 if [[ $branch == -* || $branch == @\{-*\} ]] || ! git -C "$repo_root" check-ref-format --branch "$branch" >/dev/null 2>&1; then
   printf 'Invalid branch name: %s\n' "$branch" >&2
@@ -84,13 +89,13 @@ if worktree_registered; then
   printf 'Refusing to clobber registered worktree path: %s\n' "$worktree_path" >&2
   exit 1
 fi
-
-worktree_owned() {
+worktree_owned_at() {
+  local expected_path=$1
   local line current_path=
   while IFS= read -r line; do
     case $line in
       "worktree "*) current_path=${line#worktree } ;;
-      "branch "*) [[ $current_path == "$worktree_path" && $line == "branch refs/heads/$branch" ]] && return 0 ;;
+      "branch "*) [[ $current_path == "$expected_path" && $line == "branch refs/heads/$branch" ]] && return 0 ;;
     esac
   done < <(git -C "$repo_root" worktree list --porcelain)
   return 1
@@ -122,8 +127,12 @@ if ! git -C "$repo_root" branch "$branch" "$base" >/dev/null; then
 fi
 cleanup() {
   if (( ! worktree_registered_before )); then
-    if worktree_owned; then
+    if worktree_owned_at "$worktree_path"; then
       if git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1; then
+        git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+      fi
+    elif worktree_owned_at "$staging_path"; then
+      if git -C "$repo_root" worktree remove --force "$staging_path" >/dev/null 2>&1; then
         git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
       fi
     elif (( ! branch_existed_before )) && ! branch_has_worktree; then
@@ -135,7 +144,8 @@ cleanup() {
 trap cleanup EXIT
 
 printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base" "$branch"
-git -C "$repo_root" worktree add "$worktree_path" "$branch"
+git -C "$repo_root" worktree add "$staging_path" "$branch"
+git -C "$repo_root" worktree move "$staging_path" "$worktree_path"
 mkdir -p -- "$worktree_path/.claude"
 if [[ -f $repo_root/.claude/napkin.md ]]; then
   cp -- "$repo_root/.claude/napkin.md" "$worktree_path/.claude/napkin.md"

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -11,6 +11,10 @@ if (( $# < 2 || $# > 3 )); then
 fi
 
 worktree_arg=$1
+if [[ $worktree_arg == *$'\n'* || $worktree_arg == *$'\r'* ]]; then
+  printf 'Worktree path cannot contain a line break.\n' >&2
+  exit 1
+fi
 branch=$2
 base=${3:-HEAD}
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
@@ -21,22 +25,24 @@ if [[ $git_common_dir != /* ]]; then
 fi
 git_common_dir=$(cd -- "$git_common_dir" && pwd -P)
 lock_path=$git_common_dir/dev-worktree.lock
-if ! mkdir -- "$lock_path" 2>/dev/null; then
+while ! mkdir -- "$lock_path" 2>/dev/null; do
   owner_pid=
   if [[ -r $lock_path/pid ]]; then
-    IFS= read -r owner_pid <"$lock_path/pid"
+    IFS= read -r owner_pid <"$lock_path/pid" || true
   fi
-  if [[ $owner_pid =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
-    rm -f -- "$lock_path/pid"
-    if ! rmdir -- "$lock_path" || ! mkdir -- "$lock_path" 2>/dev/null; then
-      printf 'Could not reclaim the previous worktree quickstart lock.\n' >&2
-      exit 1
-    fi
-  else
+  if [[ $owner_pid =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
     printf 'Another worktree quickstart is already running for this repository.\n' >&2
     exit 1
   fi
-fi
+  stale_lock_path=$lock_path.stale.$$
+  if ! mv -- "$lock_path" "$stale_lock_path" 2>/dev/null; then
+    continue
+  fi
+  if ! rm -f -- "$stale_lock_path/pid" || ! rmdir -- "$stale_lock_path" 2>/dev/null; then
+    printf 'Could not reclaim the previous worktree quickstart lock.\n' >&2
+    exit 1
+  fi
+done
 printf '%s\n' "$$" >"$lock_path/pid"
 release_lock() {
   rm -f -- "$lock_path/pid"

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -131,17 +131,22 @@ if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
   printf 'Refusing to clobber existing branch: %s\n' "$branch" >&2
   exit 1
 fi
+branch_created=0
 cleanup() {
   if (( ! worktree_registered_before )); then
     if worktree_owned_at "$worktree_path"; then
       if git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1; then
-        git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+        if (( branch_created )); then
+          git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+        fi
       fi
     elif worktree_owned_at "$staging_path"; then
       if git -C "$repo_root" worktree remove --force "$staging_path" >/dev/null 2>&1; then
-        git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+        if (( branch_created )); then
+          git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+        fi
       fi
-    elif (( ! branch_existed_before )) && ! branch_has_worktree; then
+    elif (( branch_created )) && ! branch_has_worktree; then
       git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
     fi
   fi
@@ -152,6 +157,7 @@ if ! git -C "$repo_root" branch "$branch" "$base" >/dev/null; then
   printf 'Could not create branch: %s\n' "$branch" >&2
   exit 1
 fi
+branch_created=1
 
 printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base" "$branch"
 git -C "$repo_root" worktree add "$staging_path" "$branch"

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -36,7 +36,8 @@ while ! mkdir -- "$lock_path" 2>/dev/null; do
   fi
   stale_lock_path=$lock_path.stale.$$
   if ! mv -- "$lock_path" "$stale_lock_path" 2>/dev/null; then
-    continue
+    printf 'Could not reclaim the previous worktree quickstart lock.\n' >&2
+    exit 1
   fi
   if ! rm -f -- "$stale_lock_path/pid" || ! rmdir -- "$stale_lock_path" 2>/dev/null; then
     printf 'Could not reclaim the previous worktree quickstart lock.\n' >&2
@@ -127,10 +128,6 @@ if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
   printf 'Refusing to clobber existing branch: %s\n' "$branch" >&2
   exit 1
 fi
-if ! git -C "$repo_root" branch "$branch" "$base" >/dev/null; then
-  printf 'Could not create branch: %s\n' "$branch" >&2
-  exit 1
-fi
 cleanup() {
   if (( ! worktree_registered_before )); then
     if worktree_owned_at "$worktree_path"; then
@@ -148,6 +145,10 @@ cleanup() {
   release_lock
 }
 trap cleanup EXIT
+if ! git -C "$repo_root" branch "$branch" "$base" >/dev/null; then
+  printf 'Could not create branch: %s\n' "$branch" >&2
+  exit 1
+fi
 
 printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base" "$branch"
 git -C "$repo_root" worktree add "$staging_path" "$branch"

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -43,17 +43,23 @@ if [[ $base == -* ]] || ! git -C "$repo_root" rev-parse --verify --quiet "$base^
   printf 'Base ref not found: %s\n' "$base" >&2
   exit 1
 fi
-worktree_added=0
+branch_existed_before=0
+if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
+  branch_existed_before=1
+fi
+worktree_added=1
 cleanup() {
-  if (( worktree_added )) && git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1; then
-    git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+  if (( worktree_added )); then
+    git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+    if (( ! branch_existed_before )); then
+      git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+    fi
   fi
 }
 trap cleanup EXIT
 
 printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base" "$branch"
 git -C "$repo_root" worktree add -b "$branch" "$worktree_path" "$base"
-worktree_added=1
 
 printf 'Installing packages with pnpm@10.32.1\n'
 if ! (

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -36,6 +36,9 @@ while ! mkdir -- "$lock_path" 2>/dev/null; do
   fi
   stale_lock_path=$lock_path.stale.$$
   if ! mv -- "$lock_path" "$stale_lock_path" 2>/dev/null; then
+    if [[ ! -e $lock_path ]]; then
+      continue
+    fi
     printf 'Could not reclaim the previous worktree quickstart lock.\n' >&2
     exit 1
   fi

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -34,7 +34,7 @@ if [[ -e $worktree_path || -L $worktree_path ]]; then
   exit 1
 fi
 
-if [[ $branch == -* ]] || ! git -C "$repo_root" check-ref-format --branch "$branch" >/dev/null 2>&1; then
+if [[ $branch == -* || $branch == @\{-*\} ]] || ! git -C "$repo_root" check-ref-format --branch "$branch" >/dev/null 2>&1; then
   printf 'Invalid branch name: %s\n' "$branch" >&2
   exit 1
 fi

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -43,17 +43,36 @@ if [[ $base == -* ]] || ! git -C "$repo_root" rev-parse --verify --quiet "$base^
   printf 'Base ref not found: %s\n' "$base" >&2
   exit 1
 fi
-branch_existed_before=0
-if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
-  branch_existed_before=1
-fi
-worktree_added=1
-cleanup() {
-  if (( worktree_added )); then
-    git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
-    if (( ! branch_existed_before )); then
-      git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
+worktree_registered() {
+  local line
+  while IFS= read -r line; do
+    if [[ $line == "worktree $worktree_path" ]]; then
+      return 0
     fi
+  done < <(git -C "$repo_root" worktree list --porcelain)
+  return 1
+}
+
+worktree_owned() {
+  local line current_path=
+  while IFS= read -r line; do
+    case $line in
+      "worktree "*) current_path=${line#worktree } ;;
+      "branch "*) [[ $current_path == "$worktree_path" && $line == "branch refs/heads/$branch" ]] && return 0 ;;
+    esac
+  done < <(git -C "$repo_root" worktree list --porcelain)
+  return 1
+}
+
+worktree_registered_before=0
+if worktree_registered; then
+  worktree_registered_before=1
+fi
+cleanup_armed=1
+cleanup() {
+  if (( cleanup_armed && ! worktree_registered_before )) && worktree_owned; then
+    git -C "$repo_root" worktree remove --force "$worktree_path" >/dev/null 2>&1 || true
+    git -C "$repo_root" branch -D -- "$branch" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -20,13 +20,26 @@ if [[ $git_common_dir != /* ]]; then
   git_common_dir=$repo_root/$git_common_dir
 fi
 git_common_dir=$(cd -- "$git_common_dir" && pwd -P)
-# Serialize helper invocations so ownership checks cannot race another helper.
 lock_path=$git_common_dir/dev-worktree.lock
 if ! mkdir -- "$lock_path" 2>/dev/null; then
-  printf 'Another worktree quickstart is already running for this repository.\n' >&2
-  exit 1
+  owner_pid=
+  if [[ -r $lock_path/pid ]]; then
+    IFS= read -r owner_pid <"$lock_path/pid"
+  fi
+  if [[ $owner_pid =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+    rm -f -- "$lock_path/pid"
+    if ! rmdir -- "$lock_path" || ! mkdir -- "$lock_path" 2>/dev/null; then
+      printf 'Could not reclaim the previous worktree quickstart lock.\n' >&2
+      exit 1
+    fi
+  else
+    printf 'Another worktree quickstart is already running for this repository.\n' >&2
+    exit 1
+  fi
 fi
+printf '%s\n' "$$" >"$lock_path/pid"
 release_lock() {
+  rm -f -- "$lock_path/pid"
   rmdir -- "$lock_path" >/dev/null 2>&1 || true
 }
 trap release_lock EXIT
@@ -100,6 +113,12 @@ fi
 branch_existed_before=0
 if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch"; then
   branch_existed_before=1
+  printf 'Refusing to clobber existing branch: %s\n' "$branch" >&2
+  exit 1
+fi
+if ! git -C "$repo_root" branch "$branch" "$base" >/dev/null; then
+  printf 'Could not create branch: %s\n' "$branch" >&2
+  exit 1
 fi
 cleanup() {
   if (( ! worktree_registered_before )); then
@@ -116,7 +135,26 @@ cleanup() {
 trap cleanup EXIT
 
 printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base" "$branch"
-git -C "$repo_root" worktree add -b "$branch" "$worktree_path" "$base"
+git -C "$repo_root" worktree add "$worktree_path" "$branch"
+mkdir -p -- "$worktree_path/.claude"
+if [[ -f $repo_root/.claude/napkin.md ]]; then
+  cp -- "$repo_root/.claude/napkin.md" "$worktree_path/.claude/napkin.md"
+else
+  printf '%s\n' \
+    '# Napkin' \
+    '' \
+    '## Corrections' \
+    '| Date | Source | What Went Wrong | What To Do Instead |' \
+    '|---|---|---|---|' \
+    '' \
+    '## User Preferences' \
+    '' \
+    '## Patterns That Work' \
+    '' \
+    '## Patterns That Do Not Work' \
+    '' \
+    '## Domain Notes' >"$worktree_path/.claude/napkin.md"
+fi
 
 printf 'Installing packages with pnpm@10.32.1\n'
 if ! (

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -180,3 +180,21 @@ test("rejects an unknown base ref before creating a worktree", () => {
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+test("rejects checkout shorthand branch names", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "checkout-shorthand");
+
+  try {
+    const result = runScript([worktreePath, "@{-1}", "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Invalid branch name/);
+    assert.equal(existsSync(worktreePath), false);
+    assert.equal(existsSync(fixture.log), false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -87,7 +87,7 @@ test("removes the worktree when package installation fails", () => {
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /Package install failed; removed worktree/);
     assert.equal(existsSync(worktreePath), false);
-    assert.equal(spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`]).status, 0);
+    assert.notEqual(spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`]).status, 0);
   } finally {
     cleanupWorktree(worktreePath, branch);
     rmSync(fixture.root, { recursive: true, force: true });

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -183,9 +183,10 @@ test("rejects an unknown base ref before creating a worktree", () => {
 test("rejects checkout shorthand branch names", () => {
   const fixture = createFakeNpm();
   const worktreePath = path.join(fixture.root, "checkout-shorthand");
+  const branch = "@{-1}";
 
   try {
-    const result = runScript([worktreePath, "@{-1}", "HEAD"], {
+    const result = runScript([worktreePath, branch, "HEAD"], {
       DEV_WORKTREE_TEST_LOG: fixture.log,
       PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
     });

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -93,6 +93,32 @@ test("removes the worktree when package installation fails", () => {
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+test("cleans up when worktree creation fails after creating its branch", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "failed-checkout");
+  const branch = `test/dev-worktree-${process.pid}-failed-checkout`;
+  const hooksPath = path.join(fixture.root, "hooks");
+  mkdirSync(hooksPath);
+  const postCheckout = path.join(hooksPath, "post-checkout");
+  writeFileSync(postCheckout, "#!/bin/sh\nexit 7\n");
+  chmodSync(postCheckout, 0o755);
+
+  try {
+    const result = runScript([worktreePath, branch, "HEAD"], {
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.hooksPath",
+      GIT_CONFIG_VALUE_0: hooksPath,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.equal(existsSync(worktreePath), false);
+    assert.notEqual(spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`]).status, 0);
+  } finally {
+    cleanupWorktree(worktreePath, branch);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test("resolves a relative worktree path from the invoking checkout", () => {
   const fixture = createFakeNpm();

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -119,6 +119,32 @@ test("cleans up when worktree creation fails after creating its branch", () => {
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });
+test("refuses a registered worktree whose directory is missing", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "registered-worktree");
+  const existingBranch = `test/dev-worktree-${process.pid}-registered`;
+  const requestedBranch = `test/dev-worktree-${process.pid}-registered-retry`;
+  execFileSync("git", ["-C", repoRoot, "worktree", "add", "-b", existingBranch, worktreePath, "HEAD"]);
+  rmSync(worktreePath, { recursive: true, force: true });
+
+  try {
+    const result = runScript([worktreePath, requestedBranch, "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /registered worktree path/);
+    assert.notEqual(
+      spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${requestedBranch}`]).status,
+      0
+    );
+  } finally {
+    execFileSync("git", ["-C", repoRoot, "worktree", "remove", "--force", worktreePath], { stdio: "ignore" });
+    cleanupWorktree(worktreePath, existingBranch);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
 
 test("resolves a relative worktree path from the invoking checkout", () => {
   const fixture = createFakeNpm();

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -61,6 +61,7 @@ test("creates an installed worktree and runs the smoke check at an absolute path
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(git("-C", worktreePath, "branch", "--show-current"), branch);
+    assert.equal(existsSync(path.join(worktreePath, ".claude", "napkin.md")), true);
     assert.match(result.stdout, /Worktree ready/);
     assert.match(result.stdout, new RegExp(`Next steps[\\s\\S]*${branch}`));
     const calls = readFileSync(fixture.log, "utf8");

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = path.join(repoRoot, "scripts", "dev-worktree.sh");
+
+function git(...args) {
+  return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" }).trim();
+}
+
+function runScript(args, env) {
+  return spawnSync("bash", [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+function createFakeNpm() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "remnic-dev-worktree-npm-"));
+  const bin = path.join(root, "bin");
+  const log = path.join(root, "npm.log");
+  mkdirSync(bin);
+  const npm = path.join(bin, "npm");
+  writeFileSync(
+    npm,
+    String.raw`#!/bin/sh
+printf '%s\n' "$*" >> "$DEV_WORKTREE_TEST_LOG"
+if [ "$*" = "$DEV_WORKTREE_TEST_FAIL_ON" ]; then exit 1; fi
+`
+  );
+  chmodSync(npm, 0o755);
+  return { root, bin, log };
+}
+
+function cleanupWorktree(worktreePath, branch) {
+  if (existsSync(worktreePath)) {
+    execFileSync("git", ["-C", repoRoot, "worktree", "remove", "--force", worktreePath]);
+  }
+  const branchExists = spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`]).status === 0;
+  if (branchExists) {
+    execFileSync("git", ["-C", repoRoot, "branch", "-D", branch], { stdio: "ignore" });
+  }
+}
+
+test("creates an installed worktree and runs the smoke check at an absolute path", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "absolute-worktree");
+  const branch = `test/dev-worktree-${process.pid}-absolute`;
+
+  try {
+    const result = runScript([worktreePath, branch, "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(git("-C", worktreePath, "branch", "--show-current"), branch);
+    assert.match(result.stdout, /Worktree ready/);
+    assert.match(result.stdout, new RegExp(`Next steps[\\s\\S]*${branch}`));
+    const calls = readFileSync(fixture.log, "utf8");
+    assert.match(calls, /exec --yes pnpm@10\.32\.1 -- install --frozen-lockfile/);
+    assert.match(calls, /exec --yes pnpm@10\.32\.1 -- --filter @remnic\/core run check-types/);
+  } finally {
+    cleanupWorktree(worktreePath, branch);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("removes the worktree when package installation fails", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "failed-install");
+  const branch = `test/dev-worktree-${process.pid}-failed-install`;
+
+  try {
+    const result = runScript([worktreePath, branch, "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      DEV_WORKTREE_TEST_FAIL_ON: "exec --yes pnpm@10.32.1 -- install --frozen-lockfile",
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Package install failed; removed worktree/);
+    assert.equal(existsSync(worktreePath), false);
+    assert.equal(spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`]).status, 0);
+  } finally {
+    cleanupWorktree(worktreePath, branch);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("resolves a relative worktree path from the invoking checkout", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "relative-worktree");
+  const relativePath = path.relative(repoRoot, worktreePath);
+  const branch = `test/dev-worktree-${process.pid}-relative`;
+
+  try {
+    const result = runScript([relativePath, branch, "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(existsSync(worktreePath));
+  } finally {
+    cleanupWorktree(worktreePath, branch);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("refuses to clobber an existing worktree path", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "already-there");
+  const branch = `test/dev-worktree-${process.pid}-existing`;
+  writeFileSync(worktreePath, "keep this file\n");
+
+  try {
+    const result = runScript([worktreePath, branch, "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /existing path/);
+    assert.equal(readFileSync(worktreePath, "utf8"), "keep this file\n");
+    assert.equal(existsSync(fixture.log), false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an unknown base ref before creating a worktree", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "invalid-base");
+  const branch = `test/dev-worktree-${process.pid}-invalid-base`;
+
+  try {
+    const result = runScript([worktreePath, branch, "refs/heads/does-not-exist"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /base ref.*not found/i);
+    assert.equal(existsSync(worktreePath), false);
+    assert.equal(existsSync(fixture.log), false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #2407

## Behavior
- Adds `scripts/dev-worktree.sh <worktree-path> <branch> [base]`.
- Resolves relative and absolute paths, validates branch and base refs, and refuses existing paths.
- Installs packages with the pinned pnpm runner, runs the core type-check smoke check, and removes the worktree on setup failure.
- Adds one Agent / automation contributors section with runner, timeout, merge, and review-thread recovery guidance.

## Verification
- `node --test tests/dev-worktree-script.test.mjs`
- `npm exec --yes pnpm@10.32.1 -- exec biome check tests/dev-worktree-script.test.mjs`
- `npm exec --yes pnpm@10.32.1 -- run preflight:quick`
- Real end-to-end run from the repository root created an installed worktree and passed `@remnic/core` check-types.

## Notes
- No changeset added because this change only updates contributor tooling, tests, and repository guidance; no published package changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor-only tooling and documentation; no runtime or published package behavior changes.
> 
> **Overview**
> Adds **`scripts/dev-worktree.sh`** so agents and automation can spin up an isolated git worktree on a new branch, install deps with pinned **pnpm@10.32.1**, run **`@remnic/core` check-types**, and tear down on failure. The script serializes runs with a repo lock, validates branch/base refs, refuses clobbering existing paths or branches, seeds **`.claude/napkin.md`**, and prints next-step push hints.
> 
> **`AGENTS.md`** gains an **Agent / automation contributors** section covering the worktree helper, pnpm invocation, check timeouts, squash merge without **`--delete-branch`**, explicit remote branch deletion, and **`check-unsticker`** when review threads stay unresolved.
> 
> **`tests/dev-worktree-script.test.mjs`** exercises success, install/checkout failures, registered missing worktrees, relative paths, and invalid inputs via a fake **`npm`** shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1440692144f1d81aa92e094cb091e7bb89f3fcc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development utility for creating isolated Git worktrees, installing dependencies, and running type checks.
  * Provides clear setup instructions and safely cleans up resources if setup fails.

* **Documentation**
  * Added guidance for automation contributors covering worktree setup, command execution, pull request merging, branch cleanup, and review workflows.

* **Tests**
  * Added coverage for successful setup, invalid inputs, existing paths, unknown revisions, and cleanup after installation or checkout failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->