### PR TITLE
fix(core): cancel shared context reads on recall abort

### DIFF
--- a/.changeset/shared-context-abort-2302.md
+++ b/.changeset/shared-context-abort-2302.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Cancel shared-context preamble reads when a recall aborts (issue #2302).

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -746,9 +746,9 @@ export class RecallInternalCoordinator {
         return null;
       const t0 = Date.now();
       const [priorities, roundtable, crossSignals] = await Promise.all([
-        this.deps.sharedContext.readPriorities(),
-        this.deps.sharedContext.readLatestRoundtable(),
-        this.deps.sharedContext.readLatestCrossSignals(),
+        this.deps.sharedContext.readPriorities(options.abortSignal),
+        this.deps.sharedContext.readLatestRoundtable(options.abortSignal),
+        this.deps.sharedContext.readLatestCrossSignals(options.abortSignal),
       ]);
       const max = Math.max(500, this.deps.config.sharedContextMaxInjectChars);
       const capSection = (

--- a/packages/remnic-core/src/shared-context/manager.ts
+++ b/packages/remnic-core/src/shared-context/manager.ts
@@ -6,6 +6,7 @@ import { log } from "../logger.js";
 import type { PluginConfig } from "../types.js";
 import { expandTildePath } from "../utils/path.js";
 import { resolveConversationContextCapabilities } from "../capabilities.js";
+import { throwIfAborted } from "../abort-error.js";
 
 export const SharedFeedbackEntrySchema = z.object({
   agent: z.string().min(1),
@@ -497,38 +498,52 @@ export class SharedContextManager {
     }
   }
 
-  async readPriorities(): Promise<string> {
+  async readPriorities(signal?: AbortSignal): Promise<string> {
+    throwIfAborted(signal, "shared context priorities read aborted");
     try {
-      return await readFile(this.prioritiesPath, "utf-8");
+      const content = await readFile(this.prioritiesPath, { encoding: "utf-8", signal });
+      throwIfAborted(signal, "shared context priorities read aborted");
+      return content;
     } catch {
+      throwIfAborted(signal, "shared context priorities read aborted");
       return "";
     }
   }
 
-  async readLatestRoundtable(): Promise<string> {
+  async readLatestRoundtable(signal?: AbortSignal): Promise<string> {
+    throwIfAborted(signal, "shared context roundtable read aborted");
     try {
       const files = (await readdir(this.roundtableDir))
         .filter((f) => f.endsWith(".md"))
         .sort()
         .reverse();
+      throwIfAborted(signal, "shared context roundtable read aborted");
       const fp = files[0] ? path.join(this.roundtableDir, files[0]) : null;
       if (!fp) return "";
-      return await readFile(fp, "utf-8");
+      const content = await readFile(fp, { encoding: "utf-8", signal });
+      throwIfAborted(signal, "shared context roundtable read aborted");
+      return content;
     } catch {
+      throwIfAborted(signal, "shared context roundtable read aborted");
       return "";
     }
   }
 
-  async readLatestCrossSignals(): Promise<string> {
+  async readLatestCrossSignals(signal?: AbortSignal): Promise<string> {
+    throwIfAborted(signal, "shared context cross-signals read aborted");
     try {
       const files = (await readdir(this.crossSignalsDir))
         .filter((f) => f.endsWith(".md"))
         .sort()
         .reverse();
+      throwIfAborted(signal, "shared context cross-signals read aborted");
       const fp = files[0] ? path.join(this.crossSignalsDir, files[0]) : null;
       if (!fp) return "";
-      return await readFile(fp, "utf-8");
+      const content = await readFile(fp, { encoding: "utf-8", signal });
+      throwIfAborted(signal, "shared context cross-signals read aborted");
+      return content;
     } catch {
+      throwIfAborted(signal, "shared context cross-signals read aborted");
       return "";
     }
   }

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -582,6 +582,70 @@ test("recallInternal aborts while phase-one preamble promises are still pending"
     release?.();
   }
 });
+test("recallInternal forwards abort to each phase-one shared-context read", async () => {
+  const orchestrator = await makeOrchestrator("engram-recall-phase-one-cancel-");
+  const callerAbortController = new AbortController();
+  type SharedContextReadSurface = {
+    readPriorities: (signal?: AbortSignal) => Promise<string>;
+    readLatestRoundtable: (signal?: AbortSignal) => Promise<string>;
+    readLatestCrossSignals: (signal?: AbortSignal) => Promise<string>;
+  };
+  type RecallInternalHarness = {
+    isRecallSectionEnabled: (id: string) => boolean;
+    sharedContext: SharedContextReadSurface;
+    recallInternal: (
+      prompt: string,
+      sessionKey: string,
+      options: { mode: "full"; abortSignal: AbortSignal },
+    ) => Promise<unknown>;
+  };
+  const harness = orchestrator as unknown as RecallInternalHarness;
+  harness.isRecallSectionEnabled = (id: string) => id === "shared-context";
+
+  let readsStarted = 0;
+  let readsCancelled = 0;
+  let resolveReadsStarted: (() => void) | null = null;
+  const allReadsStarted = new Promise<void>((resolve) => {
+    resolveReadsStarted = resolve;
+  });
+  const cancelledRead = (signal?: AbortSignal): Promise<string> =>
+    new Promise<string>((_resolve, reject) => {
+      assert.ok(signal);
+      readsStarted += 1;
+      if (readsStarted === 3) resolveReadsStarted?.();
+      signal.addEventListener(
+        "abort",
+        () => {
+          readsCancelled += 1;
+          reject(signal.reason);
+        },
+        { once: true },
+      );
+    });
+  harness.sharedContext = {
+    readPriorities: cancelledRead,
+    readLatestRoundtable: cancelledRead,
+    readLatestCrossSignals: cancelledRead,
+  };
+
+  const recallPromise = harness.recallInternal(
+    "phase one cancellation test",
+    "agent:test:phase-one-cancel",
+    {
+      mode: "full",
+      abortSignal: callerAbortController.signal,
+    },
+  );
+
+  await allReadsStarted;
+  callerAbortController.abort();
+
+  await assert.rejects(
+    recallPromise,
+    (err: unknown) => err instanceof Error && err.name === "AbortError",
+  );
+  assert.equal(readsCancelled, 3);
+});
 
 test("recallInternal does not launch phase-one preamble work for an already-aborted signal", async () => {
   const orchestrator = await makeOrchestrator(

--- a/tests/shared-context.test.ts
+++ b/tests/shared-context.test.ts
@@ -168,6 +168,27 @@ test("v4 shared context manager bootstraps structure and writes outputs", async 
   assert.match(raw, /kind: agent_output/);
   assert.match(raw, /Hello world/);
 });
+test("shared context reads reject an already-aborted signal", async () => {
+  const memoryDir = tmpDir("engram-sc-abort");
+  const sharedDir = tmpDir("engram-shared-abort");
+  await mkdir(memoryDir, { recursive: true });
+
+  const manager = new SharedContextManager(minimalConfig(memoryDir, sharedDir));
+  await manager.ensureStructure();
+  const controller = new AbortController();
+  controller.abort();
+
+  for (const read of [
+    manager.readPriorities.bind(manager),
+    manager.readLatestRoundtable.bind(manager),
+    manager.readLatestCrossSignals.bind(manager),
+  ]) {
+    await assert.rejects(
+      read(controller.signal),
+      (error: unknown) => error instanceof Error && error.name === "AbortError",
+    );
+  }
+});
 
 test("shared context output path encodes agent ids that contain traversal", async () => {
   const memoryDir = tmpDir("engram-sc-mem");


### PR DESCRIPTION
## Summary

Fixes #2302. Thread the recall AbortSignal through the shared-context read surface. Filesystem reads now receive the signal and check it before and after each read.

## Type of change

- [x] Bug fix

## Validation

- [x] Core targeted check-types
- [x] Targeted shared-context and recall-hardening tests
- [x] Added tests for signal forwarding and aborted reads
- [x] Ran `npm run preflight:quick` through pinned pnpm
- [x] Ran `npm run test:entity-hardening` through pinned pnpm
- [ ] Full root test suite (not run; targeted validation was requested)
- [ ] `npm run review:cursor` (not available)

## Changelog

- [x] Added `.changeset/shared-context-abort-2302.md`
- [x] Not needed: `CHANGELOG.md` is release-generated

## Risk assessment

- [x] No secrets or tokens added
- [x] Backwards compatibility considered: signal parameters are optional
- [x] Promise cancellation behavior verified

## Notes for reviewers

The recall preamble passes its existing signal to all three reads. Aborted reads reject with `AbortError`; missing files still return an empty string when no signal is provided.

## PR workflow

- [x] PR scope is narrow
- [x] Synced with latest `main` before review
- [x] Review fixes will be batched by subsystem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional signal parameters preserve backward compatibility; behavior change is limited to cooperative cancellation during recall abort (#2302).
> 
> **Overview**
> Fixes **#2302** by wiring the recall **`AbortSignal`** into the three phase-one shared-context preamble reads (`readPriorities`, `readLatestRoundtable`, `readLatestCrossSignals`) in `recall-internal.ts`.
> 
> **`SharedContextManager`** now takes an optional signal on those methods: it checks **`throwIfAborted`** before/after I/O, passes the signal into **`readFile`**, and rejects with **`AbortError`** when aborted instead of finishing slow disk work. Callers without a signal keep the prior behavior (missing files still yield `""`).
> 
> Adds **recall-hardening** coverage that all three reads receive the signal and cancel together, plus **shared-context** tests for already-aborted signals. Patch **changeset** for `@remnic/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bac458ee6238cc6a4e72f47ea45582521cfa425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->