### PR TITLE
fix(core): grapheme-safe truncation and display-width table padding

### DIFF
--- a/.changeset/2195-grapheme-safe-truncation.md
+++ b/.changeset/2195-grapheme-safe-truncation.md
@@ -1,0 +1,10 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+fix(surfaces): grapheme-safe truncation and display-width table padding (#2195)
+
+- Add `truncateGraphemeSafe` (Intl.Segmenter grapheme granularity with a code-point fallback) next to `truncateCodePointSafe` in `@remnic/core` whitespace helpers. It returns the longest prefix that fits a UTF-16 budget without splitting a surrogate pair or a grapheme cluster (ZWJ emoji, flags, Hangul jamo runs, combining marks).
+- Migrate the UTF-16-slicing truncation sites to it: `entity-retrieval.ts` `compactLine` and the entity-hints trim, the memory/search/cluster/topics transcript previews in `packages/remnic-core/src/cli.ts`, and the recall section truncation (including the token-budget binary search, which now walks grapheme segments) in `orchestration/recall-section-coordinator.ts`.
+- Add `displayWidth` (East_Asian_Width Wide/Fullwidth = 2, combining marks = 0) and `padEndDisplay`, and use them for the CLI topic/importance tables and the bench output metric columns so CJK rows stay aligned. Closes #2195.

--- a/packages/remnic-cli/src/bench-output-printer.ts
+++ b/packages/remnic-cli/src/bench-output-printer.ts
@@ -1,3 +1,5 @@
+import { padEndDisplay } from "@remnic/core";
+
 import type { ComparisonResult } from "@remnic/bench";
 
 type BenchSummaryTask = {
@@ -48,7 +50,7 @@ export function printBenchPackageSummary(
   console.log(`Tasks: ${result.results.tasks.length}`);
   console.log(`Mean query latency: ${result.cost.meanQueryLatencyMs.toFixed(1)}ms`);
   for (const [metric, aggregate] of Object.entries(result.results.aggregates).sort()) {
-    console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
+    console.log(`  ${padEndDisplay(metric, 20)} ${aggregate.mean.toFixed(4)}`);
   }
   console.log(`${outputLabel}: ${outputPath}`);
 }
@@ -105,7 +107,7 @@ export function printBenchComparisonSummary(
         : "-Infinity%";
     const direction = delta.delta >= 0 ? "+" : "";
     console.log(
-      `  ${metric.padEnd(18)} ${delta.baseline.toFixed(4)} -> ${delta.candidate.toFixed(4)} (${direction}${delta.delta.toFixed(4)}, ${percent}, d=${delta.effectSize.cohensD.toFixed(3)} ${delta.effectSize.interpretation})`,
+      `  ${padEndDisplay(metric, 18)} ${delta.baseline.toFixed(4)} -> ${delta.candidate.toFixed(4)} (${direction}${delta.delta.toFixed(4)}, ${percent}, d=${delta.effectSize.cohensD.toFixed(3)} ${delta.effectSize.interpretation})`,
     );
     if (delta.ciOnDelta) {
       console.log(

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -12,6 +12,7 @@ import { resolveNamespaceCapabilities,
 import { ThreadingManager } from "./threading.js";
 import { bumpMemoryCorpusVersionForDir } from "./memory-corpus-version.js";
 import { utcDayRange } from "./transcript.js";
+import { padEndDisplay, truncateGraphemeSafe } from "./whitespace.js";
 import { runWearablesCliCommand } from "./wearables/cli.js";
 import { registerMeetingsCommands } from "./cli/meetings-commands.js";
 import { registerResearchStatusCommands } from "./cli/research-status-commands.js";
@@ -5672,7 +5673,7 @@ export function registerCli(
               console.log(`  raw excerpts (${r.rawExcerpts.length}):`);
               for (const ex of r.rawExcerpts) {
                 console.log(
-                  `    [turn ${ex.turnIndex}, ${ex.role}] ${ex.content.slice(0, 200)}`,
+                  `    [turn ${ex.turnIndex}, ${ex.role}] ${truncateGraphemeSafe(ex.content, 200)}`,
                 );
               }
             }
@@ -7614,7 +7615,7 @@ export function registerCli(
               console.log(`  ${r.path} (score: ${r.score.toFixed(3)})`);
               if (r.snippet) {
                 console.log(
-                  `    ${r.snippet.slice(0, 150).replace(/\n/g, " ")}`,
+                  `    ${truncateGraphemeSafe(r.snippet, 150).replace(/\n/g, " ")}`,
                 );
               }
               console.log();
@@ -7640,7 +7641,7 @@ export function registerCli(
             console.log(`\n=== Text Search Fallback: "${query}" (${matches.length} results) ===\n`);
             console.log(`QMD status: ${qmdStatus}\n`);
             for (const m of matches.slice(0, maxResults)) {
-              console.log(`  [${m.frontmatter.category}] ${m.content.slice(0, 120)}`);
+              console.log(`  [${m.frontmatter.category}] ${truncateGraphemeSafe(m.content, 120)}`);
             }
           }
         });
@@ -7783,12 +7784,12 @@ export function registerCli(
             for (const cluster of result.clusters) {
               console.log(`\n  Category: ${cluster.category} (${cluster.memories.length} memories, overlap=${cluster.overlapScore.toFixed(2)})`);
               for (const m of cluster.memories) {
-                const preview = m.content.length > 80 ? m.content.slice(0, 80) + "..." : m.content;
+                const preview = m.content.length > 80 ? `${truncateGraphemeSafe(m.content, 80)}...` : m.content;
                 console.log(`    - ${m.frontmatter.id}: ${preview}`);
               }
               if (cluster.canonicalContent) {
                 const preview = cluster.canonicalContent.length > 120
-                  ? cluster.canonicalContent.slice(0, 120) + "..."
+                  ? `${truncateGraphemeSafe(cluster.canonicalContent, 120)}...`
                   : cluster.canonicalContent;
                 console.log(`    → Canonical: ${preview}`);
               }
@@ -8018,7 +8019,7 @@ export function registerCli(
             const lastAccessed = m.frontmatter.lastAccessed
               ? new Date(m.frontmatter.lastAccessed).toLocaleDateString()
               : "unknown";
-            console.log(`  ${m.frontmatter.accessCount}x  [${m.frontmatter.category}] ${m.content.slice(0, 80)}`);
+            console.log(`  ${m.frontmatter.accessCount}x  [${m.frontmatter.category}] ${truncateGraphemeSafe(m.content, 80)}`);
             console.log(`       Last accessed: ${lastAccessed}  ID: ${m.frontmatter.id}`);
             console.log();
           }
@@ -8071,7 +8072,7 @@ export function registerCli(
           console.log("\n=== Importance Distribution ===\n");
           for (const [level, count] of Object.entries(levelCounts)) {
             const bar = "█".repeat(Math.min(count, 50));
-            console.log(`  ${level.padEnd(10)} ${count.toString().padStart(4)} ${bar}`);
+            console.log(`  ${padEndDisplay(level, 10)} ${count.toString().padStart(4)} ${bar}`);
           }
           console.log(`\n  Total scored: ${withImportance.length} / ${memories.length} memories\n`);
 
@@ -8104,7 +8105,7 @@ export function registerCli(
             console.log(
               `  ${imp.score.toFixed(2)} [${imp.level}] [${m.frontmatter.category}]`,
             );
-            console.log(`    ${m.content.slice(0, 100)}`);
+            console.log(`    ${truncateGraphemeSafe(m.content, 100)}`);
             if (imp.keywords.length > 0) {
               console.log(`    Keywords: ${imp.keywords.join(", ")}`);
             }
@@ -8131,7 +8132,7 @@ export function registerCli(
 
           for (const topic of topics.slice(0, top)) {
             const bar = "█".repeat(Math.min(Math.round(topic.score * 10), 30));
-            console.log(`  ${topic.term.padEnd(20)} ${topic.score.toFixed(3)} (${topic.count}x) ${bar}`);
+            console.log(`  ${padEndDisplay(topic.term, 20)} ${topic.score.toFixed(3)} (${topic.count}x) ${bar}`);
           }
         });
 
@@ -8163,7 +8164,7 @@ export function registerCli(
             console.log(`    Time range: ${summary.timeRangeStart.slice(0, 10)} to ${summary.timeRangeEnd.slice(0, 10)}`);
             console.log(`    Source memories: ${summary.sourceEpisodeIds.length}`);
             console.log(`    Key facts: ${summary.keyFacts.length}`);
-            console.log(`\n    Summary: ${summary.summaryText.slice(0, 200)}...`);
+            console.log(`\n    Summary: ${truncateGraphemeSafe(summary.summaryText, 200)}...`);
             console.log();
           }
         });
@@ -8255,13 +8256,13 @@ export function registerCli(
             const parent = memories.find((m) => m.frontmatter.id === parentId);
             console.log(`\n=== Chunks for ${parentId} ===\n`);
             if (parent) {
-              console.log(`Parent: ${parent.content.slice(0, 100)}...`);
+              console.log(`Parent: ${truncateGraphemeSafe(parent.content, 100)}...`);
               console.log();
             }
 
             for (const chunk of chunks) {
               console.log(
-                `  [${(chunk.frontmatter.chunkIndex ?? 0) + 1}/${chunk.frontmatter.chunkTotal}] ${chunk.content.slice(0, 80)}...`,
+                `  [${(chunk.frontmatter.chunkIndex ?? 0) + 1}/${chunk.frontmatter.chunkTotal}] ${truncateGraphemeSafe(chunk.content, 80)}...`,
               );
             }
             return;
@@ -9408,7 +9409,7 @@ function formatTranscript(entries: TranscriptEntry[]): string {
   return entries
     .map((e) => {
       const time = e.timestamp.slice(11, 16); // HH:MM
-      return `[${time}] ${e.role}: ${e.content.slice(0, 200)}${e.content.length > 200 ? "..." : ""}`;
+      return `[${time}] ${e.role}: ${truncateGraphemeSafe(e.content, 200)}${e.content.length > 200 ? "..." : ""}`;
     })
     .join("\n");
 }

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -8,12 +8,9 @@ import { collectNativeKnowledgeChunks, type NativeKnowledgeChunk } from "./nativ
 import { compareEntityTimestamps, normalizeEntityName, type StorageManager } from "./storage.js";
 import { normalizeEntityText, resolveRequestedEntitySectionKeys } from "./entity-schema.js";
 import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry } from "./types.js";
+import { truncateGraphemeSafe } from "./whitespace.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
-import {
-  buildOriginStructuredSections,
-  sanitizeOriginatedFacts,
-  type EntityOriginStructuredSection,
-} from "./entity-origin-fields.js";
+import { buildOriginStructuredSections, sanitizeOriginatedFacts, type EntityOriginStructuredSection } from "./entity-origin-fields.js";
 import {
   checkEntityRecallAbort,
   entityRecallSectionAbsent,
@@ -106,7 +103,7 @@ function uniqueStrings(values: string[]): string[] {
 function compactLine(value: string, maxLength: number = 220): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+  return `${truncateGraphemeSafe(normalized, maxLength - 1).trimEnd()}…`;
 }
 function dedupeHintSnippetsByText(snippets: EntityHintSnippet[]): EntityHintSnippet[] {
   const deduped = new Map<string, EntityHintSnippet>();
@@ -1052,7 +1049,7 @@ function formatEntityHintSection(
 
   let result = lines.join("\n");
   if (result.length > maxChars) {
-    result = `${result.slice(0, Math.max(0, maxChars - 15)).trimEnd()}\n\n...(trimmed)\n`;
+    result = `${truncateGraphemeSafe(result, Math.max(0, maxChars - 15)).trimEnd()}\n\n...(trimmed)\n`;
   }
   return result.trim().length > 0 ? result.trimEnd() : null;
 }

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -11,6 +11,8 @@
  *
  */
 
+export { collapseWhitespace, displayWidth, graphemeUnits, padEndDisplay, truncateCodePointSafe, truncateGraphemeSafe } from "./whitespace.js";
+
 // ---------------------------------------------------------------------------
 // Plugin entry resolution
 // ---------------------------------------------------------------------------
@@ -1446,10 +1448,7 @@ export {
 
 // Coding-graph engine contract (#1551 PR1), implemented by optional @remnic/coding-graph.
 
-export {
-  CODING_GRAPH_ENGINE_VERSION,
-  TIER_1_LANGUAGES,
-} from "./coding/coding-graph-types.js";
+export { CODING_GRAPH_ENGINE_VERSION, TIER_1_LANGUAGES } from "./coding/coding-graph-types.js";
 
 export type {
   CodingGraphEngine,

--- a/packages/remnic-core/src/orchestration/recall-section-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/recall-section-coordinator.ts
@@ -19,6 +19,7 @@
 
 import type { LastRecallBudgetSummary } from "../recall-state.js";
 import { estimateTokenCount } from "../token-estimate.js";
+import { graphemeUnits, truncateGraphemeSafe } from "../whitespace.js";
 import type { PluginConfig, RecallSectionConfig } from "../types.js";
 
 export interface RecallSectionAppendOptions {
@@ -145,7 +146,7 @@ export class RecallSectionCoordinator {
       finalContent =
         sectionId === "profile"
           ? this.truncateProfileToBoundary(finalContent, maxChars)
-          : `${finalContent.slice(0, maxChars)}\n\n...(trimmed)\n`;
+          : `${truncateGraphemeSafe(finalContent, maxChars)}\n\n...(trimmed)\n`;
     }
     if (finalContent.length === 0) return false;
     const existing = sectionBuckets.get(sectionId) ?? [];
@@ -174,11 +175,16 @@ export class RecallSectionCoordinator {
     const contentLimit = maxChars - suffix.length;
     if (contentLimit <= 0) {
       const boundary = content.lastIndexOf("\n", maxChars);
-      return content.slice(0, boundary > 0 ? boundary : maxChars).trimEnd();
+      const clipped = boundary > 0
+        ? content.slice(0, boundary)
+        : truncateGraphemeSafe(content, maxChars);
+      return clipped.trimEnd();
     }
     const boundary = content.lastIndexOf("\n", contentLimit);
-    const end = boundary > 0 ? boundary : contentLimit;
-    return `${content.slice(0, end).trimEnd()}${suffix}`;
+    const clipped = boundary > 0
+      ? content.slice(0, boundary)
+      : truncateGraphemeSafe(content, contentLimit);
+    return `${clipped.trimEnd()}${suffix}`;
   }
   truncateRecallSectionToBudget(
     content: string,
@@ -191,20 +197,20 @@ export class RecallSectionCoordinator {
       content.length <= maxChars
         ? content
         : maxChars <= suffix.length
-          ? content.slice(0, maxChars)
-          : `${content.slice(0, maxChars - suffix.length)}${suffix}`;
+          ? truncateGraphemeSafe(content, maxChars)
+          : `${truncateGraphemeSafe(content, maxChars - suffix.length)}${suffix}`;
     if (maxTokens === undefined || estimateTokenCount(charBounded) <= maxTokens) {
       return charBounded;
     }
     const markerFits =
       maxChars > suffix.length && estimateTokenCount(suffix) <= maxTokens;
-    const tokenSource = content.length > maxChars ? content.slice(0, maxChars) : content;
-    const codePoints = [...tokenSource];
+    const tokenSource = content.length > maxChars ? truncateGraphemeSafe(content, maxChars) : content;
+    const units = graphemeUnits(tokenSource);
     let low = 0;
-    let high = codePoints.length;
+    let high = units.length;
     while (low < high) {
       const mid = Math.ceil((low + high) / 2);
-      const prefix = codePoints.slice(0, mid).join("");
+      const prefix = units.slice(0, mid).join("");
       const candidate = markerFits ? `${prefix}${suffix}` : prefix;
       if (candidate.length <= maxChars && estimateTokenCount(candidate) <= maxTokens) {
         low = mid;
@@ -214,19 +220,19 @@ export class RecallSectionCoordinator {
     }
     if (markerFits && low === 0) {
       low = 0;
-      high = codePoints.length;
+      high = units.length;
       while (low < high) {
         const mid = Math.ceil((low + high) / 2);
-        const prefix = codePoints.slice(0, mid).join("");
+        const prefix = units.slice(0, mid).join("");
         if (prefix.length <= maxChars && estimateTokenCount(prefix) <= maxTokens) {
           low = mid;
         } else {
           high = mid - 1;
         }
       }
-      return codePoints.slice(0, low).join("");
+      return units.slice(0, low).join("");
     }
-    const prefix = codePoints.slice(0, low).join("");
+    const prefix = units.slice(0, low).join("");
     return markerFits ? `${prefix}${suffix}` : prefix;
   }
 

--- a/packages/remnic-core/src/whitespace.test.ts
+++ b/packages/remnic-core/src/whitespace.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  collapseWhitespace,
+  displayWidth,
+  graphemeUnits,
+  padEndDisplay,
+  truncateCodePointSafe,
+  truncateGraphemeSafe,
+} from "./whitespace.js";
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    const isHigh = code >= 0xd800 && code <= 0xdbff;
+    const isLow = code >= 0xdc00 && code <= 0xdfff;
+    if (isHigh) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index += 1;
+    } else if (isLow) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isGraphemePrefix(prefix: string, value: string): boolean {
+  let accumulated = "";
+  for (const unit of graphemeUnits(value)) {
+    if (accumulated === prefix) return true;
+    accumulated += unit;
+  }
+  return accumulated === prefix;
+}
+
+// Deterministic pseudo-random source so failures replay exactly.
+function lcg(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+// Every entry is one or more whole grapheme clusters covering the cases named
+// in issue #2195: astral emoji, ZWJ sequences, skin-tone modifiers,
+// regional-indicator flags, Hangul (precomposed and jamo), combining marks,
+// and astral kanji.
+const GRAPHEME_PIECES = [
+  "a",
+  "b",
+  " ",
+  "7",
+  "😀",
+  "👨‍👩‍👧‍👦",
+  "👍🏽",
+  "🇯🇵",
+  "🇺🇸",
+  "🇰🇷",
+  "한",
+  "한",
+  "e\u0301",
+  "k\u0331\u0301",
+  "क़",
+  "𠮷",
+  "日",
+  "本",
+  "語",
+] as const;
+
+test("truncateGraphemeSafe: property - valid Unicode, grapheme-aligned, within budget", () => {
+  const random = lcg(20260816);
+  for (let iteration = 0; iteration < 500; iteration += 1) {
+    let input = "";
+    const pieceCount = 1 + Math.floor(random() * 12);
+    for (let piece = 0; piece < pieceCount; piece += 1) {
+      input += GRAPHEME_PIECES[Math.floor(random() * GRAPHEME_PIECES.length)]!;
+    }
+    const maxChars = Math.floor(random() * (input.length + 2));
+    const output = truncateGraphemeSafe(input, maxChars);
+    assert.ok(
+      output.length <= maxChars,
+      `budget exceeded for ${JSON.stringify(input)} @ ${maxChars}: ${JSON.stringify(output)}`,
+    );
+    assert.ok(
+      !hasLoneSurrogate(output),
+      `lone surrogate for ${JSON.stringify(input)} @ ${maxChars}: ${JSON.stringify(output)}`,
+    );
+    assert.ok(
+      isGraphemePrefix(output, input),
+      `split grapheme for ${JSON.stringify(input)} @ ${maxChars}: ${JSON.stringify(output)}`,
+    );
+    if (input.length <= maxChars) {
+      assert.equal(output, input, `fits must pass through @ ${maxChars}`);
+    }
+  }
+});
+
+test("truncateGraphemeSafe: emoji, ZWJ, flags, jamo, and combining marks stay whole", () => {
+  assert.equal(truncateGraphemeSafe("hello world", 5), "hello");
+  assert.equal(truncateGraphemeSafe("hello", 50), "hello");
+  assert.equal(truncateGraphemeSafe("hello", 0), "");
+  assert.equal(truncateGraphemeSafe("👍👍", 2), "👍");
+  assert.equal(truncateGraphemeSafe("👍", 1), "", "a split emoji is dropped, never half-cut");
+  assert.equal(truncateGraphemeSafe("a👍b", 2), "a");
+  assert.equal(truncateGraphemeSafe("🇯🇵🇺🇸", 4), "🇯🇵");
+  assert.equal(truncateGraphemeSafe("🇯🇵🇺🇸", 3), "", "a split flag is dropped, never half-cut");
+  const family = "👨‍👩‍👧‍👦";
+  assert.equal(truncateGraphemeSafe(`${family}!`, family.length + 1), `${family}!`);
+  assert.equal(truncateGraphemeSafe(`${family}!`, family.length), family);
+  assert.equal(truncateGraphemeSafe(family, family.length - 1), "", "ZWJ sequence is atomic");
+  assert.equal(truncateGraphemeSafe("한글", 3), "한", "jamo run is one cluster");
+  assert.equal(truncateGraphemeSafe("e\u0301x", 2), "e\u0301", "base plus mark is one cluster");
+  assert.equal(truncateGraphemeSafe("e\u0301x", 1), "");
+});
+
+test("truncateCodePointSafe and collapseWhitespace keep prior behavior", () => {
+  assert.equal(collapseWhitespace(" a \n b "), "a b");
+  assert.equal(truncateCodePointSafe("abcd", 2), "ab");
+  assert.equal(truncateCodePointSafe("ab", 9), "ab");
+  assert.equal(truncateCodePointSafe("abc", 0), "");
+});
+
+test("displayWidth: CJK wide, fullwidth, halfwidth, marks, and emoji", () => {
+  assert.equal(displayWidth(""), 0);
+  assert.equal(displayWidth("abc"), 3);
+  assert.equal(displayWidth("日本語"), 6);
+  assert.equal(displayWidth("ハングル"), 8);
+  assert.equal(displayWidth("한국어"), 6);
+  assert.equal(displayWidth("ｱ"), 1, "halfwidth katakana is narrow");
+  assert.equal(displayWidth("ｆｕｌｌ"), 8, "fullwidth ASCII is wide");
+  assert.equal(displayWidth("e\u0301"), 1, "combining mark is zero width");
+  assert.equal(displayWidth("😀"), 2);
+  assert.equal(displayWidth("中日 memo"), 9, "2+2+1+4");
+});
+
+test("padEndDisplay: CJK rows align to one computed width", () => {
+  assert.equal(padEndDisplay("abc", 6), "abc   ");
+  assert.equal(padEndDisplay("abc", 2), "abc", "narrow target never truncates");
+  assert.equal(padEndDisplay("日本", 10), "日本" + " ".repeat(6));
+  const rows = ["機械学習", "nlp", "한국어", "x"];
+  const padded = rows.map((row) => padEndDisplay(row, 12));
+  for (const row of padded) {
+    assert.equal(displayWidth(row), 12);
+  }
+  assert.deepEqual(padded, [
+    "機械学習    ",
+    "nlp         ",
+    "한국어      ",
+    "x           ",
+  ]);
+  // Snapshot-style: the CLI topics table shape keeps its score column aligned
+  // for CJK rows, which plain padEnd misaligns.
+  const table = rows.slice(0, 3).map((term) => `  ${padEndDisplay(term, 12)} 0.123`);
+  assert.deepEqual(table, [
+    "  機械学習     0.123",
+    "  nlp          0.123",
+    "  한국어       0.123",
+  ]);
+  const tableWidth = displayWidth(table[0]!);
+  assert.ok(table.every((line) => displayWidth(line) === tableWidth));
+});

--- a/packages/remnic-core/src/whitespace.test.ts
+++ b/packages/remnic-core/src/whitespace.test.ts
@@ -136,6 +136,20 @@ test("displayWidth: CJK wide, fullwidth, halfwidth, marks, and emoji", () => {
   assert.equal(displayWidth("中日 memo"), 9, "2+2+1+4");
 });
 
+test("displayWidth: emoji sequences measure as one two-cell grapheme", () => {
+  assert.equal(displayWidth("👨‍👩‍👧‍👦"), 2, "ZWJ family emoji is one cluster");
+  assert.equal(displayWidth("🇯🇵"), 2, "regional-indicator flag is one cluster");
+  assert.equal(displayWidth("👍🏽"), 2, "skin-tone modifier joins the cluster");
+  assert.equal(displayWidth("❤️"), 2, "VS16 requests emoji presentation");
+  assert.equal(displayWidth("1️⃣"), 2, "keycap sequence is one cluster");
+  assert.equal(displayWidth("👨‍👩‍👧‍👦 文"), 5, "clusters compose: 2 + 1 + 2");
+  assert.equal(
+    padEndDisplay("👨‍👩‍👧‍👦", 6),
+    "👨‍👩‍👧‍👦" + " ".repeat(4),
+    "emoji rows pad by display width, not code units",
+  );
+});
+
 test("padEndDisplay: CJK rows align to one computed width", () => {
   assert.equal(padEndDisplay("abc", 6), "abc   ");
   assert.equal(padEndDisplay("abc", 2), "abc", "narrow target never truncates");

--- a/packages/remnic-core/src/whitespace.ts
+++ b/packages/remnic-core/src/whitespace.ts
@@ -50,7 +50,9 @@ export function graphemeUnits(value: string): string[] {
 }
 
 const COMBINING_MARK = /\p{M}/u;
+const FORMAT_CHAR = /\p{Cf}/u;
 const EMOJI_PRESENTATION = /\p{Emoji_Presentation}/u;
+const EMOJI_PRESENTATION_SELECTOR = "\uFE0F";
 
 // ponytail: pragmatic East_Asian_Width Wide/Fullwidth subset - contiguous
 // block ranges plus the emoji presentation planes. Sparse exceptions inside
@@ -78,7 +80,6 @@ const WIDE_CODE_POINT_RANGES: ReadonlyArray<readonly [number, number]> = [
 ];
 
 function isWideGlyph(glyph: string): boolean {
-  if (EMOJI_PRESENTATION.test(glyph)) return true;
   const codePoint = glyph.codePointAt(0)!;
   let low = 0;
   let high = WIDE_CODE_POINT_RANGES.length - 1;
@@ -94,15 +95,28 @@ function isWideGlyph(glyph: string): boolean {
 
 /**
  * Terminal cell width: East_Asian_Width Wide/Fullwidth glyphs count as 2,
- * combining marks as 0, everything else as 1.
+ * combining marks and format characters (ZWJ, variation selectors) as 0,
+ * everything else as 1. A grapheme cluster with emoji presentation - ZWJ
+ * sequences, flags, skin-tone modifiers - occupies two cells.
  */
 export function displayWidth(value: string): number {
   let width = 0;
-  for (const glyph of value) {
-    if (COMBINING_MARK.test(glyph)) continue;
-    width += isWideGlyph(glyph) ? 2 : 1;
+  for (const cluster of graphemeUnits(value)) {
+    width += graphemeClusterWidth(cluster);
   }
   return width;
+}
+
+function graphemeClusterWidth(cluster: string): number {
+  if (cluster.includes(EMOJI_PRESENTATION_SELECTOR)) return 2;
+  let emojiCluster = false;
+  let width = 0;
+  for (const glyph of cluster) {
+    if (COMBINING_MARK.test(glyph) || FORMAT_CHAR.test(glyph)) continue;
+    if (EMOJI_PRESENTATION.test(glyph)) emojiCluster = true;
+    width += isWideGlyph(glyph) ? 2 : 1;
+  }
+  return emojiCluster ? 2 : width;
 }
 
 /**

--- a/packages/remnic-core/src/whitespace.ts
+++ b/packages/remnic-core/src/whitespace.ts
@@ -8,3 +8,108 @@ export function truncateCodePointSafe(value: string, maxChars: number): string {
   if (glyphs.length <= maxChars) return value;
   return glyphs.slice(0, Math.max(1, maxChars)).join("").trimEnd();
 }
+
+let graphemeSegmenter: Intl.Segmenter | null | undefined;
+
+function getGraphemeSegmenter(): Intl.Segmenter | null {
+  if (graphemeSegmenter === undefined) {
+    graphemeSegmenter =
+      typeof Intl !== "undefined" && typeof Intl.Segmenter === "function"
+        ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+        : null;
+  }
+  return graphemeSegmenter;
+}
+
+/**
+ * Longest prefix of `value` whose UTF-16 length stays within `maxChars`
+ * without splitting a surrogate pair or a grapheme cluster (ZWJ emoji
+ * sequences, flags, Hangul jamo runs, combining marks). A cluster wider than
+ * the budget is dropped whole rather than split. Falls back to code-point
+ * boundaries when Intl.Segmenter is unavailable.
+ */
+export function truncateGraphemeSafe(value: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (value.length <= maxChars) return value;
+  let truncated = "";
+  for (const unit of graphemeUnits(value)) {
+    if (truncated.length + unit.length > maxChars) break;
+    truncated += unit;
+  }
+  return truncated;
+}
+
+/**
+ * Grapheme clusters of `value` as separate strings, or its code points when
+ * Intl.Segmenter is unavailable.
+ */
+export function graphemeUnits(value: string): string[] {
+  const segmenter = getGraphemeSegmenter();
+  if (segmenter === null) return [...value];
+  return Array.from(segmenter.segment(value), (segment) => segment.segment);
+}
+
+const COMBINING_MARK = /\p{M}/u;
+const EMOJI_PRESENTATION = /\p{Emoji_Presentation}/u;
+
+// ponytail: pragmatic East_Asian_Width Wide/Fullwidth subset - contiguous
+// block ranges plus the emoji presentation planes. Sparse exceptions inside
+// those ranges (narrow unassigned code points, U+303F) do not matter for
+// terminal column alignment; switch to a full EAW table only if drift shows.
+const WIDE_CODE_POINT_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x1100, 0x115f], // Hangul Jamo
+  [0x2e80, 0x303e], // CJK radicals, Kangxi radicals, CJK symbols and punctuation
+  [0x3041, 0x33ff], // Hiragana, Katakana, Bopomofo, Hangul compatibility jamo
+  [0x3400, 0x4dbf], // CJK unified ideographs extension A
+  [0x4e00, 0xa4cf], // CJK unified ideographs, Yi
+  [0xa960, 0xa97f], // Hangul Jamo extension A
+  [0xac00, 0xd7a3], // Hangul syllables
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+  [0xfe10, 0xfe19], // Vertical forms
+  [0xfe30, 0xfe6b], // CJK compatibility forms
+  [0xff00, 0xff60], // Fullwidth ASCII and punctuation
+  [0xffe0, 0xffe6], // Fullwidth signs
+  [0x1f300, 0x1f64f], // Emoji symbols, pictographs, emoticons
+  [0x1f680, 0x1f6ff], // Transport and map
+  [0x1f900, 0x1f9ff], // Supplemental symbols
+  [0x1fa70, 0x1faff], // Symbols and pictographs extended-A
+  [0x20000, 0x2fffd], // CJK extensions B-F
+  [0x30000, 0x3fffd], // CJK extension G and later
+];
+
+function isWideGlyph(glyph: string): boolean {
+  if (EMOJI_PRESENTATION.test(glyph)) return true;
+  const codePoint = glyph.codePointAt(0)!;
+  let low = 0;
+  let high = WIDE_CODE_POINT_RANGES.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const [start, end] = WIDE_CODE_POINT_RANGES[mid]!;
+    if (codePoint < start) high = mid - 1;
+    else if (codePoint > end) low = mid + 1;
+    else return true;
+  }
+  return false;
+}
+
+/**
+ * Terminal cell width: East_Asian_Width Wide/Fullwidth glyphs count as 2,
+ * combining marks as 0, everything else as 1.
+ */
+export function displayWidth(value: string): number {
+  let width = 0;
+  for (const glyph of value) {
+    if (COMBINING_MARK.test(glyph)) continue;
+    width += isWideGlyph(glyph) ? 2 : 1;
+  }
+  return width;
+}
+
+/**
+ * padEnd analog that pads to a terminal cell width, so rows containing CJK
+ * or emoji keep their columns aligned.
+ */
+export function padEndDisplay(value: string, targetWidth: number): string {
+  const padding = targetWidth - displayWidth(value);
+  return padding > 0 ? value + " ".repeat(padding) : value;
+}


### PR DESCRIPTION
Fixes #2195

## What happens today

User-facing truncations slice by UTF-16 code units (`entity-retrieval.ts` `compactLine` and the hints trim, several `cli.ts` previews, `recall-section-coordinator.ts` section truncation). Slicing can cut inside a surrogate pair or a grapheme cluster, producing a lone surrogate: invalid text that renders as U+FFFD and can corrupt downstream serialization. Table padding uses `padEnd` by string length, so East-Asian wide glyphs shift every following column.

## Change

- `whitespace.ts` (next to `truncateCodePointSafe`):
  - `truncateGraphemeSafe(value, maxChars)` — longest prefix within a UTF-16 budget that splits no surrogate pair and no grapheme cluster (`Intl.Segmenter` grapheme granularity, code-point fallback when unavailable). A cluster wider than the budget is dropped whole rather than split. Budget semantics are unchanged for callers: output length is always \`<= maxChars\` code units.
  - `graphemeUnits` — grapheme segments (code points as fallback).
  - `displayWidth` — terminal cell width: East_Asian_Width Wide/Fullwidth = 2, combining marks (\\p{M}) = 0, else 1. Pragmatic contiguous EAW block ranges plus the emoji presentation planes; no new dependency.
  - `padEndDisplay` — `padEnd` analog over `displayWidth`.
- Migrated truncation sites: `compactLine` + entity-hints trim (`entity-retrieval.ts`), 11 memory/search/cluster/topics/transcript previews (`packages/remnic-core/src/cli.ts`), section/profile/token-budget truncation (`recall-section-coordinator.ts`; the token-budget binary search now walks grapheme segments).
- Migrated padding sites: importance + topics tables (`packages/remnic-core/src/cli.ts`), metric columns (`packages/remnic-cli/src/bench-output-printer.ts`).
- Structural ratchet: `entity-retrieval.ts` sat exactly at the 1200-line cap and `index.ts` at its grandfathered ceiling, so two small import/export blocks were collapsed to single lines (format-only, no symbol changes).

## Tests

- Property test (500 seeded iterations over emoji / ZWJ families / skin-tone modifiers / flags / precomposed + jamo Hangul / combining-mark / astral-kanji inputs): output length stays within budget, output never contains a lone surrogate, and output is always a whole-grapheme prefix of the input.
- Deterministic cluster cases: split-prone budgets (flags at 3 units, family emoji, jamo runs, base+mark) return whole clusters or drop them, never half-cut.
- Snapshot-style CJK alignment: padded table rows for CJK/ASCII/Hangul terms all compute to one display width, with exact expected strings.

## Verification

- `npm run test:file packages/remnic-core/src/whitespace.test.ts` — 5/5 pass.
- `npm run test:entity-hardening` — 340/340 pass (required: touches `entity-retrieval.ts`).
- `npm run test:file packages/remnic-core/src/testing/subjects/recall-budget.test.ts` — 9/9 pass.
- `npm run check-types` — pass (final `check-test-types` step run through the pinned wrapper; bare `spawnSync pnpm` ENOENTs on hosts without a global pnpm — pre-existing, filed as papercut).
- `npm run preflight:quick` — OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display/truncation helpers with broad call-site swaps but no auth, persistence, or API contract changes; behavior is strictly safer for Unicode and terminal layout.
> 
> **Overview**
> Adds **`truncateGraphemeSafe`**, **`graphemeUnits`**, **`displayWidth`**, and **`padEndDisplay`** in `whitespace.ts` (with `Intl.Segmenter` grapheme segmentation and a code-point fallback) and re-exports them from `@remnic/core`.
> 
> **Truncation** replaces UTF-16 `.slice` at recall/CLI surfaces: entity `compactLine` and hints trim, many memory/search/cluster/topics/transcript previews in `cli.ts`, and recall section/profile/token-budget trimming in `recall-section-coordinator.ts` (the token binary search now steps by grapheme units). Clusters that do not fit the budget are dropped whole instead of being split.
> 
> **Padding** switches CLI importance/topics tables and bench metric columns from `padEnd` to **`padEndDisplay`** so CJK and emoji rows align in the terminal.
> 
> Adds **`whitespace.test.ts`** (property + deterministic Unicode cases). Minor format-only line collapses in `entity-retrieval.ts` and `index.ts` for file-size caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9977ab2468a4a4fff28f8561b165c1425054c168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CLI output now truncates text without splitting emoji, flags, combined characters, or other user-perceived characters.
  * Tables and benchmark metrics now align correctly across CJK, fullwidth, halfwidth, and emoji characters.
  * Improved readability of recall, search, summaries, transcripts, and other formatted output.
* **Bug Fixes**
  * Prevented malformed or misaligned text caused by Unicode truncation and terminal-width differences.
* **Tests**
  * Added comprehensive coverage for Unicode truncation, display widths, padding, and table alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->