### PR TITLE
feat(devx): infer changesets from touched packages

### DIFF
--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -86,6 +86,9 @@ export function inferTouchedPackages(changedFiles, packages) {
 
   for (const file of changedFiles) {
     const normalized = normalizePath(file);
+    if (normalized.endsWith(".md") || normalized.startsWith("docs/") || normalized.startsWith(".changeset/")) {
+      continue;
+    }
     const packageMatch = packageForFile(normalized, packages);
     if (packageMatch) {
       if (packageMatch.kind === "python") {

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -76,13 +76,16 @@ export async function discoverPackages(repoRoot) {
 
 function isDocumentationFile(filePath) {
   const normalized = normalizePath(filePath);
-  return (
-    normalized === "README.md" ||
-    normalized === "CHANGELOG.md" ||
-    normalized.startsWith("docs/") ||
-    normalized.startsWith(".changeset/") ||
-    /^packages\/[^/]+\/README\.md$/.test(normalized)
-  );
+  if (normalized.startsWith("docs/") || normalized.startsWith(".changeset/")) {
+    return true;
+  }
+  if (!normalized.endsWith(".md")) {
+    return false;
+  }
+  if (!normalized.startsWith("packages/")) {
+    return true;
+  }
+  return /\/(README|AGENTS|CONTRIBUTING)\.md$/.test(normalized);
 }
 
 function packageForFile(filePath, packages) {

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -82,10 +82,13 @@ function isDocumentationFile(filePath) {
   if (!normalized.endsWith(".md")) {
     return false;
   }
+  if (normalized.startsWith("src/")) {
+    return /\/(README|AGENTS|CONTRIBUTING|CHANGELOG)\.md$/.test(normalized);
+  }
   if (!normalized.startsWith("packages/")) {
     return true;
   }
-  return /\/(README|AGENTS|CONTRIBUTING)\.md$/.test(normalized);
+  return /\/(README|AGENTS|CONTRIBUTING|CHANGELOG)\.md$/.test(normalized);
 }
 
 function packageForFile(filePath, packages) {
@@ -163,7 +166,7 @@ export function changedWorkingTreeFiles(repoRoot, options = {}) {
   if (!mergeBase) {
     throw new Error(`Unable to resolve merge-base for ${baseRef}. Fetch the base or pass --base <ref>.`);
   }
-  const tracked = tryGit(repoRoot, ["diff", "--name-only", mergeBase, "--"], git) ?? "";
+  const tracked = tryGit(repoRoot, ["diff", "--name-only", "--no-renames", mergeBase, "--"], git) ?? "";
   const untracked = tryGit(repoRoot, ["ls-files", "--others", "--exclude-standard"], git) ?? "";
   return [...new Set([...splitLines(tracked), ...splitLines(untracked)])].sort();
 }

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -151,9 +151,9 @@ export function renderChangeset(packages) {
   return `---\n${frontmatter}\n---\n\nTODO: Summarize the user-visible changes for ${names}.\n`;
 }
 
-function splitLines(output) {
+function splitLines(output, separator = /\r?\n/) {
   return output
-    .split(/\r?\n/)
+    .split(separator)
     .map((line) => line.trim())
     .filter(Boolean)
     .map(normalizePath);
@@ -166,9 +166,9 @@ export function changedWorkingTreeFiles(repoRoot, options = {}) {
   if (!mergeBase) {
     throw new Error(`Unable to resolve merge-base for ${baseRef}. Fetch the base or pass --base <ref>.`);
   }
-  const tracked = tryGit(repoRoot, ["diff", "--name-only", "--no-renames", mergeBase, "--"], git) ?? "";
-  const untracked = tryGit(repoRoot, ["ls-files", "--others", "--exclude-standard"], git) ?? "";
-  return [...new Set([...splitLines(tracked), ...splitLines(untracked)])].sort();
+  const tracked = tryGit(repoRoot, ["diff", "--name-only", "--no-renames", "-z", mergeBase, "--"], git) ?? "";
+  const untracked = tryGit(repoRoot, ["ls-files", "--others", "--exclude-standard", "-z"], git) ?? "";
+  return [...new Set([...splitLines(tracked, "\0"), ...splitLines(untracked, "\0")])].sort();
 }
 
 export function renderNotes(result) {

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -74,6 +74,17 @@ export async function discoverPackages(repoRoot) {
   return packages.sort((left, right) => left.dir.localeCompare(right.dir));
 }
 
+function isDocumentationFile(filePath) {
+  const normalized = normalizePath(filePath);
+  return (
+    normalized === "README.md" ||
+    normalized === "CHANGELOG.md" ||
+    normalized.startsWith("docs/") ||
+    normalized.startsWith(".changeset/") ||
+    /^packages\/[^/]+\/README\.md$/.test(normalized)
+  );
+}
+
 function packageForFile(filePath, packages) {
   const normalized = normalizePath(filePath);
   return packages.find((pkg) => normalized === pkg.dir || normalized.startsWith(`${pkg.dir}/`));
@@ -86,7 +97,7 @@ export function inferTouchedPackages(changedFiles, packages) {
 
   for (const file of changedFiles) {
     const normalized = normalizePath(file);
-    if (normalized.endsWith(".md") || normalized.startsWith("docs/") || normalized.startsWith(".changeset/")) {
+    if (isDocumentationFile(normalized)) {
       continue;
     }
     const packageMatch = packageForFile(normalized, packages);
@@ -98,6 +109,13 @@ export function inferTouchedPackages(changedFiles, packages) {
       } else {
         touched.set(packageMatch.dir, packageMatch);
       }
+      continue;
+    }
+
+    if (normalized.startsWith("src/")) {
+      const openclaw = packages.find((pkg) => pkg.dir === "packages/plugin-openclaw");
+      if (openclaw && !openclaw.private) touched.set(openclaw.dir, openclaw);
+      else if (openclaw) skipped.set(openclaw.dir, openclaw);
       continue;
     }
 
@@ -138,7 +156,10 @@ function splitLines(output) {
 export function changedWorkingTreeFiles(repoRoot, options = {}) {
   const git = options.git ?? runGit;
   const baseRef = options.baseRef ?? process.env.PREFLIGHT_BASE_REF ?? DEFAULT_BASE_REF;
-  const mergeBase = tryGit(repoRoot, ["merge-base", "HEAD", baseRef], git) ?? "HEAD~1";
+  const mergeBase = tryGit(repoRoot, ["merge-base", "HEAD", baseRef], git);
+  if (!mergeBase) {
+    throw new Error(`Unable to resolve merge-base for ${baseRef}. Fetch the base or pass --base <ref>.`);
+  }
   const tracked = tryGit(repoRoot, ["diff", "--name-only", mergeBase, "--"], git) ?? "";
   const untracked = tryGit(repoRoot, ["ls-files", "--others", "--exclude-standard"], git) ?? "";
   return [...new Set([...splitLines(tracked), ...splitLines(untracked)])].sort();

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -205,7 +205,7 @@ async function main() {
   process.stdout.write(result.markdown);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(`changeset-stub: ${error instanceof Error ? error.message : String(error)}`);
     process.exitCode = 1;

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { readdir, readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -76,9 +76,7 @@ export async function discoverPackages(repoRoot) {
 
 function packageForFile(filePath, packages) {
   const normalized = normalizePath(filePath);
-  return packages.find(
-    (pkg) => normalized === pkg.dir || normalized.startsWith(`${pkg.dir}/`),
-  );
+  return packages.find((pkg) => normalized === pkg.dir || normalized.startsWith(`${pkg.dir}/`));
 }
 
 export function inferTouchedPackages(changedFiles, packages) {
@@ -148,7 +146,7 @@ export function renderNotes(result) {
   for (const pkg of result.python) {
     notes.push(
       `changeset-stub: ${pkg.name} is Python-published; no npm changeset emitted. ` +
-        `Update ${pkg.dir}/pyproject.toml and ${pkg.dir}/plugin.yaml release metadata instead.`,
+        `Update ${pkg.dir}/pyproject.toml and ${pkg.dir}/plugin.yaml release metadata instead.`
     );
   }
   for (const pkg of result.skipped) {

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -143,16 +143,18 @@ export function changedWorkingTreeFiles(repoRoot, options = {}) {
   return [...new Set([...splitLines(tracked), ...splitLines(untracked)])].sort();
 }
 
-function printNotes(result) {
+export function renderNotes(result) {
+  const notes = [];
   for (const pkg of result.python) {
-    console.error(
+    notes.push(
       `changeset-stub: ${pkg.name} is Python-published; no npm changeset emitted. ` +
-        "Update packages/plugin-hermes/pyproject.toml and plugin.yaml release metadata instead.",
+        `Update ${pkg.dir}/pyproject.toml and ${pkg.dir}/plugin.yaml release metadata instead.`,
     );
   }
   for (const pkg of result.skipped) {
-    console.error(`changeset-stub: skipped unpublished/private package ${pkg.name} (${pkg.dir}).`);
+    notes.push(`changeset-stub: skipped unpublished/private package ${pkg.name} (${pkg.dir}).`);
   }
+  return notes.length > 0 ? `${notes.join("\n")}\n` : "";
 }
 
 export function parseArgs(argv) {
@@ -201,7 +203,7 @@ async function main() {
   }
 
   const result = await inferChangeset(args.repoRoot, { baseRef: args.baseRef });
-  printNotes(result);
+  process.stderr.write(renderNotes(result));
   process.stdout.write(result.markdown);
 }
 

--- a/scripts/changeset-stub.mjs
+++ b/scripts/changeset-stub.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const PYTHON_PUBLISHED_NAME = "remnic-hermes";
+const ROOT_PACKAGE_PATH = "package.json";
+const OPENCLAW_ROOT_MANIFEST = "openclaw.plugin.json";
+const DEFAULT_BASE_REF = "origin/main";
+
+function runGit(repoRoot, args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function tryGit(repoRoot, args, git = runGit) {
+  try {
+    return git(repoRoot, args);
+  } catch {
+    return null;
+  }
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/").replace(/^\.\//, "");
+}
+
+function parsePythonProjectName(source) {
+  const match = source.match(/^name\s*=\s*["']([^"']+)["']\s*$/m);
+  return match?.[1] ?? PYTHON_PUBLISHED_NAME;
+}
+
+export async function discoverPackages(repoRoot) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  const entries = await readdir(packagesRoot, { withFileTypes: true });
+  const packages = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const relativeDir = normalizePath(path.join("packages", entry.name));
+    const packageDir = path.join(repoRoot, relativeDir);
+    const packageJsonPath = path.join(packageDir, "package.json");
+    try {
+      const manifest = JSON.parse(await readFile(packageJsonPath, "utf8"));
+      if (typeof manifest.name === "string") {
+        packages.push({
+          dir: relativeDir,
+          name: manifest.name,
+          kind: "npm",
+          private: manifest.private === true,
+        });
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      const pyprojectPath = path.join(packageDir, "pyproject.toml");
+      try {
+        const pyproject = await readFile(pyprojectPath, "utf8");
+        packages.push({
+          dir: relativeDir,
+          name: parsePythonProjectName(pyproject),
+          kind: "python",
+          private: false,
+        });
+      } catch (pyprojectError) {
+        if (pyprojectError?.code !== "ENOENT") throw pyprojectError;
+      }
+    }
+  }
+
+  return packages.sort((left, right) => left.dir.localeCompare(right.dir));
+}
+
+function packageForFile(filePath, packages) {
+  const normalized = normalizePath(filePath);
+  return packages.find(
+    (pkg) => normalized === pkg.dir || normalized.startsWith(`${pkg.dir}/`),
+  );
+}
+
+export function inferTouchedPackages(changedFiles, packages) {
+  const touched = new Map();
+  const skipped = new Map();
+  const python = new Map();
+
+  for (const file of changedFiles) {
+    const normalized = normalizePath(file);
+    const packageMatch = packageForFile(normalized, packages);
+    if (packageMatch) {
+      if (packageMatch.kind === "python") {
+        python.set(packageMatch.dir, packageMatch);
+      } else if (packageMatch.private) {
+        skipped.set(packageMatch.dir, packageMatch);
+      } else {
+        touched.set(packageMatch.dir, packageMatch);
+      }
+      continue;
+    }
+
+    if (normalized === OPENCLAW_ROOT_MANIFEST) {
+      const openclaw = packages.find((pkg) => pkg.dir === "packages/plugin-openclaw");
+      if (openclaw && !openclaw.private) touched.set(openclaw.dir, openclaw);
+      else if (openclaw) skipped.set(openclaw.dir, openclaw);
+      continue;
+    }
+
+    if (normalized === ROOT_PACKAGE_PATH) {
+      skipped.set(".", { dir: ".", name: "remnic-workspace", kind: "npm", private: true });
+    }
+  }
+
+  return {
+    published: [...touched.values()].sort((left, right) => left.name.localeCompare(right.name)),
+    python: [...python.values()].sort((left, right) => left.name.localeCompare(right.name)),
+    skipped: [...skipped.values()].sort((left, right) => left.name.localeCompare(right.name)),
+  };
+}
+
+export function renderChangeset(packages) {
+  if (packages.length === 0) return "";
+  const frontmatter = packages.map((pkg) => `"${pkg.name}": patch`).join("\n");
+  const names = packages.map((pkg) => pkg.name).join(", ");
+  return `---\n${frontmatter}\n---\n\nTODO: Summarize the user-visible changes for ${names}.\n`;
+}
+
+function splitLines(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(normalizePath);
+}
+
+export function changedWorkingTreeFiles(repoRoot, options = {}) {
+  const git = options.git ?? runGit;
+  const baseRef = options.baseRef ?? process.env.PREFLIGHT_BASE_REF ?? DEFAULT_BASE_REF;
+  const mergeBase = tryGit(repoRoot, ["merge-base", "HEAD", baseRef], git) ?? "HEAD~1";
+  const tracked = tryGit(repoRoot, ["diff", "--name-only", mergeBase, "--"], git) ?? "";
+  const untracked = tryGit(repoRoot, ["ls-files", "--others", "--exclude-standard"], git) ?? "";
+  return [...new Set([...splitLines(tracked), ...splitLines(untracked)])].sort();
+}
+
+function printNotes(result) {
+  for (const pkg of result.python) {
+    console.error(
+      `changeset-stub: ${pkg.name} is Python-published; no npm changeset emitted. ` +
+        "Update packages/plugin-hermes/pyproject.toml and plugin.yaml release metadata instead.",
+    );
+  }
+  for (const pkg of result.skipped) {
+    console.error(`changeset-stub: skipped unpublished/private package ${pkg.name} (${pkg.dir}).`);
+  }
+}
+
+export function parseArgs(argv) {
+  const args = { baseRef: undefined, repoRoot: process.cwd() };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("Missing value for --base");
+      args.baseRef = value;
+      index += 1;
+    } else if (arg === "--repo-root") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("Missing value for --repo-root");
+      args.repoRoot = value;
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export function usage() {
+  return [
+    "Usage: node scripts/changeset-stub.mjs [--base <ref>] [--repo-root <path>]",
+    "",
+    "Prints a changeset for published packages touched by the working-tree diff.",
+  ].join("\n");
+}
+
+export async function inferChangeset(repoRoot, options = {}) {
+  const packages = options.packages ?? (await discoverPackages(repoRoot));
+  const changedFiles = options.changedFiles ?? changedWorkingTreeFiles(repoRoot, options);
+  const result = inferTouchedPackages(changedFiles, packages);
+  return { ...result, changedFiles, markdown: renderChangeset(result.published) };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const result = await inferChangeset(args.repoRoot, { baseRef: args.baseRef });
+  printNotes(result);
+  process.stdout.write(result.markdown);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`changeset-stub: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -63,6 +63,33 @@ if [[ "$MODE" == "--check-entity-hardening-path" ]]; then
   exit
 fi
 
+changeset_warning_needed() {
+  local files="$1"
+  local has_code=0
+  local has_changeset=0
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    case "$file" in
+      .changeset/*.md) has_changeset=1 ;;
+      .changeset/*|*.md|docs/*|CHANGELOG.md) ;;
+      package.json|pnpm-lock.yaml|packages/*/package.json|packages/*/openclaw.plugin.json|packages/*/.claude-plugin/plugin.json|packages/*/.codex-plugin/plugin.json) ;;
+      *) has_code=1 ;;
+    esac
+  done <<< "$files"
+  [[ "$has_code" -eq 1 && "$has_changeset" -eq 0 ]]
+}
+
+if [[ "$MODE" == "--check-changeset" ]]; then
+  if [[ "$#" -lt 2 ]]; then
+    echo "usage: $0 --check-changeset <changed-path>..." >&2
+    exit 2
+  fi
+  changed_paths="$(printf '%s\n' "${@:2}")"
+  if changeset_warning_needed "$changed_paths"; then
+    echo "[preflight] WARNING: code changes detected without a changeset. Run: node scripts/changeset-stub.mjs"
+  fi
+  exit 0
+fi
 run node tests/pr-preflight-paths.test.mjs
 
 # Core mandatory gate from docs/ops/pr-review-hardening-playbook.md
@@ -108,6 +135,13 @@ if [[ "$MODE" == "quick" ]]; then
 else
   run npm test
   run npm run build
+fi
+
+
+# Changeset reminder: this is advisory because docs-only and release-only
+# changes do not need package release metadata.
+if changeset_warning_needed "$(changed_files)"; then
+  echo "[preflight] WARNING: code changes detected without a changeset. Run: node scripts/changeset-stub.mjs"
 fi
 
 echo "[preflight] OK ($MODE)"

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -86,7 +86,7 @@ changeset_warning_needed() {
     [[ -z "$file" ]] && continue
     case "$file" in
       .changeset/*.md) has_changeset=1 ;;
-      .changeset/*|README.md|CHANGELOG.md|CONTRIBUTING.md|AGENTS.md|*/README.md|*/AGENTS.md|*/CONTRIBUTING.md|docs/*) ;;
+      .changeset/*|README.md|CHANGELOG.md|CONTRIBUTING.md|AGENTS.md|*/README.md|*/AGENTS.md|*/CONTRIBUTING.md|*/CHANGELOG.md|docs/*) ;;
       package.json|pnpm-lock.yaml|openclaw.plugin.json|packages/*/package.json|packages/*/openclaw.plugin.json|packages/*/.claude-plugin/plugin.json|packages/*/.codex-plugin/plugin.json) ;;
       *) changeset_code_file "$file" && has_code=1 ;;
     esac

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -63,6 +63,21 @@ if [[ "$MODE" == "--check-entity-hardening-path" ]]; then
   exit
 fi
 
+changeset_code_file() {
+  local file="$1"
+  case "$file" in
+    src/*) return 0 ;;
+    packages/*/*)
+      local package_name="${file#packages/}"
+      package_name="${package_name%%/*}"
+      local manifest="packages/${package_name}/package.json"
+      [[ -f "$manifest" ]] || return 1
+      node -e 'const fs = require("node:fs"); const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.exit(pkg.private === true ? 1 : 0)' "$manifest"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 changeset_warning_needed() {
   local files="$1"
   local has_code=0
@@ -71,9 +86,9 @@ changeset_warning_needed() {
     [[ -z "$file" ]] && continue
     case "$file" in
       .changeset/*.md) has_changeset=1 ;;
-      .changeset/*|README.md|CHANGELOG.md|docs/*|packages/*/README.md) ;;
+      .changeset/*|README.md|CHANGELOG.md|CONTRIBUTING.md|AGENTS.md|*/README.md|*/AGENTS.md|*/CONTRIBUTING.md|docs/*) ;;
       package.json|pnpm-lock.yaml|openclaw.plugin.json|packages/*/package.json|packages/*/openclaw.plugin.json|packages/*/.claude-plugin/plugin.json|packages/*/.codex-plugin/plugin.json) ;;
-      *) has_code=1 ;;
+      *) changeset_code_file "$file" && has_code=1 ;;
     esac
   done <<< "$files"
   [[ "$has_code" -eq 1 && "$has_changeset" -eq 0 ]]

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -71,8 +71,8 @@ changeset_warning_needed() {
     [[ -z "$file" ]] && continue
     case "$file" in
       .changeset/*.md) has_changeset=1 ;;
-      .changeset/*|*.md|docs/*|CHANGELOG.md) ;;
-      package.json|pnpm-lock.yaml|packages/*/package.json|packages/*/openclaw.plugin.json|packages/*/.claude-plugin/plugin.json|packages/*/.codex-plugin/plugin.json) ;;
+      .changeset/*|README.md|CHANGELOG.md|docs/*|packages/*/README.md) ;;
+      package.json|pnpm-lock.yaml|openclaw.plugin.json|packages/*/package.json|packages/*/openclaw.plugin.json|packages/*/.claude-plugin/plugin.json|packages/*/.codex-plugin/plugin.json) ;;
       *) has_code=1 ;;
     esac
   done <<< "$files"

--- a/tests/changeset-preflight.test.mjs
+++ b/tests/changeset-preflight.test.mjs
@@ -48,3 +48,16 @@ test("preflight stays silent for release-only root manifests", () => {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "");
 });
+test("preflight stays silent for private packages and root tooling", () => {
+  const result = check("packages/bench-ui/src/main.ts", "scripts/changeset-stub.mjs", "tests/changeset-stub.test.mjs");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});
+
+test("preflight stays silent for agent instructions", () => {
+  const result = check("src/AGENTS.md", "AGENTS.md", "CONTRIBUTING.md");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});

--- a/tests/changeset-preflight.test.mjs
+++ b/tests/changeset-preflight.test.mjs
@@ -35,3 +35,16 @@ test("preflight stays silent for documentation-only changes", () => {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "");
 });
+test("preflight warns for shipped skill markdown without a changeset", () => {
+  const result = check("packages/plugin-openclaw/skills/recall/SKILL.md");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /WARNING: code changes detected without a changeset/);
+});
+
+test("preflight stays silent for release-only root manifests", () => {
+  const result = check("openclaw.plugin.json", "packages/plugin-openclaw/package.json");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});

--- a/tests/changeset-preflight.test.mjs
+++ b/tests/changeset-preflight.test.mjs
@@ -41,6 +41,12 @@ test("preflight warns for shipped skill markdown without a changeset", () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /WARNING: code changes detected without a changeset/);
 });
+test("preflight warns for non-documentation source markdown", () => {
+  const result = check("src/runtime-notes.md");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /WARNING: code changes detected without a changeset/);
+});
 
 test("preflight stays silent for release-only root manifests", () => {
   const result = check("openclaw.plugin.json", "packages/plugin-openclaw/package.json");

--- a/tests/changeset-preflight.test.mjs
+++ b/tests/changeset-preflight.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const preflight = path.join(repoRoot, "scripts", "pr-preflight.sh");
+
+function check(...paths) {
+  return spawnSync("bash", [preflight, "--check-changeset", ...paths], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+test("preflight warns for a code diff without a changeset", () => {
+  const result = check("packages/remnic-core/src/index.ts");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /WARNING: code changes detected without a changeset/);
+  assert.match(result.stdout, /node scripts\/changeset-stub\.mjs/);
+});
+
+test("preflight stays silent when a changeset exists", () => {
+  const result = check("packages/remnic-core/src/index.ts", ".changeset/fix-core.md");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});
+
+test("preflight stays silent for documentation-only changes", () => {
+  const result = check("docs/plugins/core.md", "README.md");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -64,6 +64,13 @@ test("documentation-only changes emit nothing", async () => {
   assert.deepEqual(result.python, []);
 });
 
+test("package documentation-only changes emit nothing", () => {
+  const result = inferTouchedPackages(["packages/remnic-core/README.md"], packages);
+
+  assert.deepEqual(result.published, []);
+  assert.deepEqual(result.python, []);
+});
+
 test("working-tree diff collection uses stubbed git output from the merge-base", () => {
   const calls = [];
   const git = (_repoRoot, args) => {

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -21,7 +21,10 @@ test("changeset stub emits the touched published package", async () => {
     changedFiles: ["packages/remnic-core/src/index.ts"],
   });
 
-  assert.deepEqual(result.published.map((pkg) => pkg.name), ["@remnic/core"]);
+  assert.deepEqual(
+    result.published.map((pkg) => pkg.name),
+    ["@remnic/core"]
+  );
   assert.match(result.markdown, /"@remnic\/core": patch/);
   assert.match(result.markdown, /TODO:/);
 });
@@ -29,17 +32,23 @@ test("changeset stub emits the touched published package", async () => {
 test("changeset stub lists every touched published package", () => {
   const result = inferTouchedPackages(
     ["packages/remnic-cli/src/cli.ts", "packages/remnic-core/src/index.ts"],
-    packages,
+    packages
   );
 
-  assert.deepEqual(result.published.map((pkg) => pkg.name), ["@remnic/cli", "@remnic/core"]);
+  assert.deepEqual(
+    result.published.map((pkg) => pkg.name),
+    ["@remnic/cli", "@remnic/core"]
+  );
 });
 
 test("Python-only changes emit no npm changeset and print the release metadata explanation", () => {
   const result = inferTouchedPackages(["packages/plugin-hermes/remnic_hermes/provider.py"], packages);
 
   assert.deepEqual(result.published, []);
-  assert.deepEqual(result.python.map((pkg) => pkg.name), ["remnic-hermes"]);
+  assert.deepEqual(
+    result.python.map((pkg) => pkg.name),
+    ["remnic-hermes"]
+  );
   assert.match(renderNotes(result), /Python-published; no npm changeset emitted/);
   assert.match(renderNotes(result), /packages\/plugin-hermes\/pyproject\.toml/);
 });
@@ -80,5 +89,8 @@ test("private packages are skipped", () => {
   const result = inferTouchedPackages(["packages/bench-ui/src/main.ts"], packages);
 
   assert.deepEqual(result.published, []);
-  assert.deepEqual(result.skipped.map((pkg) => pkg.name), ["@remnic/bench-ui"]);
+  assert.deepEqual(
+    result.skipped.map((pkg) => pkg.name),
+    ["@remnic/bench-ui"]
+  );
 });

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -89,10 +89,19 @@ test("root OpenClaw compatibility sources map to the published plugin", () => {
 });
 
 test("root documentation remains documentation-only", () => {
-  const result = inferTouchedPackages(["src/AGENTS.md", "CONTRIBUTING.md"], packages);
+  const result = inferTouchedPackages(["src/AGENTS.md", "src/README.md", "CONTRIBUTING.md"], packages);
 
   assert.deepEqual(result.published, []);
   assert.deepEqual(result.python, []);
+});
+
+test("source markdown remains release-bearing unless it is a known doc file", () => {
+  const result = inferTouchedPackages(["src/runtime-notes.md"], packages);
+
+  assert.deepEqual(
+    result.published.map((pkg) => pkg.name),
+    ["@remnic/plugin-openclaw"]
+  );
 });
 test("working-tree diff collection uses stubbed git output from the merge-base", () => {
   const calls = [];
@@ -110,10 +119,27 @@ test("working-tree diff collection uses stubbed git output from the merge-base",
   ]);
   assert.deepEqual(calls, [
     ["merge-base", "HEAD", "main"],
-    ["diff", "--name-only", "base-sha", "--"],
+    ["diff", "--name-only", "--no-renames", "base-sha", "--"],
     ["ls-files", "--others", "--exclude-standard"],
   ]);
 });
+
+test("working-tree diff collection preserves both sides of a rename", () => {
+  const git = (_repoRoot, args) => {
+    if (args[0] === "merge-base") return "base-sha";
+    if (args[0] === "diff") {
+      return "packages/remnic-core/src/old.ts\npackages/remnic-cli/src/new.ts\n";
+    }
+    if (args[0] === "ls-files") return "";
+    throw new Error(`unexpected git call: ${args.join(" ")}`);
+  };
+
+  assert.deepEqual(changedWorkingTreeFiles("/repo", { baseRef: "main", git }), [
+    "packages/remnic-cli/src/new.ts",
+    "packages/remnic-core/src/old.ts",
+  ]);
+});
+
 test("working-tree diff collection rejects an unavailable merge-base", () => {
   const git = (_repoRoot, args) => {
     if (args[0] === "merge-base") return null;

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -88,6 +88,12 @@ test("root OpenClaw compatibility sources map to the published plugin", () => {
   );
 });
 
+test("root documentation remains documentation-only", () => {
+  const result = inferTouchedPackages(["src/AGENTS.md", "CONTRIBUTING.md"], packages);
+
+  assert.deepEqual(result.published, []);
+  assert.deepEqual(result.python, []);
+});
 test("working-tree diff collection uses stubbed git output from the merge-base", () => {
   const calls = [];
   const git = (_repoRoot, args) => {

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -108,8 +108,8 @@ test("working-tree diff collection uses stubbed git output from the merge-base",
   const git = (_repoRoot, args) => {
     calls.push(args);
     if (args[0] === "merge-base") return "base-sha";
-    if (args[0] === "diff") return "packages/remnic-core/src/index.ts\n";
-    if (args[0] === "ls-files") return "packages/remnic-cli/src/cli.ts\n";
+    if (args[0] === "diff") return "packages/remnic-core/src/index.ts\0";
+    if (args[0] === "ls-files") return "packages/remnic-cli/src/cli.ts\0";
     throw new Error(`unexpected git call: ${args.join(" ")}`);
   };
 
@@ -119,8 +119,8 @@ test("working-tree diff collection uses stubbed git output from the merge-base",
   ]);
   assert.deepEqual(calls, [
     ["merge-base", "HEAD", "main"],
-    ["diff", "--name-only", "--no-renames", "base-sha", "--"],
-    ["ls-files", "--others", "--exclude-standard"],
+    ["diff", "--name-only", "--no-renames", "-z", "base-sha", "--"],
+    ["ls-files", "--others", "--exclude-standard", "-z"],
   ]);
 });
 
@@ -128,7 +128,7 @@ test("working-tree diff collection preserves both sides of a rename", () => {
   const git = (_repoRoot, args) => {
     if (args[0] === "merge-base") return "base-sha";
     if (args[0] === "diff") {
-      return "packages/remnic-core/src/old.ts\npackages/remnic-cli/src/new.ts\n";
+      return "packages/remnic-core/src/é.ts\0packages/remnic-cli/src/new.ts\0";
     }
     if (args[0] === "ls-files") return "";
     throw new Error(`unexpected git call: ${args.join(" ")}`);
@@ -136,7 +136,7 @@ test("working-tree diff collection preserves both sides of a rename", () => {
 
   assert.deepEqual(changedWorkingTreeFiles("/repo", { baseRef: "main", git }), [
     "packages/remnic-cli/src/new.ts",
-    "packages/remnic-core/src/old.ts",
+    "packages/remnic-core/src/é.ts",
   ]);
 });
 

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -70,6 +70,23 @@ test("package documentation-only changes emit nothing", () => {
   assert.deepEqual(result.published, []);
   assert.deepEqual(result.python, []);
 });
+test("published skill markdown is treated as package code", () => {
+  const result = inferTouchedPackages(["packages/plugin-openclaw/skills/recall/SKILL.md"], packages);
+
+  assert.deepEqual(
+    result.published.map((pkg) => pkg.name),
+    ["@remnic/plugin-openclaw"]
+  );
+});
+
+test("root OpenClaw compatibility sources map to the published plugin", () => {
+  const result = inferTouchedPackages(["src/openclaw-entry.ts"], packages);
+
+  assert.deepEqual(
+    result.published.map((pkg) => pkg.name),
+    ["@remnic/plugin-openclaw"]
+  );
+});
 
 test("working-tree diff collection uses stubbed git output from the merge-base", () => {
   const calls = [];
@@ -90,6 +107,17 @@ test("working-tree diff collection uses stubbed git output from the merge-base",
     ["diff", "--name-only", "base-sha", "--"],
     ["ls-files", "--others", "--exclude-standard"],
   ]);
+});
+test("working-tree diff collection rejects an unavailable merge-base", () => {
+  const git = (_repoRoot, args) => {
+    if (args[0] === "merge-base") return null;
+    throw new Error(`unexpected git call: ${args.join(" ")}`);
+  };
+
+  assert.throws(
+    () => changedWorkingTreeFiles("/repo", { baseRef: "main", git }),
+    /Unable to resolve merge-base for main/
+  );
 });
 
 test("private packages are skipped", () => {

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  changedWorkingTreeFiles,
+  inferChangeset,
+  inferTouchedPackages,
+} from "../scripts/changeset-stub.mjs";
+
+const packages = [
+  { dir: "packages/remnic-core", name: "@remnic/core", kind: "npm", private: false },
+  { dir: "packages/remnic-cli", name: "@remnic/cli", kind: "npm", private: false },
+  { dir: "packages/plugin-openclaw", name: "@remnic/plugin-openclaw", kind: "npm", private: false },
+  { dir: "packages/bench-ui", name: "@remnic/bench-ui", kind: "npm", private: true },
+  { dir: "packages/plugin-hermes", name: "remnic-hermes", kind: "python", private: false },
+];
+
+test("changeset stub emits the touched published package", async () => {
+  const result = await inferChangeset("/repo", {
+    packages,
+    changedFiles: ["packages/remnic-core/src/index.ts"],
+  });
+
+  assert.deepEqual(result.published.map((pkg) => pkg.name), ["@remnic/core"]);
+  assert.match(result.markdown, /"@remnic\/core": patch/);
+  assert.match(result.markdown, /TODO:/);
+});
+
+test("changeset stub lists every touched published package", () => {
+  const result = inferTouchedPackages(
+    ["packages/remnic-cli/src/cli.ts", "packages/remnic-core/src/index.ts"],
+    packages,
+  );
+
+  assert.deepEqual(result.published.map((pkg) => pkg.name), ["@remnic/cli", "@remnic/core"]);
+});
+
+test("Python-only changes emit no npm changeset and retain an explanation target", () => {
+  const result = inferTouchedPackages(["packages/plugin-hermes/remnic_hermes/provider.py"], packages);
+
+  assert.deepEqual(result.published, []);
+  assert.deepEqual(result.python.map((pkg) => pkg.name), ["remnic-hermes"]);
+});
+
+test("documentation-only changes emit nothing", async () => {
+  const result = await inferChangeset("/repo", {
+    packages,
+    changedFiles: ["docs/plugins/hermes.md", "README.md"],
+  });
+
+  assert.equal(result.markdown, "");
+  assert.deepEqual(result.published, []);
+  assert.deepEqual(result.python, []);
+});
+
+test("working-tree diff collection uses stubbed git output from the merge-base", () => {
+  const calls = [];
+  const git = (_repoRoot, args) => {
+    calls.push(args);
+    if (args[0] === "merge-base") return "base-sha";
+    if (args[0] === "diff") return "packages/remnic-core/src/index.ts\n";
+    if (args[0] === "ls-files") return "packages/remnic-cli/src/cli.ts\n";
+    throw new Error(`unexpected git call: ${args.join(" ")}`);
+  };
+
+  assert.deepEqual(changedWorkingTreeFiles("/repo", { baseRef: "main", git }), [
+    "packages/remnic-cli/src/cli.ts",
+    "packages/remnic-core/src/index.ts",
+  ]);
+  assert.deepEqual(calls, [
+    ["merge-base", "HEAD", "main"],
+    ["diff", "--name-only", "base-sha", "--"],
+    ["ls-files", "--others", "--exclude-standard"],
+  ]);
+});
+
+test("private packages are skipped", () => {
+  const result = inferTouchedPackages(["packages/bench-ui/src/main.ts"], packages);
+
+  assert.deepEqual(result.published, []);
+  assert.deepEqual(result.skipped.map((pkg) => pkg.name), ["@remnic/bench-ui"]);
+});

--- a/tests/changeset-stub.test.mjs
+++ b/tests/changeset-stub.test.mjs
@@ -4,6 +4,7 @@ import {
   changedWorkingTreeFiles,
   inferChangeset,
   inferTouchedPackages,
+  renderNotes,
 } from "../scripts/changeset-stub.mjs";
 
 const packages = [
@@ -34,11 +35,13 @@ test("changeset stub lists every touched published package", () => {
   assert.deepEqual(result.published.map((pkg) => pkg.name), ["@remnic/cli", "@remnic/core"]);
 });
 
-test("Python-only changes emit no npm changeset and retain an explanation target", () => {
+test("Python-only changes emit no npm changeset and print the release metadata explanation", () => {
   const result = inferTouchedPackages(["packages/plugin-hermes/remnic_hermes/provider.py"], packages);
 
   assert.deepEqual(result.published, []);
   assert.deepEqual(result.python.map((pkg) => pkg.name), ["remnic-hermes"]);
+  assert.match(renderNotes(result), /Python-published; no npm changeset emitted/);
+  assert.match(renderNotes(result), /packages\/plugin-hermes\/pyproject\.toml/);
 });
 
 test("documentation-only changes emit nothing", async () => {


### PR DESCRIPTION
Fixes #2411

## Behavior
- Infer changed packages from the working-tree diff against the merge-base.
- Emit one changeset frontmatter block for all touched public npm packages.
- Print Python release metadata guidance and skip private or unpublished packages.
- Warn in preflight when code changes have no changeset, without failing the gate.

## Verification
- `node --test tests/changeset-stub.test.mjs tests/changeset-preflight.test.mjs tests/pr-preflight-paths.test.mjs`
- `bash -n scripts/pr-preflight.sh`
- `biome check` passed for changed JavaScript files.

## Notes
- Documentation-only and release-only paths remain silent.
- This PR does not add a release changeset because it changes private developer tooling only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling and advisory preflight warnings only; no runtime or release pipeline enforcement changes.
> 
> **Overview**
> Adds **`scripts/changeset-stub.mjs`**, which diffs the working tree against the merge-base (default `origin/main`), maps changed paths to published npm packages, and prints a **patch** changeset stub on stdout. Python packages get stderr guidance to update `pyproject.toml` / `plugin.yaml` instead; private packages and most docs paths are ignored. Root `src/` and `openclaw.plugin.json` changes attribute to `@remnic/plugin-openclaw`; non-doc markdown under `src/` or shipped skills still counts as release-bearing.
> 
> **`scripts/pr-preflight.sh`** gains an advisory **`--check-changeset`** mode and an end-of-preflight warning when code-like paths change without a `.changeset/*.md` file—the gate does not fail. New tests cover stub inference, git collection, and preflight warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b4375457787e71c5d0812116b6c4dd5ece0992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->