### PR TITLE
fix(devx): settle neutral reviewer results

### DIFF
--- a/.changeset/2424-pr-wait-reviewer-neutral.md
+++ b/.changeset/2424-pr-wait-reviewer-neutral.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Treat rate-limited and empty-body reviewer results as terminal neutral, with an optional reviewer timeout for pending reviews (#2424).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,7 @@ These rules are the default workflow for all agents and contributors.
    - Do not call a PR clean if the latest positive AI verdict targets an older commit.
    - A merge-ready PR needs green checks, zero unresolved review threads, and a fresh positive AI verdict on the current head.
    - Use `scripts/pr-wait-settled.sh <pr-number>` to block until the current head has terminal required checks, current reviewer results, and zero unresolved threads.
+   - Exact `Review rate limited` and empty-body results count as terminal neutral evidence. Pending reviewers remain blocking unless `--reviewer-timeout S` is set; expiry downgrades them to neutral with a warning.
 
 Reference workflow:
 `docs/ops/pr-review-hardening-playbook.md`

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -65,10 +65,11 @@ gh() {
 PR_NUMBER=""
 TIMEOUT=1800
 INTERVAL=30
+REVIEWER_TIMEOUT=""
 JSON_OUTPUT=false
 REPO="${REMNIC_REPO:-joshuaswarren/remnic}"
 usage() {
-  printf 'Usage: scripts/pr-wait-settled.sh <pr-number> [--timeout S] [--interval S] [--json]\n' >&2
+  printf 'Usage: scripts/pr-wait-settled.sh <pr-number> [--timeout S] [--interval S] [--reviewer-timeout S] [--json]\n' >&2
 }
 
 if [[ $# -lt 1 ]]; then
@@ -85,6 +86,12 @@ while [[ $# -gt 0 ]]; do
       if [[ "$1" == "--timeout" ]]; then TIMEOUT="$2"; else INTERVAL="$2"; fi
       shift 2
       ;;
+    --reviewer-timeout)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      [[ "$2" =~ ^[0-9]+([.][0-9]+)?$ ]] || { printf 'Invalid %s value: %s\n' "$1" "$2" >&2; exit 2; }
+      REVIEWER_TIMEOUT="$2"
+      shift 2
+      ;;
     --json)
       JSON_OUTPUT=true
       shift
@@ -98,6 +105,29 @@ done
 
 OWNER="${REPO%%/*}"
 NAME="${REPO##*/}"
+declare -A REVIEWER_NEUTRAL_EVIDENCE=()
+
+record_reviewer_neutral() {
+  local login="$1" evidence="$2" group
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    case "|${group}|" in
+      *"|${login}|"*)
+        REVIEWER_PRESENT["$group"]=1
+        REVIEWER_NEUTRAL_EVIDENCE["$group"]="$evidence"
+        return 0
+        ;;
+    esac
+  done
+}
+
+reviewer_timeout_reached() {
+  [[ -n "$REVIEWER_TIMEOUT" ]] || return 1
+  local now elapsed
+  now="$(date +%s.%N)"
+  elapsed="$(awk -v now="$now" -v start="$start_time" 'BEGIN { print now - start }')"
+  awk -v elapsed="$elapsed" -v timeout="$REVIEWER_TIMEOUT" 'BEGIN { exit !(elapsed >= timeout) }'
+}
+
 # These groups are the aliases configured by review-round-dispatch.yml. Kilo is
 # not listed because this repository has no Kilo workflow or required group.
 REVIEWER_GROUPS=(
@@ -127,6 +157,21 @@ json_summary() {
 append_item() {
   OUTSTANDING+=("$1")
 }
+print_reviewer_neutral_evidence() {
+  [[ "$JSON_OUTPUT" == true ]] && return
+  local group evidence
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    evidence="${REVIEWER_NEUTRAL_EVIDENCE[$group]:-}"
+    [[ -n "$evidence" ]] || continue
+    if [[ "$evidence" == reviewer\ timeout\ after* ]]; then
+      printf 'reviewer neutral (warning): %s; evidence: %s\n' "${group%%|*}" "$evidence"
+    else
+      printf 'reviewer neutral: %s; evidence: %s\n' "${group%%|*}" "$evidence"
+    fi
+  done
+}
+
+
 
 fetch_threads() {
   local after="" page total unresolved has_next end_cursor
@@ -177,6 +222,7 @@ record_reviewer() {
 fetch_and_evaluate() {
   OUTSTANDING=()
   declare -A REVIEWER_PRESENT=()
+  REVIEWER_NEUTRAL_EVIDENCE=()
   API_ERRORS=()
   HEAD_VISIBLE_AT=""
   SKIP_CURSOR=false
@@ -246,11 +292,16 @@ fetch_and_evaluate() {
     append_item "api:reviews"
   else
     while IFS=$'\t' read -r login commit state body; do
-      if is_current_sha "$commit" &&
-        [[ "$state" == "APPROVED" ||
+      if is_current_sha "$commit"; then
+        if [[ "$state" == "APPROVED" ||
           ( "$state" == "COMMENTED" &&
             "$body" =~ [Nn]o[[:space:]]+(major[[:space:]]+)?issues|[Aa]pproved|[Ll]ooks[[:space:]]+good ) ]]; then
-        record_reviewer "$login"
+          record_reviewer "$login"
+        elif [[ "$state" == "COMMENTED" && -z "$body" ]]; then
+          record_reviewer_neutral "$login" "empty review body"
+        elif [[ "$state" == "COMMENTED" && "$body" == "Review rate limited" ]]; then
+          record_reviewer_neutral "$login" "$body"
+        fi
       fi
     done <<< "$reviews_raw"
   fi
@@ -309,10 +360,19 @@ fetch_and_evaluate() {
     append_item "review-threads:${THREAD_UNRESOLVED}-unresolved"
   fi
 
-  local group
+  local reviewer_timeout_expired=false group
+  if reviewer_timeout_reached; then
+    reviewer_timeout_expired=true
+  fi
   for group in "${REVIEWER_GROUPS[@]}"; do
     [[ "$SKIP_CURSOR" == true && "$group" == "${REVIEWER_GROUPS[0]}" ]] && continue
-    [[ "${REVIEWER_PRESENT[$group]:-0}" == 1 ]] || append_item "reviewer:${group%%|*}"
+    [[ "${REVIEWER_PRESENT[$group]:-0}" == 1 ]] && continue
+    if [[ "$reviewer_timeout_expired" == true ]]; then
+      REVIEWER_PRESENT["$group"]=1
+      REVIEWER_NEUTRAL_EVIDENCE["$group"]="reviewer timeout after ${REVIEWER_TIMEOUT}s"
+    else
+      append_item "reviewer:${group%%|*}"
+    fi
   done
 }
 
@@ -328,6 +388,7 @@ while true; do
     if [[ "$JSON_OUTPUT" == true ]]; then
       json_summary settled "$HEAD_SHA" '[]'
     else
+      print_reviewer_neutral_evidence
       printf 'settled: PR #%s head %s; checks terminal, reviewers reported, 0 unresolved threads\n' "$PR_NUMBER" "$HEAD_SHA"
     fi
     exit 0
@@ -337,6 +398,7 @@ while true; do
   elapsed="$(awk -v now="$now" -v start="$start_time" 'BEGIN { print now - start }')"
   if awk -v elapsed="$elapsed" -v timeout="$TIMEOUT" 'BEGIN { exit !(elapsed >= timeout) }'; then
     outstanding_json="$(printf '%s\n' "${OUTSTANDING[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+    print_reviewer_neutral_evidence
     json_summary timeout "$HEAD_SHA" "$outstanding_json"
     exit 1
   fi

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -66,8 +66,10 @@ PR_NUMBER=""
 TIMEOUT=1800
 INTERVAL=30
 REVIEWER_TIMEOUT=""
-JSON_OUTPUT=false
+REVIEWER_TIMER_HEAD=""
+REVIEWER_WAIT_START=""
 REPO="${REMNIC_REPO:-joshuaswarren/remnic}"
+JSON_OUTPUT=false
 usage() {
   printf 'Usage: scripts/pr-wait-settled.sh <pr-number> [--timeout S] [--interval S] [--reviewer-timeout S] [--json]\n' >&2
 }
@@ -135,9 +137,10 @@ record_reviewer_negative() {
 
 reviewer_timeout_reached() {
   [[ -n "$REVIEWER_TIMEOUT" ]] || return 1
-  local now elapsed
+  local now elapsed start
   now="$(date +%s.%N)"
-  elapsed="$(awk -v now="$now" -v start="$start_time" 'BEGIN { print now - start }')"
+  start="${REVIEWER_WAIT_START:-$start_time}"
+  elapsed="$(awk -v now="$now" -v start="$start" 'BEGIN { print now - start }')"
   awk -v elapsed="$elapsed" -v timeout="$REVIEWER_TIMEOUT" 'BEGIN { exit !(elapsed >= timeout) }'
 }
 
@@ -264,6 +267,10 @@ fetch_and_evaluate() {
     API_ERRORS+=("head")
     append_item "api:head"
     return
+  fi
+  if [[ "$REVIEWER_TIMER_HEAD" != "$HEAD_SHA" ]]; then
+    REVIEWER_TIMER_HEAD="$HEAD_SHA"
+    REVIEWER_WAIT_START="$(date +%s.%N)"
   fi
   local pr_meta
   if pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,files --jq 'if (.author.login == "dependabot[bot]" and (.files | length) > 0 and all(.files[]; (.path // "" | split("/")[-1]) as $base | ["package.json", "package-lock.json", "pnpm-lock.yaml", "requirements.txt"] | index($base) != null)) then "true" else "false" end' 2>/dev/null); then

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -331,7 +331,7 @@ fetch_and_evaluate() {
           ( "$state" == "COMMENTED" &&
             "$body" =~ [Nn]o[[:space:]]+(major[[:space:]]+)?issues|[Aa]pproved|[Ll]ooks[[:space:]]+good ) ]]; then
           record_reviewer_approval "$login"
-        elif [[ "$state" == "CHANGES_REQUESTED" ]]; then
+        elif [[ "$state" == "CHANGES_REQUESTED" || "$state" == "DISMISSED" ]]; then
           record_reviewer_negative "$login" "$state"
         elif [[ "$state" == "COMMENTED" && -z "$body" ]]; then
           record_reviewer_neutral "$login" "empty review body"
@@ -425,10 +425,10 @@ while true; do
       [[ "$latest_head" != "$HEAD_SHA" ]]; then
       continue
     fi
+    print_reviewer_neutral_evidence
     if [[ "$JSON_OUTPUT" == true ]]; then
       json_summary settled "$HEAD_SHA" '[]'
     else
-      print_reviewer_neutral_evidence
       printf 'settled: PR #%s head %s; checks terminal, reviewers reported, 0 unresolved threads\n' "$PR_NUMBER" "$HEAD_SHA"
     fi
     exit 0

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -255,6 +255,20 @@ record_reviewer_approval() {
   done
 }
 
+reset_reviewer() {
+  local login="$1" group
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    case "|${group}|" in
+      *"|${login}|"*)
+        REVIEWER_PRESENT["$group"]=0
+        REVIEWER_NEUTRAL_EVIDENCE["$group"]=""
+        REVIEWER_NEGATIVE_EVIDENCE["$group"]=""
+        return 0
+        ;;
+    esac
+  done
+}
+
 fetch_and_evaluate() {
   OUTSTANDING=()
   declare -A REVIEWER_PRESENT=()
@@ -344,6 +358,8 @@ fetch_and_evaluate() {
           record_reviewer_neutral "$login" "empty review body"
         elif [[ "$state" == "COMMENTED" && "$body" == "Review rate limited" ]]; then
           record_reviewer_neutral "$login" "$body"
+        elif [[ "$state" == "COMMENTED" ]]; then
+          reset_reviewer "$login"
         fi
       fi
     done <<< "$reviews_raw"

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -117,6 +117,7 @@ record_reviewer_neutral() {
       *"|${login}|"*)
         REVIEWER_PRESENT["$group"]=1
         REVIEWER_NEUTRAL_EVIDENCE["$group"]="$evidence"
+        REVIEWER_NEGATIVE_EVIDENCE["$group"]=""
         return 0
         ;;
     esac
@@ -128,6 +129,8 @@ record_reviewer_negative() {
   for group in "${REVIEWER_GROUPS[@]}"; do
     case "|${group}|" in
       *"|${login}|"*)
+        REVIEWER_PRESENT["$group"]=0
+        REVIEWER_NEUTRAL_EVIDENCE["$group"]=""
         REVIEWER_NEGATIVE_EVIDENCE["$group"]="$verdict"
         return 0
         ;;
@@ -262,7 +265,6 @@ reset_reviewer() {
       *"|${login}|"*)
         REVIEWER_PRESENT["$group"]=0
         REVIEWER_NEUTRAL_EVIDENCE["$group"]=""
-        REVIEWER_NEGATIVE_EVIDENCE["$group"]=""
         return 0
         ;;
     esac

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -106,6 +106,7 @@ done
 OWNER="${REPO%%/*}"
 NAME="${REPO##*/}"
 declare -A REVIEWER_NEUTRAL_EVIDENCE=()
+declare -A REVIEWER_NEGATIVE_EVIDENCE=()
 
 record_reviewer_neutral() {
   local login="$1" evidence="$2" group
@@ -114,6 +115,18 @@ record_reviewer_neutral() {
       *"|${login}|"*)
         REVIEWER_PRESENT["$group"]=1
         REVIEWER_NEUTRAL_EVIDENCE["$group"]="$evidence"
+        return 0
+        ;;
+    esac
+  done
+}
+
+record_reviewer_negative() {
+  local login="$1" verdict="$2" group
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    case "|${group}|" in
+      *"|${login}|"*)
+        REVIEWER_NEGATIVE_EVIDENCE["$group"]="$verdict"
         return 0
         ;;
     esac
@@ -158,13 +171,19 @@ append_item() {
   OUTSTANDING+=("$1")
 }
 print_reviewer_neutral_evidence() {
-  [[ "$JSON_OUTPUT" == true ]] && return
-  local group evidence
+  local stream=1 group evidence
+  [[ "${1:-}" == timeout || "$JSON_OUTPUT" == true ]] && stream=2
   for group in "${REVIEWER_GROUPS[@]}"; do
     evidence="${REVIEWER_NEUTRAL_EVIDENCE[$group]:-}"
     [[ -n "$evidence" ]] || continue
     if [[ "$evidence" == reviewer\ timeout\ after* ]]; then
-      printf 'reviewer neutral (warning): %s; evidence: %s\n' "${group%%|*}" "$evidence"
+      if [[ "$stream" == 2 ]]; then
+        printf 'reviewer neutral (warning): %s; evidence: %s\n' "${group%%|*}" "$evidence" >&2
+      else
+        printf 'reviewer neutral (warning): %s; evidence: %s\n' "${group%%|*}" "$evidence"
+      fi
+    elif [[ "$stream" == 2 ]]; then
+      printf 'reviewer neutral: %s; evidence: %s\n' "${group%%|*}" "$evidence" >&2
     else
       printf 'reviewer neutral: %s; evidence: %s\n' "${group%%|*}" "$evidence"
     fi
@@ -214,7 +233,21 @@ record_reviewer() {
   local group
   for group in "${REVIEWER_GROUPS[@]}"; do
     case "|${group}|" in
-      *"|${login}|"*) REVIEWER_PRESENT["$group"]=1; return 0 ;;
+      *"|${login}|"*)
+        REVIEWER_PRESENT["$group"]=1
+        REVIEWER_NEUTRAL_EVIDENCE["$group"]=""
+        return 0
+        ;;
+    esac
+  done
+}
+
+record_reviewer_approval() {
+  local login="$1" group
+  record_reviewer "$login"
+  for group in "${REVIEWER_GROUPS[@]}"; do
+    case "|${group}|" in
+      *"|${login}|"*) REVIEWER_NEGATIVE_EVIDENCE["$group"]=""; return 0 ;;
     esac
   done
 }
@@ -223,6 +256,7 @@ fetch_and_evaluate() {
   OUTSTANDING=()
   declare -A REVIEWER_PRESENT=()
   REVIEWER_NEUTRAL_EVIDENCE=()
+  REVIEWER_NEGATIVE_EVIDENCE=()
   API_ERRORS=()
   HEAD_VISIBLE_AT=""
   SKIP_CURSOR=false
@@ -296,7 +330,9 @@ fetch_and_evaluate() {
         if [[ "$state" == "APPROVED" ||
           ( "$state" == "COMMENTED" &&
             "$body" =~ [Nn]o[[:space:]]+(major[[:space:]]+)?issues|[Aa]pproved|[Ll]ooks[[:space:]]+good ) ]]; then
-          record_reviewer "$login"
+          record_reviewer_approval "$login"
+        elif [[ "$state" == "CHANGES_REQUESTED" ]]; then
+          record_reviewer_negative "$login" "$state"
         elif [[ "$state" == "COMMENTED" && -z "$body" ]]; then
           record_reviewer_neutral "$login" "empty review body"
         elif [[ "$state" == "COMMENTED" && "$body" == "Review rate limited" ]]; then
@@ -367,6 +403,10 @@ fetch_and_evaluate() {
   for group in "${REVIEWER_GROUPS[@]}"; do
     [[ "$SKIP_CURSOR" == true && "$group" == "${REVIEWER_GROUPS[0]}" ]] && continue
     [[ "${REVIEWER_PRESENT[$group]:-0}" == 1 ]] && continue
+    if [[ -n "${REVIEWER_NEGATIVE_EVIDENCE[$group]:-}" ]]; then
+      append_item "reviewer:${group%%|*}(${REVIEWER_NEGATIVE_EVIDENCE[$group]})"
+      continue
+    fi
     if [[ "$reviewer_timeout_expired" == true ]]; then
       REVIEWER_PRESENT["$group"]=1
       REVIEWER_NEUTRAL_EVIDENCE["$group"]="reviewer timeout after ${REVIEWER_TIMEOUT}s"
@@ -398,7 +438,7 @@ while true; do
   elapsed="$(awk -v now="$now" -v start="$start_time" 'BEGIN { print now - start }')"
   if awk -v elapsed="$elapsed" -v timeout="$TIMEOUT" 'BEGIN { exit !(elapsed >= timeout) }'; then
     outstanding_json="$(printf '%s\n' "${OUTSTANDING[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
-    print_reviewer_neutral_evidence
+    print_reviewer_neutral_evidence timeout
     json_summary timeout "$HEAD_SHA" "$outstanding_json"
     exit 1
   fi

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -54,8 +54,22 @@ if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
         printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       fi
       ;;
+    rate-limited-review)
+      printf 'cursor[bot]\\t%s\\tCOMMENTED\\tReview rate limited\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
+    empty-body-review)
+      printf 'cursor[bot]\\t%s\\tCOMMENTED\\t\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
     missing-bot)
       printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
+    pending-review)
+      printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       ;;
   esac
   exit 0
@@ -118,6 +132,46 @@ test("wait settles a fully reviewed PR", async () => {
     const summary = JSON.parse(result.stdout);
     assert.equal(summary.head, headSha);
     assert.deepEqual(summary.outstanding, []);
+  });
+});
+test("wait treats a rate-limited review as terminal neutral", async () => {
+  await withGhStub("rate-limited-review", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0"]);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /Review rate limited/);
+  });
+});
+
+test("wait treats an empty-body review as terminal neutral", async () => {
+  await withGhStub("empty-body-review", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0"]);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /empty review body/);
+  });
+});
+
+test("wait downgrades a pending reviewer after reviewer timeout", async () => {
+  await withGhStub("pending-review", async (env) => {
+    const result = runWait(env, [
+      "--timeout",
+      "0",
+      "--reviewer-timeout",
+      "0",
+      "--interval",
+      "0",
+    ]);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /reviewer timeout/i);
+    assert.match(result.stdout, /warning/i);
+  });
+});
+
+test("wait keeps a pending reviewer without reviewer-timeout", async () => {
+  await withGhStub("pending-review", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0", "--json"]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /codex/i);
   });
 });
 

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -81,6 +81,12 @@ if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
       printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       ;;
+    neutral-then-commented)
+      printf 'cursor[bot]\\t%s\\tCOMMENTED\\tReview rate limited\\n' '${headSha}'
+      printf 'cursor[bot]\\t%s\\tCOMMENTED\\tNeeds more work\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
     neutral-then-approved)
       printf 'cursor[bot]\\t%s\\tCOMMENTED\\tReview rate limited\\n' '${headSha}'
       printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
@@ -171,6 +177,14 @@ test("wait clears neutral evidence after a later approval", async () => {
     const result = runWait(env, ["--timeout", "0", "--interval", "0"]);
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
     assert.doesNotMatch(result.stdout, /reviewer neutral/i);
+  });
+});
+test("wait keeps a later ordinary comment pending", async () => {
+  await withGhStub("neutral-then-commented", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0", "--json"]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /cursor-bugbot/);
   });
 });
 

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -76,6 +76,12 @@ if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
       printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       ;;
+    neutral-then-approved)
+      printf 'cursor[bot]\\t%s\\tCOMMENTED\\tReview rate limited\\n' '${headSha}'
+      printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
   esac
   exit 0
 fi
@@ -144,6 +150,14 @@ test("wait treats a rate-limited review as terminal neutral", async () => {
     const result = runWait(env, ["--timeout", "0", "--interval", "0"]);
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
     assert.match(result.stdout, /Review rate limited/);
+  });
+});
+
+test("wait clears neutral evidence after a later approval", async () => {
+  await withGhStub("neutral-then-approved", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0"]);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.doesNotMatch(result.stdout, /reviewer neutral/i);
   });
 });
 

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1 $2" == "pr checks" ]]; then
   exit 0
 fi
 if [[ "$1 $2" == "api graphql" ]]; then
-  printf '2\\t%s\\tfalse\\t\\n' "$([[ "$GH_STUB_SCENARIO" == unresolved-thread ]] && echo 1 || echo 0)"
+  printf '2\\t%s\\tfalse\\t\\n' "$([[ "$GH_STUB_SCENARIO" == unresolved-thread || "$GH_STUB_SCENARIO" == rate-limited-unresolved ]] && echo 1 || echo 0)"
   exit 0
 fi
 if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
@@ -54,7 +54,7 @@ if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
         printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       fi
       ;;
-    rate-limited-review)
+    rate-limited-review|rate-limited-unresolved)
       printf 'cursor[bot]\\t%s\\tCOMMENTED\\tReview rate limited\\n' '${headSha}'
       printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
@@ -70,6 +70,11 @@ if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
     pending-review)
       printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
+    negative-review)
+      printf 'cursor[bot]\\t%s\\tCHANGES_REQUESTED\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       ;;
   esac
   exit 0
@@ -163,6 +168,32 @@ test("wait downgrades a pending reviewer after reviewer timeout", async () => {
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
     assert.match(result.stdout, /reviewer timeout/i);
     assert.match(result.stdout, /warning/i);
+  });
+});
+test("wait keeps an explicit negative reviewer verdict blocking", async () => {
+  await withGhStub("negative-review", async (env) => {
+    const result = runWait(env, [
+      "--timeout",
+      "0",
+      "--reviewer-timeout",
+      "0",
+      "--interval",
+      "0",
+      "--json",
+    ]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /CHANGES_REQUESTED/);
+  });
+});
+
+test("wait keeps timeout JSON valid while printing neutral evidence", async () => {
+  await withGhStub("rate-limited-unresolved", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0"]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /thread/i);
+    assert.match(result.stderr, /Review rate limited/);
   });
 });
 

--- a/tests/pr-wait-settled.test.mjs
+++ b/tests/pr-wait-settled.test.mjs
@@ -76,6 +76,11 @@ if [[ "$1 $2" == "api repos/example/repo/pulls/7/reviews" ]]; then
       printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
       ;;
+    dismissed-review)
+      printf 'cursor[bot]\\t%s\\tDISMISSED\\n' '${headSha}'
+      printf 'coderabbitai[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      printf 'chatgpt-codex-connector[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
+      ;;
     neutral-then-approved)
       printf 'cursor[bot]\\t%s\\tCOMMENTED\\tReview rate limited\\n' '${headSha}'
       printf 'cursor[bot]\\t%s\\tAPPROVED\\n' '${headSha}'
@@ -152,6 +157,14 @@ test("wait treats a rate-limited review as terminal neutral", async () => {
     assert.match(result.stdout, /Review rate limited/);
   });
 });
+test("wait prints neutral evidence in settled JSON mode", async () => {
+  await withGhStub("rate-limited-review", async (env) => {
+    const result = runWait(env, ["--timeout", "0", "--interval", "0", "--json"]);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    JSON.parse(result.stdout);
+    assert.match(result.stderr, /Review rate limited/);
+  });
+});
 
 test("wait clears neutral evidence after a later approval", async () => {
   await withGhStub("neutral-then-approved", async (env) => {
@@ -198,6 +211,22 @@ test("wait keeps an explicit negative reviewer verdict blocking", async () => {
     assert.notEqual(result.status, 0);
     const summary = JSON.parse(result.stdout);
     assert.match(summary.outstanding.join(" "), /CHANGES_REQUESTED/);
+  });
+});
+test("wait keeps a dismissed reviewer verdict blocking", async () => {
+  await withGhStub("dismissed-review", async (env) => {
+    const result = runWait(env, [
+      "--timeout",
+      "0",
+      "--reviewer-timeout",
+      "0",
+      "--interval",
+      "0",
+      "--json",
+    ]);
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /DISMISSED/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Treat rate-limited and empty-body reviewer reviews as terminal neutral evidence.
- Add optional reviewer timeout downgrade with warning.
- Cover neutral classification, timeout, and default blocking behavior.

Fixes #2424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the PR wait script, agent docs, and tests—no runtime memory or auth paths.
> 
> **Overview**
> **`pr-wait-settled.sh`** now classifies current-head PR reviews so merge-wait automation can finish without spinning on bots that cannot deliver a real verdict.
> 
> **Terminal neutral:** `COMMENTED` reviews with body exactly `Review rate limited` or an empty body count as satisfied for that reviewer group (with printed `reviewer neutral` evidence). **`CHANGES_REQUESTED`** and **`DISMISSED`** still block. A later non-neutral `COMMENTED` review (e.g. “Needs more work”) leaves the group pending again; a later approval clears neutral state.
> 
> **Optional `--reviewer-timeout S`:** after the timeout, still-missing reviewer groups are downgraded to neutral with a **warning** (`reviewer timeout after …`). Without this flag, absent reviewers stay blocking.
> 
> **Docs/tests:** `AGENTS.md` documents the rules; `tests/pr-wait-settled.test.mjs` adds stub scenarios for neutral, timeout, negative verdicts, JSON vs stderr output, and neutral-then-approved/commented ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5d770144a3d0e2437f7d94bd0c15c321a7bad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->