### PR TITLE
perf(preflight): check only affected packages in quick mode

### DIFF
--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -97,7 +97,7 @@ quick_package_scope() {
     scope_all=1
   elif [[ -z "$files" ]]; then
     scope_all=1
-  elif printf '%s\n' "$files" | grep -Eq '^(tsconfig[^/]*|package\.json|pnpm-lock\.yaml)$'; then
+  elif printf '%s\n' "$files" | grep -Eq '^(tsconfig[^/]*|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$'; then
     scope_all=1
   else
     while IFS= read -r package_name; do

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -59,11 +59,16 @@ package_dependents() {
     while (expanded) {
       expanded = false;
       for (const [directory, packageJson] of packages) {
+        const peerDependencies = Object.fromEntries(
+          Object.entries(packageJson.peerDependencies ?? {}).filter(
+            ([name]) => packageJson.peerDependenciesMeta?.[name]?.optional !== true,
+          ),
+        );
         const dependencies = {
           ...packageJson.dependencies,
           ...packageJson.devDependencies,
           ...packageJson.optionalDependencies,
-          ...packageJson.peerDependencies,
+          ...peerDependencies,
         };
         if (
           Object.keys(dependencies ?? {}).some((name) => {

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -41,11 +41,53 @@ all_package_dirs() {
   '
 }
 
+package_dependents() {
+  QUICK_SCOPE_SEEDS="$1" node -e '
+    const { existsSync, readFileSync, readdirSync } = require("node:fs");
+    const packages = new Map();
+    const namesByPackage = new Map();
+    for (const directory of readdirSync("packages").sort()) {
+      const packagePath = `packages/${directory}/package.json`;
+      if (!existsSync(packagePath)) continue;
+      const packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+      packages.set(directory, packageJson);
+      namesByPackage.set(packageJson.name, directory);
+    }
+
+    const selected = new Set((process.env.QUICK_SCOPE_SEEDS ?? "").split("\n").filter(Boolean));
+    let expanded = true;
+    while (expanded) {
+      expanded = false;
+      for (const [directory, packageJson] of packages) {
+        const dependencies = {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+          ...packageJson.optionalDependencies,
+          ...packageJson.peerDependencies,
+        };
+        if (
+          Object.keys(dependencies ?? {}).some((name) => {
+            const dependencyDirectory = namesByPackage.get(name);
+            return dependencyDirectory !== undefined && selected.has(dependencyDirectory);
+          }) &&
+          !selected.has(directory)
+        ) {
+          selected.add(directory);
+          expanded = true;
+        }
+      }
+    }
+    for (const directory of [...selected].sort()) console.log(directory);
+  '
+}
+
 quick_package_scope() {
   local files
   local scope_all=0
   local package_name
   local package_dir
+  local scope_seeds
+  local expanded_scope
   local -a all_packages=()
   local -a checked_packages=()
   local -a skipped_packages=()
@@ -65,6 +107,12 @@ quick_package_scope() {
         checked_packages+=("$package_name")
       fi
     done < <(printf '%s\n' "$files" | sed -n 's#^packages/\([^/]*\)\(/.*\)\?$#\1#p' | sort -u)
+
+    if ((${#checked_packages[@]} > 0)); then
+      scope_seeds="$(printf '%s\n' "${checked_packages[@]}")"
+      expanded_scope="$(package_dependents "$scope_seeds")"
+      mapfile -t checked_packages <<< "$expanded_scope"
+    fi
   fi
 
   if ((scope_all)); then
@@ -94,13 +142,17 @@ quick_changed_files() {
 
   if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
     merge_base="$(git merge-base HEAD "$base_ref")" || return 1
-    git diff --name-only "$merge_base"...HEAD
-    return
+    git diff --name-only "$merge_base"...HEAD || return 1
+    git diff --name-only || return 1
+    git diff --name-only --cached || return 1
+    return 0
   fi
 
   if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
-    git diff --name-only HEAD~1...HEAD
-    return
+    git diff --name-only HEAD~1...HEAD || return 1
+    git diff --name-only || return 1
+    git diff --name-only --cached || return 1
+    return 0
   fi
 
   return 1
@@ -133,7 +185,7 @@ run_quick_type_checks() {
 
   # Root type-checking and the core build remain prerequisites for package checks.
   run pnpm --filter @remnic/core build
-  run tsc --noEmit
+  run pnpm exec tsc --noEmit
   if ((${#QUICK_SCOPE_CHECKED[@]} > 0)); then
     local -a package_filters=()
     local package_name

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -32,6 +32,129 @@ changed_files() {
     git diff --name-only HEAD~1...HEAD
   fi
 }
+all_package_dirs() {
+  node -e '
+    const { existsSync, readdirSync } = require("node:fs");
+    for (const name of readdirSync("packages").sort()) {
+      if (existsSync(`packages/${name}/package.json`)) console.log(name);
+    }
+  '
+}
+
+quick_package_scope() {
+  local files
+  local scope_all=0
+  local package_name
+  local package_dir
+  local -a all_packages=()
+  local -a checked_packages=()
+  local -a skipped_packages=()
+
+  mapfile -t all_packages < <(all_package_dirs)
+  if ! files="$(quick_changed_files)"; then
+    scope_all=1
+  elif [[ -z "$files" ]]; then
+    scope_all=1
+  elif printf '%s\n' "$files" | grep -Eq '^(tsconfig[^/]*|package\.json|pnpm-lock\.yaml)$'; then
+    scope_all=1
+  else
+    while IFS= read -r package_name; do
+      [[ -n "$package_name" ]] || continue
+      package_dir="packages/$package_name"
+      if [[ -d "$package_dir" ]]; then
+        checked_packages+=("$package_name")
+      fi
+    done < <(printf '%s\n' "$files" | sed -n 's#^packages/\([^/]*\)\(/.*\)\?$#\1#p' | sort -u)
+  fi
+
+  if ((scope_all)); then
+    checked_packages=("${all_packages[@]}")
+  fi
+
+  for package_name in "${all_packages[@]}"; do
+    if printf '%s\n' "${checked_packages[@]}" | grep -Fxq "$package_name"; then
+      continue
+    fi
+    skipped_packages+=("$package_name")
+  done
+
+  QUICK_SCOPE_ALL="$scope_all"
+  QUICK_SCOPE_CHECKED=("${checked_packages[@]}")
+  QUICK_SCOPE_SKIPPED=("${skipped_packages[@]}")
+}
+
+quick_changed_files() {
+  local base_ref="${PREFLIGHT_BASE_REF:-origin/main}"
+  local merge_base
+
+  if [[ ${PREFLIGHT_CHANGED_FILES+x} ]]; then
+    printf '%s\n' "${PREFLIGHT_CHANGED_FILES}"
+    return 0
+  fi
+
+  if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    merge_base="$(git merge-base HEAD "$base_ref")" || return 1
+    git diff --name-only "$merge_base"...HEAD
+    return
+  fi
+
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    git diff --name-only HEAD~1...HEAD
+    return
+  fi
+
+  return 1
+}
+
+print_quick_package_scope() {
+  quick_package_scope
+  if ((QUICK_SCOPE_ALL)); then
+    echo "[preflight] Quick package scope: all packages"
+  else
+    echo "[preflight] Quick package scope: affected packages"
+  fi
+  echo "[preflight] Quick mode skips untouched package checks; use full preflight for workspace-wide errors."
+  printf '[preflight] Checked packages:'
+  printf ' %s' "${QUICK_SCOPE_CHECKED[@]}"
+  printf '\n'
+  printf '[preflight] Skipped packages:'
+  printf ' %s' "${QUICK_SCOPE_SKIPPED[@]}"
+  printf '\n'
+}
+
+run_quick_type_checks() {
+  quick_package_scope
+  print_quick_package_scope
+
+  if ((QUICK_SCOPE_ALL)); then
+    run npm run check-types
+    return
+  fi
+
+  # Root type-checking and the core build remain prerequisites for package checks.
+  run pnpm --filter @remnic/core build
+  run tsc --noEmit
+  if ((${#QUICK_SCOPE_CHECKED[@]} > 0)); then
+    local -a package_filters=()
+    local package_name
+    for package_name in "${QUICK_SCOPE_CHECKED[@]}"; do
+      package_filters+=(--filter "./packages/$package_name")
+    done
+    run pnpm --recursive --if-present "${package_filters[@]}" run check-types
+  else
+    echo "[preflight] No affected packages; skipped recursive package check-types"
+  fi
+  run node scripts/check-test-types.mjs
+}
+
+QUICK_SCOPE_ALL=0
+QUICK_SCOPE_CHECKED=()
+QUICK_SCOPE_SKIPPED=()
+
+if [[ "$MODE" == "--print-quick-package-scope" ]]; then
+  print_quick_package_scope
+  exit
+fi
 
 needs_entity_hardening() {
   local files
@@ -67,7 +190,11 @@ run node tests/pr-preflight-paths.test.mjs
 
 # Core mandatory gate from docs/ops/pr-review-hardening-playbook.md
 run npm run lint
-run npm run check-types
+if [[ "$MODE" == "quick" ]]; then
+  run_quick_type_checks
+else
+  run npm run check-types
+fi
 run npm run check-config-contract
 run npm run plugin:inspect
 run bash scripts/check-review-patterns.sh

--- a/tests/pr-preflight-paths.test.mjs
+++ b/tests/pr-preflight-paths.test.mjs
@@ -61,6 +61,11 @@ assert.match(affectedScope.stdout, /Quick package scope: affected packages/);
 assert.match(affectedScope.stdout, /Checked packages: remnic-cli/);
 assert.match(affectedScope.stdout, /Skipped packages:.*remnic-core/);
 
+const coreScope = packageScope("packages/remnic-core/src/index.ts");
+assert.equal(coreScope.status, 0, coreScope.stderr);
+assert.match(coreScope.stdout, /Checked packages:.*plugin-openclaw/);
+assert.match(coreScope.stdout, /Skipped packages:.*bench-ui/);
+
 const rootConfigScope = packageScope("tsconfig.json");
 assert.equal(rootConfigScope.status, 0, rootConfigScope.stderr);
 assert.match(rootConfigScope.stdout, /Quick package scope: all packages/);

--- a/tests/pr-preflight-paths.test.mjs
+++ b/tests/pr-preflight-paths.test.mjs
@@ -44,8 +44,32 @@ function gateStatus(path) {
 
 for (const path of guardedPaths) {
   const result = gateStatus(path);
+
   assert.equal(result.status, 0, `expected entity hardening for ${path}: ${result.stderr}`);
 }
+function packageScope(files) {
+  return spawnSync("bash", [preflightScript, "--print-quick-package-scope"], {
+    cwd: rootDir,
+    encoding: "utf8",
+    env: { ...process.env, PREFLIGHT_CHANGED_FILES: files },
+  });
+}
+
+const affectedScope = packageScope("packages/remnic-cli/src/index.ts\nREADME.md");
+assert.equal(affectedScope.status, 0, affectedScope.stderr);
+assert.match(affectedScope.stdout, /Quick package scope: affected packages/);
+assert.match(affectedScope.stdout, /Checked packages: remnic-cli/);
+assert.match(affectedScope.stdout, /Skipped packages:.*remnic-core/);
+
+const rootConfigScope = packageScope("tsconfig.json");
+assert.equal(rootConfigScope.status, 0, rootConfigScope.stderr);
+assert.match(rootConfigScope.stdout, /Quick package scope: all packages/);
+assert.match(rootConfigScope.stdout, /Checked packages:.*remnic-cli/);
+assert.match(rootConfigScope.stdout, /Skipped packages:\s*$/m);
+
+const emptyScope = packageScope("");
+assert.equal(emptyScope.status, 0, emptyScope.stderr);
+assert.match(emptyScope.stdout, /Quick package scope: all packages/);
 
 for (const path of excludedPaths) {
   const result = gateStatus(path);

--- a/tests/pr-preflight-paths.test.mjs
+++ b/tests/pr-preflight-paths.test.mjs
@@ -72,6 +72,10 @@ assert.match(rootConfigScope.stdout, /Quick package scope: all packages/);
 assert.match(rootConfigScope.stdout, /Checked packages:.*remnic-cli/);
 assert.match(rootConfigScope.stdout, /Skipped packages:\s*$/m);
 
+const workspaceConfigScope = packageScope("pnpm-workspace.yaml");
+assert.equal(workspaceConfigScope.status, 0, workspaceConfigScope.stderr);
+assert.match(workspaceConfigScope.stdout, /Quick package scope: all packages/);
+
 const emptyScope = packageScope("");
 assert.equal(emptyScope.status, 0, emptyScope.stderr);
 assert.match(emptyScope.stdout, /Quick package scope: all packages/);


### PR DESCRIPTION
Fixes #2408

## Behavior
- Derive quick-mode package scope from the merge-base diff.
- Fall back to all package checks for root workspace config, empty diffs, or unresolved diffs.
- Print checked and skipped package directories.
- Keep the full preflight type-check path unchanged.

## Verification
- `bash -n scripts/pr-preflight.sh`
- `npm exec --yes pnpm@10.32.1 -- exec tsx --test tests/pr-preflight-paths.test.mjs`
- Touched-package type errors fail the filtered check.
- Untouched-package type errors do not run in the filtered check.
- Full workspace baseline type checks: 92.70s before filtering.
- Warm synthetic quick run: 157.62s, then failed at the existing `check-test-types` baseline wrapper failure.

## Notes
- The warm run used a synthetic `packages/connector-replit/src/index.ts` diff.
- The local workspace has existing optional dependency and test-typecheck failures outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect dependency expansion could skip type errors in untouched packages during quick runs; mitigated by fallbacks to all packages and unchanged full preflight/CI paths.
> 
> **Overview**
> **Quick preflight** no longer runs the full workspace `check-types`; it derives a package list from the PR diff (merge-base, plus unstaged/cached changes via `quick_changed_files`), expands it to **reverse dependents** of touched packages, and runs `pnpm` `check-types` only on that set after `@remnic/core` build and root `tsc --noEmit`.
> 
> Scope widens to **all packages** when the diff is empty/unresolved or touches root workspace files (`tsconfig*`, root `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`). The script logs checked vs skipped packages and adds `--print-quick-package-scope` (with `PREFLIGHT_CHANGED_FILES` for tests). **Full** preflight still uses `npm run check-types` unchanged.
> 
> `tests/pr-preflight-paths.test.mjs` asserts affected vs all-packages scope for CLI-only changes, core dependents, and root config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4493b2fbb459c2b00873c3fcf37393b23a013656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->