### PR TITLE
test(plugin-openclaw): cover flush-plan ingest concurrency

### DIFF
--- a/.changeset/2393-flush-plan-ingest-tests.md
+++ b/.changeset/2393-flush-plan-ingest-tests.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Add deterministic regression coverage for flush-plan append, recovery, and lock-loss paths.

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { DelegateDaemonTarget } from "./bridge.js";
+import { ingestFlushPlanNotes } from "./delegate-flush-plan-ingest.js";
+
+interface ObserveServer {
+  port: number;
+  close: () => Promise<void>;
+}
+
+interface FlushPlanFiles {
+  workspaceDir: string;
+  plan: string;
+  inflight: string;
+  rotating: string;
+  lock: string;
+}
+
+test("keeps a host append made while the flush post is in flight", async () => {
+  const files = await createFlushPlanFiles("append");
+  const observed: string[] = [];
+  let server: ObserveServer | undefined;
+  try {
+    await mkdir(path.dirname(files.plan), { recursive: true });
+    await writeFile(files.plan, "- first note\n", "utf8");
+    server = await startObserveServer(async (content) => {
+      observed.push(content);
+      if (observed.length === 1) {
+        await appendFile(files.plan, "- appended while posting\n", "utf8");
+      }
+    });
+
+    await ingestFlushPlanNotes(optionsFor(server.port, files.workspaceDir, "append"));
+
+    assert.deepEqual(observed, ["- first note\n", "- appended while posting\n"]);
+    assert.equal(await readIfPresent(files.plan), undefined);
+    assert.equal(await readIfPresent(files.inflight), undefined);
+  } finally {
+    await server?.close();
+    await rm(files.workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("recovers rotating and inflight leftovers in write order", async () => {
+  const files = await createFlushPlanFiles("recovery");
+  const observed: string[] = [];
+  let server: ObserveServer | undefined;
+  try {
+    await mkdir(path.dirname(files.plan), { recursive: true });
+    await writeFile(files.rotating, "- stranded during rotation\n", "utf8");
+    await writeFile(files.inflight, "- stranded in flight\n", "utf8");
+    await writeFile(files.plan, "- newer host note\n", "utf8");
+    server = await startObserveServer((content) => {
+      observed.push(content);
+    });
+
+    await ingestFlushPlanNotes(optionsFor(server.port, files.workspaceDir, "recovery"));
+
+    assert.deepEqual(observed, [
+      "- stranded in flight\n- stranded during rotation\n- newer host note\n",
+    ]);
+    assert.equal(await readIfPresent(files.plan), undefined);
+    assert.equal(await readIfPresent(files.inflight), undefined);
+    assert.equal(await readIfPresent(files.rotating), undefined);
+  } finally {
+    await server?.close();
+    await rm(files.workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("stops after lock loss during a flush instead of posting another chunk", async () => {
+  const files = await createFlushPlanFiles("lock-loss");
+  const notes = Array.from({ length: 2_000 }, (_, index) => `- note ${index} ${"x".repeat(70)}\n`).join("");
+  const observed: string[] = [];
+  let server: ObserveServer | undefined;
+  try {
+    await mkdir(path.dirname(files.plan), { recursive: true });
+    await writeFile(files.plan, notes, "utf8");
+    server = await startObserveServer(async (content) => {
+      observed.push(content);
+      if (observed.length === 1) await unlink(files.lock);
+    });
+
+    await ingestFlushPlanNotes(optionsFor(server.port, files.workspaceDir, "lock-loss"));
+
+    assert.equal(observed.length, 1, "lock loss declines the rest of this flush");
+    assert.ok(observed[0] !== undefined && observed[0].length < notes.length);
+    assert.equal(await readIfPresent(files.inflight), notes, "the new owner receives the untouched snapshot");
+  } finally {
+    await server?.close();
+    await rm(files.workspaceDir, { recursive: true, force: true });
+  }
+});
+
+async function createFlushPlanFiles(serviceId: string): Promise<FlushPlanFiles> {
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-flush-plan-test-"));
+  const plan = path.join(workspaceDir, "state", "plugins", serviceId, "flush-plan.md");
+  return {
+    workspaceDir,
+    plan,
+    inflight: `${plan}.inflight`,
+    rotating: `${plan}.rotating`,
+    lock: `${plan}.lock`,
+  };
+}
+
+function optionsFor(port: number, workspaceDir: string, serviceId: string) {
+  return {
+    target: {
+      host: "127.0.0.1",
+      port,
+      resolveAuthToken: () => ({ token: "test-token", source: "daemon configuration" as const }),
+    },
+    serviceId,
+    workspaceDir,
+    sessionKey: "test-session",
+    namespace: undefined,
+    remainingTimeoutMs: () => 10_000,
+  } satisfies Parameters<typeof ingestFlushPlanNotes>[0];
+}
+
+async function startObserveServer(onObserve: (content: string) => Promise<void> | void): Promise<ObserveServer> {
+  const server = http.createServer((request, response) => {
+    let raw = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      raw += chunk;
+    });
+    request.on("end", () => {
+      void (async () => {
+        const body = JSON.parse(raw) as {
+          messages?: Array<{ content?: string }>;
+        };
+        await onObserve(body.messages?.[0]?.content ?? "");
+        response.statusCode = 200;
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ ok: true }));
+      })().catch(() => {
+        response.statusCode = 500;
+        response.end();
+      });
+    });
+  });
+  const listening = Promise.withResolvers<void>();
+  server.once("error", listening.reject);
+  server.listen(0, "127.0.0.1", listening.resolve);
+  await listening.promise;
+  const address = server.address();
+  if (address === null || typeof address !== "object") {
+    await closeServer(server);
+    throw new Error("observe stub did not bind");
+  }
+  return { port: address.port, close: () => closeServer(server) };
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  const closed = Promise.withResolvers<void>();
+  server.close((error) => (error ? closed.reject(error) : closed.resolve()));
+  await closed.promise;
+}
+
+async function readIfPresent(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
@@ -126,6 +126,16 @@ function optionsFor(port: number, workspaceDir: string, serviceId: string) {
 
 async function startObserveServer(onObserve: (content: string) => Promise<void> | void): Promise<ObserveServer> {
   const server = http.createServer((request, response) => {
+    const validRequest =
+      request.method === "POST" &&
+      request.url === "/engram/v1/observe" &&
+      request.headers.authorization === "Bearer test-token" &&
+      request.headers["content-type"] === "application/json";
+    if (!validRequest) {
+      response.statusCode = 400;
+      response.end();
+      return;
+    }
     let raw = "";
     request.setEncoding("utf8");
     request.on("data", (chunk) => {
@@ -134,9 +144,22 @@ async function startObserveServer(onObserve: (content: string) => Promise<void> 
     request.on("end", () => {
       void (async () => {
         const body = JSON.parse(raw) as {
-          messages?: Array<{ content?: string }>;
+          sessionKey?: unknown;
+          messages?: unknown;
         };
-        await onObserve(body.messages?.[0]?.content ?? "");
+        const message =
+          Array.isArray(body.messages) &&
+          body.messages.length === 1 &&
+          typeof body.messages[0] === "object" &&
+          body.messages[0] !== null
+            ? (body.messages[0] as { content?: unknown })
+            : undefined;
+        if (body.sessionKey !== "test-session" || typeof message?.content !== "string") {
+          response.statusCode = 400;
+          response.end();
+          return;
+        }
+        await onObserve(message.content);
         response.statusCode = 200;
         response.setHeader("content-type", "application/json");
         response.end(JSON.stringify({ ok: true }));


### PR DESCRIPTION
## Summary

Add a dedicated deterministic test module for flush-plan ingestion. The tests cover host appends during posting, recovery from `.rotating` and `.inflight` leftovers, and lock loss before a second chunk.

Fixes #2393

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [ ] `npm run check-types` (root command unavailable because `pnpm` is not installed)
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `bash scripts/check-review-patterns.sh`
- [x] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`
- [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening`
- [ ] Ran `npm run review:cursor` locally (Cursor CLI unavailable)

Targeted validation passed:
- `npx tsx --test ./packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts`
- `npm exec --yes pnpm@10.32.1 -- --filter @remnic/plugin-openclaw run check-types`

## Changelog

- [ ] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Not needed (changeset added)

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered

## Notes for reviewers

The lock-loss test deliberately removes the lock while the first observe request is pending. It asserts that ingestion sends no second chunk and leaves the original snapshot for the replacement owner.

## PR workflow

- [x] PR scope is narrow
- [x] Synced with latest `main` before requesting AI review
- [x] Batched review fixes by subsystem instead of micro-pushing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and changeset changes; no runtime or API behavior modified in this diff.
> 
> **Overview**
> Adds **`delegate-flush-plan-ingest.test.ts`** with integration-style tests against a local `/engram/v1/observe` stub, exercising **`ingestFlushPlanNotes`** without changing production code.
> 
> Coverage locks in three edge cases: **host appends while the first observe POST is in flight** (expects a second chunk and a clean plan), **recovery when `.inflight`, `.rotating`, and the live plan coexist** (expects inflight → rotating → plan ordering and cleanup), and **lock loss mid multi-chunk flush** (expects only one POST and the full snapshot left in `.inflight` for the next owner). A patch **changeset** documents the added regression coverage for `@remnic/plugin-openclaw`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c939123cb0f97901c5914ecebf2f5a9985944d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patch release improves reliability for flush-plan ingestion during concurrent appends, recovery, and lock-loss scenarios.
  * Ensures recovered and in-progress files are processed in the correct order while preserving or cleaning up files appropriately.

* **Tests**
  * Added integration coverage for concurrent ingestion, recovery behavior, and interrupted flush operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->