### PR TITLE
test(bench): pin trap audit usage shape

### DIFF
--- a/.changeset/2320-trap-audit-usage-shape.md
+++ b/.changeset/2320-trap-audit-usage-shape.md
@@ -1,0 +1,5 @@
+---
+"@remnic/bench": patch
+---
+
+Pin the complete normalized token usage shape in the repeated-failure trap-audit resume test (issue #2320).

--- a/packages/bench/src/coding-graph/repeated-failure-trap-audit.test.ts
+++ b/packages/bench/src/coding-graph/repeated-failure-trap-audit.test.ts
@@ -232,9 +232,9 @@ async function seedTerminalAuditRows(
         input: 2,
         output: 1,
         total: 3,
-        cachedInput: 0,
-        cacheWriteInput: 0,
-        reasoningOutput: 0,
+        cachedInput: 2,
+        cacheWriteInput: 1,
+        reasoningOutput: 4,
       };
       const retryTracePath = `traces/${rowKey}/attempt-1.json`;
       const retryTraceBytes = `${JSON.stringify({
@@ -653,13 +653,14 @@ test("runTrapAudit rejects a tampered prior retry trace with unchanged usage", a
         reasoningOutput: number;
       };
     };
+    // Keep strict equality here: this test pins the complete normalized usage contract.
     assert.deepEqual(retryTrace.usage, {
       input: 2,
       output: 1,
       total: 3,
-      cachedInput: 0,
-      cacheWriteInput: 0,
-      reasoningOutput: 0,
+      cachedInput: 2,
+      cacheWriteInput: 1,
+      reasoningOutput: 4,
     });
     await writeFile(retryTracePath, `${JSON.stringify({ ...retryTrace, tampered: true })}\n`);
 


### PR DESCRIPTION
## Summary

Fixes #2320. Keep the trap-audit retry trace assertion strict against the complete normalized usage shape. The normalizer and strict trace schema require `input`, `output`, `total`, `cachedInput`, `cacheWriteInput`, and `reasoningOutput`; full equality pins that contract and catches field loss. The retry fixture now uses non-zero values for all three provider detail fields, so the test verifies those fields survive trace persistence and resume validation.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [ ] `npm run check-types` (root command not run; scoped check passed below)
- [ ] `npm test` (not run)
- [ ] `npm run build` (not run)
- [x] `bash scripts/check-review-patterns.sh` (via `npm run preflight:quick`)
- [x] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md` (not applicable)
- [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening` (not applicable)
- [ ] Ran `npm run review:cursor` locally, or documented why it was unavailable (not run)

Scoped checks:
- `npx tsx --test packages/bench/src/coding-graph/repeated-failure-trap-audit.test.ts` (22 passed)
- `npm exec --yes pnpm@10.32.1 -- --filter @remnic/bench run check-types`
- `npm run preflight:quick` with pinned pnpm on PATH

## Changelog

- [ ] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Not needed (added `.changeset/2320-trap-audit-usage-shape.md`)

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [ ] Migration/config impact documented (not applicable)

## Notes for reviewers

The test now exercises non-zero cached input, cache-write input, and reasoning output values. The strict deep equality checks the full normalized shape.

## PR workflow

- [x] PR scope is narrow, or the split justification is explained here
- [x] Synced with latest `main` before requesting AI review
- [x] Batched review fixes by subsystem instead of micro-pushing