### PR TITLE
fix(devx): harden PR settle gh parsing

### DIFF
--- a/.changeset/pr-wait-settled-2423.md
+++ b/.changeset/pr-wait-settled-2423.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Make `scripts/pr-wait-settled.sh` tolerate tool-manager output before `gh` results and use `gh --jq` for structured reads (issue #2423).

--- a/scripts/pr-wait-settled.sh
+++ b/scripts/pr-wait-settled.sh
@@ -3,12 +3,70 @@ set -euo pipefail
 
 # Wait for a PR head to finish all checks, reviewer activity, and review threads.
 # Reviewer aliases mirror .github/workflows/review-round-dispatch.yml.
+# Resolve the real gh binary when a tool-manager wrapper appears first on PATH.
+resolve_mise_gh() {
+  local candidate
+  command -v mise >/dev/null 2>&1 || return 1
+  candidate="$(mise which gh 2>/dev/null || true)"
+  [[ -x "$candidate" ]] || return 1
+  printf '%s\n' "$candidate"
+}
+
+resolve_gh() {
+  if [[ -n "${REMNIC_GH_BIN:-}" ]]; then
+    printf '%s\n' "$REMNIC_GH_BIN"
+    return
+  fi
+  local candidate kind source
+  while IFS= read -r candidate; do
+    [[ -x "$candidate" ]] || continue
+    case "$candidate" in
+      */shims/gh)
+        resolve_mise_gh && return
+        continue
+        ;;
+    esac
+    kind="$(file -b "$candidate" 2>/dev/null || true)"
+    if [[ "$kind" == *script* || "$kind" == *text* ]]; then
+      source="$(sed -n '1,8p' "$candidate" 2>/dev/null || true)"
+      if [[ "$source" == *mise* ]]; then
+        resolve_mise_gh && return
+        continue
+      fi
+    fi
+    printf '%s\n' "$candidate"
+    return
+  done < <(type -P -a gh 2>/dev/null | awk '!seen[$0]++')
+  command -v gh
+}
+
+strip_gh_banner() {
+  awk '
+    !started && $0 ~ /^[[:space:]]*mise[[:space:]].*config[.]toml[[:space:]]+tools:[[:space:]]+gh@[^[:space:]]+[[:space:]]*$/ { next }
+    { started = 1; print }
+  '
+}
+
+strip_leading_non_json() {
+  awk '
+    !started {
+      if ($0 ~ /^[[:space:]]*[\[{]/) started = 1
+      else next
+    }
+    { print }
+  '
+}
+
+GH_BIN="$(resolve_gh)"
+gh() {
+  "$GH_BIN" "$@" 2> >(strip_gh_banner >&2) | strip_gh_banner
+}
+
 PR_NUMBER=""
 TIMEOUT=1800
 INTERVAL=30
 JSON_OUTPUT=false
 REPO="${REMNIC_REPO:-joshuaswarren/remnic}"
-
 usage() {
   printf 'Usage: scripts/pr-wait-settled.sh <pr-number> [--timeout S] [--interval S] [--json]\n' >&2
 }
@@ -128,15 +186,33 @@ fetch_and_evaluate() {
     return
   fi
   local pr_meta
-  if pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,files 2>/dev/null); then
-    if [[ "$(jq -r 'if (.author.login == "dependabot[bot]" and (.files | length) > 0 and all(.files[]; (.path // "" | split("/")[-1]) as $base | ["package.json", "package-lock.json", "pnpm-lock.yaml", "requirements.txt"] | index($base) != null)) then "true" else "false" end' <<< "$pr_meta")" == true ]]; then
+  if pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,files --jq 'if (.author.login == "dependabot[bot]" and (.files | length) > 0 and all(.files[]; (.path // "" | split("/")[-1]) as $base | ["package.json", "package-lock.json", "pnpm-lock.yaml", "requirements.txt"] | index($base) != null)) then "true" else "false" end' 2>/dev/null); then
+    if [[ "$pr_meta" == true ]]; then
       SKIP_CURSOR=true
     fi
   fi
-
   local checks_raw reviews_raw issue_comments_raw check_runs_raw
-  checks_raw="$(gh pr checks "$PR_NUMBER" --repo "$REPO" --required --json name,state 2>/dev/null || true)"
-  if [[ -z "$checks_raw" ]]; then
+
+  local checks_status=0
+  checks_raw="$(gh pr checks "$PR_NUMBER" --repo "$REPO" --required --json name,state --jq 'if length == 0 then "__NO_REQUIRED_CHECKS__" else .[] | [.name, (.state // "unknown")] | @tsv end' 2>&1)" || checks_status=$?
+  if (( checks_status != 0 )); then
+    if [[ "$checks_raw" == *"checks reported"* ]]; then
+      checks_raw="__NO_REQUIRED_CHECKS__"
+    elif [[ "$checks_raw" != *$'\t'* && "$checks_raw" != [\[]* ]]; then
+      API_ERRORS+=("checks")
+      append_item "api:checks"
+      checks_raw="__CHECKS_API_ERROR__"
+    fi
+  fi
+  if (( checks_status != 0 )) && [[ "$checks_raw" != *$'\t'* && "$checks_raw" == [\[]* ]] &&
+    ! printf '%s\n' "$checks_raw" | strip_leading_non_json | jq -e 'type == "array"' >/dev/null 2>&1; then
+    API_ERRORS+=("checks")
+    append_item "api:checks"
+    checks_raw="__CHECKS_API_ERROR__"
+  fi
+  if [[ "$checks_raw" == "__CHECKS_API_ERROR__" || "$checks_raw" == "__NO_REQUIRED_CHECKS__" || "$checks_raw" == "[]" ]]; then
+    :
+  elif [[ -z "$checks_raw" ]]; then
     API_ERRORS+=("checks")
     append_item "api:checks"
   else
@@ -144,7 +220,15 @@ fetch_and_evaluate() {
     while IFS=$'\t' read -r check_name check_state; do
       [[ -n "$check_name" ]] || continue
       CHECK_STATES["$check_name"]+="${check_state^^}"$'\n'
-    done < <(jq -r '.[] | [.name, (.state // "unknown")] | @tsv' <<< "$checks_raw")
+    done < <(
+      if [[ "$checks_raw" == *$'\t'* ]]; then
+        printf '%s\n' "$checks_raw"
+      elif [[ "$checks_raw" == [\[]* ]]; then
+        printf '%s\n' "$checks_raw" | strip_leading_non_json | jq -r '.[] | [.name, (.state // "unknown")] | @tsv'
+      else
+        printf '%s\n' "$checks_raw"
+      fi
+    )
     for check_name in "${!CHECK_STATES[@]}"; do
       local has_pass=false first_state=""
       while IFS= read -r check_state; do

--- a/tests/pr-wait-settled-script.test.mjs
+++ b/tests/pr-wait-settled-script.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = path.resolve(import.meta.dirname, "..", "scripts", "pr-wait-settled.sh");
+
+const headSha = "0123456789abcdef0123456789abcdef01234567";
+
+function createBannerGh(checksOutput = "ci\\tSUCCESS\\n") {
+  const root = mkdtempSync(path.join(os.tmpdir(), "remnic-pr-wait-gh-"));
+  const ghPath = path.join(root, "gh");
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env bash
+printf '%s\\n' 'mise ~/.config/mise/config.toml tools: gh@2.97.0'
+case "$*" in
+  *'pr view'*'headRefOid'*) printf '%s\\n' '${headSha}' ;;
+  *'pr view'*'author'*) printf '%s\\n' 'false' ;;
+  *'pr checks'*)
+    if [[ '${checksOutput}' == '__GH_NO_CHECKS_ERROR__' ]]; then
+      printf '%s\\n' 'no required checks reported on the main branch' >&2
+      exit 1
+    fi
+    printf '%b' '${checksOutput}' ;;
+  *'pulls/'*'/reviews'*)
+    printf 'cursor\\t${headSha}\\tAPPROVED\\t\\n'
+    printf 'coderabbitai\\t${headSha}\\tAPPROVED\\t\\n'
+    printf 'chatgpt-codex-connector\\t${headSha}\\tAPPROVED\\t\\n'
+    ;;
+  *'check-suites'*) printf '%s\\n' '2026-08-16T00:00:00Z' ;;
+  *'api graphql'*) printf '0\\t0\\tfalse\\t\\n' ;;
+esac
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { root, ghPath };
+}
+
+test("handles mise banner output from gh before structured results", () => {
+  const { root, ghPath } = createBannerGh();
+  try {
+    const result = spawnSync("bash", [scriptPath, "123", "--timeout", "5", "--interval", "0", "--json"], {
+      env: { ...process.env, REMNIC_GH_BIN: ghPath },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      status: "settled",
+      head: headSha,
+      outstanding: [],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("settles when gh reports no required checks", () => {
+  const { root, ghPath } = createBannerGh("__GH_NO_CHECKS_ERROR__");
+  try {
+    const result = spawnSync("bash", [scriptPath, "123", "--timeout", "5", "--interval", "0", "--json"], {
+      env: { ...process.env, REMNIC_GH_BIN: ghPath },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      status: "settled",
+      head: headSha,
+      outstanding: [],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("keeps required checks whose names resemble banner or JSON lines", () => {
+  const { root, ghPath } = createBannerGh("mise workspace tools: lint\\tPENDING\\n[check]\\tPENDING\\n");
+  try {
+    const result = spawnSync("bash", [scriptPath, "123", "--timeout", "0", "--interval", "0", "--json"], {
+      env: { ...process.env, REMNIC_GH_BIN: ghPath },
+      encoding: "utf8",
+    });
+
+    assert.notEqual(result.status, 0);
+    const summary = JSON.parse(result.stdout);
+    assert.match(summary.outstanding.join(" "), /mise workspace tools: lint/);
+    assert.match(summary.outstanding.join(" "), /\[check\]/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #2423

Resolve the real gh binary when tool-manager wrappers appear on PATH. Use gh --jq for structured reads and strip mise banner lines before parsing. Add a regression test with banner-prefixed gh output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only shell script and tests; no runtime product or auth/data paths affected.
> 
> **Overview**
> Hardens **`scripts/pr-wait-settled.sh`** so PR “settled” polling works when **mise** (or similar) wraps `gh` and prints banner lines before real CLI output.
> 
> The script now **resolves the actual `gh` binary** (via `REMNIC_GH_BIN`, shim detection, or `mise which gh`), **strips mise banner lines** from stdout/stderr, and uses **`gh --jq`** for structured reads instead of piping full JSON through `jq` locally. **Required-check handling** is more defensive: it treats “no required checks” as settled, separates API errors from empty results, and can parse TSV or JSON (with `strip_leading_non_json` when noise precedes JSON).
> 
> Adds **`tests/pr-wait-settled-script.test.mjs`** with a fake `gh` that emits mise banners—covering successful settle, no-required-checks, and check names that look like banner/metadata lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fade6673b58c88fc49be76c97bdd2f95cba0d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request status checks when command-line tools produce banners or unexpected output.
  * More reliably detects lockfile-only updates and required-check failures.
  * Preserves useful command output and distinguishes missing checks from API errors.
  * Supports multiple output formats when processing required checks.

* **Tests**
  * Added coverage for noisy tool output, missing required checks, and check names resembling metadata or banner lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->