### PR TITLE
feat(devx): add single-file test runner

### DIFF
--- a/.changeset/2427-test-file-fast-path.md
+++ b/.changeset/2427-test-file-fast-path.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `npm run test:file` for fast, targeted root test runs with clear missing-file errors (#2427).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,7 @@ Set command deadlines before you start long checks:
 | `npm run test:file <path>` | 300s |
 | Full test suites | 1800s |
 | Builds | 1800s |
+
 Use `npm run test:file <path>` for targeted testing without running the full root suite.
 
 Merge with `gh pr merge <number> --squash`. Do not add `--delete-branch` when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,8 +229,10 @@ Set command deadlines before you start long checks:
 | --- | ---: |
 | `npm run preflight:quick` | 900s |
 | `npm run test:entity-hardening` | 900s |
+| `npm run test:file <path>` | 300s |
 | Full test suites | 1800s |
 | Builds | 1800s |
+Use `npm run test:file <path>` for targeted testing without running the full root suite.
 
 Merge with `gh pr merge <number> --squash`. Do not add `--delete-branch` when
 `main` is checked out in another worktree. Delete the remote branch explicitly:

--- a/package.json
+++ b/package.json
@@ -998,6 +998,7 @@
     "check-types": "node scripts/pnpm.mjs --filter @remnic/core build && tsc --noEmit && node scripts/pnpm.mjs --recursive --if-present --filter=\"./packages/*\" run check-types && node scripts/check-test-types.mjs",
     "check-config-contract": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx scripts/validate-config-contract.ts",
     "test": "node scripts/pnpm.mjs --filter @remnic/core build && node scripts/run-root-tests.mjs",
+    "test:file": "node scripts/test-file.mjs",
     "test:openclaw-scenarios": "node scripts/with-source-conditions.mjs node scripts/pnpm.mjs exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "node scripts/with-source-conditions.mjs node scripts/pnpm.mjs exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/orchestrator-characterization.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts tests/entity-alias-isolation.test.ts tests/cache-invalidation-coherence.test.ts",

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { ensurePackageBuild } from "./build-staleness.mjs";
+import { isAnySourceNewerThan } from "./build-staleness.mjs";
 import { appendNodeOption } from "./root-test-runner-env.mjs";
 import {
   loadNativeManifest,
@@ -37,8 +37,17 @@ const files = fileArgs.map((fileArg) => {
   return filePath;
 });
 
-ensurePackageBuild(
-  repoRoot,
+function ensureBuild(pkgName, distPath, sourcePaths) {
+  if (existsSync(distPath) && !isAnySourceNewerThan(sourcePaths, distPath)) return;
+  const build = spawnSync(
+    process.execPath,
+    [join(repoRoot, "scripts", "pnpm.mjs"), "--filter", pkgName, "build"],
+    { cwd: repoRoot, stdio: "inherit" },
+  );
+  if (build.status !== 0) process.exit(build.status ?? 1);
+}
+
+ensureBuild(
   "@remnic/core",
   join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
   [
@@ -49,8 +58,7 @@ ensurePackageBuild(
   ],
 );
 
-ensurePackageBuild(
-  repoRoot,
+ensureBuild(
   "@remnic/bench",
   join(repoRoot, "packages", "bench", "dist", "index.js"),
   [
@@ -60,6 +68,7 @@ ensurePackageBuild(
     join(repoRoot, "packages", "bench", "tsconfig.json"),
   ],
 );
+
 let filesToRun = files;
 let nativeProbe = probeBetterSqlite3(repoRoot);
 if (!nativeProbe.ok) {
@@ -104,13 +113,11 @@ process.on("exit", cleanupTestRunScratchDir);
 let testProcess;
 for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
   process.on(signal, () => {
-    cleanupTestRunScratchDir();
-    if (testProcess && !testProcess.killed) {
-      testProcess.kill(signal);
-      return;
-    }
+    if (testProcess && !testProcess.killed) testProcess.kill(signal);
     process.removeAllListeners(signal);
-    process.kill(process.pid, signal);
+    cleanupTestRunScratchDir();
+    process.exitCode = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129 }[signal] ?? 1;
+    process.exit(process.exitCode);
   });
 }
 

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
@@ -34,6 +34,18 @@ const files = fileArgs.map((fileArg) => {
 
 ensurePackageBuild(
   repoRoot,
+  "@remnic/core",
+  join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+  [
+    join(repoRoot, "packages", "remnic-core", "src"),
+    join(repoRoot, "packages", "remnic-core", "package.json"),
+    join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+    join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+  ],
+);
+
+ensurePackageBuild(
+  repoRoot,
   "@remnic/bench",
   join(repoRoot, "packages", "bench", "dist", "index.js"),
   [
@@ -56,9 +68,14 @@ function cleanupTestRunScratchDir() {
   }
 }
 process.on("exit", cleanupTestRunScratchDir);
+let testProcess;
 for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
   process.on(signal, () => {
     cleanupTestRunScratchDir();
+    if (testProcess && !testProcess.killed) {
+      testProcess.kill(signal);
+      return;
+    }
     process.removeAllListeners(signal);
     process.kill(process.pid, signal);
   });
@@ -66,22 +83,31 @@ for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
 
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
-const result = spawnSync(tsxBin, ["--test", ...runnerArgs, ...files], {
-  cwd: repoRoot,
-  env: {
-    ...process.env,
-    PATH: `${workspaceBinDir}${delimiter}${process.env.PATH ?? ""}`,
-    NODE_OPTIONS: appendNodeOption(process.env.NODE_OPTIONS, "--conditions=remnic-source"),
-    TMPDIR: testRunScratchDir,
-    TMP: testRunScratchDir,
-    TEMP: testRunScratchDir,
-  },
-  stdio: "inherit",
+const result = await new Promise((resolve) => {
+  testProcess = spawn(tsxBin, ["--test", ...runnerArgs, ...files], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${workspaceBinDir}${delimiter}${process.env.PATH ?? ""}`,
+      NODE_OPTIONS: appendNodeOption(process.env.NODE_OPTIONS, "--conditions=remnic-source"),
+      TMPDIR: testRunScratchDir,
+      TMP: testRunScratchDir,
+      TEMP: testRunScratchDir,
+    },
+    stdio: "inherit",
+  });
+  testProcess.on("error", (error) => resolve({ error }));
+  testProcess.on("close", (status, signal) => resolve({ status, signal }));
 });
 
 if (result.error) {
   console.error(`Failed to launch ${tsxBin}: ${result.error.message}`);
   process.exit(1);
+}
+
+if (result.signal) {
+  process.removeAllListeners(result.signal);
+  process.kill(process.pid, result.signal);
 }
 
 process.exit(result.status ?? 1);

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -1,11 +1,16 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { ensurePackageBuild } from "./build-staleness.mjs";
 import { appendNodeOption } from "./root-test-runner-env.mjs";
+import {
+  loadNativeManifest,
+  partitionNativeDependent,
+  probeBetterSqlite3,
+} from "./root-test-runner-lib.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -55,6 +60,34 @@ ensurePackageBuild(
     join(repoRoot, "packages", "bench", "tsconfig.json"),
   ],
 );
+let filesToRun = files;
+let nativeProbe = probeBetterSqlite3(repoRoot);
+if (!nativeProbe.ok) {
+  console.warn(`[test-file] better-sqlite3 binding unavailable: ${nativeProbe.reason}`);
+  const heal = spawnSync(process.execPath, [join(repoRoot, "scripts", "ensure-better-sqlite3.mjs")], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+  if (heal.status === 0) nativeProbe = probeBetterSqlite3(repoRoot);
+}
+
+if (!nativeProbe.ok) {
+  if (process.env.REMNIC_REQUIRE_NATIVE_TESTS === "1") {
+    console.error(
+      `[test-file] ERROR: better-sqlite3 binding unavailable (${nativeProbe.reason}) and ` +
+        "REMNIC_REQUIRE_NATIVE_TESTS=1 forbids skipping native-dependent tests.",
+    );
+    process.exit(1);
+  }
+  const manifest = loadNativeManifest(join(repoRoot, "scripts", "native-dependent-tests.json"));
+  const relativeFiles = files.map((file) => relative(repoRoot, file).split(sep).join("/"));
+  const selectedManifest = manifest.files.filter((entry) => relativeFiles.includes(entry));
+  const { run, excluded } = partitionNativeDependent(relativeFiles, selectedManifest);
+  filesToRun = files.filter((_, index) => run.includes(relativeFiles[index]));
+  for (const file of excluded) console.warn(`[test-file] SKIP ${file}`);
+  if (filesToRun.length === 0) process.exit(0);
+}
 
 const testRunScratchDir = mkdtempSync(join(tmpdir(), "rt-"));
 let testRunScratchCleaned = false;
@@ -84,7 +117,7 @@ for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
 const result = await new Promise((resolve) => {
-  testProcess = spawn(tsxBin, ["--test", ...runnerArgs, ...files], {
+  testProcess = spawn(tsxBin, ["--test", ...runnerArgs, ...filesToRun], {
     cwd: repoRoot,
     env: {
       ...process.env,
@@ -95,6 +128,7 @@ const result = await new Promise((resolve) => {
       TEMP: testRunScratchDir,
     },
     stdio: "inherit",
+    shell: process.platform === "win32",
   });
   testProcess.on("error", (error) => resolve({ error }));
   testProcess.on("close", (status, signal) => resolve({ status, signal }));
@@ -106,8 +140,7 @@ if (result.error) {
 }
 
 if (result.signal) {
-  process.removeAllListeners(result.signal);
-  process.kill(process.pid, result.signal);
+  process.exitCode = { SIGINT: 130, SIGTERM: 143, SIGHUP: 129 }[result.signal] ?? 1;
+} else {
+  process.exitCode = result.status ?? 1;
 }
-
-process.exit(result.status ?? 1);

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -1,9 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { appendNodeOption } from "./root-test-runner-env.mjs";
+
 import { ensurePackageBuild } from "./build-staleness.mjs";
+import { appendNodeOption } from "./root-test-runner-env.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -29,6 +31,7 @@ const files = fileArgs.map((fileArg) => {
   }
   return filePath;
 });
+
 ensurePackageBuild(
   repoRoot,
   "@remnic/bench",
@@ -41,6 +44,26 @@ ensurePackageBuild(
   ],
 );
 
+const testRunScratchDir = mkdtempSync(join(tmpdir(), "rt-"));
+let testRunScratchCleaned = false;
+function cleanupTestRunScratchDir() {
+  if (testRunScratchCleaned) return;
+  testRunScratchCleaned = true;
+  try {
+    rmSync(testRunScratchDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup must not mask the test result.
+  }
+}
+process.on("exit", cleanupTestRunScratchDir);
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    cleanupTestRunScratchDir();
+    process.removeAllListeners(signal);
+    process.kill(process.pid, signal);
+  });
+}
+
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
 const result = spawnSync(tsxBin, ["--test", ...runnerArgs, ...files], {
@@ -49,6 +72,9 @@ const result = spawnSync(tsxBin, ["--test", ...runnerArgs, ...files], {
     ...process.env,
     PATH: `${workspaceBinDir}${delimiter}${process.env.PATH ?? ""}`,
     NODE_OPTIONS: appendNodeOption(process.env.NODE_OPTIONS, "--conditions=remnic-source"),
+    TMPDIR: testRunScratchDir,
+    TMP: testRunScratchDir,
+    TEMP: testRunScratchDir,
   },
   stdio: "inherit",
 });

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendNodeOption } from "./root-test-runner-env.mjs";
+import { ensurePackageBuild } from "./build-staleness.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -28,6 +29,17 @@ const files = fileArgs.map((fileArg) => {
   }
   return filePath;
 });
+ensurePackageBuild(
+  repoRoot,
+  "@remnic/bench",
+  join(repoRoot, "packages", "bench", "dist", "index.js"),
+  [
+    join(repoRoot, "packages", "bench", "src"),
+    join(repoRoot, "packages", "bench", "package.json"),
+    join(repoRoot, "packages", "bench", "tsup.config.ts"),
+    join(repoRoot, "packages", "bench", "tsconfig.json"),
+  ],
+);
 
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const workspaceBinDir = join(repoRoot, "node_modules", ".bin");

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { appendNodeOption } from "./root-test-runner-env.mjs";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const rawArgs = process.argv.slice(2);
+const separatorIndex = rawArgs.indexOf("--");
+const fileArgs = separatorIndex === -1 ? rawArgs : rawArgs.slice(0, separatorIndex);
+const runnerArgs = separatorIndex === -1 ? [] : rawArgs.slice(separatorIndex + 1);
+
+if (fileArgs.length === 0) {
+  console.error("Usage: npm run test:file -- <test-file> [...test-files] [-- <tsx-args>]");
+  process.exit(1);
+}
+
+const files = fileArgs.map((fileArg) => {
+  const filePath = isAbsolute(fileArg) ? fileArg : resolve(process.cwd(), fileArg);
+  if (!existsSync(filePath)) {
+    console.error(`Test file not found: ${fileArg}`);
+    process.exit(1);
+  }
+  if (!statSync(filePath).isFile()) {
+    console.error(`Test path is not a file: ${fileArg}`);
+    process.exit(1);
+  }
+  return filePath;
+});
+
+const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
+const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
+const result = spawnSync(tsxBin, ["--test", ...files, ...runnerArgs], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    PATH: `${workspaceBinDir}${delimiter}${process.env.PATH ?? ""}`,
+    NODE_OPTIONS: appendNodeOption(process.env.NODE_OPTIONS, "--conditions=remnic-source"),
+  },
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(`Failed to launch ${tsxBin}: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -31,7 +31,7 @@ const files = fileArgs.map((fileArg) => {
 
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
-const result = spawnSync(tsxBin, ["--test", ...files, ...runnerArgs], {
+const result = spawnSync(tsxBin, ["--test", ...runnerArgs, ...files], {
   cwd: repoRoot,
   env: {
     ...process.env,

--- a/tests/test-file.test.mjs
+++ b/tests/test-file.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const scriptPath = join(repoRoot, "scripts", "test-file.mjs");
+
+function run(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+test("runs one root test file and forwards tsx arguments", () => {
+  const result = run([
+    "tests/root-test-runner-lib.test.mjs",
+    "--",
+    "--test-name-pattern",
+    "selectTestPatterns with no groups",
+  ]);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test("reports a missing test file and exits non-zero", () => {
+  const result = run(["tests/does-not-exist.test.mjs"]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Test file not found: tests\/does-not-exist\.test\.mjs/);
+});

--- a/tests/test-file.test.mjs
+++ b/tests/test-file.test.mjs
@@ -14,15 +14,21 @@ function run(args) {
   });
 }
 
-test("runs one root test file and forwards tsx arguments", () => {
+test("runs one root test file", () => {
+  const result = run(["tests/root-test-runner-lib.test.mjs"]);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test("forwards tsx arguments after the separator", () => {
   const result = run([
     "tests/root-test-runner-lib.test.mjs",
     "--",
     "--test-name-pattern",
-    "selectTestPatterns with no groups",
+    "[",
   ]);
 
-  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.notEqual(result.status, 0);
 });
 
 test("reports a missing test file and exits non-zero", () => {


### PR DESCRIPTION
Add a fast path for running one or more root test files with the repository's canonical tsx setup.

- Add `npm run test:file` with missing-file validation.
- Forward tsx arguments after `--`.
- Document the command deadline and targeted-testing use.
- Add focused success and failure coverage.

Fixes #2427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only test tooling that reuses existing root-test helpers; no production runtime or auth/data paths change.
> 
> **Overview**
> Adds **`npm run test:file`** as a fast path to run one or more root test files with the same **`tsx --test`** setup as the full suite, without invoking `run-root-tests.mjs`.
> 
> The new **`scripts/test-file.mjs`** validates that paths exist and are files (clear **“Test file not found”** errors), optionally builds **`@remnic/core`** and **`@remnic/bench`** when stale, reuses the root runner’s **better-sqlite3** probe/heal/skip behavior, sets **`--conditions=remnic-source`**, isolates temp dirs, and forwards extra **`tsx`** args after **`--`**.
> 
> **`AGENTS.md`** documents a **300s** deadline and when to use targeted runs. **`tests/test-file.test.mjs`** covers a successful single-file run, argument forwarding, and missing-file failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d469d5d2f13b5ba1e022ebb632ec264decae743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `npm run test:file <path>` for running individual test files.
  * Supports forwarding test-runner arguments and reports missing-file errors clearly.
  * Automatically prepares required builds and cleans up temporary test resources.

* **Documentation**
  * Documented the targeted test command and its 300-second timeout.

* **Tests**
  * Added coverage for successful runs, argument forwarding, and missing-file failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->