### PR TITLE
feat(devx): add settled PR wait command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ These rules are the default workflow for all agents and contributors.
 5. Treat external AI review as stale unless it matches the current head.
    - Do not call a PR clean if the latest positive AI verdict targets an older commit.
    - A merge-ready PR needs green checks, zero unresolved review threads, and a fresh positive AI verdict on the current head.
+   - Use `scripts/pr-wait-settled.sh <pr-number>` to block until the current head has terminal required checks, current reviewer results, and zero unresolved threads.
 
 Reference workflow:
 `docs/ops/pr-review-hardening-playbook.md`

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -128,13 +128,17 @@ fetch_and_evaluate() {
     API_ERRORS+=("checks")
     append_item "api:checks"
   else
+    declare -A CHECK_STATES=()
     while IFS=$'\t' read -r check_name check_state; do
       [[ -n "$check_name" ]] || continue
-      case "${check_state^^}" in
-        SUCCESS|NEUTRAL|SKIPPED) ;;
-        *) append_item "check:${check_name}(${check_state:-unknown})" ;;
-      esac
+      CHECK_STATES["$check_name"]="${check_state^^}"
     done < <(jq -r '.[] | [.name, (.state // "unknown")] | @tsv' <<< "$checks_raw")
+    for check_name in "${!CHECK_STATES[@]}"; do
+      case "${CHECK_STATES[$check_name]}" in
+        SUCCESS|NEUTRAL|SKIPPED) ;;
+        *) append_item "check:${check_name}(${CHECK_STATES[$check_name]})" ;;
+      esac
+    done
   fi
 
   if ! reviews_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --jq '.[] | [.user.login, (.commit_id // "")] | @tsv' 2>/dev/null); then

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -100,6 +100,12 @@ is_current_sha() {
   [[ -n "$commit" && ( "$HEAD_SHA" == "$commit"* || "$commit" == "$HEAD_SHA"* ) ]]
 }
 
+is_fresh_reaction() {
+  local created_at="$1"
+  [[ -n "${HEAD_VISIBLE_AT:-}" && -n "$created_at" &&
+    ( "$created_at" == "$HEAD_VISIBLE_AT" || "$created_at" > "$HEAD_VISIBLE_AT" ) ]]
+}
+
 record_reviewer() {
   local login="$1"
   local group
@@ -114,15 +120,21 @@ fetch_and_evaluate() {
   OUTSTANDING=()
   declare -A REVIEWER_PRESENT=()
   API_ERRORS=()
-  LEDGER_COMPLETE=false
-  HEAD_SHA=""
+  HEAD_VISIBLE_AT=""
+  SKIP_CURSOR=false
   if ! HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null); then
     API_ERRORS+=("head")
     append_item "api:head"
     return
   fi
+  local pr_meta
+  if pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,files 2>/dev/null); then
+    if [[ "$(jq -r 'if (.author.login == "dependabot[bot]" and (.files | length) > 0 and all(.files[]; (.path // "" | split("/")[-1]) as $base | ["package.json", "package-lock.json", "pnpm-lock.yaml", "requirements.txt"] | index($base) != null)) then "true" else "false" end' <<< "$pr_meta")" == true ]]; then
+      SKIP_CURSOR=true
+    fi
+  fi
 
-  local checks_raw reviews_raw comments_raw issue_comments_raw check_runs_raw
+  local checks_raw reviews_raw issue_comments_raw check_runs_raw
   checks_raw="$(gh pr checks "$PR_NUMBER" --repo "$REPO" --required --json name,state 2>/dev/null || true)"
   if [[ -z "$checks_raw" ]]; then
     API_ERRORS+=("checks")
@@ -131,32 +143,32 @@ fetch_and_evaluate() {
     declare -A CHECK_STATES=()
     while IFS=$'\t' read -r check_name check_state; do
       [[ -n "$check_name" ]] || continue
-      CHECK_STATES["$check_name"]="${check_state^^}"
+      CHECK_STATES["$check_name"]+="${check_state^^}"$'\n'
     done < <(jq -r '.[] | [.name, (.state // "unknown")] | @tsv' <<< "$checks_raw")
     for check_name in "${!CHECK_STATES[@]}"; do
-      case "${CHECK_STATES[$check_name]}" in
-        SUCCESS|NEUTRAL|SKIPPED) ;;
-        *) append_item "check:${check_name}(${CHECK_STATES[$check_name]})" ;;
-      esac
+      local has_pass=false first_state=""
+      while IFS= read -r check_state; do
+        [[ -n "$first_state" ]] || first_state="$check_state"
+        case "$check_state" in
+          SUCCESS|NEUTRAL|SKIPPED) has_pass=true ;;
+        esac
+      done <<< "${CHECK_STATES[$check_name]}"
+      [[ "$has_pass" == true ]] || append_item "check:${check_name}(${first_state})"
     done
   fi
 
-  if ! reviews_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --jq '.[] | [.user.login, (.commit_id // "")] | @tsv' 2>/dev/null); then
+  if ! reviews_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --jq '.[] | [.user.login, (.commit_id // ""), (.state // ""), (.body // "" | gsub("[\r\n\t]"; " "))] | @tsv' 2>/dev/null); then
     API_ERRORS+=("reviews")
     append_item "api:reviews"
   else
-    while IFS=$'\t' read -r login commit; do
-      is_current_sha "$commit" && record_reviewer "$login"
+    while IFS=$'\t' read -r login commit state body; do
+      if is_current_sha "$commit" &&
+        [[ "$state" == "APPROVED" ||
+          ( "$state" == "COMMENTED" &&
+            "$body" =~ [Nn]o[[:space:]]+(major[[:space:]]+)?issues|[Aa]pproved|[Ll]ooks[[:space:]]+good ) ]]; then
+        record_reviewer "$login"
+      fi
     done <<< "$reviews_raw"
-  fi
-
-  if ! comments_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, (.commit_id // "")] | @tsv' 2>/dev/null); then
-    API_ERRORS+=("review-comments")
-    append_item "api:review-comments"
-  else
-    while IFS=$'\t' read -r login commit; do
-      is_current_sha "$commit" && record_reviewer "$login"
-    done <<< "$comments_raw"
   fi
 
   if ! issue_comments_raw=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, (.body // "" | gsub("[\r\n\t]"; " "))] | @tsv' 2>/dev/null); then
@@ -164,20 +176,31 @@ fetch_and_evaluate() {
     append_item "api:issue-comments"
   else
     while IFS=$'\t' read -r login body; do
-      if [[ "$login" == "github-actions[bot]" || "$login" == "github-actions" ]] &&
-        [[ "$body" == *"remnic-review-round:v1"* &&
-          "$body" == *"\"headSha\":\"${HEAD_SHA}\""* &&
-          "$body" == *"\"status\":\"closed\""* &&
-          "$body" == *"\"closeReason\":\"round-complete\""* ]]; then
-        LEDGER_COMPLETE=true
-      fi
-      if [[ "$login" == "chatgpt-codex-connector[bot]" || "$login" == "chatgpt-codex-connector" ]]; then
-        if [[ "$body" =~ [Rr]eviewed[[:space:]]+commit[^[:xdigit:]]+([[:xdigit:]]{7,40}) ]] &&
-          is_current_sha "${BASH_REMATCH[1]}"; then
-          record_reviewer "$login"
-        fi
+      if [[ "$login" == "chatgpt-codex-connector[bot]" || "$login" == "chatgpt-codex-connector" ]] &&
+        [[ "$body" =~ [Rr]eviewed[[:space:]]+commit[^[:xdigit:]]+([[:xdigit:]]{7,40}) ]] &&
+        is_current_sha "${BASH_REMATCH[1]}" &&
+        [[ "$body" =~ [Dd]idn.t[[:space:]]+find|[Nn]o[[:space:]]+(major[[:space:]]+)?issues|[Aa]pproved|[Ll]ooks[[:space:]]+good ]]; then
+        record_reviewer "$login"
       fi
     done <<< "$issue_comments_raw"
+  fi
+  local check_suite_times reaction_raw
+  if check_suite_times=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-suites" --paginate --jq '.check_suites[] | (.created_at // "")' 2>/dev/null); then
+    while IFS= read -r created_at; do
+      [[ -n "$created_at" ]] || continue
+      if [[ -z "$HEAD_VISIBLE_AT" || "$created_at" < "$HEAD_VISIBLE_AT" ]]; then
+        HEAD_VISIBLE_AT="$created_at"
+      fi
+    done <<< "$check_suite_times"
+  fi
+  if reaction_raw=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/reactions" --paginate --jq '.[] | [.user.login, .content, (.created_at // "")] | @tsv' 2>/dev/null); then
+    while IFS=$'\t' read -r login content created_at; do
+      if [[ "$login" == "chatgpt-codex-connector[bot]" || "$login" == "chatgpt-codex-connector" ]] &&
+        [[ "$content" =~ ^(\+1|heart|hooray|rocket)$ ]] &&
+        is_fresh_reaction "$created_at"; then
+        record_reviewer "$login"
+      fi
+    done <<< "$reaction_raw"
   fi
   if ! check_runs_raw=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs[] | [.name, (.app.slug // ""), (.status // ""), (.conclusion // ""), (.head_sha // "")] | @tsv' 2>/dev/null); then
     API_ERRORS+=("check-runs")
@@ -186,8 +209,9 @@ fetch_and_evaluate() {
     while IFS=$'\t' read -r check_name app_slug run_status conclusion run_sha; do
       [[ "$run_sha" == "$HEAD_SHA" ]] || continue
       [[ "$run_status" == "completed" ]] || continue
-      [[ -n "$conclusion" ]] || continue
-      record_reviewer "$app_slug"
+      case "$conclusion" in
+        success|neutral|skipped) record_reviewer "$app_slug" ;;
+      esac
     done <<< "$check_runs_raw"
   fi
 
@@ -199,17 +223,21 @@ fetch_and_evaluate() {
   fi
 
   local group
-  if [[ "$LEDGER_COMPLETE" != true ]]; then
-    for group in "${REVIEWER_GROUPS[@]}"; do
-      [[ "${REVIEWER_PRESENT[$group]:-0}" == 1 ]] || append_item "reviewer:${group%%|*}"
-    done
-  fi
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    [[ "$SKIP_CURSOR" == true && "$group" == "${REVIEWER_GROUPS[0]}" ]] && continue
+    [[ "${REVIEWER_PRESENT[$group]:-0}" == 1 ]] || append_item "reviewer:${group%%|*}"
+  done
 }
 
 start_time="$(date +%s.%N)"
 while true; do
   fetch_and_evaluate
   if [[ ${#OUTSTANDING[@]} -eq 0 ]]; then
+    latest_head=""
+    if ! latest_head=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null) ||
+      [[ "$latest_head" != "$HEAD_SHA" ]]; then
+      continue
+    fi
     if [[ "$JSON_OUTPUT" == true ]]; then
       json_summary settled "$HEAD_SHA" '[]'
     else

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -176,11 +176,14 @@ fetch_and_evaluate() {
     append_item "api:issue-comments"
   else
     while IFS=$'\t' read -r login body; do
-      if [[ "$login" == "chatgpt-codex-connector[bot]" || "$login" == "chatgpt-codex-connector" ]] &&
-        [[ "$body" =~ [Rr]eviewed[[:space:]]+commit[^[:xdigit:]]+([[:xdigit:]]{7,40}) ]] &&
+      if [[ "$body" =~ [Rr]eviewed[[:space:]]+commit[^[:xdigit:]]+([[:xdigit:]]{7,40}) ]] &&
         is_current_sha "${BASH_REMATCH[1]}" &&
         [[ "$body" =~ [Dd]idn.t[[:space:]]+find|[Nn]o[[:space:]]+(major[[:space:]]+)?issues|[Aa]pproved|[Ll]ooks[[:space:]]+good ]]; then
-        record_reviewer "$login"
+        case "$login" in
+          cursor[bot]|cursor-bugbot[bot]|cursor|cursor-bugbot|chatgpt-codex-connector[bot]|chatgpt-codex-connector)
+            record_reviewer "$login"
+            ;;
+        esac
       fi
     done <<< "$issue_comments_raw"
   fi
@@ -210,7 +213,7 @@ fetch_and_evaluate() {
       [[ "$run_sha" == "$HEAD_SHA" ]] || continue
       [[ "$run_status" == "completed" ]] || continue
       case "$conclusion" in
-        success|neutral|skipped) record_reviewer "$app_slug" ;;
+        success|neutral) record_reviewer "$app_slug" ;;
       esac
     done <<< "$check_runs_raw"
   fi

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait for a PR head to finish all checks, reviewer activity, and review threads.
+# Reviewer aliases mirror .github/workflows/review-round-dispatch.yml.
+PR_NUMBER=""
+TIMEOUT=1800
+INTERVAL=30
+JSON_OUTPUT=false
+REPO="${REMNIC_REPO:-joshuaswarren/remnic}"
+
+usage() {
+  printf 'Usage: scripts/pr-wait-settled.sh <pr-number> [--timeout S] [--interval S] [--json]\n' >&2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+PR_NUMBER="$1"
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout|--interval)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      [[ "$2" =~ ^[0-9]+([.][0-9]+)?$ ]] || { printf 'Invalid %s value: %s\n' "$1" "$2" >&2; exit 2; }
+      if [[ "$1" == "--timeout" ]]; then TIMEOUT="$2"; else INTERVAL="$2"; fi
+      shift 2
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+# These groups are the aliases configured by review-round-dispatch.yml. Kilo is
+# not listed because this repository has no Kilo workflow or required group.
+REVIEWER_GROUPS=(
+  'cursor-bugbot[bot]|cursor[bot]|cursor-bugbot|cursor'
+  'coderabbitai[bot]|coderabbitai'
+  'chatgpt-codex-connector[bot]|chatgpt-codex-connector'
+)
+
+REVIEW_THREADS_QUERY='query($owner: String!, $name: String!, $pr: Int!, $after: String = null) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved }
+      }
+    }
+  }
+}'
+
+json_summary() {
+  local status="$1" head="$2" outstanding_json="$3"
+  jq -cn --arg status "$status" --arg head "$head" --argjson outstanding "$outstanding_json" \
+    '{status: $status, head: $head, outstanding: $outstanding}'
+}
+
+append_item() {
+  OUTSTANDING+=("$1")
+}
+
+fetch_threads() {
+  local after="" page total unresolved has_next end_cursor
+  THREAD_TOTAL=0
+  THREAD_UNRESOLVED=0
+  while true; do
+    local args=(api graphql -f query="$REVIEW_THREADS_QUERY" -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER")
+    [[ -n "$after" ]] && args+=(-f after="$after")
+    if ! page=$(gh "${args[@]}" --jq '.data.repository.pullRequest.reviewThreads as $threads | [($threads.totalCount // 0), ([($threads.nodes // [])[] | select(.isResolved == false)] | length), ($threads.pageInfo.hasNextPage // false), ($threads.pageInfo.endCursor // "")] | @tsv' 2>/dev/null); then
+      return 1
+    fi
+    if [[ "$page" != *$'\n'* ]]; then
+      IFS=$'\t' read -r total unresolved has_next end_cursor <<< "$page"
+      if [[ "$total" =~ ^[0-9]+$ && "$unresolved" =~ ^[0-9]+$ && "$has_next" =~ ^(true|false)$ ]]; then
+        [[ "$THREAD_TOTAL" -gt 0 ]] || THREAD_TOTAL="$total"
+        THREAD_UNRESOLVED=$((THREAD_UNRESOLVED + unresolved))
+        [[ "$has_next" == "true" ]] || return 0
+        [[ -n "$end_cursor" && "$end_cursor" != "$after" ]] || return 1
+        after="$end_cursor"
+        continue
+      fi
+    fi
+    return 1
+  done
+}
+
+is_current_sha() {
+  local commit="$1"
+  [[ -n "$commit" && ( "$HEAD_SHA" == "$commit"* || "$commit" == "$HEAD_SHA"* ) ]]
+}
+
+record_reviewer() {
+  local login="$1"
+  local group
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    case "|${group}|" in
+      *"|${login}|"*) REVIEWER_PRESENT["$group"]=1; return 0 ;;
+    esac
+  done
+}
+
+fetch_and_evaluate() {
+  OUTSTANDING=()
+  declare -A REVIEWER_PRESENT=()
+  API_ERRORS=()
+  LEDGER_COMPLETE=false
+  HEAD_SHA=""
+  if ! HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null); then
+    API_ERRORS+=("head")
+    append_item "api:head"
+    return
+  fi
+
+  local checks_raw reviews_raw comments_raw issue_comments_raw check_runs_raw
+  checks_raw="$(gh pr checks "$PR_NUMBER" --repo "$REPO" --required --json name,state 2>/dev/null || true)"
+  if [[ -z "$checks_raw" ]]; then
+    API_ERRORS+=("checks")
+    append_item "api:checks"
+  else
+    while IFS=$'\t' read -r check_name check_state; do
+      [[ -n "$check_name" ]] || continue
+      case "${check_state^^}" in
+        SUCCESS|NEUTRAL|SKIPPED) ;;
+        *) append_item "check:${check_name}(${check_state:-unknown})" ;;
+      esac
+    done < <(jq -r '.[] | [.name, (.state // "unknown")] | @tsv' <<< "$checks_raw")
+  fi
+
+  if ! reviews_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --jq '.[] | [.user.login, (.commit_id // "")] | @tsv' 2>/dev/null); then
+    API_ERRORS+=("reviews")
+    append_item "api:reviews"
+  else
+    while IFS=$'\t' read -r login commit; do
+      is_current_sha "$commit" && record_reviewer "$login"
+    done <<< "$reviews_raw"
+  fi
+
+  if ! comments_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, (.commit_id // "")] | @tsv' 2>/dev/null); then
+    API_ERRORS+=("review-comments")
+    append_item "api:review-comments"
+  else
+    while IFS=$'\t' read -r login commit; do
+      is_current_sha "$commit" && record_reviewer "$login"
+    done <<< "$comments_raw"
+  fi
+
+  if ! issue_comments_raw=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, (.body // "" | gsub("[\r\n\t]"; " "))] | @tsv' 2>/dev/null); then
+    API_ERRORS+=("issue-comments")
+    append_item "api:issue-comments"
+  else
+    while IFS=$'\t' read -r login body; do
+      if [[ "$login" == "github-actions[bot]" || "$login" == "github-actions" ]] &&
+        [[ "$body" == *"remnic-review-round:v1"* &&
+          "$body" == *"\"headSha\":\"${HEAD_SHA}\""* &&
+          "$body" == *"\"status\":\"closed\""* &&
+          "$body" == *"\"closeReason\":\"round-complete\""* ]]; then
+        LEDGER_COMPLETE=true
+      fi
+      if [[ "$login" == "chatgpt-codex-connector[bot]" || "$login" == "chatgpt-codex-connector" ]]; then
+        if [[ "$body" =~ [Rr]eviewed[[:space:]]+commit[^[:xdigit:]]+([[:xdigit:]]{7,40}) ]] &&
+          is_current_sha "${BASH_REMATCH[1]}"; then
+          record_reviewer "$login"
+        fi
+      fi
+    done <<< "$issue_comments_raw"
+  fi
+  if ! check_runs_raw=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs[] | [.name, (.app.slug // ""), (.status // ""), (.conclusion // ""), (.head_sha // "")] | @tsv' 2>/dev/null); then
+    API_ERRORS+=("check-runs")
+    append_item "api:check-runs"
+  else
+    while IFS=$'\t' read -r check_name app_slug run_status conclusion run_sha; do
+      [[ "$run_sha" == "$HEAD_SHA" ]] || continue
+      [[ "$run_status" == "completed" ]] || continue
+      [[ -n "$conclusion" ]] || continue
+      record_reviewer "$app_slug"
+    done <<< "$check_runs_raw"
+  fi
+
+  if ! fetch_threads; then
+    API_ERRORS+=("review-threads")
+    append_item "api:review-threads"
+  elif [[ "$THREAD_UNRESOLVED" -gt 0 ]]; then
+    append_item "review-threads:${THREAD_UNRESOLVED}-unresolved"
+  fi
+
+  local group
+  if [[ "$LEDGER_COMPLETE" != true ]]; then
+    for group in "${REVIEWER_GROUPS[@]}"; do
+      [[ "${REVIEWER_PRESENT[$group]:-0}" == 1 ]] || append_item "reviewer:${group%%|*}"
+    done
+  fi
+}
+
+start_time="$(date +%s.%N)"
+while true; do
+  fetch_and_evaluate
+  if [[ ${#OUTSTANDING[@]} -eq 0 ]]; then
+    if [[ "$JSON_OUTPUT" == true ]]; then
+      json_summary settled "$HEAD_SHA" '[]'
+    else
+      printf 'settled: PR #%s head %s; checks terminal, reviewers reported, 0 unresolved threads\n' "$PR_NUMBER" "$HEAD_SHA"
+    fi
+    exit 0
+  fi
+
+  now="$(date +%s.%N)"
+  elapsed="$(awk -v now="$now" -v start="$start_time" 'BEGIN { print now - start }')"
+  if awk -v elapsed="$elapsed" -v timeout="$TIMEOUT" 'BEGIN { exit !(elapsed >= timeout) }'; then
+    outstanding_json="$(printf '%s\n' "${OUTSTANDING[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+    json_summary timeout "$HEAD_SHA" "$outstanding_json"
+    exit 1
+  fi
+  sleep "$INTERVAL"
+done

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -32,6 +32,7 @@ if [[ "$1 $2" == "pr checks" ]]; then
       printf '[{"name":"ci","state":"PENDING"},{"name":"ai-reviewers","state":"SUCCESS"}]\\n'
       exit 8
       ;;
+    superseded-neutral) printf '[{"name":"ci","state":"SUCCESS"},{"name":"ai-reviewers","state":"CANCELLED"},{"name":"ai-reviewers","state":"NEUTRAL"}]\\n' ;;
     *) printf '[{"name":"ci","state":"SUCCESS"},{"name":"ai-reviewers","state":"NEUTRAL"}]\\n' ;;
   esac
   exit 0
@@ -96,7 +97,7 @@ function runWait(env, args) {
 test("wait settles a fully reviewed PR", async () => {
   await withGhStub("green", async (env) => {
     const result = runWait(env, ["--timeout", "0", "--interval", "0", "--json"]);
-    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
     const summary = JSON.parse(result.stdout);
     assert.equal(summary.head, headSha);
     assert.deepEqual(summary.outstanding, []);

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -79,9 +79,11 @@ if [[ "$1 $2" == "api repos/example/repo/issues/7/comments" ]]; then
   exit 0
 fi
 if [[ "$1 $2" == "api repos/example/repo/commits/${headSha}/check-runs" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == skipped-reviewer ]]; then
+    printf 'Cursor Bugbot\\tcursor\\tcompleted\\tskipped\\t%s\\n' '${headSha}'
+  fi
   exit 0
 fi
-echo "unexpected gh invocation: $*" >&2
 exit 2
 `
   );
@@ -157,5 +159,13 @@ test("wait accepts a fresh Codex positive reaction", async () => {
   await withGhStub("codex-reaction", async (env) => {
     const result = runWait(env, ["--timeout", "0", "--json"]);
     assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("wait does not count a skipped reviewer check", async () => {
+  await withGhStub("skipped-reviewer", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--json"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /cursor-bugbot/);
   });
 });

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -23,7 +23,11 @@ count=$((count + 1))
 printf '%s\\n' "$count" > "$GH_STUB_COUNT"
 
 if [[ "$1 $2" == "pr view" ]]; then
-  printf '%s\\n' '${headSha}'
+  if [[ "$*" == *"author,files"* ]]; then
+    printf '{"author":{"login":"someone"},"files":[{"path":"src/main.ts"}]}\\n'
+  else
+    printf '%s\\n' '${headSha}'
+  fi
   exit 0
 fi
 if [[ "$1 $2" == "pr checks" ]]; then
@@ -43,10 +47,12 @@ if [[ "$1 $2" == "api graphql" ]]; then
 fi
 if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
   case "$GH_STUB_SCENARIO" in
-    green|superseded-neutral)
+    green|superseded-neutral|codex-reaction)
       printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
-      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      if [[ "$GH_STUB_SCENARIO" != codex-reaction ]]; then
+        printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      fi
       ;;
     missing-bot)
       printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
@@ -57,10 +63,19 @@ fi
 if [[ "$1 $2" == "api repos/example/repo/pulls/7/comments" ]]; then
   exit 0
 fi
-if [[ "$1 $2" == "api repos/example/repo/issues/7/comments" ]]; then
-  if [[ "$GH_STUB_SCENARIO" == round-ledger ]]; then
-    printf 'github-actions[bot]\\t<!-- remnic-review-round:v1 {\"headSha\":\"${headSha}\",\"status\":\"closed\",\"closeReason\":\"round-complete\"} -->\\n'
+if [[ "$1 $2" == "api repos/example/repo/commits/${headSha}/check-suites" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == codex-reaction ]]; then
+    printf '2026-06-01T00:00:00Z\\n'
   fi
+  exit 0
+fi
+if [[ "$1 $2" == "api repos/example/repo/issues/7/reactions" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == codex-reaction ]]; then
+    printf 'chatgpt-codex-connector[bot]\\t+1\\t2026-06-02T00:00:00Z\\n'
+  fi
+  exit 0
+fi
+if [[ "$1 $2" == "api repos/example/repo/issues/7/comments" ]]; then
   exit 0
 fi
 if [[ "$1 $2" == "api repos/example/repo/commits/${headSha}/check-runs" ]]; then
@@ -138,8 +153,8 @@ test("wait accepts a superseded neutral ai-reviewers check", async () => {
   });
 });
 
-test("wait accepts a completed current-head round ledger", async () => {
-  await withGhStub("round-ledger", async (env) => {
+test("wait accepts a fresh Codex positive reaction", async () => {
+  await withGhStub("codex-reaction", async (env) => {
     const result = runWait(env, ["--timeout", "0", "--json"]);
     assert.equal(result.status, 0, result.stderr);
   });

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "pr-wait-settled.sh");
+const headSha = "deadbeef1234567890abcdef1234567890abcdef";
+
+async function withGhStub(scenario, fn) {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "remnic-pr-wait-"));
+  const binDir = path.join(tmp, "bin");
+  const countPath = path.join(tmp, "count");
+  await mkdir(binDir);
+  await writeFile(
+    path.join(binDir, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+count="$(cat "$GH_STUB_COUNT" 2>/dev/null || echo 0)"
+count=$((count + 1))
+printf '%s\\n' "$count" > "$GH_STUB_COUNT"
+
+if [[ "$1 $2" == "pr view" ]]; then
+  printf '%s\\n' '${headSha}'
+  exit 0
+fi
+if [[ "$1 $2" == "pr checks" ]]; then
+  case "$GH_STUB_SCENARIO" in
+    pending-check)
+      printf '[{"name":"ci","state":"PENDING"},{"name":"ai-reviewers","state":"SUCCESS"}]\\n'
+      exit 8
+      ;;
+    *) printf '[{"name":"ci","state":"SUCCESS"},{"name":"ai-reviewers","state":"NEUTRAL"}]\\n' ;;
+  esac
+  exit 0
+fi
+if [[ "$1 $2" == "api graphql" ]]; then
+  printf '2\\t%s\\tfalse\\t\\n' "$([[ "$GH_STUB_SCENARIO" == unresolved-thread ]] && echo 1 || echo 0)"
+  exit 0
+fi
+if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
+  case "$GH_STUB_SCENARIO" in
+    green|superseded-neutral)
+      printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
+    missing-bot)
+      printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
+  esac
+  exit 0
+fi
+if [[ "$1 $2" == "api repos/example/repo/pulls/7/comments" ]]; then
+  exit 0
+fi
+if [[ "$1 $2" == "api repos/example/repo/issues/7/comments" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == round-ledger ]]; then
+    printf 'github-actions[bot]\\t<!-- remnic-review-round:v1 {\"headSha\":\"${headSha}\",\"status\":\"closed\",\"closeReason\":\"round-complete\"} -->\\n'
+  fi
+  exit 0
+fi
+if [[ "$1 $2" == "api repos/example/repo/commits/${headSha}/check-runs" ]]; then
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 2
+`
+  );
+  await chmod(path.join(binDir, "gh"), 0o755);
+  const env = {
+    ...process.env,
+    GH_STUB_COUNT: countPath,
+    GH_STUB_SCENARIO: scenario,
+    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    REMNIC_REPO: "example/repo",
+  };
+  try {
+    await fn(env);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+function runWait(env, args) {
+  return spawnSync("bash", [scriptPath, "7", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+}
+
+test("wait settles a fully reviewed PR", async () => {
+  await withGhStub("green", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0", "--json"]);
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.head, headSha);
+    assert.deepEqual(summary.outstanding, []);
+  });
+});
+
+test("wait reports a pending check after the timeout", async () => {
+  await withGhStub("pending-check", async (env) => {
+    const result = runWait(env, ["--timeout", "0.1", "--interval", "0.05"]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /ci/);
+  });
+});
+
+test("wait reports a reviewer missing on the current head", async () => {
+  await withGhStub("missing-bot", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--json"]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /coderabbit|codex/i);
+  });
+});
+
+test("wait reports unresolved review threads", async () => {
+  await withGhStub("unresolved-thread", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--json"]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /thread/i);
+  });
+});
+
+test("wait accepts a superseded neutral ai-reviewers check", async () => {
+  await withGhStub("superseded-neutral", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--json"]);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("wait accepts a completed current-head round ledger", async () => {
+  await withGhStub("round-ledger", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--json"]);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});


### PR DESCRIPTION
Fixes #2410

## Behavior
- Add scripts/pr-wait-settled.sh with timeout, interval, and JSON options.
- Track the current head SHA, required checks, positive reviewer results, and unresolved threads.
- Ignore expected superseded duplicate ai-reviewers runs when a positive terminal result exists.
- Accept current-head Codex positive reactions with head-visibility freshness checks.
- Honor the documented Dependabot manifest-only Cursor exception.
- Report outstanding items as one JSON line on timeout.

## Verification
- node --test tests/pr-wait-settled.test.mjs
- npm exec --yes pnpm@10.32.1 -- exec biome check tests/pr-wait-settled.test.mjs
- npm exec --yes pnpm@10.32.1 -- run preflight:quick
- bash -n scripts/pr-wait-settled.sh

## Notes
- Shellcheck was not available in the local environment.
- The repository has no Kilo required reviewer group, so Kilo is not part of the reviewer evidence list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DevX-only shell script and tests with no runtime, auth, or data-path changes; risk is limited to incorrect merge-readiness heuristics if GitHub API behavior diverges from assumptions.
> 
> **Overview**
> Adds **`scripts/pr-wait-settled.sh`**, a polling helper that blocks until a PR’s **current head** looks merge-ready: required checks are terminal, configured AI reviewers have positive evidence on that head, and review threads are resolved. It supports **`--timeout`**, **`--interval`**, and **`--json`** (one JSON line on success or timeout listing outstanding items).
> 
> The script encodes repo-specific review policy: reviewer groups aligned with **`review-round-dispatch.yml`**, treating duplicate **`ai-reviewers`** runs as OK when any run is SUCCESS/NEUTRAL/SKIPPED, accepting Codex **reactions** only after head-visibility timing, skipping Cursor for Dependabot manifest-only PRs, and re-checking head SHA before declaring settled.
> 
> **`AGENTS.md`** now points agents at this script for the “fresh head + green + threads” gate. **`tests/pr-wait-settled.test.mjs`** exercises the script with a stubbed **`gh`** (green path, pending checks, missing reviewers, unresolved threads, superseded neutral checks, Codex reactions, skipped reviewer check-runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238f59499550e9b01ab27447ac194bc9ea664cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->