### PR TITLE
fix(core): order projected harmonic sources by insertion recency

### DIFF
--- a/.changeset/2340-insertion-recency-sort.md
+++ b/.changeset/2340-insertion-recency-sort.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Order projected harmonic sources newest-first using the per-source insertion timestamps already stored on abstraction nodes, so projected titles and summaries describe the most recently inserted facts instead of the three oldest. Equal or missing timestamps keep the previous ascending id order.

--- a/packages/remnic-core/src/harmonic-construction.test.ts
+++ b/packages/remnic-core/src/harmonic-construction.test.ts
@@ -1326,7 +1326,8 @@ async function persistRecencyFixture(memoryDir: string): Promise<{
 
 async function rewriteTopicInsertedAt(
   storageDir: string,
-  insertedAtById: Record<string, string> | null
+  insertedAtById: Record<string, string> | null,
+  recordedAt?: string
 ): Promise<void> {
   const nodesDir = path.join(storageDir, "state", "abstraction-nodes", "nodes");
   for (const dayEntry of await readdir(nodesDir, { withFileTypes: true })) {
@@ -1342,7 +1343,10 @@ async function rewriteTopicInsertedAt(
       } else {
         metadata[HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY] = JSON.stringify(insertedAtById);
       }
-      await writeFile(filePath, `${JSON.stringify({ ...node, metadata }, null, 2)}\n`);
+      await writeFile(
+        filePath,
+        `${JSON.stringify({ ...node, metadata, ...(recordedAt ? { recordedAt } : {}) }, null, 2)}\n`
+      );
     }
   }
 }
@@ -1393,8 +1397,8 @@ test("harmonic projection keeps ascending id order for equal or missing insertio
   try {
     const { storageDir, persistedIds, contentById } = await persistRecencyFixture(memoryDir);
     const ascendingIds = [...persistedIds].sort(compareDeterministicStrings);
-    const [first, second, third] = ascendingIds.map((memoryId) => memoryId);
-    assert.ok(first && second && third);
+    const [first, second, third, fourth, fifth] = ascendingIds.map((memoryId) => memoryId);
+    assert.ok(first && second && third && fourth && fifth);
     const expectedSummary = [first, second, third]
       .map((memoryId) => contentById.get(memoryId))
       .join("; ");
@@ -1415,6 +1419,26 @@ test("harmonic projection keeps ascending id order for equal or missing insertio
     assert.deepEqual(topic.node.sourceMemoryIds, ascendingIds);
     assert.equal(topic.node.title, contentById.get(first));
     assert.equal(topic.node.summary, expectedSummary);
+
+    await rewriteTopicInsertedAt(
+      storageDir,
+      {
+        [first]: "not-a-timestamp",
+        [second]: "2026-01-01T00:00:00.000Z",
+        [third]: "2026-02-01T00:00:00.000Z",
+        [fourth]: "definitely not a date",
+        [fifth]: "2026-03-01T00:00:00.000Z",
+      },
+      "2026-06-01T00:00:00.000Z"
+    );
+    topic = await findProjectedTopic(storageDir);
+    assert.ok(topic);
+    assert.deepEqual(topic.node.sourceMemoryIds, [first, fourth, fifth, third, second]);
+    assert.equal(topic.node.title, contentById.get(first));
+    assert.equal(
+      topic.node.summary,
+      [first, fourth, fifth].map((memoryId) => contentById.get(memoryId)).join("; ")
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/harmonic-construction.test.ts
+++ b/packages/remnic-core/src/harmonic-construction.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { appendFile, mkdir, mkdtemp, open, readFile, rm, stat, unlink, utimes, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, open, readdir, readFile, rm, stat, unlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY,
   getAbstractionNodeStoreStatus,
   upsertAbstractionNode,
   upsertAbstractionNodes,
@@ -26,12 +27,14 @@ import {
   deriveHarmonicRecords,
   normalizeCueAnchorInputs,
 } from "./harmonic-construction.js";
-import { searchHarmonicRetrieval } from "./harmonic-retrieval.js";
+import { searchHarmonicRetrieval, type HarmonicRetrievalResult } from "./harmonic-retrieval.js";
 import { readJsonFile, withJsonStoreMutationLock } from "./json-store.js";
 import {
   filterHarmonicEntityMentions,
   persistConstructedHarmonicRecords,
 } from "./orchestration/harmonic-construction-persist.js";
+import { compareDeterministicStrings } from "./deterministic-order.js";
+import { stripAttributesSuffix } from "./structured-attributes.js";
 import { Orchestrator } from "./orchestrator.js";
 import { ExtractedFactSchema, ExtractionResultSchema } from "./schemas.js";
 import type { ExtractionResult, MemoryFile } from "./types.js";
@@ -1254,6 +1257,164 @@ test("harmonic anchors stay scoped to projected active sources in a mixed episod
         result.matchedAnchors.some((anchor) => anchor.anchorValue === "Orion surviving transport")
       )
     );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+async function persistRecencyFixture(memoryDir: string): Promise<{
+  storageDir: string;
+  persistedIds: string[];
+  contentById: Map<string, string>;
+}> {
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    chunkingEnabled: false,
+    harmonicRetrievalEnabled: true,
+    abstractionAnchorsEnabled: false,
+  });
+  const orchestrator = new Orchestrator(config) as unknown as PersistenceHarness;
+  const storage = await orchestrator.getStorage("default");
+  await storage.ensureDirectories();
+  const contents = [
+    "Atlas fact zero of the oldest insertion pair.",
+    "Atlas fact one of the oldest insertion pair.",
+    "Atlas fact two at the middle insertion time.",
+    "Atlas fact three of the newest insertion pair.",
+    "Atlas fact four of the newest insertion pair.",
+  ];
+  const { persistedIds } = await orchestrator.persistExtraction(
+    {
+      facts: contents.map((content) => ({
+        category: "fact",
+        content,
+        confidence: 0.99,
+        tags: ["atlas"],
+        entityRef: "atlas-project",
+        cueAnchors: [],
+      })),
+      entities: [{ name: "atlas-project", type: "company", facts: [] }],
+      profileUpdates: [],
+      questions: [],
+      relationships: [],
+      episodeTitle: "Atlas insertion ordering",
+    },
+    storage,
+    null,
+    { sessionKey: "session:harmonic-recency" }
+  );
+  const expectedContents = new Set(contents);
+  const contentById = new Map<string, string>();
+  const factIds: string[] = [];
+  for (const persistedId of persistedIds) {
+    const memory = await storage.getMemoryById(persistedId);
+    if (!memory) continue;
+    const content = memory.frontmatter.structuredAttributes
+      ? stripAttributesSuffix(memory.content)
+      : memory.content;
+    if (!expectedContents.has(content)) continue;
+    factIds.push(persistedId);
+    contentById.set(persistedId, content);
+  }
+  assert.equal(factIds.length, 5, `expected the five fact memories, got ${persistedIds.length} persisted`);
+  return { storageDir: storage.dir, persistedIds: factIds, contentById };
+}
+
+async function rewriteTopicInsertedAt(
+  storageDir: string,
+  insertedAtById: Record<string, string> | null
+): Promise<void> {
+  const nodesDir = path.join(storageDir, "state", "abstraction-nodes", "nodes");
+  for (const dayEntry of await readdir(nodesDir, { withFileTypes: true })) {
+    if (!dayEntry.isDirectory()) continue;
+    for (const entryName of await readdir(path.join(nodesDir, dayEntry.name))) {
+      if (!entryName.endsWith(".json")) continue;
+      const filePath = path.join(nodesDir, dayEntry.name, entryName);
+      const node = JSON.parse(await readFile(filePath, "utf8")) as Record<string, unknown>;
+      if (node.kind !== "topic") continue;
+      const metadata = { ...(node.metadata as Record<string, string>) };
+      if (insertedAtById === null) {
+        delete metadata[HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY];
+      } else {
+        metadata[HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY] = JSON.stringify(insertedAtById);
+      }
+      await writeFile(filePath, `${JSON.stringify({ ...node, metadata }, null, 2)}\n`);
+    }
+  }
+}
+
+async function findProjectedTopic(
+  storageDir: string
+): Promise<HarmonicRetrievalResult | undefined> {
+  const results = await searchHarmonicRetrieval({
+    memoryDir: storageDir,
+    query: "atlas",
+    maxResults: 5,
+    anchorsEnabled: false,
+  });
+  return results.find((result) => result.node.kind === "topic");
+}
+
+test("harmonic projection orders sources newest-first with deterministic tiebreak", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-harmonic-recency-"));
+  try {
+    const { storageDir, persistedIds, contentById } = await persistRecencyFixture(memoryDir);
+    const ascendingIds = [...persistedIds].sort(compareDeterministicStrings);
+    const [first, second, third, fourth, fifth] = ascendingIds.map((memoryId) => memoryId);
+    assert.ok(first && second && third && fourth && fifth);
+    const oldest = "2026-01-01T00:00:00.000Z";
+    const middle = "2026-02-01T00:00:00.000Z";
+    const newest = "2026-03-01T00:00:00.000Z";
+    const insertedAtByRank = [oldest, oldest, middle, newest, newest];
+    await rewriteTopicInsertedAt(
+      storageDir,
+      Object.fromEntries(ascendingIds.map((memoryId, index) => [memoryId, insertedAtByRank[index]]))
+    );
+
+    const topic = await findProjectedTopic(storageDir);
+    assert.ok(topic, "topic node must stay retrievable");
+    assert.deepEqual(topic.node.sourceMemoryIds, [fourth, fifth, third, first, second]);
+    assert.equal(topic.node.title, contentById.get(fourth));
+    assert.equal(
+      topic.node.summary,
+      [fourth, fifth, third].map((memoryId) => contentById.get(memoryId)).join("; ")
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("harmonic projection keeps ascending id order for equal or missing insertion timestamps", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-harmonic-recency-equal-"));
+  try {
+    const { storageDir, persistedIds, contentById } = await persistRecencyFixture(memoryDir);
+    const ascendingIds = [...persistedIds].sort(compareDeterministicStrings);
+    const [first, second, third] = ascendingIds.map((memoryId) => memoryId);
+    assert.ok(first && second && third);
+    const expectedSummary = [first, second, third]
+      .map((memoryId) => contentById.get(memoryId))
+      .join("; ");
+
+    await rewriteTopicInsertedAt(
+      storageDir,
+      Object.fromEntries(ascendingIds.map((memoryId) => [memoryId, "2026-01-01T00:00:00.000Z"]))
+    );
+    let topic = await findProjectedTopic(storageDir);
+    assert.ok(topic);
+    assert.deepEqual(topic.node.sourceMemoryIds, ascendingIds);
+    assert.equal(topic.node.title, contentById.get(first));
+    assert.equal(topic.node.summary, expectedSummary);
+
+    await rewriteTopicInsertedAt(storageDir, null);
+    topic = await findProjectedTopic(storageDir);
+    assert.ok(topic);
+    assert.deepEqual(topic.node.sourceMemoryIds, ascendingIds);
+    assert.equal(topic.node.title, contentById.get(first));
+    assert.equal(topic.node.summary, expectedSummary);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/harmonic-retrieval.ts
+++ b/packages/remnic-core/src/harmonic-retrieval.ts
@@ -13,6 +13,7 @@ import { compareDeterministicStrings } from "./deterministic-order.js";
 import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
 import { stripAttributesSuffix } from "./structured-attributes.js";
 import { isValidityExpiredNow } from "./temporal-validity.js";
+import { isRecord } from "./store-contract.js";
 import type { MemoryFile } from "./types.js";
 
 type SourceMemoryMap = Map<string, MemoryFile>;
@@ -42,6 +43,22 @@ async function readSourceMemories(options: {
   return sourceMemories;
 }
 
+function parseSourceMemoryInsertedAt(node: AbstractionNode): Map<string, string> {
+  const insertedAtById = new Map<string, string>();
+  const insertedAtRaw = node.metadata?.[HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY];
+  if (!insertedAtRaw) return insertedAtById;
+  try {
+    const parsed = JSON.parse(insertedAtRaw) as unknown;
+    if (!isRecord(parsed)) return insertedAtById;
+    for (const [memoryId, value] of Object.entries(parsed)) {
+      if (typeof value === "string") insertedAtById.set(memoryId, value);
+    }
+  } catch {
+    // Malformed insertion metadata leaves ordering on the recordedAt fallback.
+  }
+  return insertedAtById;
+}
+
 function projectSourceBackedNode(
   node: AbstractionNode,
   sourceMemories: SourceMemoryMap,
@@ -62,6 +79,19 @@ function projectSourceBackedNode(
   });
   if (activeSourceMemoryIds.length === 0) return null;
 
+ // Newest-first source order keeps the projected title and summary on the most
+ // recently inserted facts. Equal or missing timestamps fall back to ascending
+ // id order, which matches the stored sourceMemoryIds order.
+ const insertedAtById = parseSourceMemoryInsertedAt(node);
+ const insertedAtMs = (memoryId: string): number => {
+   const parsedMs = Date.parse(insertedAtById.get(memoryId) ?? "");
+   return Number.isFinite(parsedMs) ? parsedMs : Date.parse(node.recordedAt);
+ };
+ activeSourceMemoryIds.sort(
+   (left, right) =>
+     insertedAtMs(right) - insertedAtMs(left) || compareDeterministicStrings(left, right)
+ );
+
   const activeMemories = activeSourceMemoryIds.flatMap((memoryId) => {
     const memory = sourceMemories.get(memoryId);
     return memory ? [memory] : [];
@@ -69,40 +99,32 @@ function projectSourceBackedNode(
   const activeContents = activeMemories.map((memory) =>
     memory.frontmatter.structuredAttributes ? stripAttributesSuffix(memory.content) : memory.content
   );
-  let metadata: Record<string, string> | undefined;
-  const insertedAtRaw = node.metadata?.[HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY];
-  if (insertedAtRaw) {
-    try {
-      const insertedAt = JSON.parse(insertedAtRaw) as Record<string, unknown>;
-      const activeInsertedAt = activeSourceMemoryIds.flatMap((memoryId) => {
-        const value = insertedAt[memoryId];
-        return typeof value === "string" ? [[memoryId, value] as const] : [];
-      });
-      if (activeInsertedAt.length > 0) {
-        metadata = {
-          [HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY]: JSON.stringify(Object.fromEntries(activeInsertedAt)),
-        };
-      }
-    } catch {
-      metadata = undefined;
-    }
+ let metadata: Record<string, string> | undefined;
+ const activeInsertedAt = activeSourceMemoryIds.flatMap((memoryId) => {
+   const value = insertedAtById.get(memoryId);
+   return typeof value === "string" ? [[memoryId, value] as const] : [];
+ });
+ if (activeInsertedAt.length > 0) {
+   metadata = {
+     [HARMONIC_SOURCE_MEMORY_INSERTED_AT_KEY]: JSON.stringify(Object.fromEntries(activeInsertedAt)),
+   };
   }
 
-  return {
-    ...node,
-    sourceMemoryIds: activeSourceMemoryIds,
-    title: activeContents[0]?.slice(0, 80) ?? node.title,
-    summary: activeContents.slice(0, 3).join("; ").slice(0, 400),
-    tags: [...new Set(activeMemories.flatMap((memory) => memory.frontmatter.tags))].sort(compareDeterministicStrings),
-    entityRefs: [
-      ...new Set(
-        activeMemories.flatMap((memory) =>
-          typeof memory.frontmatter.entityRef === "string" ? [memory.frontmatter.entityRef] : []
-        )
-      ),
-    ].sort(compareDeterministicStrings),
-    metadata,
-  };
+ return {
+   ...node,
+   sourceMemoryIds: activeSourceMemoryIds,
+   title: activeContents[0]?.slice(0, 80) ?? node.title,
+   summary: activeContents.slice(0, 3).join("; ").slice(0, 400),
+   tags: [...new Set(activeMemories.flatMap((memory) => memory.frontmatter.tags))].sort(compareDeterministicStrings),
+   entityRefs: [
+     ...new Set(
+       activeMemories.flatMap((memory) =>
+         typeof memory.frontmatter.entityRef === "string" ? [memory.frontmatter.entityRef] : []
+       )
+     ),
+   ].sort(compareDeterministicStrings),
+   metadata,
+ };
 }
 
 function anchorMatchesProjectedNode(


### PR DESCRIPTION
## Summary

Order the sources of a projected harmonic node newest-first by the per-source insertion timestamps the store already maintains (`remnic.harmonic.sourceMemoryInsertedAt.v1`), before the projection rebuilds the title from the first source and the summary from the first three.

Investigation outcome for #2340: insertion order IS recoverable. `mergeRecentSourceMemoryIds` already stamps each retained source with an ISO `insertedAt` (distinct, monotonically increasing within a merge) and persists that map in node metadata. The projection parsed it only to rebuild the active subset and ignored it for ordering, so a mature topic projected its three oldest facts. Ascending id order alone is NOT a safe proxy: ids from a single batch share a timestamp-second, and merges stamp per-id times that follow id order only within one batch.

## Change

- `projectSourceBackedNode` (packages/remnic-core/src/harmonic-retrieval.ts) now sorts `activeSourceMemoryIds` newest-first by `Date.parse(insertedAt)` with `compareDeterministicStrings` ascending-id tiebreak, matching the comparator convention `mergeRecentSourceMemoryIds` uses for retention.
- Missing metadata key, missing per-id entry, or an unparseable value falls back to the node's `recordedAt` (the same fallback `sourceMemoryInsertedAt` applies at store time). A node without insertion metadata therefore projects exactly as before: ascending id order.
- Metadata parsing moved into a small helper; the rebuilt metadata map now also follows recency order.

## Tests

Two deterministic tests in `harmonic-construction.test.ts` persist five same-entity facts, then rewrite the topic node's insertion metadata directly in the store:

- newest-first order with an equal-timestamp tie in both the newest and oldest pair (asserts full `sourceMemoryIds` order, title source, and three-fact summary);
- all-equal timestamps keep ascending id order with identical title/summary to the previous behavior, and removing the metadata key entirely (legacy nodes) keeps the same order.

Targeted validation: `npm run test:file packages/remnic-core/src/harmonic-construction.test.ts` (37 pass, 0 fail) and `tsc --noEmit` in packages/remnic-core.

Fixes #2340

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to harmonic retrieval projection ordering with explicit fallbacks and new tests; no auth, persistence schema, or API surface changes.
> 
> **Overview**
> **Harmonic retrieval projection** now sorts active source memories **newest-first** using per-source `insertedAt` from `remnic.harmonic.sourceMemoryInsertedAt.v1` metadata, so projected **titles** (first source) and **summaries** (first three) reflect recent facts instead of the oldest stored ids.
> 
> Sorting uses `Date.parse(insertedAt)` with **ascending id** tiebreak via `compareDeterministicStrings`. Missing or invalid per-id timestamps fall back to the node’s `recordedAt`, preserving **legacy ascending-id** behavior when insertion metadata is absent or all timestamps tie.
> 
> Parsing is centralized in `parseSourceMemoryInsertedAt`; rebuilt metadata follows the same recency order. Integration tests persist five facts and assert order, title, and summary under varied timestamp scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520bfd2e60533066cefc687e347c965000e7650f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Projected harmonic sources now appear in newest-first order based on insertion time.
  - Sources with equal or unavailable timestamps use a consistent ID-based order.
  - Projected titles and summaries are selected according to the updated source ordering.

- **Bug Fixes**
  - Improved handling of malformed, invalid, or missing insertion metadata without disrupting retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->