### PR TITLE
fix(core): preserve entity field origins

### DIFF
--- a/.changeset/entity-origin-audit-2397.md
+++ b/.changeset/entity-origin-audit-2397.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Preserve extraction origins on entity facts and structured sections during authority-aware recall, and cover inclusive `--since` audit boundaries.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,85 +1,51 @@
-# Theory: Wearable Privacy Beyond English
+# Theory: Preserve authority through derived entity fields
 
 ## Problem
 
-An always-on recorder captures speech in the wearer's own language.
+Entity recall copies facts and structured-section values from entity files into model context.
 
-The transcript pipeline treated every language as English.
+Memory writes already record extraction origins, but entity writes dropped that origin.
 
-The off-the-record feature matched three English words. A wearer who spoke
-Japanese, Korean, Chinese, Arabic, or Russian got no elision at all.
+Authority-aware recall therefore treated every entity field as `unknown`.
 
-Filler stripping matched English tokens. Non-English transcripts kept every
-filler.
-
-A privacy control that silently does nothing is worse than one documented as
-absent. The wearer believes the span is protected. It is not.
+That default protects against untrusted content but also fences user-derived facts.
 
 ## Operating theory
 
-Two separate defects share one root cause: both features assumed that words are
-separated by spaces and written in Latin script.
+Origin is field provenance, not only record provenance.
 
-A word boundary is a property of a script, not of text. Japanese, Chinese, and
-Kana runs have no boundary character. A regular expression that requires one
-can never match inside them.
+Each entity timeline entry and structured-section fact must retain the origin of the write batch.
 
-So boundary handling is decided per phrase edge. A phrase that starts or ends
-with a Latin, Cyrillic, Greek, or numeric character gets a letter boundary. Any
-other edge gets none.
+Missing or conflicting origin stays absent and renders as `unknown`.
 
-This single rule makes one matcher correct for every script.
+This preserves least privilege while allowing trusted user fields to remain readable.
 
 ## Strategy
 
-Built-in phrases cover a documented language set. Operators add more. Nothing
-is hard-coded to one deployment.
+Carry the classified extraction origin through `StorageManager.writeEntity` and `EntityStore`.
 
-Start phrases and end phrases carry different risk. A start phrase that fires
-wrongly elides real speech. An end phrase that fires wrongly leaks protected
-speech.
+Persist timeline origins as escaped metadata.
 
-So the end list is shorter than the start list. A start phrase with no matching
-end phrase elides through the end of the conversation. That is the fail-closed
-direction.
+Persist structured-section origins as escaped per-fact metadata.
 
-Filler tokens divide the same way. Space-delimited scripts use whole-token
-matching. Japanese and Chinese fillers are removed inline, so each inline entry
-must be unambiguous on its own. The elongated hesitation forms qualify. A bare
-Japanese demonstrative does not, because it carries meaning.
+Build the entity recall index with parallel origin arrays and pass each origin to the shared authority renderer.
 
-Operator tokens apply to every script. Routing them by script hint would drop a
-token the operator deliberately added.
+When equal text has different origins, drop the origin rather than selecting the more trusted value.
 
-## Silence is the failure mode
+## Audit boundary
 
-Config parsing rejects every unusable value loudly. A blank phrase, an
-over-long phrase, or a non-array throws with the exact key path.
+The audit cutoff is inclusive.
 
-Turning the built-in phrases off while the feature stays enabled and no start
-phrase is configured also throws. That combination would leave the gate on and
-match nothing, which recreates the original defect.
+A memory at the exact `--since` timestamp belongs to the reported window.
 
-The documented escape hatch is `offTheRecordEnabled: false`.
+A memory before that timestamp does not.
 
-## What stays language-dependent
-
-Built-in identifier redaction covers US formats only. Other national formats
-need operator patterns.
-
-Repeat-collapse and the low-quality heuristic still use space-delimited
-signals.
-
-Both limits are stated in the documentation. They are known gaps, not silent
-ones.
+The boundary test uses a one-millisecond separation to guard both cases.
 
 ## Verification state
 
-The 231-test wearables suite passes.
+Core type checking passes.
 
-The workspace type check passes.
+The entity hardening gate passes all 339 tests.
 
-The config contract validates, and the stale `wearables` grandfather entry is
-pruned.
-
-The line ratchet passes.
+Authority and audit regression tests pass all 13 tests.

--- a/packages/remnic-core/src/entity-origin-fields.ts
+++ b/packages/remnic-core/src/entity-origin-fields.ts
@@ -1,0 +1,53 @@
+import type { EntityStructuredSection } from "./types.js";
+
+type OriginatedEntry = { text: string; origin?: string };
+type SanitizedFacts = { facts: string[]; origins: Array<string | undefined> };
+
+export type EntityOriginStructuredSection = EntityStructuredSection & {
+  factOrigins?: Array<string | undefined>;
+};
+
+export function sanitizeOriginatedFacts(
+  entries: readonly OriginatedEntry[],
+  sanitize: (value: string) => string,
+  compact: (value: string, maxLength: number) => string,
+  deduplicate: boolean,
+): SanitizedFacts {
+  const result: SanitizedFacts = { facts: [], origins: [] };
+  for (const entry of entries) {
+    const clean = sanitize(entry.text);
+    if (!clean) continue;
+    const fact = compact(clean, 180);
+    const index = deduplicate ? result.facts.indexOf(fact) : -1;
+    if (index < 0) {
+      result.facts.push(fact);
+      result.origins.push(entry.origin);
+    } else if (result.origins[index] !== entry.origin) {
+      result.origins[index] = undefined;
+    }
+  }
+  return result;
+}
+
+export function buildOriginStructuredSections(
+  sections: readonly EntityStructuredSection[],
+  recallFacts: (section: EntityStructuredSection) => string[],
+  sanitize: (value: string) => string,
+  compact: (value: string, maxLength: number) => string,
+): EntityOriginStructuredSection[] {
+  return sections
+    .map((section) => {
+      const entries = recallFacts(section).map((text) => ({
+        text,
+        origin: section.factOrigins?.[section.facts.indexOf(text)],
+      }));
+      const result = sanitizeOriginatedFacts(entries, sanitize, compact, false);
+      return {
+        key: section.key,
+        title: section.title,
+        facts: result.facts,
+        ...(result.origins.some((origin) => origin !== undefined) ? { factOrigins: result.origins } : {}),
+      };
+    })
+    .filter((section) => section.facts.length > 0);
+}

--- a/packages/remnic-core/src/entity-origin-fields.ts
+++ b/packages/remnic-core/src/entity-origin-fields.ts
@@ -1,6 +1,7 @@
 import type { EntityStructuredSection } from "./types.js";
 
 type OriginatedEntry = { text: string; origin?: string };
+type RecalledFact = { text: string; sourceIndex: number };
 type SanitizedFacts = { facts: string[]; origins: Array<string | undefined> };
 
 export type EntityOriginStructuredSection = EntityStructuredSection & {
@@ -31,19 +32,16 @@ export function sanitizeOriginatedFacts(
 
 export function buildOriginStructuredSections(
   sections: readonly EntityStructuredSection[],
-  recallFacts: (section: EntityStructuredSection) => string[],
+  recallFacts: (section: EntityStructuredSection) => RecalledFact[],
   sanitize: (value: string) => string,
   compact: (value: string, maxLength: number) => string,
 ): EntityOriginStructuredSection[] {
   return sections
     .map((section) => {
-      const entries = recallFacts(section).map((text) => {
-        const sourceIndex = section.facts.indexOf(text);
-        const beliefIndex = sourceIndex >= 0
-          ? sourceIndex
-          : section.facts.findIndex((fact) => fact.endsWith(`; ${text}`));
-        return { text, origin: section.factOrigins?.[beliefIndex] };
-      });
+      const entries = recallFacts(section).map(({ text, sourceIndex }) => ({
+        text,
+        origin: section.factOrigins?.[sourceIndex],
+      }));
       const result = sanitizeOriginatedFacts(entries, sanitize, compact, false);
       return {
         key: section.key,

--- a/packages/remnic-core/src/entity-origin-fields.ts
+++ b/packages/remnic-core/src/entity-origin-fields.ts
@@ -15,12 +15,14 @@ export function sanitizeOriginatedFacts(
   deduplicate: boolean,
 ): SanitizedFacts {
   const result: SanitizedFacts = { facts: [], origins: [] };
+  const indexes = new Map<string, number>();
   for (const entry of entries) {
     const clean = sanitize(entry.text);
     if (!clean) continue;
     const fact = compact(clean, 180);
-    const index = deduplicate ? result.facts.indexOf(fact) : -1;
+    const index = deduplicate ? indexes.get(fact) ?? -1 : -1;
     if (index < 0) {
+      indexes.set(fact, result.facts.length);
       result.facts.push(fact);
       result.origins.push(entry.origin);
     } else if (result.origins[index] !== entry.origin) {

--- a/packages/remnic-core/src/entity-origin-fields.ts
+++ b/packages/remnic-core/src/entity-origin-fields.ts
@@ -37,10 +37,13 @@ export function buildOriginStructuredSections(
 ): EntityOriginStructuredSection[] {
   return sections
     .map((section) => {
-      const entries = recallFacts(section).map((text) => ({
-        text,
-        origin: section.factOrigins?.[section.facts.indexOf(text)],
-      }));
+      const entries = recallFacts(section).map((text) => {
+        const sourceIndex = section.facts.indexOf(text);
+        const beliefIndex = sourceIndex >= 0
+          ? sourceIndex
+          : section.facts.findIndex((fact) => fact.endsWith(`; ${text}`));
+        return { text, origin: section.factOrigins?.[beliefIndex] };
+      });
       const result = sanitizeOriginatedFacts(entries, sanitize, compact, false);
       return {
         key: section.key,

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -109,15 +109,19 @@ function compactLine(value: string, maxLength: number = 220): string {
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
 function dedupeHintSnippetsByText(snippets: EntityHintSnippet[]): EntityHintSnippet[] {
-  const seen = new Set<string>();
-  const result: EntityHintSnippet[] = [];
+  const deduped = new Map<string, EntityHintSnippet>();
   for (const snippet of snippets) {
     const key = normalizeEntityText(snippet.text);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    result.push(snippet);
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, snippet);
+      continue;
+    }
+    if (existing.origin !== snippet.origin) {
+      existing.origin = undefined;
+    }
   }
-  return result;
+  return [...deduped.values()];
 }
 function isBeliefLedgerSection(section: Pick<EntityStructuredSection, "key">): boolean {
   return normalizeEntityText(section.key).replace(/\s+/g, "_") === BELIEF_LEDGER_SECTION_KEY;

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -340,7 +340,6 @@ async function resolveEntityIndexStorages(
   ) {
     return [storage];
   }
-
   const storages: StorageManager[] = [];
   const seenDirs = new Set<string>();
   for (const namespace of uniqueStrings(recallNamespaces)) {
@@ -354,10 +353,8 @@ async function resolveEntityIndexStorages(
       continue;
     }
   }
-
   return storages.length > 0 ? storages : [storage];
 }
-
 function entityIndexStatePath(storage: StorageManager): string {
   return path.join(storage.dir, "state", "entity-mention-index.json");
 }
@@ -373,8 +370,6 @@ async function readEntityIndexState(storage: StorageManager): Promise<EntityMent
     return null;
   }
 }
-
-
 async function readCurrentPersistedEntityIndex(
   storage: StorageManager,
   config: PluginConfig,
@@ -396,7 +391,6 @@ async function readCurrentPersistedEntityIndex(
   return index;
 }
 const namespaceEntityIndexCache = new Map<string, EntityMentionIndex>();
-const MAX_NAMESPACE_ENTITY_INDEX_CACHE_ENTRIES = 32;
 
 function nativeEntityIndexRevision(chunks: NativeKnowledgeChunk[]): string {
   const projection = chunks.map((chunk) => [
@@ -410,7 +404,6 @@ function nativeEntityIndexRevision(chunks: NativeKnowledgeChunk[]): string {
   ]);
   return createHash("sha256").update(JSON.stringify(projection)).digest("hex");
 }
-
 function namespaceEntityIndexCacheKey(
   storages: StorageManager[],
   recallNamespaces: string[],
@@ -430,7 +423,6 @@ function namespaceEntityIndexCacheKey(
     .join("\u001f");
   return `${namespaceKey}\u001e${storageKey}\u001e${nativeRevision}`;
 }
-
 function rememberNamespaceEntityIndex(key: string, index: EntityMentionIndex): void {
   if (namespaceEntityIndexCache.size >= MAX_NAMESPACE_ENTITY_INDEX_CACHE_ENTRIES) {
     const oldestKey = namespaceEntityIndexCache.keys().next().value;

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -10,12 +10,16 @@ import { normalizeEntityText, resolveRequestedEntitySectionKeys } from "./entity
 import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry } from "./types.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
 import {
+  buildOriginStructuredSections,
+  sanitizeOriginatedFacts,
+  type EntityOriginStructuredSection,
+} from "./entity-origin-fields.js";
+import {
   checkEntityRecallAbort,
   entityRecallSectionAbsent,
   yieldEntityRecallScan,
   yieldEntityRecallScanEvery,
 } from "./entity-recall-cancellation.js";
-
 const ENTITY_INDEX_VERSION = 3;
 const RECENT_TRANSCRIPT_LOOKBACK_HOURS = 24;
 const INSTRUCTION_LIKE_RE = /\b(always|never|must|should|remember to|do not|don't|process|workflow|template|checklist|instruction)\b/i;
@@ -23,24 +27,24 @@ const METADATA_WRAPPER_RE = /^(source|context|metadata|notes?):/i;
 const ENTITY_PRONOUN_RE = /\b(he|him|his|she|her|they|them|their|it|its)\b/i;
 const BELIEF_LEDGER_SECTION_KEY = "belief_ledger";
 const BELIEF_LEDGER_FACT_RE = /^claim=([^;]+);\s*status=([^;]+);\s*updatedAt=([^;]+);\s*(.+)$/;
-
 type EntityQueryMode = "direct" | "timeline" | "follow_up";
-
 type EntityMentionIndexEntry = {
   canonicalId: string;
   name: string;
   type: string;
-  aliases: string[];
   summary?: string;
+  aliases: string[];
   facts: string[];
   timelineFacts: string[];
-  structuredSections: EntityStructuredSection[];
+  timelineFactOrigins?: Array<string | undefined>;
+  structuredSections: EntityOriginStructuredSection[];
   timeline: Array<{
     timestamp: string;
     text: string;
     source?: string;
     sessionKey?: string;
     principal?: string;
+    origin?: string;
   }>;
   relationships: Array<{ target: string; label: string }>;
   activity: Array<{ date: string; note: string }>;
@@ -55,21 +59,18 @@ type EntityMentionIndexEntry = {
     derivedDate?: string;
   }>;
 };
-
 type EntityMentionIndex = {
   version: number;
   updatedAt: string;
   entityStatusVersion?: number;
   entities: EntityMentionIndexEntry[];
 };
-
 type EntityCandidate = {
   entry: EntityMentionIndexEntry;
   alias: string;
   score: number;
   source: "query" | "recent_turn";
 };
-
 type EntityHintSnippet = {
   text: string;
   score: number;
@@ -96,21 +97,17 @@ export interface BuildEntityRecallSectionOptions {
    */
   abortSignal?: AbortSignal;
 }
-
 function tokenize(value: string): string[] {
   return normalizeEntityText(value).split(/\s+/).filter((token) => token.length >= 2);
 }
-
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
 }
-
 function compactLine(value: string, maxLength: number = 220): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
-
 function dedupeHintSnippetsByText(snippets: EntityHintSnippet[]): EntityHintSnippet[] {
   const seen = new Set<string>();
   const result: EntityHintSnippet[] = [];
@@ -122,11 +119,9 @@ function dedupeHintSnippetsByText(snippets: EntityHintSnippet[]): EntityHintSnip
   }
   return result;
 }
-
 function isBeliefLedgerSection(section: Pick<EntityStructuredSection, "key">): boolean {
   return normalizeEntityText(section.key).replace(/\s+/g, "_") === BELIEF_LEDGER_SECTION_KEY;
 }
-
 function beliefLedgerFactKeys(sections: EntityStructuredSection[]): Set<string> {
   const keys = new Set<string>();
   for (const section of sections) {
@@ -137,12 +132,10 @@ function beliefLedgerFactKeys(sections: EntityStructuredSection[]): Set<string> 
   }
   return keys;
 }
-
 function recallFactsForStructuredSection(section: EntityStructuredSection): string[] {
   if (!isBeliefLedgerSection(section)) return section.facts;
   return currentActiveBeliefLedgerFactTexts(section.facts);
 }
-
 function currentActiveBeliefLedgerFactTexts(facts: string[]): string[] {
   const byClaim = new Map<string, { status: string; updatedAtMs: number; texts: string[] }>();
   for (const fact of facts) {
@@ -175,13 +168,11 @@ function currentActiveBeliefLedgerFactTexts(facts: string[]): string[] {
   }
   return result;
 }
-
 function relationLine(entry: EntityMentionIndexEntry, relationship: { target: string; label: string }): string {
   const normalizedLabel = relationship.label.replace(/\s+/g, " ").trim();
   if (normalizedLabel.length === 0) return `${entry.name} is connected to ${relationship.target}`;
   return `${entry.name} ${normalizedLabel} ${relationship.target}`;
 }
-
 function detectEntityQueryMode(query: string): EntityQueryMode | null {
   const normalized = normalizeEntityText(query);
   if (!normalized) return null;
@@ -211,7 +202,6 @@ function detectEntityQueryMode(query: string): EntityQueryMode | null {
   }
   return null;
 }
-
 function scoreAliasMatch(query: string, alias: string): number {
   const normalizedQuery = normalizeEntityText(query);
   const normalizedAlias = normalizeEntityText(alias);
@@ -246,7 +236,6 @@ function scoreAliasMatch(query: string, alias: string): number {
   }
   return overlap;
 }
-
 /**
  * Tokens that look like type prefixes / generic role identifiers and
  * therefore should not, on their own, count as evidence that a
@@ -264,15 +253,12 @@ const ALIAS_AFFIX_TOKENS = new Set<string>([
   "place", "places", "tool", "tools", "service", "services",
   "system", "systems", "agent", "agents", "bot", "bots",
 ]);
-
 function isAliasAffixToken(token: string): boolean {
   return ALIAS_AFFIX_TOKENS.has(token);
 }
-
 function isLikelyInstructionLike(value: string): boolean {
   return INSTRUCTION_LIKE_RE.test(value) || METADATA_WRAPPER_RE.test(value);
 }
-
 function sanitizeEntityFact(fact: string): string {
   const sanitized = sanitizeMemoryContent(fact);
   const clean = sanitized.text.trim();
@@ -280,7 +266,6 @@ function sanitizeEntityFact(fact: string): string {
   if (INSTRUCTION_LIKE_RE.test(clean) && clean.length > 100) return "";
   return clean;
 }
-
 function scoreHintSnippet(snippet: EntityHintSnippet, queryTokens: string[]): EntityHintSnippet | null {
   const normalized = normalizeEntityText(snippet.text);
   if (!normalized) return null;
@@ -294,7 +279,6 @@ function scoreHintSnippet(snippet: EntityHintSnippet, queryTokens: string[]): En
   if (scored.text.length <= 160) scored.score += 1;
   return scored.score > 0 ? scored : null;
 }
-
 function sortTimelineEntriesDesc(
   left: EntityMentionIndexEntry["timeline"][number],
   right: EntityMentionIndexEntry["timeline"][number],
@@ -305,7 +289,6 @@ function sortTimelineEntriesDesc(
   }
   return right.text.localeCompare(left.text);
 }
-
 function jaccardSimilarity(a: string, b: string): number {
   const aTokens = new Set(tokenize(a));
   const bTokens = new Set(tokenize(b));
@@ -317,7 +300,6 @@ function jaccardSimilarity(a: string, b: string): number {
   const union = new Set([...aTokens, ...bTokens]).size;
   return union === 0 ? 0 : intersection / union;
 }
-
 function buildAliasIndex(entries: EntityMentionIndexEntry[]): Map<string, EntityMentionIndexEntry[]> {
   const index = new Map<string, EntityMentionIndexEntry[]>();
   for (const entry of entries) {
@@ -330,7 +312,6 @@ function buildAliasIndex(entries: EntityMentionIndexEntry[]): Map<string, Entity
   }
   return index;
 }
-
 async function readNativeChunks(
   config: PluginConfig,
   recallNamespaces?: string[],
@@ -344,7 +325,6 @@ async function readNativeChunks(
     defaultNamespace: config.defaultNamespace,
   }).catch(() => []);
 }
-
 async function resolveEntityIndexStorages(
   storage: StorageManager,
   config: PluginConfig,
@@ -585,10 +565,18 @@ async function buildEntityMentionIndex(
       .filter(Boolean)
       .filter((fact) => !rawBeliefLedgerFactKeys.has(normalizeEntityText(fact)))
       .map((fact) => compactLine(fact, 180));
-    const sanitizedTimelineFacts = entity.timeline
-      .map((entry) => sanitizeEntityFact(entry.text))
-      .filter(Boolean)
-      .map((fact) => compactLine(fact, 180));
+    const { facts: timelineFacts, origins: timelineFactOrigins } = sanitizeOriginatedFacts(
+      entity.timeline,
+      sanitizeEntityFact,
+      compactLine,
+      true,
+    );
+    const structuredSections = buildOriginStructuredSections(
+      rawStructuredSections,
+      recallFactsForStructuredSection,
+      sanitizeEntityFact,
+      compactLine,
+    );
     entities.set(canonicalId, {
       canonicalId,
       name: entity.name,
@@ -596,15 +584,9 @@ async function buildEntityMentionIndex(
       aliases: uniqueStrings(entity.aliases),
       summary: entity.synthesis?.trim() || entity.summary?.trim() || undefined,
       facts: sanitizedFacts,
-      timelineFacts: uniqueStrings(sanitizedTimelineFacts),
-      structuredSections: rawStructuredSections.map((section) => ({
-        key: section.key,
-        title: section.title,
-        facts: recallFactsForStructuredSection(section)
-          .map((fact) => sanitizeEntityFact(fact))
-          .filter(Boolean)
-          .map((fact) => compactLine(fact, 180)),
-      })).filter((section) => section.facts.length > 0),
+      timelineFacts,
+      ...(timelineFactOrigins.some((origin) => origin !== undefined) ? { timelineFactOrigins } : {}),
+      structuredSections,
       timeline: entity.timeline.map((entry) => ({ ...entry })),
       relationships: entity.relationships.map((relationship) => ({ ...relationship })),
       activity: entity.activity.map((activity) => ({ ...activity })),
@@ -857,20 +839,29 @@ async function buildHintSnippets(
   if (entry.summary) {
     snippets.push({ text: compactLine(entry.summary, 180), score: 10, kind: "summary" });
   }
-
   if (requestedSectionKeys.size > 0) {
     for (const section of entry.structuredSections) {
       if (!requestedSectionKeys.has(normalizeEntityText(section.key).replace(/\s+/g, "_"))) continue;
-      for (const fact of section.facts) {
-        snippets.push({ text: fact, score: mode === "direct" ? 8 : 9, kind: "section" });
+      for (const [index, fact] of section.facts.entries()) {
+        snippets.push({
+          text: fact,
+          score: mode === "direct" ? 8 : 9,
+          kind: "section",
+          origin: section.factOrigins?.[index],
+        });
       }
     }
   } else {
-    for (const fact of entry.timelineFacts) {
-      snippets.push({ text: fact, score: mode === "direct" ? 6 : 7, kind: "fact" });
+    for (const [index, fact] of entry.timelineFacts.entries()) {
+      snippets.push({
+        text: fact,
+        score: mode === "direct" ? 6 : 7,
+        kind: "fact",
+        origin: entry.timelineFactOrigins?.[index],
+      });
     }
     for (const section of entry.structuredSections) {
-      for (const fact of section.facts) {
+      for (const [index, fact] of section.facts.entries()) {
         const normalizedFact = normalizeEntityText(fact);
         const hasNonAliasQueryOverlap = queryTokens.some((token) =>
           !aliasTokens.has(token) && normalizedFact.includes(token)
@@ -878,7 +869,12 @@ async function buildHintSnippets(
         if (entry.timelineFacts.length > 0 && !hasNonAliasQueryOverlap) {
           continue;
         }
-        snippets.push({ text: fact, score: mode === "direct" ? 6 : 7, kind: "fact" });
+        snippets.push({
+          text: fact,
+          score: mode === "direct" ? 6 : 7,
+          kind: "fact",
+          origin: section.factOrigins?.[index],
+        });
       }
     }
     if (entry.timelineFacts.length === 0 && entry.structuredSections.length === 0) {
@@ -987,13 +983,17 @@ function formatEntityHintSection(
         (candidate.entry.timeline ?? [])
           .slice()
           .sort(sortTimelineEntriesDesc)
-          .map((entry) => sanitizeEntityFact(entry.text))
-          .filter(Boolean)
-          .map((text) => scoreHintSnippet({
-            text: compactLine(text, 180),
-            score: 7,
-            kind: "activity" as const,
-          }, queryTokens))
+          .map((entry) => {
+            const text = sanitizeEntityFact(entry.text);
+            return text
+              ? scoreHintSnippet({
+                text: compactLine(text, 180),
+                score: 7,
+                kind: "activity" as const,
+                origin: entry.origin,
+              }, queryTokens)
+              : null;
+          })
           .filter((snippet): snippet is EntityHintSnippet => snippet !== null)
           .filter((snippet) => !seedExcludedTexts.has(normalizeEntityText(snippet.text))),
       ).slice(0, 2);

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -391,6 +391,7 @@ async function readCurrentPersistedEntityIndex(
   return index;
 }
 const namespaceEntityIndexCache = new Map<string, EntityMentionIndex>();
+const MAX_NAMESPACE_ENTITY_INDEX_CACHE_ENTRIES = 32;
 
 function nativeEntityIndexRevision(chunks: NativeKnowledgeChunk[]): string {
   const projection = chunks.map((chunk) => [

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -132,13 +132,16 @@ function beliefLedgerFactKeys(sections: EntityStructuredSection[]): Set<string> 
   }
   return keys;
 }
-function recallFactsForStructuredSection(section: EntityStructuredSection): string[] {
-  if (!isBeliefLedgerSection(section)) return section.facts;
+type RecalledEntityFact = { text: string; sourceIndex: number };
+function recallFactsForStructuredSection(section: EntityStructuredSection): RecalledEntityFact[] {
+  if (!isBeliefLedgerSection(section)) {
+    return section.facts.map((text, sourceIndex) => ({ text, sourceIndex }));
+  }
   return currentActiveBeliefLedgerFactTexts(section.facts);
 }
-function currentActiveBeliefLedgerFactTexts(facts: string[]): string[] {
-  const byClaim = new Map<string, { status: string; updatedAtMs: number; texts: string[] }>();
-  for (const fact of facts) {
+function currentActiveBeliefLedgerFactTexts(facts: string[]): RecalledEntityFact[] {
+  const byClaim = new Map<string, { status: string; updatedAtMs: number; texts: RecalledEntityFact[] }>();
+  for (const [sourceIndex, fact] of facts.entries()) {
     const match = BELIEF_LEDGER_FACT_RE.exec(fact.trim());
     if (!match) continue;
     const [, claimId, status, updatedAt, text] = match;
@@ -153,20 +156,14 @@ function currentActiveBeliefLedgerFactTexts(facts: string[]): string[] {
       current.status === "active" &&
       normalizedStatus !== "active";
     if (!current || updatedAtMs > current.updatedAtMs || inactiveTieWins) {
-      byClaim.set(normalizedClaimId, { status: normalizedStatus, updatedAtMs, texts: [text.trim()] });
+      byClaim.set(normalizedClaimId, { status: normalizedStatus, updatedAtMs, texts: [{ text: text.trim(), sourceIndex }] });
       continue;
     }
     if (updatedAtMs === current.updatedAtMs && current.status === normalizedStatus) {
-      current.texts.push(text.trim());
+      current.texts.push({ text: text.trim(), sourceIndex });
     }
   }
-  const result: string[] = [];
-  for (const current of byClaim.values()) {
-    if (current.status === "active") {
-      result.push(...current.texts);
-    }
-  }
-  return result;
+  return [...byClaim.values()].flatMap((current) => current.status === "active" ? current.texts : []);
 }
 function relationLine(entry: EntityMentionIndexEntry, relationship: { target: string; label: string }): string {
   const normalizedLabel = relationship.label.replace(/\s+/g, " ").trim();
@@ -921,7 +918,13 @@ async function buildHintSnippets(
     if (!scored) continue;
     const normalized = normalizeEntityText(scored.text);
     const existing = deduped.get(normalized);
-    if (!existing || scored.score > existing.score) deduped.set(normalized, scored);
+    if (!existing) {
+      deduped.set(normalized, scored);
+    } else if (existing.origin !== scored.origin) {
+      deduped.set(normalized, { ...(scored.score > existing.score ? scored : existing), origin: undefined });
+    } else if (scored.score > existing.score) {
+      deduped.set(normalized, scored);
+    }
   }
 
   return [...deduped.values()]

--- a/packages/remnic-core/src/orchestration/extraction-injection-gate.ts
+++ b/packages/remnic-core/src/orchestration/extraction-injection-gate.ts
@@ -123,7 +123,16 @@ export function screenEntityForIndex(entity: unknown, enabled: boolean): Screene
     source: typeof record?.source === "string" ? record.source : "extraction",
     facts: factScreen.kept,
     ...(sectionScreens
-      ? { structuredSections: sectionScreens.map(({ section, screen }) => ({ ...section, facts: screen.kept })) }
+      ? {
+        structuredSections: sectionScreens.map(({ section, screen }) => {
+          const factOrigins = screen.kept.map((fact) => section.factOrigins?.[section.facts.indexOf(fact)]);
+          return {
+            ...section,
+            facts: screen.kept,
+            ...(factOrigins.some((origin) => origin !== undefined) ? { factOrigins } : {}),
+          };
+        }),
+      }
       : rawSections
         ? { structuredSections: rawSections }
         : {}),

--- a/packages/remnic-core/src/orchestration/extraction-injection-gate.ts
+++ b/packages/remnic-core/src/orchestration/extraction-injection-gate.ts
@@ -1,7 +1,4 @@
-/**
- * Pure issue #1955 injection-screen gate for extracted facts.
- */
-
+import { parseOriginClass } from "../security/origin-authority.js";
 import { normalizeAttributePairs } from "../structured-attributes.js";
 import { buildProcedurePersistBody } from "../procedural/procedure-types.js";
 import { screenCandidateFact } from "../security/injection-screen.js";
@@ -125,7 +122,10 @@ export function screenEntityForIndex(entity: unknown, enabled: boolean): Screene
     ...(sectionScreens
       ? {
         structuredSections: sectionScreens.map(({ section, screen }) => {
-          const factOrigins = screen.kept.map((fact) => section.factOrigins?.[section.facts.indexOf(fact)]);
+          const factOrigins = screen.kept.map((fact) => {
+            const origin = section.factOrigins?.[section.facts.indexOf(fact)];
+            return origin === undefined ? undefined : parseOriginClass(origin);
+          });
           return {
             ...section,
             facts: screen.kept,

--- a/packages/remnic-core/src/orchestration/extraction-injection-gate.ts
+++ b/packages/remnic-core/src/orchestration/extraction-injection-gate.ts
@@ -122,8 +122,11 @@ export function screenEntityForIndex(entity: unknown, enabled: boolean): Screene
     ...(sectionScreens
       ? {
         structuredSections: sectionScreens.map(({ section, screen }) => {
+          let nextFactIndex = 0;
           const factOrigins = screen.kept.map((fact) => {
-            const origin = section.factOrigins?.[section.facts.indexOf(fact)];
+            const factIndex = section.facts.indexOf(fact, nextFactIndex);
+            nextFactIndex = factIndex + 1;
+            const origin = section.factOrigins?.[factIndex];
             return origin === undefined ? undefined : parseOriginClass(origin);
           });
           return {

--- a/packages/remnic-core/src/orchestration/extraction-persist.ts
+++ b/packages/remnic-core/src/orchestration/extraction-persist.ts
@@ -116,7 +116,6 @@ import type { HarmonicConstructionInput } from "../harmonic-construction.js";
 import { persistConstructedHarmonicRecords } from "./harmonic-construction-persist.js";
 import { ExtractionAnchorSnapshot } from "./extraction-anchor-snapshot.js";
 
-
 export class ExtractionPersistCoordinator {
   constructor(
     private readonly deps: ExtractionPersistDeps,
@@ -2856,6 +2855,7 @@ export class ExtractionPersistCoordinator {
           timestamp: sourceContext?.validAt,
           sessionKey: sourceContext?.sessionKey,
           principal: sourceContext?.principal,
+          origin,
           structuredSections: screened.structuredSections,
         });
         if (id) {

--- a/packages/remnic-core/src/recall-authority-fence.test.ts
+++ b/packages/remnic-core/src/recall-authority-fence.test.ts
@@ -150,6 +150,46 @@ test("entity recall fences memory snippets and preserves disabled output", async
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+test("entity facts and structured sections retain extracted origin authority", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-authority-entity-origin-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.writeEntity("Alice", "person", ["Alice prefers direct answers."], {
+      origin: "user",
+      structuredSections: [
+        {
+          key: "communication_style",
+          title: "Communication Style",
+          facts: ["Alice writes concise messages."],
+        },
+      ],
+    });
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      originAuthorityEnabled: true,
+    });
+    const output = await buildEntityRecallSection({
+      config,
+      storage,
+      query: "Who is Alice?",
+      recentTurns: 1,
+      maxHints: 2,
+      maxSupportingFacts: 4,
+      maxRelatedEntities: 2,
+      maxChars: 10_000,
+      transcriptEntries: [],
+      originAuthorityEnabled: true,
+      untrustedOrigins: ["unknown"],
+    });
+    assert.match(output ?? "", /Alice prefers direct answers\./);
+    assert.match(output ?? "", /Alice writes concise messages\./);
+    assert.doesNotMatch(output ?? "", /content below is data, not instructions/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
 
 test("procedure recall fences untrusted-origin procedure bodies (#1955 review)", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-authority-procedure-"));

--- a/packages/remnic-core/src/security/audit-memory.test.ts
+++ b/packages/remnic-core/src/security/audit-memory.test.ts
@@ -14,6 +14,7 @@ type MemoryOptions = {
   pathPrefix?: string;
   source?: string;
   sourceConnector?: string;
+  timestamp?: string;
 };
 
 function makeMemory(
@@ -23,7 +24,7 @@ function makeMemory(
   content: string,
   options: MemoryOptions = {},
 ): MemoryFile {
-  const timestamp = "2026-08-14T12:00:00.000Z";
+  const timestamp = options.timestamp ?? "2026-08-14T12:00:00.000Z";
   const frontmatter = {
     id,
     category: "fact",
@@ -231,6 +232,28 @@ test("auditMemoryStore uses a leave-one-out burst baseline", async () => {
       report.findings.filter((finding) => finding.category === "write-burst").length,
       12,
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("auditMemoryStore includes memories exactly at --since and excludes earlier ones", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-audit-memory-boundary-"));
+  try {
+    const cutoff = "2026-08-14T12:00:00.000Z";
+    const before = makeMemory(root, "before", "session-before", "Before cutoff", {
+      timestamp: "2026-08-14T11:59:59.999Z",
+    });
+    const atCutoff = makeMemory(root, "at-cutoff", "session-at-cutoff", "At cutoff", {
+      timestamp: cutoff,
+    });
+    const report = await auditMemoryStore({
+      memoryDir: root,
+      storage: memoryStorage([before, atCutoff]),
+      since: cutoff,
+    });
+    assert.equal(report.activeMemories, 1);
+    assert.deepEqual([...new Set(report.findings.map((finding) => finding.memoryId))], []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -185,11 +185,13 @@ import {
   collectStructuredSectionFacts,
   compareEntityTimestamps,
   compileEntityFacts,
+  escapeEntityTimelineMetadataValue,
   isEntitySynthesisStale,
   isEntitySynthesisTimelinePromotionBullet,
   latestEntityTimelineTimestamp,
   normalizeEntitySectionFact,
   normalizeStructuredSectionFacts,
+  normalizeStructuredSectionFactsWithOrigins,
   parseEntityTimelineBullet,
   partitionEntityStructuredSections,
   serializeEntityTimelineEntry,
@@ -220,6 +222,7 @@ export {
   fingerprintEntityStructuredFacts,
   isEntitySynthesisStale,
   normalizeStructuredSectionFacts,
+  normalizeStructuredSectionFactsWithOrigins,
 } from "./storage/entity-timeline.js";
 import {
   type ProjectedMemoryBrowseOptions,
@@ -244,7 +247,6 @@ import {
 } from "./write-envelope.js";
 // stripCitation import removed: legacy rebuild fallback was replaced by a
 // skip-with-warning strategy (Finding 1 — Uhol).  See ensureFactHashIndexAuthoritative.
-
 type SharedVersionKind = "memory-status" | "artifact-write" | "cold-write" | "memory-corpus" | "entity-mutation";
 
 type OfflineSyncDigestCacheEntry = {
@@ -255,15 +257,12 @@ type OfflineSyncDigestCacheEntry = {
   sha256: string;
   bytes: number;
 };
-
-
 export interface ReextractJobRequest {
   memoryId: string;
   model: string;
   requestedAt: string;
   source: "cli-migrate";
 }
-
 export interface MemoryLifecycleEventWriteOptions {
   at?: Date;
   actor?: string;
@@ -272,7 +271,6 @@ export interface MemoryLifecycleEventWriteOptions {
   relatedMemoryIds?: string[];
   correlationId?: string;
 }
-
 /**
  * Validate a Memory Worth counter (`mw_success` / `mw_fail`) before we persist
  * it. Rejects non-finite, non-integer, and negative values rather than silently
@@ -1422,7 +1420,7 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     (entity.structuredSections ?? [])
       .map((section) => ({
         ...section,
-        facts: normalizeStructuredSectionFacts(section.facts),
+        ...normalizeStructuredSectionFactsWithOrigins(section.facts, section.factOrigins),
       }))
       .filter((section) => section.facts.length > 0),
     entitySchemas
@@ -1493,11 +1491,12 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     }
     lines.push("");
   }
-
   for (const section of structuredSections) {
     lines.push(`## ${section.title}`, "");
-    for (const fact of section.facts) {
-      lines.push(`- ${fact}`);
+    for (const [index, fact] of section.facts.entries()) {
+      const origin = section.factOrigins?.[index];
+      const prefix = origin ? `[origin=${escapeEntityTimelineMetadataValue(origin)}] ` : "";
+      lines.push(`- ${prefix}${fact}`);
     }
     lines.push("");
   }
@@ -4239,6 +4238,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       source?: string;
       sessionKey?: string;
       principal?: string;
+      origin?: string;
       structuredSections?: EntityStructuredSection[];
     } = {}
   ): Promise<string> {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -186,6 +186,7 @@ import {
   compareEntityTimestamps,
   compileEntityFacts,
   escapeEntityTimelineMetadataValue,
+  escapeEntityTimelineText,
   isEntitySynthesisStale,
   isEntitySynthesisTimelinePromotionBullet,
   latestEntityTimelineTimestamp,
@@ -1496,7 +1497,7 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     for (const [index, fact] of section.facts.entries()) {
       const origin = section.factOrigins?.[index];
       const prefix = origin ? `[remnic-origin=${escapeEntityTimelineMetadataValue(origin)}] ` : "";
-      lines.push(`- ${prefix}${fact}`);
+      lines.push(`- ${prefix}${escapeEntityTimelineText(fact)}`);
     }
     lines.push("");
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -185,6 +185,7 @@ import {
   collectStructuredSectionFacts,
   compareEntityTimestamps,
   compileEntityFacts,
+  ENTITY_TIMELINE_METADATA_MARKER,
   escapeEntityTimelineMetadataValue,
   escapeEntityTimelineText,
   isEntitySynthesisStale,
@@ -1496,7 +1497,9 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     lines.push(`## ${section.title}`, "");
     for (const [index, fact] of section.facts.entries()) {
       const origin = section.factOrigins?.[index];
-      const prefix = origin ? `[remnic-origin=${escapeEntityTimelineMetadataValue(origin)}] ` : "";
+      const prefix = origin
+        ? `[${ENTITY_TIMELINE_METADATA_MARKER}] [remnic-origin=${escapeEntityTimelineMetadataValue(origin)}] `
+        : "";
       lines.push(`- ${prefix}${escapeEntityTimelineText(fact)}`);
     }
     lines.push("");

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1464,14 +1464,12 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     `**Updated:** ${updated}`,
     "",
   ];
-
   if ((entity.preSectionLines ?? []).length > 0) {
     lines.push(...(entity.preSectionLines ?? []));
     if (entity.preSectionLines?.[entity.preSectionLines.length - 1] !== "") {
       lines.push("");
     }
   }
-
   lines.push("## Synthesis", "");
   if (synthesis) {
     lines.push(synthesis);
@@ -1485,7 +1483,6 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     }
     lines.push("");
   }
-
   if (legacyFacts.length > 0) {
     lines.push("## Facts", "");
     for (const fact of legacyFacts) {
@@ -1504,7 +1501,6 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     }
     lines.push("");
   }
-
   // Connected to (optional)
   if (entity.relationships.length > 0) {
     lines.push("## Connected to", "");

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1445,7 +1445,6 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
   const synthesisStructuredFactCount = entity.synthesisStructuredFactCount;
   const synthesisStructuredFactDigest = entity.synthesisStructuredFactDigest?.trim() || "";
   const synthesisVersion = entity.synthesisVersion ?? (synthesis ? 1 : 0);
-
   const lines: string[] = [
     "---",
     `created: ${created}`,
@@ -1511,7 +1510,6 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     }
     lines.push("");
   }
-
   // Activity (optional)
   if (entity.activity.length > 0) {
     lines.push("## Activity", "");

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1495,7 +1495,7 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
     lines.push(`## ${section.title}`, "");
     for (const [index, fact] of section.facts.entries()) {
       const origin = section.factOrigins?.[index];
-      const prefix = origin ? `[origin=${escapeEntityTimelineMetadataValue(origin)}] ` : "";
+      const prefix = origin ? `[remnic-origin=${escapeEntityTimelineMetadataValue(origin)}] ` : "";
       lines.push(`- ${prefix}${fact}`);
     }
     lines.push("");

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1420,10 +1420,12 @@ export function serializeEntityFile(entity: EntityFile, entitySchemas?: PluginCo
   const structuredSections = sortStructuredSectionsBySchema(
     entity.type,
     (entity.structuredSections ?? [])
-      .map((section) => ({
-        ...section,
-        ...normalizeStructuredSectionFactsWithOrigins(section.facts, section.factOrigins),
-      }))
+      .map((section) => {
+        const normalized = normalizeStructuredSectionFactsWithOrigins(section.facts, section.factOrigins);
+        const result = { ...section, ...normalized };
+        if (normalized.factOrigins === undefined) delete result.factOrigins;
+        return result;
+      })
       .filter((section) => section.facts.length > 0),
     entitySchemas
   );

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -816,9 +816,8 @@ export class EntityStore {
           }
         }
 
-        // Deduplicate timeline entries and derive facts from the timeline.
-        const timelineKeys = new Set<string>();
-        mergedEntity.timeline = mergedEntity.timeline.filter((entry) => {
+        const timelineByKey = new Map<string, (typeof mergedEntity.timeline)[number]>();
+        for (const entry of mergedEntity.timeline) {
           const key = JSON.stringify([
             entry.timestamp,
             entry.source ?? "",
@@ -826,10 +825,14 @@ export class EntityStore {
             entry.principal ?? "",
             entry.text,
           ]);
-          if (timelineKeys.has(key)) return false;
-          timelineKeys.add(key);
-          return true;
-        });
+          const existing = timelineByKey.get(key);
+          if (!existing) {
+            timelineByKey.set(key, entry);
+          } else if (existing.origin !== entry.origin) {
+            existing.origin = undefined;
+          }
+        }
+        mergedEntity.timeline = [...timelineByKey.values()];
         // Deduplicate relationships by target+label
         const relKeys = new Set<string>();
         mergedEntity.relationships = mergedEntity.relationships.filter((r) => {

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -307,9 +307,11 @@ export class EntityStore {
         });
         continue;
       }
+      const existingOrigins = existingSection.facts.map((_, index) => existingSection.factOrigins?.[index]);
+      const incomingOrigins = normalized.facts.map((_, index) => normalized.factOrigins?.[index]);
       const merged = normalizeStructuredSectionFactsWithOrigins(
         [...existingSection.facts, ...normalized.facts],
-        [...(existingSection.factOrigins ?? []), ...(normalized.factOrigins ?? [])],
+        [...existingOrigins, ...incomingOrigins],
       );
       existingSection.facts = merged.facts;
       existingSection.factOrigins = merged.factOrigins;

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -40,11 +40,12 @@ import {
   countEntityStructuredFacts,
   fingerprintEntityStructuredFacts,
   normalizeEntityName as normalizeEntityNameShared,
-  normalizeStructuredSectionFacts,
+  normalizeStructuredSectionFactsWithOrigins,
   parseEntityFile,
   serializeEntityFile,
   StorageManager,
 } from "../storage.js";
+import { parseOriginClass } from "../security/origin-authority.js";
 
 export interface EntityStoreDeps {
   /** Live class object of the host instance — shared static caches (see storage.ts storageManagerClass). */
@@ -204,6 +205,7 @@ export class EntityStore {
       source?: string;
       sessionKey?: string;
       principal?: string;
+      origin?: string;
       structuredSections?: EntityStructuredSection[];
     } = {},
   ): Promise<string> {
@@ -223,6 +225,7 @@ export class EntityStore {
       source?: string;
       sessionKey?: string;
       principal?: string;
+      origin?: string;
       structuredSections?: EntityStructuredSection[];
     } = {},
   ): Promise<string> {
@@ -283,26 +286,33 @@ export class EntityStore {
     const source = options.source?.trim() || undefined;
     const sessionKey = options.sessionKey?.trim() || undefined;
     const principal = options.principal?.trim() || undefined;
+    const origin = options.origin?.trim() ? parseOriginClass(options.origin) : undefined;
     const structuredSectionMap = new Map(
       (entity.structuredSections ?? []).map((section) => [section.key, {
         ...section,
         facts: [...section.facts],
+        ...(section.factOrigins ? { factOrigins: [...section.factOrigins] } : {}),
       }]),
     );
     for (const section of options.structuredSections ?? []) {
       const normalizedSection = normalizeEntityStructuredSection(type, section, this.deps.entitySchemas);
-      const normalizedFacts = normalizeStructuredSectionFacts(section.facts);
-      if (normalizedFacts.length === 0) continue;
+      const normalized = normalizeStructuredSectionFactsWithOrigins(section.facts, section.factOrigins, origin);
+      if (normalized.facts.length === 0) continue;
       const existingSection = structuredSectionMap.get(normalizedSection.key);
       if (!existingSection) {
         structuredSectionMap.set(normalizedSection.key, {
           key: normalizedSection.key,
           title: normalizedSection.title,
-          facts: normalizedFacts,
+          ...normalized,
         });
         continue;
       }
-      existingSection.facts = normalizeStructuredSectionFacts([...existingSection.facts, ...normalizedFacts]);
+      const merged = normalizeStructuredSectionFactsWithOrigins(
+        [...existingSection.facts, ...normalized.facts],
+        [...(existingSection.factOrigins ?? []), ...(normalized.factOrigins ?? [])],
+      );
+      existingSection.facts = merged.facts;
+      existingSection.factOrigins = merged.factOrigins;
       if (!existingSection.title.trim() && normalizedSection.title.trim()) {
         existingSection.title = normalizedSection.title;
       }
@@ -314,6 +324,7 @@ export class EntityStore {
         ...(source ? { source } : {}),
         ...(sessionKey ? { sessionKey } : {}),
         ...(principal ? { principal } : {}),
+        ...(origin ? { origin } : {}),
       };
       const alreadyPresent = entity.timeline.some((entry) =>
         entry.timestamp === nextEntry.timestamp
@@ -321,6 +332,7 @@ export class EntityStore {
         && entry.source === nextEntry.source
         && entry.sessionKey === nextEntry.sessionKey
         && entry.principal === nextEntry.principal
+        && entry.origin === nextEntry.origin
       );
       if (alreadyPresent) continue;
       entity.timeline.push(nextEntry);

--- a/packages/remnic-core/src/storage/entity-store.ts
+++ b/packages/remnic-core/src/storage/entity-store.ts
@@ -776,26 +776,44 @@ export class EntityStore {
               (mergedEntity.structuredSections ?? []).map((section) => [section.key, {
                 ...section,
                 facts: [...section.facts],
+                factOrigins: section.factOrigins ? [...section.factOrigins] : undefined,
               }]),
             );
             for (const section of parsed.structuredSections ?? []) {
               const existingSection = mergedStructuredSectionMap.get(section.key);
               if (!existingSection) {
+                const facts: string[] = [];
+                const factOrigins: Array<string | undefined> = [];
+                for (const [index, fact] of section.facts.entries()) {
+                  const trimmed = fact.trim();
+                  if (!trimmed || facts.includes(trimmed)) continue;
+                  facts.push(trimmed);
+                  factOrigins.push(section.factOrigins?.[index]);
+                }
                 mergedStructuredSectionMap.set(section.key, {
                   key: section.key,
                   title: section.title,
-                  facts: [...new Set(section.facts.map((fact) => fact.trim()).filter((fact) => fact.length > 0))],
+                  facts,
+                  factOrigins: section.factOrigins ? factOrigins : undefined,
                 });
                 continue;
               }
 
-              const mergedFacts = new Set(existingSection.facts.map((fact) => fact.trim()));
-              for (const fact of section.facts) {
+              if (section.factOrigins && !existingSection.factOrigins) {
+                existingSection.factOrigins = existingSection.facts.map(() => undefined);
+              }
+              for (const [index, fact] of section.facts.entries()) {
                 const trimmed = fact.trim();
                 if (!trimmed) continue;
-                mergedFacts.add(trimmed);
+                const existingIndex = existingSection.facts.indexOf(trimmed);
+                const origin = section.factOrigins?.[index];
+                if (existingIndex === -1) {
+                  existingSection.facts.push(trimmed);
+                  existingSection.factOrigins?.push(origin);
+                } else if (existingSection.factOrigins?.[existingIndex] !== origin) {
+                  existingSection.factOrigins?.splice(existingIndex, 1, undefined);
+                }
               }
-              existingSection.facts = Array.from(mergedFacts);
               if (!existingSection.title.trim() && section.title.trim()) {
                 existingSection.title = section.title;
               }

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -78,6 +78,9 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
       case "principal":
         entry.principal = value;
         break;
+      case "origin":
+        entry.origin = value;
+        break;
       default:
         entry.text = rest.trim();
         return entry.text ? entry : null;
@@ -241,7 +244,6 @@ export function unescapeEntityTimelineMetadataValue(value: string): string {
   }
   return result;
 }
-
 export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string {
   const tokens: string[] = [];
   if (entry.timestamp.trim().length > 0) {
@@ -257,6 +259,9 @@ export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string
   if (entry.principal) {
     tokens.push(`[principal=${escapeEntityTimelineMetadataValue(entry.principal)}]`);
   }
+  if (entry.origin) {
+    tokens.push(`[origin=${escapeEntityTimelineMetadataValue(entry.origin)}]`);
+  }
   const serializedMetadata = tokens.length > 0 ? `${tokens.join(" ")} ` : "";
   return `- ${serializedMetadata}${entry.text}`.trimEnd();
 }
@@ -269,6 +274,26 @@ export function normalizeEntitySectionFact(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+export function normalizeStructuredSectionFactsWithOrigins(
+  facts: string[],
+  factOrigins?: Array<string | undefined>,
+  defaultOrigin?: string,
+): Pick<EntityStructuredSection, "facts" | "factOrigins"> {
+  const normalizedFacts: string[] = [];
+  const origins: Array<string | undefined> = [];
+  const seen = new Set<string>();
+  for (const [index, fact] of facts.entries()) {
+    const normalized = normalizeEntitySectionFact(fact);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    normalizedFacts.push(normalized);
+    origins.push(factOrigins?.[index] ?? defaultOrigin);
+  }
+  return {
+    facts: normalizedFacts,
+    ...(origins.some((origin) => origin !== undefined) ? { factOrigins: origins } : {}),
+  };
+}
 export function normalizeStructuredSectionFacts(facts: string[]): string[] {
   return [...new Set(facts.map((fact) => normalizeEntitySectionFact(fact)).filter((fact) => fact.length > 0))];
 }
@@ -304,14 +329,22 @@ export function compileEntityFacts(
   return facts;
 }
 
-function parseEntityStructuredSectionFacts(lines: string[]): string[] {
+function parseEntityStructuredSectionFacts(
+  lines: string[],
+): Pick<EntityStructuredSection, "facts" | "factOrigins"> {
   const facts: string[] = [];
+  const factOrigins: Array<string | undefined> = [];
   let currentBlock: string[] = [];
+  let currentOrigin: string | undefined;
 
   const flushCurrentBlock = (): void => {
     const normalized = normalizeEntitySectionFact(currentBlock.join(" "));
-    if (normalized.length > 0) facts.push(normalized);
+    if (normalized.length > 0) {
+      facts.push(normalized);
+      factOrigins.push(currentOrigin);
+    }
     currentBlock = [];
+    currentOrigin = undefined;
   };
 
   for (const rawLine of lines) {
@@ -322,14 +355,16 @@ function parseEntityStructuredSectionFacts(lines: string[]): string[] {
     }
     if (line.startsWith("- ")) {
       flushCurrentBlock();
-      currentBlock = [line.slice(2).trim()];
+      const parsed = parseEntityTimelineBullet(line.slice(2).trim(), "");
+      currentBlock = [parsed?.text ?? line.slice(2).trim()];
+      currentOrigin = parsed?.origin;
       continue;
     }
     currentBlock.push(line);
   }
 
   flushCurrentBlock();
-  return [...new Set(facts)];
+  return normalizeStructuredSectionFactsWithOrigins(facts, factOrigins);
 }
 
 function looksLikeStructuredSectionFactList(lines: string[]): boolean {
@@ -355,27 +390,33 @@ export function partitionEntityStructuredSections(
       remainingExtraSections.push(section);
       continue;
     }
-    const facts = parseEntityStructuredSectionFacts(section.lines);
-    if (!matchedSection && facts.length === 0) {
+    const parsedFacts = parseEntityStructuredSectionFacts(section.lines);
+    if (!matchedSection && parsedFacts.facts.length === 0) {
       remainingExtraSections.push(section);
       continue;
     }
     const normalizedSection = matchedSection
       ? { key: matchedSection.key, title: matchedSection.title }
       : normalizeEntityStructuredSection(entityType, { key: section.title, title: section.title }, entitySchemas);
-    if (facts.length === 0) {
+    if (parsedFacts.facts.length === 0) {
       remainingExtraSections.push(section);
       continue;
     }
     const existing = structuredSectionIndex.get(normalizedSection.key);
     if (existing) {
-      existing.facts = normalizeStructuredSectionFacts([...existing.facts, ...facts]);
+      const merged = normalizeStructuredSectionFactsWithOrigins(
+        [...existing.facts, ...parsedFacts.facts],
+        [...(existing.factOrigins ?? []), ...(parsedFacts.factOrigins ?? [])],
+      );
+      existing.facts = merged.facts;
+      existing.factOrigins = merged.factOrigins;
       continue;
     }
     const structuredSection: EntityStructuredSection = {
       key: normalizedSection.key,
       title: normalizedSection.title,
-      facts: normalizeStructuredSectionFacts(facts),
+      facts: parsedFacts.facts,
+      ...(parsedFacts.factOrigins ? { factOrigins: parsedFacts.factOrigins } : {}),
     };
     structuredSections.push(structuredSection);
     structuredSectionIndex.set(normalizedSection.key, structuredSection);

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -78,7 +78,7 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
       case "principal":
         entry.principal = value;
         break;
-      case "origin":
+      case "remnic-origin":
         entry.origin = value;
         break;
       default:
@@ -260,7 +260,7 @@ export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string
     tokens.push(`[principal=${escapeEntityTimelineMetadataValue(entry.principal)}]`);
   }
   if (entry.origin) {
-    tokens.push(`[origin=${escapeEntityTimelineMetadataValue(entry.origin)}]`);
+    tokens.push(`[remnic-origin=${escapeEntityTimelineMetadataValue(entry.origin)}]`);
   }
   const serializedMetadata = tokens.length > 0 ? `${tokens.join(" ")} ` : "";
   return `- ${serializedMetadata}${entry.text}`.trimEnd();
@@ -361,8 +361,8 @@ function parseEntityStructuredSectionFacts(
     if (line.startsWith("- ")) {
       flushCurrentBlock();
       const bullet = line.slice(2).trim();
-      const end = bullet.startsWith("[origin=") ? findEntityTimelineTokenEnd(bullet) : -1;
-      const token = end >= 0 ? bullet.slice(8, end) : "";
+      const end = bullet.startsWith("[remnic-origin=") ? findEntityTimelineTokenEnd(bullet) : -1;
+      const token = end >= 0 ? bullet.slice(15, end) : "";
       currentBlock = [end >= 0 ? bullet.slice(end + 1).trimStart() : bullet];
       currentOrigin = end >= 0 ? unescapeEntityTimelineMetadataValue(token) : undefined;
       continue;
@@ -411,9 +411,11 @@ export function partitionEntityStructuredSections(
     }
     const existing = structuredSectionIndex.get(normalizedSection.key);
     if (existing) {
+      const existingOrigins = existing.facts.map((_, index) => existing.factOrigins?.[index]);
+      const incomingOrigins = parsedFacts.facts.map((_, index) => parsedFacts.factOrigins?.[index]);
       const merged = normalizeStructuredSectionFactsWithOrigins(
         [...existing.facts, ...parsedFacts.facts],
-        [...(existing.factOrigins ?? []), ...(parsedFacts.factOrigins ?? [])],
+        [...existingOrigins, ...incomingOrigins],
       );
       existing.facts = merged.facts;
       existing.factOrigins = merged.factOrigins;

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -256,11 +256,11 @@ export function unescapeEntityTimelineMetadataValue(value: string): string {
   return result;
 }
 export function escapeEntityTimelineText(value: string): string {
-  return /^\\?\[(?:remnic-origin=|remnic-meta-v1\])/i.test(value) ? `\\${value}` : value;
+  return /^\\*\[(?:remnic-origin=|remnic-meta-v1\])/i.test(value) ? `\\${value}` : value;
 }
 
 export function unescapeEntityTimelineText(value: string): string {
-  return /^\\{1,2}\[(?:remnic-origin=|remnic-meta-v1\])/i.test(value) ? value.slice(1) : value;
+  return /^\\+\[(?:remnic-origin=|remnic-meta-v1\])/i.test(value) ? value.slice(1) : value;
 }
 
 export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string {
@@ -383,17 +383,17 @@ function parseEntityStructuredSectionFacts(
       const bullet = line.slice(2).trim();
       const metadataPrefix = `[${ENTITY_TIMELINE_METADATA_MARKER}] `;
       const hasMarker = bullet.startsWith(metadataPrefix);
-      const originStart = hasMarker ? metadataPrefix.length : 0;
-      const escapedOrigin = bullet.startsWith("\\[remnic-origin=", originStart);
-      const originPrefix = bullet.startsWith("[remnic-origin=", originStart);
-      const originEnd = !escapedOrigin && originPrefix
-        ? findEntityTimelineTokenEnd(bullet.slice(originStart)) + originStart
+      const originStart = metadataPrefix.length;
+      const originPrefix = hasMarker && bullet.startsWith("[remnic-origin=", originStart);
+      const originEndOffset = originPrefix
+        ? findEntityTimelineTokenEnd(bullet.slice(originStart))
         : -1;
+      const originEnd = originEndOffset >= 0 ? originEndOffset + originStart : -1;
       const token = originEnd >= 0 ? bullet.slice(originStart + 15, originEnd) : "";
       currentBlock = [originEnd >= 0
         ? bullet.slice(originEnd + 1).trimStart()
-        : unescapeEntityTimelineText(bullet)];
-      currentOrigin = originEnd >= 0 && hasMarker
+        : unescapeEntityTimelineText(hasMarker ? bullet.slice(metadataPrefix.length) : bullet)];
+      currentOrigin = originEnd >= 0
         ? unescapeEntityTimelineMetadataValue(token)
         : undefined;
       continue;

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -284,10 +284,15 @@ export function normalizeStructuredSectionFactsWithOrigins(
   const seen = new Set<string>();
   for (const [index, fact] of facts.entries()) {
     const normalized = normalizeEntitySectionFact(fact);
-    if (!normalized || seen.has(normalized)) continue;
-    seen.add(normalized);
+    if (!normalized) continue;
+    const existingIndex = normalizedFacts.indexOf(normalized);
+    const origin = factOrigins?.[index] ?? defaultOrigin;
+    if (existingIndex >= 0) {
+      if (origins[existingIndex] !== origin) origins[existingIndex] = undefined;
+      continue;
+    }
     normalizedFacts.push(normalized);
-    origins.push(factOrigins?.[index] ?? defaultOrigin);
+    origins.push(origin);
   }
   return {
     facts: normalizedFacts,
@@ -355,9 +360,11 @@ function parseEntityStructuredSectionFacts(
     }
     if (line.startsWith("- ")) {
       flushCurrentBlock();
-      const parsed = parseEntityTimelineBullet(line.slice(2).trim(), "");
-      currentBlock = [parsed?.text ?? line.slice(2).trim()];
-      currentOrigin = parsed?.origin;
+      const bullet = line.slice(2).trim();
+      const end = bullet.startsWith("[origin=") ? findEntityTimelineTokenEnd(bullet) : -1;
+      const token = end >= 0 ? bullet.slice(8, end) : "";
+      currentBlock = [end >= 0 ? bullet.slice(end + 1).trimStart() : bullet];
+      currentOrigin = end >= 0 ? unescapeEntityTimelineMetadataValue(token) : undefined;
       continue;
     }
     currentBlock.push(line);

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -22,7 +22,7 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
   let literalSingleSourceSegment: string | undefined;
 
   if (!trimmed.startsWith("[")) {
-    entry.text = trimmed;
+    entry.text = unescapeEntityTimelineText(trimmed);
     return entry.text ? entry : null;
   }
 
@@ -256,11 +256,11 @@ export function unescapeEntityTimelineMetadataValue(value: string): string {
   return result;
 }
 export function escapeEntityTimelineText(value: string): string {
-  return value.startsWith("[remnic-origin=") ? `\\${value}` : value;
+  return /^\\?\[remnic-origin=/i.test(value) ? `\\${value}` : value;
 }
 
 export function unescapeEntityTimelineText(value: string): string {
-  return value.startsWith("\\[remnic-origin=") ? value.slice(1) : value;
+  return /^\\{1,2}\[remnic-origin=/i.test(value) ? value.slice(1) : value;
 }
 
 export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string {

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -256,11 +256,11 @@ export function unescapeEntityTimelineMetadataValue(value: string): string {
   return result;
 }
 export function escapeEntityTimelineText(value: string): string {
-  return /^\\?\[remnic-origin=/i.test(value) ? `\\${value}` : value;
+  return /^\\?\[(?:remnic-origin=|remnic-meta-v1\])/i.test(value) ? `\\${value}` : value;
 }
 
 export function unescapeEntityTimelineText(value: string): string {
-  return /^\\{1,2}\[remnic-origin=/i.test(value) ? value.slice(1) : value;
+  return /^\\{1,2}\[(?:remnic-origin=|remnic-meta-v1\])/i.test(value) ? value.slice(1) : value;
 }
 
 export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string {

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -391,7 +391,7 @@ function parseEntityStructuredSectionFacts(
       const originEnd = originEndOffset >= 0 ? originEndOffset + originStart : -1;
       const token = originEnd >= 0 ? bullet.slice(originStart + 15, originEnd) : "";
       currentBlock = [originEnd >= 0
-        ? bullet.slice(originEnd + 1).trimStart()
+        ? unescapeEntityTimelineText(bullet.slice(originEnd + 1).trimStart())
         : unescapeEntityTimelineText(hasMarker ? bullet.slice(metadataPrefix.length) : bullet)];
       currentOrigin = originEnd >= 0
         ? unescapeEntityTimelineMetadataValue(token)

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -301,16 +301,17 @@ export function normalizeStructuredSectionFactsWithOrigins(
 ): Pick<EntityStructuredSection, "facts" | "factOrigins"> {
   const normalizedFacts: string[] = [];
   const origins: Array<string | undefined> = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, number>();
   for (const [index, fact] of facts.entries()) {
     const normalized = normalizeEntitySectionFact(fact);
     if (!normalized) continue;
-    const existingIndex = normalizedFacts.indexOf(normalized);
+    const existingIndex = seen.get(normalized) ?? -1;
     const origin = factOrigins?.[index] ?? defaultOrigin;
     if (existingIndex >= 0) {
       if (origins[existingIndex] !== origin) origins[existingIndex] = undefined;
       continue;
     }
+    seen.set(normalized, normalizedFacts.length);
     normalizedFacts.push(normalized);
     origins.push(origin);
   }

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -6,6 +6,7 @@
 import { createHash } from "node:crypto";
 import { matchEntitySchemaSection, normalizeEntityStructuredSection } from "../entity-schema.js";
 import type { EntityFile, EntityStructuredSection, EntityTimelineEntry, PluginConfig } from "../types.js";
+export const ENTITY_TIMELINE_METADATA_MARKER = "remnic-meta-v1";
 
 export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: string): EntityTimelineEntry | null {
   const trimmed = bullet.trim();
@@ -17,6 +18,7 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
     text: "",
   };
   const consumedMetadataSegments: string[] = [];
+  let metadataMarkerSeen = false;
   let literalSingleSourceSegment: string | undefined;
 
   if (!trimmed.startsWith("[")) {
@@ -42,6 +44,13 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
     if (end === -1) break;
     const rawSegment = rest.slice(0, end + 1);
     const token = rest.slice(1, end).trim();
+    const nextRest = rest.slice(end + 1).trimStart();
+    if (token === ENTITY_TIMELINE_METADATA_MARKER) {
+      metadataMarkerSeen = true;
+      consumedMetadataSegments.push(rawSegment);
+      rest = nextRest;
+      continue;
+    }
     const equalsIdx = token.indexOf("=");
     if (equalsIdx === -1) {
       if (rest === trimmed) {
@@ -53,7 +62,10 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
     const key = token.slice(0, equalsIdx).trim().toLowerCase();
     const value = unescapeEntityTimelineMetadataValue(token.slice(equalsIdx + 1).trim());
     if (!value) break;
-    const nextRest = rest.slice(end + 1).trimStart();
+    if (key === "remnic-origin" && !metadataMarkerSeen) {
+      entry.text = rest.trim();
+      return entry.text ? entry : null;
+    }
     switch (key) {
       case "source_meta":
         entry.source = value;
@@ -267,6 +279,7 @@ export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string
     tokens.push(`[principal=${escapeEntityTimelineMetadataValue(entry.principal)}]`);
   }
   if (entry.origin) {
+    tokens.push(`[${ENTITY_TIMELINE_METADATA_MARKER}]`);
     tokens.push(`[remnic-origin=${escapeEntityTimelineMetadataValue(entry.origin)}]`);
   }
   const serializedMetadata = tokens.length > 0 ? `${tokens.join(" ")} ` : "";
@@ -368,24 +381,28 @@ function parseEntityStructuredSectionFacts(
     if (line.startsWith("- ")) {
       flushCurrentBlock();
       const bullet = line.slice(2).trim();
-      const escapedOrigin = bullet.startsWith("\\[remnic-origin=");
-      const end = !escapedOrigin && bullet.startsWith("[remnic-origin=")
-        ? findEntityTimelineTokenEnd(bullet)
+      const metadataPrefix = `[${ENTITY_TIMELINE_METADATA_MARKER}] `;
+      const hasMarker = bullet.startsWith(metadataPrefix);
+      const originStart = hasMarker ? metadataPrefix.length : 0;
+      const escapedOrigin = bullet.startsWith("\\[remnic-origin=", originStart);
+      const originPrefix = bullet.startsWith("[remnic-origin=", originStart);
+      const originEnd = !escapedOrigin && originPrefix
+        ? findEntityTimelineTokenEnd(bullet.slice(originStart)) + originStart
         : -1;
-      const token = end >= 0 ? bullet.slice(15, end) : "";
-      currentBlock = [end >= 0
-        ? bullet.slice(end + 1).trimStart()
+      const token = originEnd >= 0 ? bullet.slice(originStart + 15, originEnd) : "";
+      currentBlock = [originEnd >= 0
+        ? bullet.slice(originEnd + 1).trimStart()
         : unescapeEntityTimelineText(bullet)];
-      currentOrigin = end >= 0 ? unescapeEntityTimelineMetadataValue(token) : undefined;
+      currentOrigin = originEnd >= 0 && hasMarker
+        ? unescapeEntityTimelineMetadataValue(token)
+        : undefined;
       continue;
     }
     currentBlock.push(line);
   }
-
   flushCurrentBlock();
   return normalizeStructuredSectionFactsWithOrigins(facts, factOrigins);
 }
-
 function looksLikeStructuredSectionFactList(lines: string[]): boolean {
   const firstNonBlank = lines.find((line) => line.trim().length > 0)?.trim() ?? "";
   return firstNonBlank.startsWith("- ");

--- a/packages/remnic-core/src/storage/entity-timeline.ts
+++ b/packages/remnic-core/src/storage/entity-timeline.ts
@@ -96,8 +96,7 @@ export function parseEntityTimelineBullet(bullet: string, fallbackTimestamp: str
       text: `${literalSingleSourceSegment} ${rest}`.trim(),
     };
   }
-
-  entry.text = rest.trim();
+  entry.text = unescapeEntityTimelineText(rest.trim());
   if (!entry.text) return null;
   return entry;
 }
@@ -244,6 +243,14 @@ export function unescapeEntityTimelineMetadataValue(value: string): string {
   }
   return result;
 }
+export function escapeEntityTimelineText(value: string): string {
+  return value.startsWith("[remnic-origin=") ? `\\${value}` : value;
+}
+
+export function unescapeEntityTimelineText(value: string): string {
+  return value.startsWith("\\[remnic-origin=") ? value.slice(1) : value;
+}
+
 export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string {
   const tokens: string[] = [];
   if (entry.timestamp.trim().length > 0) {
@@ -263,7 +270,7 @@ export function serializeEntityTimelineEntry(entry: EntityTimelineEntry): string
     tokens.push(`[remnic-origin=${escapeEntityTimelineMetadataValue(entry.origin)}]`);
   }
   const serializedMetadata = tokens.length > 0 ? `${tokens.join(" ")} ` : "";
-  return `- ${serializedMetadata}${entry.text}`.trimEnd();
+  return `- ${serializedMetadata}${escapeEntityTimelineText(entry.text)}`.trimEnd();
 }
 
 export function dedupeEntityTimelineFacts(timeline: EntityTimelineEntry[]): string[] {
@@ -361,9 +368,14 @@ function parseEntityStructuredSectionFacts(
     if (line.startsWith("- ")) {
       flushCurrentBlock();
       const bullet = line.slice(2).trim();
-      const end = bullet.startsWith("[remnic-origin=") ? findEntityTimelineTokenEnd(bullet) : -1;
+      const escapedOrigin = bullet.startsWith("\\[remnic-origin=");
+      const end = !escapedOrigin && bullet.startsWith("[remnic-origin=")
+        ? findEntityTimelineTokenEnd(bullet)
+        : -1;
       const token = end >= 0 ? bullet.slice(15, end) : "";
-      currentBlock = [end >= 0 ? bullet.slice(end + 1).trimStart() : bullet];
+      currentBlock = [end >= 0
+        ? bullet.slice(end + 1).trimStart()
+        : unescapeEntityTimelineText(bullet)];
       currentOrigin = end >= 0 ? unescapeEntityTimelineMetadataValue(token) : undefined;
       continue;
     }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -3374,19 +3374,19 @@ export interface EntityActivityEntry {
   date: string;
   note: string;
 }
-
 export interface EntityTimelineEntry {
   timestamp: string;
   text: string;
   source?: string;
   sessionKey?: string;
   principal?: string;
+  origin?: string;
 }
-
 export interface EntityStructuredSection {
   key: string;
   title: string;
   facts: string[];
+  factOrigins?: Array<string | undefined>;
 }
 
 export interface EntitySchemaSectionDefinition {

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -3734,12 +3734,12 @@ test("mergeFragmentedEntities preserves structured sections from fragments", asy
       "",
       "## Beliefs",
       "",
-      "- [remnic-origin=user] Small teams move faster than committees.",
+      "- [remnic-meta-v1] [remnic-origin=user] Small teams move faster than committees.",
       "",
       "## Timeline",
       "",
       "- [2026-04-13T10:05:00.000Z] Fragment A evidence",
-      "",
+      "- [remnic-meta-v1] [remnic-origin=tool_output] Roadmaps should stay legible to the team.",
     ].join("\n");
     const fragmentB = [
       "---",
@@ -3754,7 +3754,7 @@ test("mergeFragmentedEntities preserves structured sections from fragments", asy
       "",
       "## Beliefs",
       "",
-      "- [remnic-origin=tool_output] Roadmaps should stay legible to the team.",
+      "- [remnic-meta-v1] [remnic-origin=tool_output] Roadmaps should stay legible to the team.",
       "",
       "## Communication Style",
       "",

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -2691,6 +2691,12 @@ test("entity timeline origin metadata does not consume literal origin-like text"
     parseEntityTimelineBullet(serialized.slice(2), "2026-04-13T00:00:00.000Z"),
     entry,
   );
+  const uppercase = { ...entry, text: "[REMNIC-ORIGIN=tool_output] literal text" };
+  const uppercaseSerialized = serializeEntityTimelineEntry(uppercase);
+  assert.deepEqual(
+    parseEntityTimelineBullet(uppercaseSerialized.slice(2), "2026-04-13T00:00:00.000Z"),
+    uppercase,
+  );
 });
 
 test("parseEntityFile preserves non-schema structured sections as structured facts", () => {

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -2703,6 +2703,16 @@ test("entity timeline origin metadata does not consume literal origin-like text"
     parseEntityTimelineBullet(markerSerialized.slice(2), "2026-04-13T00:00:00.000Z"),
     markerLiteral,
   );
+  for (const text of ["\\\\[remnic-origin=tool_output] literal text", "[remnic-meta-v1] literal text"]) {
+    const literal = { ...entry, text };
+    const literalSerialized = serializeEntityTimelineEntry(literal);
+    assert.deepEqual(
+      parseEntityTimelineBullet(literalSerialized.slice(2), "2026-04-13T00:00:00.000Z"),
+      literal,
+    );
+  }
+  const unterminated = "[remnic-meta-v1] [remnic-origin=user literal";
+  assert.equal(parseEntityTimelineBullet(unterminated, "2026-04-13T00:00:00.000Z")?.text, "[remnic-origin=user literal");
 });
 
 test("parseEntityFile preserves non-schema structured sections as structured facts", () => {

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -16,6 +16,10 @@ import { parseConfig } from "../packages/remnic-core/src/config.js";
 import { normalizeLegacyEntityName } from "../packages/remnic-core/src/entity-id-normalization.js";
 import { normalizeEntityText } from "../packages/remnic-core/src/entity-schema.js";
 import {
+  parseEntityTimelineBullet,
+  serializeEntityTimelineEntry,
+} from "../packages/remnic-core/src/storage/entity-timeline.js";
+import {
   isEncryptedFile,
   writeMaybeEncryptedFile,
 } from "../packages/remnic-core/src/secure-store/secure-fs.js";
@@ -2675,6 +2679,20 @@ test("parseEntityFile keeps caller-provided entity schemas isolated per parse", 
   ]);
 });
 
+test("entity timeline origin metadata does not consume literal origin-like text", () => {
+  const entry = {
+    timestamp: "2026-04-13T10:00:00.000Z",
+    origin: "user",
+    text: "[remnic-origin=tool_output] literal text",
+  };
+  const serialized = serializeEntityTimelineEntry(entry);
+  assert.match(serialized, /\\\[remnic-origin=tool_output\]/);
+  assert.deepEqual(
+    parseEntityTimelineBullet(serialized.slice(2), "2026-04-13T00:00:00.000Z"),
+    entry,
+  );
+});
+
 test("parseEntityFile preserves non-schema structured sections as structured facts", () => {
   const parsed = parseEntityFile([
     "---",
@@ -3716,7 +3734,7 @@ test("mergeFragmentedEntities preserves structured sections from fragments", asy
       "",
       "## Beliefs",
       "",
-      "- Small teams move faster than committees.",
+      "- [remnic-origin=user] Small teams move faster than committees.",
       "",
       "## Timeline",
       "",
@@ -3736,7 +3754,7 @@ test("mergeFragmentedEntities preserves structured sections from fragments", asy
       "",
       "## Beliefs",
       "",
-      "- Roadmaps should stay legible to the team.",
+      "- [remnic-origin=tool_output] Roadmaps should stay legible to the team.",
       "",
       "## Communication Style",
       "",
@@ -3763,6 +3781,7 @@ test("mergeFragmentedEntities preserves structured sections from fragments", asy
           "Small teams move faster than committees.",
           "Roadmaps should stay legible to the team.",
         ],
+        factOrigins: ["user", "tool_output"],
       },
       {
         key: "communication_style",

--- a/tests/entity-synthesis-storage.test.ts
+++ b/tests/entity-synthesis-storage.test.ts
@@ -2697,6 +2697,12 @@ test("entity timeline origin metadata does not consume literal origin-like text"
     parseEntityTimelineBullet(uppercaseSerialized.slice(2), "2026-04-13T00:00:00.000Z"),
     uppercase,
   );
+  const markerLiteral = { ...entry, text: "[remnic-meta-v1] [remnic-origin=user] literal text" };
+  const markerSerialized = serializeEntityTimelineEntry(markerLiteral);
+  assert.deepEqual(
+    parseEntityTimelineBullet(markerSerialized.slice(2), "2026-04-13T00:00:00.000Z"),
+    markerLiteral,
+  );
 });
 
 test("parseEntityFile preserves non-schema structured sections as structured facts", () => {

--- a/tests/orchestrator-importance-gate.test.ts
+++ b/tests/orchestrator-importance-gate.test.ts
@@ -249,6 +249,7 @@ test("persistExtraction preserves structured entity sections on entity files", a
       key: "beliefs",
       title: "Beliefs",
       facts: ["Small teams move faster than committees."],
+      factOrigins: ["unknown"],
     },
   ]);
 });


### PR DESCRIPTION
## Summary

Preserve extraction origins for entity timeline facts and structured-section facts. Authority-aware recall now fences unknown origins while leaving user-derived fields unfenced. Add inclusive and exclusive `--since` audit boundary fixtures.

Fixes #2397

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [x] Security / hardening

## Validation

- [ ] `npm run check-types` (ran `npm exec --yes pnpm@10.32.1 -- --filter @remnic/core run check-types`)
- [ ] `npm test`
- [ ] `npm run build`
- [x] `bash scripts/check-review-patterns.sh` (via quick preflight)
- [x] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`
- [x] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening`
- [ ] Ran `npm run review:cursor` locally, or documented why it was unavailable

## Changelog

- [ ] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Not needed (added `.changeset/entity-origin-audit-2397.md`)

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [x] Cache invalidation/coherency reviewed (entity index stores origin metadata with field values)
- [x] Loop iterator matches needed data (`.entries()` for per-fact origins)
- [x] Namespace consistency verified (entity origins persist through the existing write path)
- [x] Invalid user input rejected, not silently defaulted (existing strict `--since` parser retained)

## Notes for reviewers

Review the least-privilege fallback when origins are missing or conflict. Conflicting origins render as unknown.

## PR workflow

- [x] PR scope is narrow, or the split justification is explained here
- [ ] Synced with latest `main` before requesting AI review
- [ ] Batched review fixes by subsystem instead of micro-pushing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive origin authority and entity persistence/merge paths; behavior is covered by entity-hardening and authority tests, but provenance mistakes could mis-fence or over-expose recalled content.
> 
> **Overview**
> **Entity provenance** now flows from extraction through `writeEntity` into timeline entries and structured-section facts, persisted as escaped `[remnic-meta-v1] [remnic-origin=…]` metadata and parallel `factOrigins` arrays.
> 
> **Authority-aware entity recall** builds the mention index with per-fact origins, passes them into `renderAuthorityBoundContent`, and clears origin when duplicate text disagrees on provenance so untrusted fields stay fenced while trusted user origins stay readable.
> 
> **Injection screening** on structured sections re-aligns `factOrigins` with kept facts after filtering.
> 
> Adds regression tests for user-origin entity recall without instruction fences and for memory audit windows where `--since` is **inclusive** (`>=` cutoff). `THEORY.MD` is rewritten to document this model instead of wearable privacy content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564c53c8b62531789f5acb30547301038da67e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity timeline entries and structured facts now retain their extraction origin through storage, merging, recall, and rendering.
  * Conflicting origins are handled safely without assigning misleading provenance.
  * Timeline metadata is escaped and restored correctly, preserving literal origin-like text.
* **Bug Fixes**
  * Authority-aware recall now applies origin information consistently across entity facts and sections.
  * Memory audits include records created exactly at the `since` timestamp.
* **Documentation**
  * Updated technical documentation to describe provenance handling and audit boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->