### PR TITLE
fix(devx): guard subagent worktree writes

### DIFF
--- a/.changeset/worktree-discipline-2426.md
+++ b/.changeset/worktree-discipline-2426.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add worktree-discipline guards to developer worktree setup (issue #2426).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,7 @@ Reference workflow:
 
 Use `scripts/dev-worktree.sh <worktree-path> <branch> [base]` to create an
 isolated, installed worktree with a core type-check smoke check.
+- **Subagent worktree discipline.** Verify `pwd` before every write; use absolute paths rooted at this worktree; NEVER write to the main checkout or sibling worktrees; agent file tools may ignore cwd.
 
 Run pnpm through the pinned package manager:
 

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -166,6 +166,7 @@ mkdir -p -- "$worktree_path/.claude"
 worktree_discipline='Verify `pwd` before every write; use absolute paths rooted at this worktree; NEVER write to the main checkout or sibling worktrees; agent file tools may ignore cwd.'
 if [[ -f $repo_root/.claude/napkin.md ]]; then
   cp -- "$repo_root/.claude/napkin.md" "$worktree_path/.claude/napkin.md"
+  chmod u+rw -- "$worktree_path/.claude/napkin.md"
   printf '\n## Worktree Discipline\n%s\n' "$worktree_discipline" >>"$worktree_path/.claude/napkin.md"
 else
   printf '%s\n' \

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -163,8 +163,10 @@ printf 'Creating worktree at %s from %s on branch %s\n' "$worktree_path" "$base"
 git -C "$repo_root" worktree add "$staging_path" "$branch"
 git -C "$repo_root" worktree move "$staging_path" "$worktree_path"
 mkdir -p -- "$worktree_path/.claude"
+worktree_discipline='Verify `pwd` before every write; use absolute paths rooted at this worktree; NEVER write to the main checkout or sibling worktrees; agent file tools may ignore cwd.'
 if [[ -f $repo_root/.claude/napkin.md ]]; then
   cp -- "$repo_root/.claude/napkin.md" "$worktree_path/.claude/napkin.md"
+  printf '\n## Worktree Discipline\n%s\n' "$worktree_discipline" >>"$worktree_path/.claude/napkin.md"
 else
   printf '%s\n' \
     '# Napkin' \
@@ -179,7 +181,10 @@ else
     '' \
     '## Patterns That Do Not Work' \
     '' \
-    '## Domain Notes' >"$worktree_path/.claude/napkin.md"
+    '## Domain Notes' \
+    '' \
+    '## Worktree Discipline' \
+    "$worktree_discipline" >"$worktree_path/.claude/napkin.md"
 fi
 
 printf 'Installing packages with pnpm@10.32.1\n'
@@ -207,3 +212,4 @@ printf 'Next steps:\n'
 printf '  cd %q\n' "$worktree_path"
 printf '  git status\n'
 printf '  git push -u origin %q\n' "$branch"
+printf 'Worktree discipline: %s\n' "$worktree_discipline"

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -93,7 +93,7 @@ test("seeds worktree discipline when the source napkin is absent", () => {
   execFileSync("git", ["-C", isolatedRoot, "add", "README.md"]);
   execFileSync(
     "git",
-    ["-C", isolatedRoot, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "initial"],
+    ["-C", isolatedRoot, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "-c", "commit.gpgsign=false", "commit", "-m", "initial"],
     { stdio: "ignore" }
   );
 

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -15,8 +15,8 @@ function git(...args) {
   return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" }).trim();
 }
 
-function runScript(args, env) {
-  return spawnSync("bash", [scriptPath, ...args], {
+function runScript(args, env, script = scriptPath) {
+  return spawnSync("bash", [script, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
     env: { ...process.env, ...env },
@@ -40,13 +40,13 @@ if [ "$*" = "$DEV_WORKTREE_TEST_FAIL_ON" ]; then exit 1; fi
   return { root, bin, log };
 }
 
-function cleanupWorktree(worktreePath, branch) {
+function cleanupWorktree(worktreePath, branch, root = repoRoot) {
   if (existsSync(worktreePath)) {
-    execFileSync("git", ["-C", repoRoot, "worktree", "remove", "--force", worktreePath]);
+    execFileSync("git", ["-C", root, "worktree", "remove", "--force", worktreePath]);
   }
-  const branchExists = spawnSync("git", ["-C", repoRoot, "show-ref", "--verify", `refs/heads/${branch}`]).status === 0;
+  const branchExists = spawnSync("git", ["-C", root, "show-ref", "--verify", `refs/heads/${branch}`]).status === 0;
   if (branchExists) {
-    execFileSync("git", ["-C", repoRoot, "branch", "-D", branch], { stdio: "ignore" });
+    execFileSync("git", ["-C", root, "branch", "-D", branch], { stdio: "ignore" });
   }
 }
 
@@ -80,31 +80,41 @@ test("creates an installed worktree and runs the smoke check at an absolute path
 
 test("seeds worktree discipline when the source napkin is absent", () => {
   const fixture = createFakeNpm();
+  const isolatedRoot = mkdtempSync(path.join(os.tmpdir(), "remnic-dev-worktree-repo-"));
+  const isolatedScripts = path.join(isolatedRoot, "scripts");
+  const isolatedScript = path.join(isolatedScripts, "dev-worktree.sh");
   const worktreePath = path.join(fixture.root, "fresh-napkin-worktree");
   const branch = `test/dev-worktree-${process.pid}-fresh-napkin`;
-  const sourceNapkin = path.join(repoRoot, ".claude", "napkin.md");
-  const backupNapkin = `${sourceNapkin}.test-backup`;
-  const sourceNapkinExisted = existsSync(sourceNapkin);
-  if (sourceNapkinExisted) {
-    renameSync(sourceNapkin, backupNapkin);
-  }
+  mkdirSync(isolatedScripts);
+  copyFileSync(scriptPath, isolatedScript);
+  chmodSync(isolatedScript, 0o755);
+  execFileSync("git", ["-C", isolatedRoot, "init", "--initial-branch=main"], { stdio: "ignore" });
+  writeFileSync(path.join(isolatedRoot, "README.md"), "test repository\n");
+  execFileSync("git", ["-C", isolatedRoot, "add", "README.md"]);
+  execFileSync(
+    "git",
+    ["-C", isolatedRoot, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "initial"],
+    { stdio: "ignore" }
+  );
 
   try {
-    const result = runScript([worktreePath, branch, "HEAD"], {
-      DEV_WORKTREE_TEST_LOG: fixture.log,
-      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
-    });
+    const result = runScript(
+      [worktreePath, branch, "HEAD"],
+      {
+        DEV_WORKTREE_TEST_LOG: fixture.log,
+        PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+      isolatedScript
+    );
 
     assert.equal(result.status, 0, result.stderr);
     assert.ok(readFileSync(path.join(worktreePath, ".claude", "napkin.md"), "utf8").includes(`## Worktree Discipline\n${worktreeDiscipline}`));
     assert.ok(result.stdout.includes(`Worktree discipline: ${worktreeDiscipline}`));
   } finally {
     try {
-      cleanupWorktree(worktreePath, branch);
+      cleanupWorktree(worktreePath, branch, isolatedRoot);
     } finally {
-      if (sourceNapkinExisted) {
-        renameSync(backupNapkin, sourceNapkin);
-      }
+      rmSync(isolatedRoot, { recursive: true, force: true });
       rmSync(fixture.root, { recursive: true, force: true });
     }
   }

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -84,7 +84,10 @@ test("seeds worktree discipline when the source napkin is absent", () => {
   const branch = `test/dev-worktree-${process.pid}-fresh-napkin`;
   const sourceNapkin = path.join(repoRoot, ".claude", "napkin.md");
   const backupNapkin = `${sourceNapkin}.test-backup`;
-  renameSync(sourceNapkin, backupNapkin);
+  const sourceNapkinExisted = existsSync(sourceNapkin);
+  if (sourceNapkinExisted) {
+    renameSync(sourceNapkin, backupNapkin);
+  }
 
   try {
     const result = runScript([worktreePath, branch, "HEAD"], {
@@ -96,9 +99,14 @@ test("seeds worktree discipline when the source napkin is absent", () => {
     assert.ok(readFileSync(path.join(worktreePath, ".claude", "napkin.md"), "utf8").includes(`## Worktree Discipline\n${worktreeDiscipline}`));
     assert.ok(result.stdout.includes(`Worktree discipline: ${worktreeDiscipline}`));
   } finally {
-    cleanupWorktree(worktreePath, branch);
-    renameSync(backupNapkin, sourceNapkin);
-    rmSync(fixture.root, { recursive: true, force: true });
+    try {
+      cleanupWorktree(worktreePath, branch);
+    } finally {
+      if (sourceNapkinExisted) {
+        renameSync(backupNapkin, sourceNapkin);
+      }
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
   }
 });
 

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const scriptPath = path.join(repoRoot, "scripts", "dev-worktree.sh");
+const worktreeDiscipline =
+  "Verify `pwd` before every write; use absolute paths rooted at this worktree; NEVER write to the main checkout or sibling worktrees; agent file tools may ignore cwd.";
 
 function git(...args) {
   return execFileSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" }).trim();
@@ -62,6 +64,9 @@ test("creates an installed worktree and runs the smoke check at an absolute path
     assert.equal(result.status, 0, result.stderr);
     assert.equal(git("-C", worktreePath, "branch", "--show-current"), branch);
     assert.equal(existsSync(path.join(worktreePath, ".claude", "napkin.md")), true);
+    const napkin = readFileSync(path.join(worktreePath, ".claude", "napkin.md"), "utf8");
+    assert.ok(napkin.includes(`## Worktree Discipline\n${worktreeDiscipline}`));
+    assert.ok(result.stdout.includes(`Worktree discipline: ${worktreeDiscipline}`));
     assert.match(result.stdout, /Worktree ready/);
     assert.match(result.stdout, new RegExp(`Next steps[\\s\\S]*${branch}`));
     const calls = readFileSync(fixture.log, "utf8");
@@ -69,6 +74,30 @@ test("creates an installed worktree and runs the smoke check at an absolute path
     assert.match(calls, /exec --yes pnpm@10\.32\.1 -- --filter @remnic\/core run check-types/);
   } finally {
     cleanupWorktree(worktreePath, branch);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("seeds worktree discipline when the source napkin is absent", () => {
+  const fixture = createFakeNpm();
+  const worktreePath = path.join(fixture.root, "fresh-napkin-worktree");
+  const branch = `test/dev-worktree-${process.pid}-fresh-napkin`;
+  const sourceNapkin = path.join(repoRoot, ".claude", "napkin.md");
+  const backupNapkin = `${sourceNapkin}.test-backup`;
+  renameSync(sourceNapkin, backupNapkin);
+
+  try {
+    const result = runScript([worktreePath, branch, "HEAD"], {
+      DEV_WORKTREE_TEST_LOG: fixture.log,
+      PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(readFileSync(path.join(worktreePath, ".claude", "napkin.md"), "utf8").includes(`## Worktree Discipline\n${worktreeDiscipline}`));
+    assert.ok(result.stdout.includes(`Worktree discipline: ${worktreeDiscipline}`));
+  } finally {
+    cleanupWorktree(worktreePath, branch);
+    renameSync(backupNapkin, sourceNapkin);
     rmSync(fixture.root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- Seed worktree discipline in both napkin creation paths.
- Print the discipline rule in the setup summary.
- Document the rule for contributors and test both paths.

Fixes #2426

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling and documentation only; no runtime product or security-sensitive paths.
> 
> **Overview**
> Adds **worktree discipline** guidance so agents/subagents stay scoped to the worktree they were created in (verify `pwd`, absolute paths, never touch main or sibling worktrees).
> 
> `scripts/dev-worktree.sh` defines a single discipline string, appends a **Worktree Discipline** section to `.claude/napkin.md` (whether copied from the repo or freshly generated), makes the napkin writable after copy, and prints the rule in the success summary. **AGENTS.md** documents the same rule for automation contributors. A patch changeset records `@remnic/core`.
> 
> Tests assert napkin content and stdout for the normal repo path, plus a new isolated-repo case when no source napkin exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3345215db7acaafcf5d11822c92225ba745a277e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->