### PR TITLE
fix(core): require non-lossy discriminators on legacy identity paths

### DIFF
--- a/.changeset/2367-legacy-identity-hardening.md
+++ b/.changeset/2367-legacy-identity-hardening.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Harden the legacy-identity migration path so a lossy legacy hash never selects or replaces an identity on its own (issue #2367). `buildTombstoneStore` now scopes its corpus path snapshot and source-content map to one tombstone ledger revision, so a legacy row appended by a peer process is verified on the next staleness reload instead of staying unverified until restart (unverified rows remain withheld from lookup tiers). `TombstoneStore.rebuild` requires an unambiguous legacy hash before replacing a persisted identity, keeping the explicit hash primary with the current body hash as an alias when the legacy normalizer is lossy (CJK-only bodies, accented skeletons). `parsedMemoryIdentity` in the reconcile manifest keeps an ambiguous persisted hash primary and exposes the recovered current identity as `contentHashAliases` (accepted by the peer manifest parser), so a replica carrying the same canonical source identity still collapses. Closes #2367.

--- a/packages/remnic-cli/src/converge-peer-manifest.ts
+++ b/packages/remnic-cli/src/converge-peer-manifest.ts
@@ -53,10 +53,31 @@ function parseMemory(value: unknown): ReconcileMemoryIdentity | undefined {
   if (typeof memory.status !== "string" || !MEMORY_STATUSES.has(memory.status as MemoryStatus)) {
     throw new Error("peer manifest memory metadata had invalid status");
   }
+  const contentHash = memory.contentHash.toLowerCase();
+  let contentHashAliases: string[] | undefined;
+  if (memory.contentHashAliases !== undefined) {
+    if (
+      !Array.isArray(memory.contentHashAliases) ||
+      memory.contentHashAliases.some(
+        (alias) => typeof alias !== "string" || !SHA256_PATTERN.test(alias),
+      )
+    ) {
+      throw new Error("peer manifest memory metadata had invalid contentHashAliases");
+    }
+    const deduped = [
+      ...new Set(
+        memory.contentHashAliases
+          .map((alias) => (alias as string).toLowerCase())
+          .filter((alias) => alias !== contentHash),
+      ),
+    ];
+    if (deduped.length > 0) contentHashAliases = deduped;
+  }
   return {
     id: memory.id,
     category: memory.category,
-    contentHash: memory.contentHash.toLowerCase(),
+    contentHash,
+    ...(contentHashAliases === undefined ? {} : { contentHashAliases }),
     status: memory.status as MemoryStatus,
   };
 }

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -830,11 +830,13 @@ describe("TombstoneStore — revocation supersedes tombstone", () => {
 });
 
 describe("TombstoneStore — rebuild identity preservation (issue #2367)", () => {
-  it("does not displace an explicit contentHashSource that collides with a CJK body under the legacy normalizer", async () => {
+  it("repairs a CJK collision instead of indexing the empty legacy skeleton (issue #2367)", async () => {
     const env = await makeStore("default");
-    // Two distinct CJK-only strings collide under the lossy legacy
-    // normalizer (both skeletons are empty), so a persisted legacy hash of
-    // the source numerically equals the legacy hash of the body.
+    // Two distinct CJK-only strings collide under the lossy legacy normalizer
+    // (both skeletons are empty), so a persisted legacy hash of the source
+    // numerically equals the legacy hash of the body. The empty skeleton
+    // identifies nothing, so rebuild must repair the row to the current body
+    // hash rather than publish the collision key on the exact tier.
     const source = "利用者は紅茶を好む。";
     const body = "利用者は珈琲を好む。";
     const unrelated = "利用者は抹茶を好む。";
@@ -849,21 +851,27 @@ describe("TombstoneStore — rebuild identity preservation (issue #2367)", () =>
         contentHash: persistedHash,
         reason: "correction",
         createdBy: "user_correction",
-        createdAt: "2026-01-01T00:00:00.000Z",
+        createdAt: "2026-01-01T:00:00:00.000Z",
       },
     ]);
 
     const entry = env.store.snapshot().find((e) => e.kind === "tombstone");
     assert.ok(entry);
-    assert.equal(entry.contentHash, persistedHash);
-    assert.equal(entry.currentContentHashAlias, computeHash(body));
-    // The body stays blocked through the alias; unrelated CJK bodies do not.
+    assert.equal(entry.contentHash, computeHash(body));
+    assert.equal(entry.currentContentHashAlias, undefined);
+    // The body stays blocked; the shared empty-skeleton key is NOT indexed,
+    // so unrelated CJK bodies (and empty-content writes) are not blocked
+    // through it.
     assert.equal(
       env.store.lookup({ namespace: "default", contentHash: computeHash(body) })?.matchedTier,
       "exact",
     );
     assert.equal(
       env.store.lookup({ namespace: "default", contentHash: computeHash(unrelated) }),
+      null,
+    );
+    assert.equal(
+      env.store.lookup({ namespace: "default", contentHash: computeLegacyContentHash(unrelated) }),
       null,
     );
   });

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -851,7 +851,7 @@ describe("TombstoneStore — rebuild identity preservation (issue #2367)", () =>
         contentHash: persistedHash,
         reason: "correction",
         createdBy: "user_correction",
-        createdAt: "2026-01-01T:00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
     ]);
 
@@ -873,6 +873,45 @@ describe("TombstoneStore — rebuild identity preservation (issue #2367)", () =>
     assert.equal(
       env.store.lookup({ namespace: "default", contentHash: computeLegacyContentHash(unrelated) }),
       null,
+    );
+  });
+
+  it("preserves an explicit identity hash on an empty-skeleton body instead of repairing it", async () => {
+    const env = await makeStore("default");
+    // A CJK-only body normalizes to an empty legacy skeleton, but the
+    // persisted hash here is a DISTINCT explicit contentHashSource — it does
+    // not equal the body's legacy hash, so it identifies an external source,
+    // not the body. Rebuild must keep it (plus the body alias), not replace
+    // it with the current body hash.
+    const body = "利用者は紅茶を好む。";
+    const source = "canonical://source/fact-cjk-explicit";
+    const explicitHash = computeHash(source);
+    assert.notEqual(explicitHash, computeLegacyContentHash(body));
+    assert.notEqual(explicitHash, computeHash(body));
+
+    await env.store.rebuild([
+      {
+        memoryId: "fact-cjk-explicit",
+        rawContent: body,
+        contentHash: explicitHash,
+        reason: "correction",
+        createdBy: "user_correction",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const entry = env.store.snapshot().find((e) => e.kind === "tombstone");
+    assert.ok(entry);
+    assert.equal(entry.contentHash, explicitHash);
+    assert.equal(entry.currentContentHashAlias, computeHash(body));
+    // The explicit identity and the body are both blocked.
+    assert.equal(
+      env.store.lookup({ namespace: "default", contentHash: explicitHash })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      env.store.lookup({ namespace: "default", contentHash: computeHash(body) })?.matchedTier,
+      "exact",
     );
   });
 

--- a/packages/remnic-core/src/lifecycle/tombstones.test.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.test.ts
@@ -829,6 +829,93 @@ describe("TombstoneStore — revocation supersedes tombstone", () => {
   });
 });
 
+describe("TombstoneStore — rebuild identity preservation (issue #2367)", () => {
+  it("does not displace an explicit contentHashSource that collides with a CJK body under the legacy normalizer", async () => {
+    const env = await makeStore("default");
+    // Two distinct CJK-only strings collide under the lossy legacy
+    // normalizer (both skeletons are empty), so a persisted legacy hash of
+    // the source numerically equals the legacy hash of the body.
+    const source = "利用者は紅茶を好む。";
+    const body = "利用者は珈琲を好む。";
+    const unrelated = "利用者は抹茶を好む。";
+    const persistedHash = computeLegacyContentHash(source);
+    assert.equal(persistedHash, computeLegacyContentHash(body));
+    assert.notEqual(computeHash(source), computeHash(body));
+
+    await env.store.rebuild([
+      {
+        memoryId: "fact-cjk-override",
+        rawContent: body,
+        contentHash: persistedHash,
+        reason: "correction",
+        createdBy: "user_correction",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const entry = env.store.snapshot().find((e) => e.kind === "tombstone");
+    assert.ok(entry);
+    assert.equal(entry.contentHash, persistedHash);
+    assert.equal(entry.currentContentHashAlias, computeHash(body));
+    // The body stays blocked through the alias; unrelated CJK bodies do not.
+    assert.equal(
+      env.store.lookup({ namespace: "default", contentHash: computeHash(body) })?.matchedTier,
+      "exact",
+    );
+    assert.equal(
+      env.store.lookup({ namespace: "default", contentHash: computeHash(unrelated) }),
+      null,
+    );
+  });
+
+  it("preserves a persisted hash whose ASCII skeleton collides with an accented body", async () => {
+    const env = await makeStore("default");
+    const body = "The user prefers café.";
+    await env.store.rebuild([
+      {
+        memoryId: "fact-accented-override",
+        rawContent: body,
+        contentHash: computeLegacyContentHash(body),
+        reason: "correction",
+        createdBy: "user_correction",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    const entry = env.store.snapshot().find((e) => e.kind === "tombstone");
+    assert.ok(entry);
+    // The legacy equality is ambiguous (the skeleton "the user prefers caf"
+    // is shared with distinct strings), so the persisted identity is kept and
+    // the current body hash rides along as the alias.
+    assert.equal(entry.contentHash, computeLegacyContentHash(body));
+    assert.equal(entry.currentContentHashAlias, computeHash(body));
+    assert.equal(
+      env.store.lookup({ namespace: "default", contentHash: computeHash(body) })?.matchedTier,
+      "exact",
+    );
+  });
+
+  it("keeps a single identity when the persisted hash already equals the current body hash", async () => {
+    const env = await makeStore("default");
+    const body = "The cache uses Redis.";
+    await env.store.rebuild([
+      {
+        memoryId: "fact-unambiguous",
+        rawContent: body,
+        contentHash: computeLegacyContentHash(body),
+        reason: "correction",
+        createdBy: "user_correction",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    const entry = env.store.snapshot().find((e) => e.kind === "tombstone");
+    assert.ok(entry);
+    // Pure-ASCII body: legacy and current normalizers agree, so the legacy
+    // hash equals the current hash and there is nothing to preserve.
+    assert.equal(entry.contentHash, computeHash(body));
+    assert.equal(entry.currentContentHashAlias, undefined);
+  });
+});
+
 describe("TombstoneStore — rebuild equivalence", () => {
   it("rebuild from a fixture corpus reproduces identical lookup decisions", async () => {
     const env = await makeStore("default");

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -909,13 +909,23 @@ export class TombstoneStore {
           // hash would displace a live identity (issue #2367). Preserving
           // keeps BOTH keys: contentHash stays the persisted identity and
           // currentContentHashAlias still blocks the body.
-          // An EMPTY legacy skeleton is excluded: every non-ASCII-only body
-          // maps to it, so it identifies nothing and would collide unrelated
-          // tombstones on one exact-tier key. Repair those rows instead.
+
+          // Repair only when the persisted hash provably identifies THIS
+          // body's stale legacy hash: either the unambiguous case (legacy and
+          // current normalizations agree), or the empty-skeleton case — every
+          // non-ASCII-only body normalizes to the empty legacy skeleton, so a
+          // persisted hash equal to hash("") is the shared non-identifying
+          // legacy body hash and publishing it on the exact tier would
+          // collide unrelated tombstones. Any OTHER persisted hash on an
+          // empty-skeleton body is a distinct explicit identity (e.g.
+          // contentHashSource) and must be preserved.
+          const legacyBodyHash = computeLegacyContentHash(m.rawContent);
+          const repairEmptySkeleton =
+            normalizeLegacyContent(m.rawContent).length === 0 && persistedHash === legacyBodyHash;
           const preserveOverride =
             persistedHash !== undefined &&
             persistedHash !== currentHash &&
-            normalizeLegacyContent(m.rawContent).length > 0 &&
+            !repairEmptySkeleton &&
             !isUnambiguousLegacyContentHash(m.rawContent, persistedHash, currentNormalizedText);
           return {
             id:

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -41,7 +41,11 @@
 // ---------------------------------------------------------------------------
 
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
-import { computeLegacyContentHash, isUnambiguousLegacyContentHash } from "../content-hash.js";
+import {
+  computeLegacyContentHash,
+  isUnambiguousLegacyContentHash,
+  normalizeLegacyContent,
+} from "../content-hash.js";
 
 /** Why a tombstone was emitted. */
 export type TombstoneReason =
@@ -899,15 +903,19 @@ export class TombstoneStore {
           // A persisted hash equal to the body's LEGACY hash only proves the
           // record predates the Unicode normalizer when that legacy hash is
           // unambiguous. When the legacy normalizer is lossy for this body
-          // (CJK-only text, or any body whose ASCII skeleton collides with a
-          // distinct contentHashSource), the equality cannot distinguish "old
-          // body hash" from "explicit source identity" — replacing the
-          // persisted hash would displace a live identity (issue #2367).
-          // Preserving keeps BOTH keys: contentHash stays the persisted
-          // identity and currentContentHashAlias still blocks the body.
+          // (any body whose ASCII skeleton collides with a distinct
+          // contentHashSource), the equality cannot distinguish "old body
+          // hash" from "explicit source identity" — replacing the persisted
+          // hash would displace a live identity (issue #2367). Preserving
+          // keeps BOTH keys: contentHash stays the persisted identity and
+          // currentContentHashAlias still blocks the body.
+          // An EMPTY legacy skeleton is excluded: every non-ASCII-only body
+          // maps to it, so it identifies nothing and would collide unrelated
+          // tombstones on one exact-tier key. Repair those rows instead.
           const preserveOverride =
             persistedHash !== undefined &&
             persistedHash !== currentHash &&
+            normalizeLegacyContent(m.rawContent).length > 0 &&
             !isUnambiguousLegacyContentHash(m.rawContent, persistedHash, currentNormalizedText);
           return {
             id:

--- a/packages/remnic-core/src/lifecycle/tombstones.ts
+++ b/packages/remnic-core/src/lifecycle/tombstones.ts
@@ -41,7 +41,7 @@
 // ---------------------------------------------------------------------------
 
 import { serializeMutations, withHeldFileLock } from "../utils/serialize-mutations.js";
-import { computeLegacyContentHash } from "../content-hash.js";
+import { computeLegacyContentHash, isUnambiguousLegacyContentHash } from "../content-hash.js";
 
 /** Why a tombstone was emitted. */
 export type TombstoneReason =
@@ -896,10 +896,19 @@ export class TombstoneStore {
           const currentHash = this.options.hashContent(m.rawContent);
           const currentNormalizedText = this.options.normalizeText(m.rawContent);
           const persistedHash = m.contentHash;
+          // A persisted hash equal to the body's LEGACY hash only proves the
+          // record predates the Unicode normalizer when that legacy hash is
+          // unambiguous. When the legacy normalizer is lossy for this body
+          // (CJK-only text, or any body whose ASCII skeleton collides with a
+          // distinct contentHashSource), the equality cannot distinguish "old
+          // body hash" from "explicit source identity" — replacing the
+          // persisted hash would displace a live identity (issue #2367).
+          // Preserving keeps BOTH keys: contentHash stays the persisted
+          // identity and currentContentHashAlias still blocks the body.
           const preserveOverride =
             persistedHash !== undefined &&
             persistedHash !== currentHash &&
-            persistedHash !== computeLegacyContentHash(m.rawContent);
+            !isUnambiguousLegacyContentHash(m.rawContent, persistedHash, currentNormalizedText);
           return {
             id:
               existingBySource.get(`${m.memoryId}\u{0000}${m.supersessionKey ?? ""}`) ??

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -234,6 +234,36 @@ test("reconcile collapse matches an explicit-source replica through the persiste
   assert.equal(collapsed.entries[0]?.reason, "semantic_duplicate");
 });
 
+test("reconcile manifest does not collapse distinct pure-CJK legacy facts through the empty skeleton (issue #2367)", async () => {
+  const first = "利用者は紅茶を好む。";
+  const second = "利用者は珈琲を好む。";
+  assert.equal(computeLegacyContentHash(first), computeLegacyContentHash(second));
+  const build = async (id: string, content: string) => {
+    const serialized = memoryFile({ id, content, contentHash: computeLegacyContentHash(content) });
+    const file = { path: `facts/${id}.md`, sha256: fileHash(serialized) };
+    const manifest = await buildReconcileManifest({
+      files: [file],
+      parseMemory: parseFrontmatter,
+      readFile: async () => serialized,
+    });
+    return { file, manifest };
+  };
+  const a = await build("legacy-cjk-first", first);
+  const b = await build("legacy-cjk-second", second);
+  const plan = planReconciliation([
+    { namespace: "default", local: [a.file], peer: [b.file] },
+  ]);
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", a.manifest]]),
+    new Map([["default", b.manifest]]),
+  );
+
+  assert.equal(collapsed.converged, false);
+  assert.equal(collapsed.entries.length, 2);
+});
+
 test("reconcile manifest does not add a legacy alias to a current Unicode identity", async () => {
   const unicode = "The user prefers café.";
   const ascii = "The user prefers caf.";

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -100,11 +100,16 @@ test("reconcile manifest reparses cached pre-version identities after Unicode mi
   });
 
   assert.equal(reads, 1);
+  // The café body is lossy under the legacy normalizer, so the persisted
+  // legacy hash stays primary and the recovered current identity rides along
+  // as an alias (issue #2367).
   assert.equal(
     manifest.files[0]?.memory?.contentHash,
-    ContentHashIndex.computeHash(content),
+    legacyHash,
   );
-  assert.equal("contentHashAliases" in (manifest.files[0]?.memory ?? {}), false);
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(content),
+  ]);
 });
 
 test("reconcile manifest replaces a pure-CJK legacy identity with its current hash", async () => {
@@ -146,7 +151,10 @@ test("reconcile manifest recovers a raw hash source beneath citation and attribu
     readFile: async () => serialized,
   });
 
-  assert.equal(manifest.files[0]?.memory?.contentHash, ContentHashIndex.computeHash(content));
+  assert.equal(manifest.files[0]?.memory?.contentHash, computeLegacyContentHash(content));
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(content),
+  ]);
 });
 
 test("reconcile manifest recovers raw identity beneath a configured citation", async () => {
@@ -169,7 +177,61 @@ test("reconcile manifest recovers raw identity beneath a configured citation", a
     citationTemplate,
   });
 
-  assert.equal(manifest.files[0]?.memory?.contentHash, ContentHashIndex.computeHash(content));
+  assert.equal(manifest.files[0]?.memory?.contentHash, computeLegacyContentHash(content));
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(content),
+  ]);
+});
+
+test("reconcile manifest prefers a persisted explicit hash over a colliding legacy body hash (issue #2367)", async () => {
+  // Source `caf` with body `café`: hash("caf") numerically equals the legacy
+  // hash of the stored body, but it is the fact's explicit contentHashSource
+  // identity written by the current normalizer. The legacy candidate match
+  // must not replace it.
+  const source = "caf";
+  const body = "café";
+  const persistedHash = ContentHashIndex.computeHash(source);
+  assert.equal(persistedHash, computeLegacyContentHash(body));
+  const serialized = memoryFile({ id: "explicit-source", content: body, contentHash: persistedHash });
+  const manifest = await buildReconcileManifest({
+    files: [{ path: "facts/explicit-source.md", sha256: fileHash(serialized) }],
+    parseMemory: parseFrontmatter,
+    readFile: async () => serialized,
+  });
+
+  assert.equal(manifest.files[0]?.memory?.contentHash, persistedHash);
+  assert.notEqual(manifest.files[0]?.memory?.contentHash, ContentHashIndex.computeHash(body));
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(body),
+  ]);
+});
+
+test("reconcile collapse matches an explicit-source replica through the persisted hash (issue #2367)", async () => {
+  const source = "caf";
+  const persistedHash = ContentHashIndex.computeHash(source);
+  const localSerialized = memoryFile({ id: "explicit-local", content: "café", contentHash: persistedHash });
+  const peerSerialized = memoryFile({ id: "explicit-peer", content: source, contentHash: persistedHash });
+  const localFile = { path: "facts/explicit-local.md", sha256: fileHash(localSerialized) };
+  const peerFile = { path: "facts/explicit-peer.md", sha256: fileHash(peerSerialized) };
+  const build = async (file: typeof localFile, raw: string) =>
+    await buildReconcileManifest({
+      files: [file],
+      parseMemory: parseFrontmatter,
+      readFile: async () => raw,
+    });
+  const local = await build(localFile, localSerialized);
+  const peer = await build(peerFile, peerSerialized);
+  const plan = planReconciliation([{ namespace: "default", local: [localFile], peer: [peerFile] }]);
+
+  const collapsed = collapseActiveFactDuplicates(
+    plan,
+    new Map([["default", local]]),
+    new Map([["default", peer]]),
+  );
+
+  assert.equal(collapsed.converged, true);
+  assert.equal(collapsed.entries.length, 1);
+  assert.equal(collapsed.entries[0]?.reason, "semantic_duplicate");
 });
 
 test("reconcile manifest does not add a legacy alias to a current Unicode identity", async () => {

--- a/packages/remnic-core/src/reconcile/manifest.test.ts
+++ b/packages/remnic-core/src/reconcile/manifest.test.ts
@@ -50,6 +50,7 @@ test("reconcile manifest keeps file identity separate from canonical semantic id
     category: "fact",
     contentHash: semanticHash,
     normalizerVersion: 4,
+    identityResolutionVersion: 2,
     status: "active",
   });
 });
@@ -107,6 +108,42 @@ test("reconcile manifest reparses cached pre-version identities after Unicode mi
     manifest.files[0]?.memory?.contentHash,
     legacyHash,
   );
+  assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
+    ContentHashIndex.computeHash(content),
+  ]);
+});
+
+test("reconcile manifest reparses cached identities lacking the identity-resolution version", async () => {
+  const content = "The user prefers café.";
+  const legacyHash = computeLegacyContentHash(content);
+  const serialized = memoryFile({ id: "legacy-identity-version", content, contentHash: legacyHash });
+  const file = { path: "facts/legacy-identity-version.md", sha256: fileHash(serialized) };
+  let reads = 0;
+
+  const manifest = await buildReconcileManifest({
+    files: [file],
+    parseMemory: parseFrontmatter,
+    readFile: async () => {
+      reads += 1;
+      return serialized;
+    },
+    // Same normalizerVersion, but written before identity-resolution
+    // versioning existed: the entry carries no aliases and must NOT be
+    // reused (issue #2367 review round 2).
+    cachedFiles: [{
+      ...file,
+      memory: {
+        id: "legacy-identity-version",
+        category: "fact",
+        contentHash: legacyHash,
+        normalizerVersion: 4,
+        status: "active",
+      },
+    }],
+  });
+
+  assert.equal(reads, 1);
+  assert.equal(manifest.files[0]?.memory?.identityResolutionVersion, 2);
   assert.deepEqual(manifest.files[0]?.memory?.contentHashAliases, [
     ContentHashIndex.computeHash(content),
   ]);

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -23,6 +23,13 @@ export interface ReconcileMemoryIdentity {
   id: string;
   category: string;
   contentHash: string;
+  /**
+   * Recovered current-normalizer identities for a record whose persisted hash
+   * is ambiguous under the legacy normalizer (issue #2367). The persisted
+   * hash stays primary; these participate in duplicate bucketing so a
+   * replica carrying the current form of the same fact still collapses.
+   */
+  contentHashAliases?: readonly string[];
   normalizerVersion?: number;
   status: MemoryStatus;
 }
@@ -88,16 +95,32 @@ function parsedMemoryIdentity(
   const legacyMatch = [...candidates].reverse().find(
     (content) => computeLegacyContentHash(content) === storedHash
   );
-  const contentHash = currentMatch
-    ? ContentHashIndex.computeHash(currentMatch)
-    : legacyMatch
-      ? ContentHashIndex.computeHash(legacyMatch)
-      : storedHash ?? bodyHash;
+  let contentHash: string;
+  let contentHashAliases: string[] | undefined;
+  if (currentMatch) {
+    contentHash = ContentHashIndex.computeHash(currentMatch);
+  } else if (legacyMatch && normalizeLegacyContent(legacyMatch).length > 0) {
+    // A non-empty legacy equality is ambiguous (issue #2367): the persisted
+    // hash may be an explicit contentHashSource identity that merely collides
+    // with the body's ASCII skeleton under the lossy legacy normalizer, and
+    // nothing in the record proves which it is. Keep the persisted hash as
+    // the primary identity and expose the recovered current identity as an
+    // alias so replicas carrying either form still collapse.
+    contentHash = storedHash ?? bodyHash;
+    const recovered = ContentHashIndex.computeHash(legacyMatch);
+    if (recovered !== contentHash) contentHashAliases = [recovered];
+  } else {
+    // An EMPTY legacy skeleton identifies nothing (every non-ASCII body maps
+    // to it), so preserving it would collapse unrelated records. Recovering
+    // the current identity here is repair, not replacement.
+    contentHash = legacyMatch ? ContentHashIndex.computeHash(legacyMatch) : storedHash ?? bodyHash;
+  }
 
   return {
     id: parsed.frontmatter.id,
     category: parsed.frontmatter.category,
     contentHash,
+    ...(contentHashAliases ? { contentHashAliases } : {}),
     normalizerVersion: CONTENT_HASH_NORMALIZER_VERSION,
     status: inferMemoryStatus(parsed.frontmatter, filePath),
   };
@@ -168,7 +191,7 @@ function activeFactByPath(manifest: ReconcileManifest | undefined): Map<string, 
 }
 
 function memoryIdentityHashes(memory: ReconcileMemoryIdentity): string[] {
-  return [memory.contentHash];
+  return [memory.contentHash, ...(memory.contentHashAliases ?? [])];
 }
 
 function contentHashRows(

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -18,6 +18,15 @@ import {
 export const RECONCILE_MANIFEST_FORMAT = "remnic-reconcile-manifest";
 export const RECONCILE_MANIFEST_SCHEMA_VERSION = 1;
 const CONTENT_HASH_NORMALIZER_VERSION = 4;
+/**
+ * Version of the identity-resolution LOGIC (alias recovery, candidate
+ * ordering), independent of the content normalizer: a cached manifest entry
+ * written before an identity-resolution change carries an older value and is
+ * reparsed even when its normalizerVersion still matches (issue #2367
+ * review round 2). Bump when parsedMemoryIdentity's output shape or
+ * semantics change.
+ */
+const IDENTITY_RESOLUTION_VERSION = 2;
 
 export interface ReconcileMemoryIdentity {
   id: string;
@@ -30,7 +39,9 @@ export interface ReconcileMemoryIdentity {
    * replica carrying the current form of the same fact still collapses.
    */
   contentHashAliases?: readonly string[];
+  /** See IDENTITY_RESOLUTION_VERSION; absent on pre-versioning cache entries. */
   normalizerVersion?: number;
+  identityResolutionVersion?: number;
   status: MemoryStatus;
 }
 
@@ -122,6 +133,7 @@ function parsedMemoryIdentity(
     contentHash,
     ...(contentHashAliases ? { contentHashAliases } : {}),
     normalizerVersion: CONTENT_HASH_NORMALIZER_VERSION,
+    identityResolutionVersion: IDENTITY_RESOLUTION_VERSION,
     status: inferMemoryStatus(parsed.frontmatter, filePath),
   };
 }
@@ -159,7 +171,8 @@ export async function buildReconcileManifest(options: BuildReconcileManifestOpti
     if (
       cached?.sha256.toLowerCase() === file.sha256.toLowerCase() &&
       (cached.memory === undefined ||
-        cached.memory.normalizerVersion === CONTENT_HASH_NORMALIZER_VERSION)
+        (cached.memory.normalizerVersion === CONTENT_HASH_NORMALIZER_VERSION &&
+          cached.memory.identityResolutionVersion === IDENTITY_RESOLUTION_VERSION))
     ) {
       files.push({ ...file, ...(cached.memory ? { memory: cached.memory } : {}) });
       continue;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -26,6 +26,7 @@ import { resolveSafeStoragePath } from "./storage-paths.js";
 import { log } from "./logger.js";
 import { createMemorySnapshot } from "./memory-snapshot.js";
 import { assertMemoryFrontmatterId, warnProjectionFallback } from "./storage-guards.js";
+import { createTombstoneMigrationSourceContents } from "./storage/tombstone-migration-sources.js";
 import { MemoryReadStore, readWindowedMemories, type WindowedMemoryReadOptions, type WindowedMemoryReadResult } from "./storage/memory-read-store.js";
 import { hasSupersessionAudit } from "./storage/supersession-audit.js";
 import { runCommittedInvalidation } from "./storage/committed-invalidation.js";
@@ -3016,46 +3017,24 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
   }
 
   private buildTombstoneStore(): TombstoneStore {
-    let sourcePathsPromise: Promise<string[]> | undefined;
-    let sourceContentsByIdPromise: Promise<Map<string, readonly string[]>> | undefined;
     const options: TombstoneStoreOptions = {
       enabled: this.tombstonesConfig.enabled,
       semanticMatch: this.tombstonesConfig.semanticMatch,
       semanticThreshold: this.tombstonesConfig.semanticThreshold,
       hashContent: ContentHashIndex.computeHash,
       normalizeText: ContentHashIndex.normalizeContent,
-      sourceContentsForMemoryIds: async (sourceMemoryIds) => {
-        const requested = new Set(sourceMemoryIds);
-        const sourcePaths = await (sourcePathsPromise ??=
-          this.memoryReadStore.collectTombstoneMigrationPaths());
-        const directPaths = sourcePaths.filter((filePath) =>
-          requested.has(path.basename(filePath, ".md"))
-        );
-        const contents = new Map<string, readonly string[]>();
-        for (const memory of await this.readParsedMemoriesFromPaths(directPaths, 50)) {
-          const id = memory.frontmatter.id;
-          if (requested.has(id) && !contents.has(id)) {
-            contents.set(id, this.storedContentIdentityCandidates(memory.content));
-          }
-        }
-        if (contents.size === requested.size) return contents;
-        sourceContentsByIdPromise ??= (async () => {
-          const allContents = new Map<string, readonly string[]>();
-          for (const memory of await this.readParsedMemoriesFromPaths(sourcePaths, 50)) {
-            const id = memory.frontmatter.id;
-            if (!allContents.has(id)) {
-              allContents.set(id, this.storedContentIdentityCandidates(memory.content));
-            }
-          }
-          return allContents;
-        })();
-        const allContents = await sourceContentsByIdPromise;
-        for (const id of requested) {
-          const content = allContents.get(id);
-          if (content !== undefined) contents.set(id, content);
-        }
-        return contents;
-      },
+      // Corpus-path + source-content caches are scoped to one ledger revision
+      // so a peer-appended legacy row is verified on the next staleness reload
+      // (issue #2367). Implementation lives in storage/tombstone-migration-sources.ts.
+      sourceContentsForMemoryIds: createTombstoneMigrationSourceContents({
+        tombstonesPath: () => this.tombstonesPath,
+        collectTombstoneMigrationPaths: () =>
+          this.memoryReadStore.collectTombstoneMigrationPaths(),
+        readParsedMemoriesFromPaths: (filePaths, batchSize) =>
+          this.readParsedMemoriesFromPaths(filePaths, batchSize),
+        storedContentIdentityCandidates: (content) =>
+          this.storedContentIdentityCandidates(content),
+      }),
     };
     const io: TombstoneFileIo = {
       read: (filePath) => this.readStorageSecureFile(filePath),

--- a/packages/remnic-core/src/storage/tombstone-migration-sources.test.ts
+++ b/packages/remnic-core/src/storage/tombstone-migration-sources.test.ts
@@ -1,0 +1,116 @@
+import * as assert from "node:assert/strict";
+import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createTombstoneMigrationSourceContents } from "./tombstone-migration-sources.js";
+import type { MemoryFile } from "../types.js";
+
+function memory(id: string, content: string): MemoryFile {
+  return {
+    path: `facts/${id}.md`,
+    rawContent: content,
+    frontmatter: { id, category: "fact", status: "active" },
+  } as unknown as MemoryFile;
+}
+
+interface Harness {
+  dir: string;
+  ledgerPath: string;
+  collectCalls: number;
+  readsByPaths: string[][];
+  gateCollect: Promise<void>;
+  releaseCollect: () => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = await mkdtemp(path.join(tmpdir(), "tomb-migration-race-"));
+  const ledgerPath = path.join(dir, "tombstones.jsonl");
+  await writeFile(ledgerPath, "", "utf8");
+  let gateCollect: (() => void) | undefined;
+  const gate = new Promise<void>((resolve) => {
+    gateCollect = resolve;
+  });
+  const harness: Harness = {
+    dir,
+    ledgerPath,
+    collectCalls: 0,
+    readsByPaths: [],
+    gateCollect: gate,
+    releaseCollect: () => gateCollect?.(),
+  };
+  return harness;
+}
+
+test("an in-flight fill does not publish a stale cache after the ledger advances", async () => {
+  const h = await makeHarness();
+  try {
+    const generations: string[][] = [["facts/old-a.md"], ["facts/new-a.md", "facts/old-a.md"]];
+    const contents = new Map<string, string>([
+      ["facts/old-a.md", "old body"],
+      ["facts/new-a.md", "new body"],
+    ]);
+    const sourceContents = createTombstoneMigrationSourceContents({
+      tombstonesPath: () => h.ledgerPath,
+      collectTombstoneMigrationPaths: async () => {
+        const callIndex = h.collectCalls + 1;
+        h.collectCalls = callIndex;
+        if (callIndex === 1) {
+          // First fill stalls while a peer retires a legacy memory; the
+          // generation is bound at call entry so the stall cannot upgrade
+          // it to the fresh revision.
+          await h.gateCollect;
+        }
+        return generations[Math.min(callIndex - 1, generations.length - 1)]!;
+      },
+      readParsedMemoriesFromPaths: async (filePaths: string[]) => {
+        h.readsByPaths.push([...filePaths]);
+        return filePaths
+          .filter((filePath) => contents.has(filePath))
+          .map((filePath) => memory(path.basename(filePath, ".md"), contents.get(filePath)!));
+      },
+      storedContentIdentityCandidates: (content: string) => [content],
+    });
+
+    // The first callback requests an id whose path exists only in the new
+    // ledger revision, so a stale snapshot would miss it entirely.
+    const first = sourceContents(["new-a"]);
+    // Advance the ledger mtime so a later callback drops both caches while
+    // the first fill is still awaiting its (stale) path snapshot.
+    await utimes(h.ledgerPath, new Date(), new Date(Date.now() + 5000));
+    const second = sourceContents(["old-a"]);
+    h.releaseCollect();
+
+    // Without the revision guard, the first callback would miss on the
+    // stale snapshot, publish a full map built from it, and resolve empty.
+    const firstResult = await first;
+    assert.deepEqual([...firstResult.keys()], ["new-a"]);
+    const secondResult = await second;
+    assert.deepEqual([...secondResult.keys()], ["old-a"]);
+    assert.equal(h.collectCalls >= 2, true, "restart re-collects paths against the fresh revision");
+  } finally {
+    await rm(h.dir, { recursive: true, force: true });
+  }
+});
+
+test("a stable ledger revision reuses the collected paths across callbacks", async () => {
+  const h = await makeHarness();
+  try {
+    const sourceContents = createTombstoneMigrationSourceContents({
+      tombstonesPath: () => h.ledgerPath,
+      collectTombstoneMigrationPaths: async () => {
+        h.collectCalls += 1;
+        return ["facts/a.md"];
+      },
+      readParsedMemoriesFromPaths: async (filePaths: string[]) =>
+        filePaths.map((filePath) => memory(path.basename(filePath, ".md"), "body")),
+      storedContentIdentityCandidates: (content: string) => [content],
+    });
+    await sourceContents(["a"]);
+    await sourceContents(["a"]);
+    assert.equal(h.collectCalls, 1, "unchanged ledger mtime reuses the path snapshot");
+  } finally {
+    await rm(h.dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage/tombstone-migration-sources.ts
+++ b/packages/remnic-core/src/storage/tombstone-migration-sources.ts
@@ -1,0 +1,77 @@
+import { statSync } from "node:fs";
+import path from "node:path";
+import type { TombstoneStoreOptions } from "../lifecycle/tombstones.js";
+import type { MemoryFile } from "../types.js";
+
+/**
+ * Deps injected by `StorageManager.buildTombstoneStore` so this module owns no
+ * storage-god-file imports (issue #1533 ratchet).
+ */
+export interface TombstoneMigrationSourceDeps {
+  /** On-disk tombstone ledger path; its mtime scopes both caches below. */
+  tombstonesPath: () => string;
+  collectTombstoneMigrationPaths: () => Promise<string[]>;
+  readParsedMemoriesFromPaths: (filePaths: string[], batchSize?: number) => Promise<MemoryFile[]>;
+  storedContentIdentityCandidates: (content: string) => string[];
+}
+
+/**
+ * Build the `sourceContentsForMemoryIds` callback `TombstoneStore` uses to
+ * verify pre-Unicode rows against their retired source memories. The corpus
+ * path snapshot and the resolved source-content map are memoized for one
+ * ledger revision only (issue #2367): a peer process can create and retire a
+ * legacy-format memory after this snapshot, and the staleness reload must
+ * resolve the new row against a FRESH path list — otherwise the row stays
+ * unverified (withheld from the lookup tiers) until restart.
+ */
+export function createTombstoneMigrationSourceContents(
+  deps: TombstoneMigrationSourceDeps,
+): NonNullable<TombstoneStoreOptions["sourceContentsForMemoryIds"]> {
+  let sourcePathsPromise: Promise<string[]> | undefined;
+  let sourceContentsByIdPromise: Promise<Map<string, readonly string[]>> | undefined;
+  let ledgerMtimeMs: number | null = null;
+  const dropCachesIfLedgerChanged = (): void => {
+    let mtimeMs: number | null;
+    try {
+      mtimeMs = Math.floor(statSync(deps.tombstonesPath()).mtimeMs);
+    } catch {
+      return; // ENOENT / stat failure — keep whatever is cached.
+    }
+    if (mtimeMs === ledgerMtimeMs) return;
+    ledgerMtimeMs = mtimeMs;
+    sourcePathsPromise = undefined;
+    sourceContentsByIdPromise = undefined;
+  };
+  return async (sourceMemoryIds) => {
+    dropCachesIfLedgerChanged();
+    const requested = new Set(sourceMemoryIds);
+    const sourcePaths = await (sourcePathsPromise ??= deps.collectTombstoneMigrationPaths());
+    const directPaths = sourcePaths.filter((filePath) =>
+      requested.has(path.basename(filePath, ".md"))
+    );
+    const contents = new Map<string, readonly string[]>();
+    for (const memory of await deps.readParsedMemoriesFromPaths(directPaths, 50)) {
+      const id = memory.frontmatter.id;
+      if (requested.has(id) && !contents.has(id)) {
+        contents.set(id, deps.storedContentIdentityCandidates(memory.content));
+      }
+    }
+    if (contents.size === requested.size) return contents;
+    sourceContentsByIdPromise ??= (async () => {
+      const allContents = new Map<string, readonly string[]>();
+      for (const memory of await deps.readParsedMemoriesFromPaths(sourcePaths, 50)) {
+        const id = memory.frontmatter.id;
+        if (!allContents.has(id)) {
+          allContents.set(id, deps.storedContentIdentityCandidates(memory.content));
+        }
+      }
+      return allContents;
+    })();
+    const allContents = await sourceContentsByIdPromise;
+    for (const id of requested) {
+      const content = allContents.get(id);
+      if (content !== undefined) contents.set(id, content);
+    }
+    return contents;
+  };
+}

--- a/packages/remnic-core/src/storage/tombstone-migration-sources.ts
+++ b/packages/remnic-core/src/storage/tombstone-migration-sources.ts
@@ -43,35 +43,44 @@ export function createTombstoneMigrationSourceContents(
     sourceContentsByIdPromise = undefined;
   };
   return async (sourceMemoryIds) => {
-    dropCachesIfLedgerChanged();
-    const requested = new Set(sourceMemoryIds);
-    const sourcePaths = await (sourcePathsPromise ??= deps.collectTombstoneMigrationPaths());
-    const directPaths = sourcePaths.filter((filePath) =>
-      requested.has(path.basename(filePath, ".md"))
-    );
-    const contents = new Map<string, readonly string[]>();
-    for (const memory of await deps.readParsedMemoriesFromPaths(directPaths, 50)) {
-      const id = memory.frontmatter.id;
-      if (requested.has(id) && !contents.has(id)) {
-        contents.set(id, deps.storedContentIdentityCandidates(memory.content));
-      }
-    }
-    if (contents.size === requested.size) return contents;
-    sourceContentsByIdPromise ??= (async () => {
-      const allContents = new Map<string, readonly string[]>();
-      for (const memory of await deps.readParsedMemoriesFromPaths(sourcePaths, 50)) {
+    for (;;) {
+      dropCachesIfLedgerChanged();
+      // In-flight fills are bound to the ledger revision they started
+      // against: if the ledger advances while a fill awaits, restart
+      // against the fresh revision instead of publishing a cache built
+      // from a stale path snapshot (issue #2367 review round 2).
+      const revision = ledgerMtimeMs;
+      const requested = new Set(sourceMemoryIds);
+      const sourcePaths = await (sourcePathsPromise ??= deps.collectTombstoneMigrationPaths());
+      if (ledgerMtimeMs !== revision) continue;
+      const directPaths = sourcePaths.filter((filePath) =>
+        requested.has(path.basename(filePath, ".md"))
+      );
+      const contents = new Map<string, readonly string[]>();
+      for (const memory of await deps.readParsedMemoriesFromPaths(directPaths, 50)) {
         const id = memory.frontmatter.id;
-        if (!allContents.has(id)) {
-          allContents.set(id, deps.storedContentIdentityCandidates(memory.content));
+        if (requested.has(id) && !contents.has(id)) {
+          contents.set(id, deps.storedContentIdentityCandidates(memory.content));
         }
       }
-      return allContents;
-    })();
-    const allContents = await sourceContentsByIdPromise;
-    for (const id of requested) {
-      const content = allContents.get(id);
-      if (content !== undefined) contents.set(id, content);
+      if (contents.size === requested.size) return contents;
+      const fill = (sourceContentsByIdPromise ??= (async () => {
+        const allContents = new Map<string, readonly string[]>();
+        for (const memory of await deps.readParsedMemoriesFromPaths(sourcePaths, 50)) {
+          const id = memory.frontmatter.id;
+          if (!allContents.has(id)) {
+            allContents.set(id, deps.storedContentIdentityCandidates(memory.content));
+          }
+        }
+        return allContents;
+      })());
+      const allContents = await fill;
+      if (ledgerMtimeMs !== revision) continue;
+      for (const id of requested) {
+        const content = allContents.get(id);
+        if (content !== undefined) contents.set(id, content);
+      }
+      return contents;
     }
-    return contents;
   };
 }

--- a/packages/remnic-core/src/storage/tombstone-migration-sources.ts
+++ b/packages/remnic-core/src/storage/tombstone-migration-sources.ts
@@ -63,6 +63,10 @@ export function createTombstoneMigrationSourceContents(
           contents.set(id, deps.storedContentIdentityCandidates(memory.content));
         }
       }
+      // Re-check after the direct-path read too: a concurrent drop during
+      // that await must not let this call publish a fill built from the
+      // stale snapshot into the freshly cleared slot (issue #2367 round 3).
+      if (ledgerMtimeMs !== revision) continue;
       if (contents.size === requested.size) return contents;
       const fill = (sourceContentsByIdPromise ??= (async () => {
         const allContents = new Map<string, readonly string[]>();

--- a/scripts/lifecycle-matrix/coverage.json
+++ b/scripts/lifecycle-matrix/coverage.json
@@ -235,7 +235,8 @@
     "packages/remnic-core/src/maintenance/projection-support.ts": "memory-projection",
     "packages/remnic-core/src/maintenance/rebuild-memory-projection.ts": "memory-projection",
     "packages/remnic-core/src/orchestration/projection-rebuild-schedule.ts": "memory-projection",
-    "packages/plugin-openclaw/src/delegate-runtime.ts": "openclaw-delegate-runtime"
+    "packages/plugin-openclaw/src/delegate-runtime.ts": "openclaw-delegate-runtime",
+    "packages/remnic-core/src/storage/tombstone-migration-sources.ts": "tombstone-blocked-capture"
   },
   "grandfathered": [
     "packages/remnic-core/src/lifecycle.ts",

--- a/tests/non-resurrection.test.ts
+++ b/tests/non-resurrection.test.ts
@@ -20,7 +20,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { StorageManager } from "../src/storage.ts";
 import { computeSupersessionKey } from "../packages/remnic-core/src/temporal-supersession.ts";
 import { computeLegacyContentHash, normalizeLegacyContent } from "../packages/remnic-core/src/content-hash.ts";
@@ -503,6 +503,79 @@ test("legacy migration resolves retired source content from archive storage", as
 
     assert.equal(result.tombstoneBlocked, true);
     assertBlocked(await readBack(restarted, result.id), "exact");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("issue #2367: a legacy row appended after store construction is verified without restart", async () => {
+  const { storage, dir } = await makeStorage();
+  const ledgerPath = path.join(dir, "state", "tombstones.jsonl");
+  const peerContent = "The user prefers tea.";
+  try {
+    // First migration pass: an unresolvable pre-upgrade row forces the store
+    // to snapshot the corpus paths while the corpus is still empty. A
+    // read-only probe keeps the store cached (a memory write would reset it).
+    await writeFile(
+      ledgerPath,
+      `${JSON.stringify({
+        id: "tomb-2367-ghost",
+        kind: "tombstone",
+        reason: "correction",
+        createdBy: "user_correction",
+        sourceMemoryId: "fact-ghost",
+        contentHash: computeLegacyContentHash("ghost body"),
+        normalizedText: normalizeLegacyContent("ghost body"),
+        namespace: NAMESPACE,
+        createdAt: "2026-08-15T00:00:00.000Z",
+      })}\n`,
+      "utf8",
+    );
+    assert.equal(await storage.hasExactTombstone({ sourceMemoryId: "fact-ghost" }), true);
+
+    // Coarse mtime so the peer append below is guaranteed to move it even on
+    // filesystems with coarse timestamp granularity.
+    const coarse = new Date(Date.now() - 60_000);
+    await utimes(ledgerPath, coarse, coarse);
+
+    // Peer process: creates a memory in the legacy format and retires it.
+    const peerId = "fact-2367-peer";
+    await writeFile(
+      path.join(dir, "facts", `${peerId}.md`),
+      ["---", `id: ${peerId}`, "category: fact", "---", "", peerContent].join("\n"),
+      "utf8",
+    );
+    await writeFile(
+      ledgerPath,
+      `${JSON.stringify({
+        id: "tomb-2367-peer",
+        kind: "tombstone",
+        reason: "correction",
+        createdBy: "user_correction",
+        sourceMemoryId: peerId,
+        contentHash: computeLegacyContentHash(peerContent),
+        normalizedText: normalizeLegacyContent(peerContent),
+        namespace: NAMESPACE,
+        createdAt: "2026-08-15T00:01:00.000Z",
+      })}\n`,
+      { flag: "a" },
+    );
+
+    // Same process, no restart: the staleness reload must resolve the new row
+    // against a FRESH corpus snapshot, not the one cached before the peer
+    // append — otherwise the row stays unverified and the retired fact
+    // resurrects active.
+    const write = await storage.writeMemory("fact", peerContent, { source: "extraction" });
+    assert.equal(write.tombstoneBlocked, true);
+    assertBlocked(await readBack(storage, write.id), "exact");
+    const migrated = await readFile(ledgerPath, "utf8");
+    const peerRow = migrated.split("\n").find((line) => line.includes(peerId));
+    assert.ok(peerRow, "peer row must survive migration");
+    const peerEntry = JSON.parse(peerRow) as { contentHash: string; normalizerVersion?: number };
+    // Pure-ASCII body: the verified current hash equals the legacy hash, and
+    // the row is published at normalizerVersion 2.
+    assert.equal(peerEntry.contentHash, computeLegacyContentHash(peerContent));
+    assert.equal(peerEntry.normalizerVersion, 2);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #2367

Three declined-at-cap follow-ups from the prior Unicode-identity migration
PR, sharing one invariant: a lossy legacy content hash must never select or
replace an identity on its own.

## 1. Refresh migration sources when legacy rows arrive (P1)

`buildTombstoneStore` memoized the corpus path snapshot and the resolved
source-content map for the lifetime of the store. A peer process creating
and retiring a legacy-format memory after that snapshot left the new row
resolved against the stale path list, so it stayed unverified (withheld
from the exact, normalized, and semantic tiers) until restart — a missed
block, not a wrong block, but a resurrection window.

Both caches are now scoped to one tombstone-ledger revision: when the
ledger mtime moves, the next migration pass rescans the corpus. The logic
is extracted to `storage/tombstone-migration-sources.ts`, which also
shrinks `storage.ts` below its ratchet ceiling (7315 → 7294 lines).

## 2. Preserve ambiguous hash sources during tombstone rebuild (P1)

`rebuild()`'s `preserveOverride` treated `persistedHash ===
computeLegacyContentHash(body)` as proof the persisted hash was merely the
old body hash. That equality is ambiguous whenever the legacy normalizer
is lossy for the body (two distinct CJK-only bodies, or any accented body
whose ASCII skeleton collides with a distinct `contentHashSource`), so an
explicit identity was displaced by the current body hash and a later write
using the original source hash missed the exact tier. Rebuild now requires
`isUnambiguousLegacyContentHash` before replacing; otherwise the persisted
hash stays primary and the current body hash rides along as
`currentContentHashAlias` (both keys index the exact tier).

## 3. Preserve explicit hashes that collide with legacy body hashes (P2)

`parsedMemoryIdentity` preferred a legacy candidate match over an explicit
persisted hash (source `caf`, body `café`: `hash("caf")` numerically equals
the legacy hash of `café`), replacing the valid persisted identity with
`hash("café")` and breaking collapse with a replica carrying the same
canonical source identity. A non-empty legacy match is now ambiguous by
construction — nothing in the record proves which normalizer produced the
persisted hash — so the persisted hash stays primary and the recovered
current identity is exposed as `contentHashAliases`, which participates in
duplicate bucketing (the bucketing plumbing already iterates a hash list)
and is accepted by the peer-manifest parser with strict validation.
Cross-version replica collapse keeps working through the alias.

Empty legacy skeletons (pure-CJK bodies) still convert on the manifest
path: `sha256("")` is shared by every non-ASCII-only body, so preserving
it as an identity would collapse unrelated records. Converting there is
repair, not replacement.

## Safe by default

- Unverified legacy rows remain withheld from all lookup tiers.
- Every preserved identity is paired with the current body hash alias, so
  the exact tier blocks a superset of what it blocked before.
- Pure-ASCII and current-normalizer rows are byte-identical to before.

## Regression coverage

- (a) `tests/non-resurrection.test.ts` — a legacy row appended after store
  construction (cross-process shape: read-only probe → peer append →
  write) becomes verified after the ledger mtime change without restart;
  fails without the storage fix.
- (b) `lifecycle/tombstones.test.ts` — two distinct CJK bodies colliding
  under the legacy normalizer do not displace an explicit
  contentHashSource during rebuild; the body stays blocked via the alias
  and unrelated CJK bodies stay unblocked; fails without the rebuild fix.
- (c) `reconcile/manifest.test.ts` — the persisted explicit hash is
  preferred over the legacy candidate match, and a replica pair carrying
  the same canonical source identity collapses; fails without the
  manifest fix.
- Control tests pin unchanged behavior for pure-ASCII rebuild rows and
  current Unicode manifest identities.

Gates: `npm run check-types`, `npm run test:entity-hardening` (340 pass),
`npm run preflight:quick`, and the touched suites (tombstones, reconcile
manifest, non-resurrection, converge, converge-peer-manifest — 125 pass)
all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes tombstone blocking, rebuild identity rules, and peer reconcile collapse—core memory lifecycle paths where mistakes can allow resurrection or wrong deduplication.
> 
> **Overview**
> **Hardens legacy-identity handling (#2367)** so a lossy legacy content hash never selects or replaces an identity on its own.
> 
> **Tombstone migration sources** are extracted to `storage/tombstone-migration-sources.ts` and memoized only for one tombstone-ledger revision (mtime). Peer-appended legacy rows get verified on the next staleness reload instead of staying unverified until restart.
> 
> **`TombstoneStore.rebuild`** only replaces a persisted hash when it is unambiguous (`isUnambiguousLegacyContentHash`); empty-skeleton CJK collisions are repaired to the current body hash; otherwise the persisted hash stays primary with `currentContentHashAlias` for the body.
> 
> **Reconcile manifests** add `identityResolutionVersion` (cache invalidation), `contentHashAliases` on ambiguous legacy matches, and peer-manifest parsing for aliases; duplicate bucketing considers primary + aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca926b8063026e13fd0c86f8c079817aa7c9dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved identity preservation for legacy and Unicode content, including ambiguous hashes and explicit persisted identities.
  - Prevented distinct content from being incorrectly merged during reconciliation.
  - Preserved current content hashes as aliases when legacy identities remain valid.
  - Improved tombstone handling to prevent deleted content from being resurrected, including changes detected while the application is running.

- **Reliability**
  - Enhanced migration and reconciliation for renamed, updated, or legacy content.
  - Improved cache handling when ledger revisions change, preventing stale identity data from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->