### PR TITLE
feat(devx): add agent checkpoint state for crash recovery

### DIFF
--- a/.changeset/agent-checkpoint-2443.md
+++ b/.changeset/agent-checkpoint-2443.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a local agent checkpoint script so worktree milestones survive harness crashes (issue #2443).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ Reference workflow:
 Use `scripts/dev-worktree.sh <worktree-path> <branch> [base]` to create an
 isolated, installed worktree with a core type-check smoke check.
 - **Subagent worktree discipline.** Verify `pwd` before every write; use absolute paths rooted at this worktree; NEVER write to the main checkout or sibling worktrees; agent file tools may ignore cwd.
+- **Checkpoint after each milestone.** After a commit is pushed, a PR is opened, or threads are resolved, run `node scripts/agent-checkpoint.mjs write --note "<milestone>"` so a coordinator can resume after a crash.
 
 Run pnpm through the pinned package manager wrapper:
 

--- a/scripts/agent-checkpoint.mjs
+++ b/scripts/agent-checkpoint.mjs
@@ -49,7 +49,11 @@ function parseArgs(argv) {
       continue;
     }
     if (arg === "--note") {
-      note = argv[i + 1] ?? "";
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("-") || value.trim() === "") {
+        fail("--note requires a non-empty value", 2);
+      }
+      note = value;
       i += 1;
       continue;
     }

--- a/scripts/agent-checkpoint.mjs
+++ b/scripts/agent-checkpoint.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const STATE_NAME = "AGENT-STATE.md";
+const TAIL = 20;
+
+function git(args) {
+  return spawnSync("git", args, { encoding: "utf8" });
+}
+
+function fail(message, status = 1) {
+  process.stderr.write(message.endsWith("\n") ? message : `${message}\n`);
+  process.exit(status);
+}
+
+function usage() {
+  fail(
+    [
+      "usage: agent-checkpoint.mjs write [--note <text>] [milestone...]",
+      "       agent-checkpoint.mjs read [--json]",
+    ].join("\n"),
+    2,
+  );
+}
+
+function resolveGitDir() {
+  const result = git(["rev-parse", "--absolute-git-dir"]);
+  if (result.status !== 0) {
+    fail((result.stderr || "not a git repository").trim());
+  }
+  return result.stdout.trim();
+}
+
+function statePath() {
+  return path.join(resolveGitDir(), STATE_NAME);
+}
+
+function parseArgs(argv) {
+  let cmd;
+  let note;
+  let json = false;
+  const rest = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--note") {
+      note = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      usage();
+    }
+    if (!cmd && (arg === "write" || arg === "read")) {
+      cmd = arg;
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { cmd, note, json, rest };
+}
+
+function writeCheckpoint({ note, rest }) {
+  const head = git(["rev-parse", "--short", "HEAD"]);
+  if (head.status !== 0) {
+    fail((head.stderr || "unable to resolve HEAD").trim());
+  }
+  const milestone =
+    note !== undefined ? note : rest.join(" ").trim() || "checkpoint";
+  const line = `${new Date().toISOString()} | ${head.stdout.trim()} | ${milestone}\n`;
+  appendFileSync(statePath(), line);
+}
+
+function parseLine(line) {
+  const parts = line.split(" | ");
+  if (parts.length < 3) {
+    return { raw: line };
+  }
+  return {
+    timestamp: parts[0],
+    head: parts[1],
+    note: parts.slice(2).join(" | "),
+  };
+}
+
+function readCheckpoint({ json }) {
+  const file = statePath();
+  if (!existsSync(file)) {
+    process.exit(1);
+  }
+  const entries = readFileSync(file, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+  if (entries.length === 0) {
+    process.exit(1);
+  }
+  const tail = entries.slice(-TAIL);
+  process.stdout.write(
+    json ? `${JSON.stringify(tail.map(parseLine))}\n` : `${tail.join("\n")}\n`,
+  );
+}
+
+const parsed = parseArgs(process.argv.slice(2));
+if (parsed.cmd === "write") {
+  writeCheckpoint(parsed);
+} else if (parsed.cmd === "read") {
+  readCheckpoint(parsed);
+} else {
+  usage();
+}

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -213,4 +213,5 @@ printf 'Next steps:\n'
 printf '  cd %q\n' "$worktree_path"
 printf '  git status\n'
 printf '  git push -u origin %q\n' "$branch"
+printf '  node scripts/agent-checkpoint.mjs write --note "<milestone>"\n'
 printf 'Worktree discipline: %s\n' "$worktree_discipline"

--- a/tests/agent-checkpoint.test.mjs
+++ b/tests/agent-checkpoint.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -81,6 +81,21 @@ test("read returns entries and exit codes", () => {
     assert.equal(parsed[0].note, "alpha");
     assert.match(parsed[0].timestamp, /^\d{4}-\d{2}-\d{2}T.*Z$/);
     assert.equal(parsed[0].head, git(root, "rev-parse", "--short", "HEAD"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("write rejects a missing or flag-like --note value", () => {
+  const root = createRepo();
+  try {
+    const missing = run(root, ["write", "--note"]);
+    assert.equal(missing.status, 2);
+    const flagLike = run(root, ["write", "--note", "--json"]);
+    assert.equal(flagLike.status, 2);
+    const empty = run(root, ["write", "--note", ""]);
+    assert.equal(empty.status, 2);
+    assert.equal(existsSync(stateFile(root)), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/agent-checkpoint.test.mjs
+++ b/tests/agent-checkpoint.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scriptPath = path.join(repoRoot, "scripts", "agent-checkpoint.mjs");
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function createRepo() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "remnic-agent-checkpoint-"));
+  git(root, "init");
+  git(root, "config", "user.email", "dev@example.com");
+  git(root, "config", "user.name", "Dev");
+  writeFileSync(path.join(root, "README"), "ok\n");
+  git(root, "add", "README");
+  git(root, "commit", "-m", "init");
+  return root;
+}
+
+function run(cwd, args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+function stateFile(cwd) {
+  return path.join(git(cwd, "rev-parse", "--absolute-git-dir"), "AGENT-STATE.md");
+}
+
+test("write creates and appends formatted entries", () => {
+  const root = createRepo();
+  try {
+    const head = git(root, "rev-parse", "--short", "HEAD");
+    const created = run(root, ["write", "--note", "first milestone"]);
+    assert.equal(created.status, 0, created.stderr);
+    const first = readFileSync(stateFile(root), "utf8");
+    assert.match(
+      first,
+      new RegExp(`^\\d{4}-\\d{2}-\\d{2}T[^\\n]*Z \\| ${head} \\| first milestone\\n$`),
+    );
+
+    const appended = run(root, ["write", "inferred", "from", "args"]);
+    assert.equal(appended.status, 0, appended.stderr);
+    const lines = readFileSync(stateFile(root), "utf8").trimEnd().split("\n");
+    assert.equal(lines.length, 2);
+    assert.match(lines[1], new RegExp(`\\| ${head} \\| inferred from args$`));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("read returns entries and exit codes", () => {
+  const root = createRepo();
+  try {
+    const missing = run(root, ["read"]);
+    assert.equal(missing.status, 1);
+
+    writeFileSync(stateFile(root), "");
+    const empty = run(root, ["read"]);
+    assert.equal(empty.status, 1);
+
+    const written = run(root, ["write", "--note", "alpha"]);
+    assert.equal(written.status, 0, written.stderr);
+
+    const text = run(root, ["read"]);
+    assert.equal(text.status, 0, text.stderr);
+    assert.match(text.stdout, /\| alpha\n$/);
+
+    const json = run(root, ["read", "--json"]);
+    assert.equal(json.status, 0, json.stderr);
+    const parsed = JSON.parse(json.stdout);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].note, "alpha");
+    assert.match(parsed[0].timestamp, /^\d{4}-\d{2}-\d{2}T.*Z$/);
+    assert.equal(parsed[0].head, git(root, "rev-parse", "--short", "HEAD"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/dev-worktree-script.test.mjs
+++ b/tests/dev-worktree-script.test.mjs
@@ -69,6 +69,7 @@ test("creates an installed worktree and runs the smoke check at an absolute path
     assert.ok(result.stdout.includes(`Worktree discipline: ${worktreeDiscipline}`));
     assert.match(result.stdout, /Worktree ready/);
     assert.match(result.stdout, new RegExp(`Next steps[\\s\\S]*${branch}`));
+    assert.match(result.stdout, /node scripts\/agent-checkpoint\.mjs write --note/);
     const calls = readFileSync(fixture.log, "utf8");
     assert.match(calls, /exec --yes pnpm@10\.32\.1 -- install --frozen-lockfile/);
     assert.match(calls, /exec --yes pnpm@10\.32\.1 -- --filter @remnic\/core run check-types/);


### PR DESCRIPTION
## Summary

Harness crashes were leaving uncommitted milestone state only in dirty worktrees. This adds `scripts/agent-checkpoint.mjs` so agents can append a local `$GIT_DIR/AGENT-STATE.md` line after each milestone, and so a coordinator can `read` the tail after a crash.

- `write [--note <text>]` appends `<iso8601> | <git short head> | <note or inferred milestone>`
- `read` prints the last 20 entries (exit 1 if absent/empty); `--json` for structured output
- Git dir is resolved with `git rev-parse --absolute-git-dir` (worktree-local)
- `dev-worktree.sh` Next steps banner and AGENTS.md automation section tell agents to checkpoint

Fixes #2443

## Type of change

- [x] Feature

## Validation

- [x] `npm run test:file -- tests/agent-checkpoint.test.mjs`
- [x] `npm run test:file -- tests/dev-worktree-script.test.mjs -- --test-name-pattern "creates an installed worktree"`
- [x] Manual round-trip: `write --note test` then `read` in a temp git repo
- [x] Added/updated tests for behavior changes
- [ ] `npm run check-types` (docs/script-only; no type surface)
- [ ] `npm test` (targeted tests above)
- [ ] `npm run build` (not needed)
- [ ] `bash scripts/check-review-patterns.sh`
- [ ] `npm run review:cursor` unavailable in this environment

## Changelog

- [x] Changeset added (`.changeset/agent-checkpoint-2443.md`)
- [x] Not needed in CHANGELOG.md directly — release process consumes the changeset

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [x] Invalid user input rejected, not silently defaulted (CLI flags)

## Notes for reviewers

Local-only file inside the worktree git dir. No new dependencies. No server state.

## PR workflow

- [x] PR scope is narrow
- [x] Synced with latest `main` before requesting AI review
- [x] Batched review fixes by subsystem instead of micro-pushing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only local CLI and documentation; no runtime, auth, or shared server state.
> 
> **Overview**
> Adds **`scripts/agent-checkpoint.mjs`** so automation can append milestone records to **`$GIT_DIR/AGENT-STATE.md`** (worktree-local via `git rev-parse --absolute-git-dir`). **`write`** logs ISO timestamp, short HEAD, and a `--note` or inferred label; **`read`** prints the last 20 lines (or **`--json`**), exiting 1 when the file is missing or empty.
> 
> **`AGENTS.md`** and **`dev-worktree.sh`** “Next steps” now tell agents to run checkpoint **`write`** after pushes, PRs, or thread resolution. Coverage includes **`tests/agent-checkpoint.test.mjs`** and an assertion in **`tests/dev-worktree-script.test.mjs`**, plus a **`@remnic/core`** patch changeset for #2443.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69dd52e6e2741efec7a30855e76a7afd20a1254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->