### PR TITLE
feat(devx): add pr-threads digest command

### DIFF
--- a/.changeset/pr-threads-2441.md
+++ b/.changeset/pr-threads-2441.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `scripts/pr-threads.mjs` to print PR review threads with IDs and full bodies (issue #2441).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,7 @@ These rules are the default workflow for all agents and contributors.
    - Do not let a PR drift for multiple review rounds and then merge `main` halfway through unless forced by a conflict.
 
 3. Batch review fixes by subsystem.
-   - Re-scan unresolved comments, fix the whole subsystem, run verification once, then push once.
+   - Re-scan unresolved comments with `node scripts/pr-threads.mjs <pr-number>` (canonical thread intake: id, author, isResolved, full body). Default is unresolved only; `--all` includes resolved; `--json` emits an array. Fix the whole subsystem, run verification once, then push once.
    - Avoid serial micro-pushes that only expose the next adjacent invariant.
 
 4. Run the local hardening gate before claiming review-clean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `node scripts/pr-threads.mjs <pr>` prints review thread IDs, authors, resolution state, and full bodies (`#2441`).
+
 ## [v9.57.0] — 2026-08-15
 
 ### Changed

--- a/scripts/pr-threads.mjs
+++ b/scripts/pr-threads.mjs
@@ -193,6 +193,15 @@ export function selectThreads(threads, { all = false } = {}) {
   return all ? threads : threads.filter((thread) => !thread.isResolved);
 }
 
+export function nextPageCursor(pageInfo, after) {
+  if (!pageInfo?.hasNextPage) return null;
+  const cursor = pageInfo.endCursor;
+  if (typeof cursor !== "string" || cursor.length === 0 || cursor === after) {
+    throw new Error("reviewThreads pagination cursor is missing or repeated");
+  }
+  return cursor;
+}
+
 export function formatHuman(threads) {
   return threads
     .map((thread) => `id: ${thread.id}\nauthor: ${thread.author}\nisResolved: ${thread.isResolved}\n\n${thread.body}\n`)
@@ -220,9 +229,9 @@ function fetchThreads({ ghBin, owner, name, pr, env }) {
       "graphql",
       "-f",
       `query=${REVIEW_THREADS_QUERY}`,
-      "-F",
+      "-f",
       `owner=${owner}`,
-      "-F",
+      "-f",
       `name=${name}`,
       "-F",
       `pr=${pr}`,
@@ -237,8 +246,7 @@ function fetchThreads({ ghBin, owner, name, pr, env }) {
     }
     threads.push(...threadsFromPayload(payload));
     const pageInfo = repositoryPayload(payload)?.pullRequest?.reviewThreads?.pageInfo;
-    if (!pageInfo?.hasNextPage) break;
-    after = pageInfo.endCursor;
+    after = nextPageCursor(pageInfo, after);
     if (!after) break;
   }
   return threads;

--- a/scripts/pr-threads.mjs
+++ b/scripts/pr-threads.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * Print PR review threads with IDs and full bodies (issue #2441).
+ *
+ *   node scripts/pr-threads.mjs <pr> [--all] [--json]
+ *
+ * Default: unresolved threads. `--all` includes resolved. `--json` emits an
+ * array of { id, author, isResolved, body }. Bodies are never truncated.
+ *
+ * `gh` is resolved the same way as scripts/pr-wait-settled.sh (issue #2423):
+ * skip mise shims, honor REMNIC_GH_BIN, and strip a leading mise banner or
+ * other non-JSON lines before parse.
+ */
+import { accessSync, closeSync, constants, openSync, readSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const USAGE = "Usage: node scripts/pr-threads.mjs <pr> [--all] [--json]";
+const DEFAULT_REPO = "joshuaswarren/remnic";
+const MISE_GH_BANNER =
+  /^[ \t]*mise[ \t].*config\.toml[ \t]+tools:[ \t]+gh@[^\s]+[ \t]*$/;
+
+const REVIEW_THREADS_QUERY = `query($owner: String!, $name: String!, $pr: Int!, $after: String = null) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { author { login } body }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export function parseArgs(argv) {
+  let pr = null;
+  let all = false;
+  let json = false;
+  for (const arg of argv) {
+    if (arg === "--all") {
+      all = true;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      return { help: true };
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown flag: ${arg}\n${USAGE}`);
+    }
+    if (pr != null) {
+      throw new Error(`Unexpected argument: ${arg}\n${USAGE}`);
+    }
+    pr = arg;
+  }
+  const n = Number(pr);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(USAGE);
+  }
+  return { pr: n, all, json, help: false };
+}
+
+export function stripGhBanner(text) {
+  const lines = String(text).split(/\r?\n/);
+  let started = false;
+  const out = [];
+  for (const line of lines) {
+    if (!started && MISE_GH_BANNER.test(line)) continue;
+    started = true;
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+export function stripLeadingNonJson(text) {
+  const lines = String(text).split(/\r?\n/);
+  let started = false;
+  const out = [];
+  for (const line of lines) {
+    if (!started) {
+      if (!/^[ \t]*[\[{]/.test(line)) continue;
+      started = true;
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+function isExecutable(filePath) {
+  try {
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fileLooksLikeMiseWrapper(filePath) {
+  let fd;
+  try {
+    fd = openSync(filePath, "r");
+    const buf = Buffer.alloc(512);
+    const n = readSync(fd, buf, 0, 512, 0);
+    const head = buf.subarray(0, n).toString("utf8");
+    return head.startsWith("#!") && head.includes("mise");
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function resolveMiseGh() {
+  const result = spawnSync("mise", ["which", "gh"], { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  const candidate = (result.stdout ?? "").trim().split(/\r?\n/).filter(Boolean).at(-1);
+  return candidate && isExecutable(candidate) ? candidate : null;
+}
+
+export function resolveGh(env = process.env) {
+  if (env.REMNIC_GH_BIN) return env.REMNIC_GH_BIN;
+  const names = process.platform === "win32" ? ["gh.exe", "gh.cmd", "gh"] : ["gh"];
+  for (const dir of (env.PATH ?? "").split(path.delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (!isExecutable(candidate)) continue;
+      const posix = candidate.replaceAll("\\", "/");
+      if (posix.endsWith("/shims/gh") || posix.endsWith("/shims/gh.exe")) {
+        const resolved = resolveMiseGh();
+        if (resolved) return resolved;
+        continue;
+      }
+      if (fileLooksLikeMiseWrapper(candidate)) {
+        const resolved = resolveMiseGh();
+        if (resolved) return resolved;
+        continue;
+      }
+      return candidate;
+    }
+  }
+  return "gh";
+}
+
+export function parseGhJson(stdout) {
+  const text = stripLeadingNonJson(stripGhBanner(stdout ?? ""));
+  if (!text.trim()) {
+    throw new Error("gh returned empty output");
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`gh returned non-JSON: ${err.message}`);
+  }
+}
+
+function repositoryPayload(payload) {
+  if (payload && typeof payload === "object" && payload.data && typeof payload.data === "object") {
+    return payload.data.repository;
+  }
+  return payload?.repository;
+}
+
+export function threadsFromPayload(payload) {
+  const repository = repositoryPayload(payload);
+  const pullRequest = repository?.pullRequest;
+  if (!pullRequest) {
+    throw new Error("PR not found");
+  }
+  const nodes = pullRequest.reviewThreads?.nodes;
+  if (!Array.isArray(nodes)) return [];
+  return nodes.map((thread) => {
+    const comment = thread?.comments?.nodes?.[0];
+    return {
+      id: typeof thread?.id === "string" ? thread.id : "",
+      author: comment?.author?.login ?? "unknown",
+      isResolved: thread?.isResolved === true,
+      body: typeof comment?.body === "string" ? comment.body : "",
+    };
+  });
+}
+
+export function selectThreads(threads, { all = false } = {}) {
+  return all ? threads : threads.filter((thread) => !thread.isResolved);
+}
+
+export function formatHuman(threads) {
+  return threads
+    .map((thread) => `id: ${thread.id}\nauthor: ${thread.author}\nisResolved: ${thread.isResolved}\n\n${thread.body}\n`)
+    .join("\n");
+}
+
+function runGhJson(ghBin, args, env) {
+  const result = spawnSync(ghBin, args, { encoding: "utf8", env });
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+  const stderr = stripGhBanner(result.stderr ?? "").trim();
+  if (result.status !== 0) {
+    throw new Error(stderr || `gh exited ${result.status}`);
+  }
+  return parseGhJson(result.stdout);
+}
+
+function fetchThreads({ ghBin, owner, name, pr, env }) {
+  const threads = [];
+  let after = null;
+  for (;;) {
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${REVIEW_THREADS_QUERY}`,
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${name}`,
+      "-F",
+      `pr=${pr}`,
+    ];
+    if (after) {
+      args.push("-f", `after=${after}`);
+    }
+    const payload = runGhJson(ghBin, args, env);
+    if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+      const message = payload.errors.map((err) => err?.message).filter(Boolean).join("; ");
+      throw new Error(message || "GraphQL error");
+    }
+    threads.push(...threadsFromPayload(payload));
+    const pageInfo = repositoryPayload(payload)?.pullRequest?.reviewThreads?.pageInfo;
+    if (!pageInfo?.hasNextPage) break;
+    after = pageInfo.endCursor;
+    if (!after) break;
+  }
+  return threads;
+}
+
+export function main(argv = process.argv.slice(2), io = console, env = process.env) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    io.error(USAGE);
+    return 0;
+  }
+  const repo = env.REMNIC_REPO || DEFAULT_REPO;
+  const slash = repo.indexOf("/");
+  if (slash <= 0 || slash === repo.length - 1) {
+    throw new Error("REMNIC_REPO must be owner/name");
+  }
+  const owner = repo.slice(0, slash);
+  const name = repo.slice(slash + 1);
+  const threads = selectThreads(
+    fetchThreads({
+      ghBin: resolveGh(env),
+      owner,
+      name,
+      pr: args.pr,
+      env,
+    }),
+    args,
+  );
+  if (args.json) {
+    io.log(JSON.stringify(threads, null, 2));
+  } else {
+    const text = formatHuman(threads);
+    if (text) io.log(text);
+  }
+  return 0;
+}
+
+const invoked = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invoked) {
+  try {
+    process.exitCode = main();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  }
+}

--- a/tests/fixtures/pr-threads/threads.json
+++ b/tests/fixtures/pr-threads/threads.json
@@ -1,0 +1,38 @@
+{
+  "repository": {
+    "pullRequest": {
+      "reviewThreads": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "endCursor": null
+        },
+        "nodes": [
+          {
+            "id": "PRRT_kwDOUnresolved2441",
+            "isResolved": false,
+            "comments": {
+              "nodes": [
+                {
+                  "author": { "login": "coderabbitai" },
+                  "body": "The GraphQL reviewThreads query currently truncates each comment body to 400-500 characters before the agent can reply or resolve the thread. Thread IDs are required for addPullRequestReviewThreadReply and resolveReviewThread, but they only appear on the full reviewThreads connection. This paragraph exists so the fixture body is longer than the historical truncation limit and the digest command must pass it through unchanged. Repeat-padding follows so a 500-character slice cannot accidentally satisfy the test: AAAAAAAAAA BBBBBBBBBB CCCCCCCCCC DDDDDDDDDD EEEEEEEEEE FFFFFFFFFF GGGGGGGGGG HHHHHHHHHH IIIIIIIIII JJJJJJJJJJ KKKKKKKKKK LLLLLLLLLL MMMMMMMMMM NNNNNNNNNN OOOOOOOOOO PPPPPPPPPP QQQQQQQQQQ RRRRRRRRRR SSSSSSSSSS TTTTTTTTTT. Marker: FULL_BODY_PASSTHROUGH_TOKEN_2441"
+                }
+              ]
+            }
+          },
+          {
+            "id": "PRRT_kwDOResolved2441",
+            "isResolved": true,
+            "comments": {
+              "nodes": [
+                {
+                  "author": { "login": "cursor" },
+                  "body": "Already addressed in the previous round."
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/pr-threads.test.mjs
+++ b/tests/pr-threads.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 
 import {
   formatHuman,
+  nextPageCursor,
   parseArgs,
   parseGhJson,
   selectThreads,
@@ -29,6 +30,9 @@ function createGhStub() {
     ghPath,
     `#!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "\${GH_STUB_ARGS:-}" ]]; then
+  printf '%s\\n' "$*" > "\${GH_STUB_ARGS}"
+fi
 if [[ -n "\${GH_STUB_BANNER_LINE:-}" ]]; then
   printf '%s\\n' "\${GH_STUB_BANNER_LINE}"
 fi
@@ -41,8 +45,9 @@ cat "\${GH_STUB_FIXTURE}"
 
 function runThreads(args, { banner = false } = {}) {
   const { root, ghPath } = createGhStub();
+  const argsPath = path.join(root, "gh-args");
   try {
-    return spawnSync(process.execPath, [scriptPath, ...args], {
+    const result = spawnSync(process.execPath, [scriptPath, ...args], {
       cwd: repoRoot,
       encoding: "utf8",
       env: {
@@ -50,9 +55,17 @@ function runThreads(args, { banner = false } = {}) {
         REMNIC_GH_BIN: ghPath,
         REMNIC_REPO: "example/repo",
         GH_STUB_FIXTURE: fixturePath,
+        GH_STUB_ARGS: argsPath,
         ...(banner ? { GH_STUB_BANNER_LINE: MISE_BANNER } : {}),
       },
     });
+    let ghArgs = "";
+    try {
+      ghArgs = readFileSync(argsPath, "utf8");
+    } catch {
+      ghArgs = "";
+    }
+    return { ...result, ghArgs };
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -146,3 +159,22 @@ test("human output prints id, author, and the full body", () => {
   assert.equal(result.stdout.includes("PRRT_kwDOResolved2441"), false);
   assert.equal(result.stdout.trimEnd(), formatHuman(selectThreads(threadsFromPayload(fixture))).trimEnd());
 });
+
+test("owner and name are passed as raw string flags", () => {
+  const result = runThreads(["12", "--json"]);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.ghArgs, /(^|\s)-f owner=example(\s|$)/);
+  assert.match(result.ghArgs, /(^|\s)-f name=repo(\s|$)/);
+  assert.match(result.ghArgs, /(^|\s)-F pr=12(\s|$)/);
+  assert.equal(result.ghArgs.includes("-F owner="), false);
+  assert.equal(result.ghArgs.includes("-F name="), false);
+});
+
+test("nextPageCursor fails closed on a missing or repeated cursor", () => {
+  assert.equal(nextPageCursor({ hasNextPage: false, endCursor: "c1" }, null), null);
+  assert.equal(nextPageCursor({ hasNextPage: true, endCursor: "c2" }, "c1"), "c2");
+  assert.throws(() => nextPageCursor({ hasNextPage: true, endCursor: "" }, null), /missing or repeated/);
+  assert.throws(() => nextPageCursor({ hasNextPage: true, endCursor: "c1" }, "c1"), /missing or repeated/);
+  assert.throws(() => nextPageCursor({ hasNextPage: true }, null), /missing or repeated/);
+});
+

--- a/tests/pr-threads.test.mjs
+++ b/tests/pr-threads.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  formatHuman,
+  parseArgs,
+  parseGhJson,
+  selectThreads,
+  stripGhBanner,
+  stripLeadingNonJson,
+  threadsFromPayload,
+} from "../scripts/pr-threads.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "pr-threads.mjs");
+const fixturePath = path.join(repoRoot, "tests", "fixtures", "pr-threads", "threads.json");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+const unresolvedBody = fixture.repository.pullRequest.reviewThreads.nodes[0].comments.nodes[0].body;
+const MISE_BANNER = "mise ~/.config/mise/config.toml tools: gh@2.97.0";
+
+function createGhStub() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "remnic-pr-threads-gh-"));
+  const ghPath = path.join(root, "gh");
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "\${GH_STUB_BANNER_LINE:-}" ]]; then
+  printf '%s\\n' "\${GH_STUB_BANNER_LINE}"
+fi
+cat "\${GH_STUB_FIXTURE}"
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { root, ghPath };
+}
+
+function runThreads(args, { banner = false } = {}) {
+  const { root, ghPath } = createGhStub();
+  try {
+    return spawnSync(process.execPath, [scriptPath, ...args], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        REMNIC_GH_BIN: ghPath,
+        REMNIC_REPO: "example/repo",
+        GH_STUB_FIXTURE: fixturePath,
+        ...(banner ? { GH_STUB_BANNER_LINE: MISE_BANNER } : {}),
+      },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function assertThreadShape(thread) {
+  assert.equal(typeof thread.id, "string");
+  assert.ok(thread.id.length > 0);
+  assert.equal(typeof thread.author, "string");
+  assert.equal(typeof thread.isResolved, "boolean");
+  assert.equal(typeof thread.body, "string");
+}
+
+test("fixture unresolved body exceeds the historical truncation limit", () => {
+  assert.ok(unresolvedBody.length > 500);
+  assert.match(unresolvedBody, /FULL_BODY_PASSTHROUGH_TOKEN_2441/);
+});
+
+test("parseArgs defaults to unresolved-only human output", () => {
+  assert.deepEqual(parseArgs(["17"]), { pr: 17, all: false, json: false, help: false });
+  assert.deepEqual(parseArgs(["17", "--all", "--json"]), { pr: 17, all: true, json: true, help: false });
+});
+
+test("parseArgs rejects a missing or non-positive PR number", () => {
+  assert.throws(() => parseArgs([]), /Usage:/);
+  assert.throws(() => parseArgs(["--json"]), /Usage:/);
+  assert.throws(() => parseArgs(["0"]), /Usage:/);
+});
+
+test("banner and leading non-JSON lines are stripped before parse", () => {
+  const payload = { ok: true };
+  const prefixed = `${MISE_BANNER}\nnot-json\n${JSON.stringify(payload)}\n`;
+  assert.equal(stripGhBanner(`${MISE_BANNER}\n{"a":1}\n`), '{"a":1}\n');
+  assert.equal(stripLeadingNonJson("noise\n[1,2]\n"), "[1,2]\n");
+  assert.deepEqual(parseGhJson(prefixed), payload);
+});
+
+test("threadsFromPayload keeps full bodies and filters resolved by default", () => {
+  const threads = threadsFromPayload(fixture);
+  assert.equal(threads.length, 2);
+  assert.equal(threads[0].id, "PRRT_kwDOUnresolved2441");
+  assert.equal(threads[0].body, unresolvedBody);
+  assert.equal(selectThreads(threads).length, 1);
+  assert.equal(selectThreads(threads, { all: true }).length, 2);
+});
+
+test("json mode passes full bodies and ids from clean gh output", () => {
+  const result = runThreads(["12", "--json"]);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(parsed));
+  assert.equal(parsed.length, 1);
+  assertThreadShape(parsed[0]);
+  assert.equal(parsed[0].id, "PRRT_kwDOUnresolved2441");
+  assert.equal(parsed[0].author, "coderabbitai");
+  assert.equal(parsed[0].isResolved, false);
+  assert.equal(parsed[0].body, unresolvedBody);
+  assert.equal(parsed[0].body.length, unresolvedBody.length);
+});
+
+test("json mode strips a mise banner before parse", () => {
+  const result = runThreads(["12", "--json"], { banner: true });
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(parsed));
+  assert.equal(parsed[0].id, "PRRT_kwDOUnresolved2441");
+  assert.equal(parsed[0].body, unresolvedBody);
+});
+
+test("--all json includes resolved threads", () => {
+  const result = runThreads(["12", "--all", "--json"]);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.length, 2);
+  parsed.forEach(assertThreadShape);
+  assert.deepEqual(
+    parsed.map((thread) => thread.id),
+    ["PRRT_kwDOUnresolved2441", "PRRT_kwDOResolved2441"],
+  );
+  assert.equal(parsed[1].isResolved, true);
+  assert.equal(parsed[1].author, "cursor");
+});
+
+test("human output prints id, author, and the full body", () => {
+  const result = runThreads(["12"]);
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+  assert.match(result.stdout, /id: PRRT_kwDOUnresolved2441/);
+  assert.match(result.stdout, /author: coderabbitai/);
+  assert.match(result.stdout, /isResolved: false/);
+  assert.equal(result.stdout.includes(unresolvedBody), true);
+  assert.equal(result.stdout.includes("PRRT_kwDOResolved2441"), false);
+  assert.equal(result.stdout.trimEnd(), formatHuman(selectThreads(threadsFromPayload(fixture))).trimEnd());
+});


### PR DESCRIPTION
## Summary

Add `node scripts/pr-threads.mjs <pr> [--all] [--json]` as the canonical review-thread intake: one GraphQL call prints thread id, author, isResolved, and the **full** body (no 400–500 character truncation). Default is unresolved only.

The command resolves the real `gh` binary (or honors `REMNIC_GH_BIN`) and strips a leading mise banner / non-JSON lines the same way `scripts/pr-wait-settled.sh` does after #2423.

Cited in AGENTS.md's review-loop section.

Fixes #2441

## Type of change

- [x] Feature

## Validation

- [x] Added/updated tests for behavior changes
- [x] `node --test tests/pr-threads.test.mjs` (stubbed `gh`, banner-prefixed and clean fixtures)
- [x] Live: `node scripts/pr-threads.mjs 2444 --json` → `[]`
- [x] Live: `node scripts/pr-threads.mjs 2432 --all --json` → full bodies + thread IDs

## Changelog

- [x] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Changeset included

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only CLI, docs, and tests; no runtime product or auth/data-path changes.
> 
> **Overview**
> Adds **`node scripts/pr-threads.mjs <pr>`** as the canonical way to list PR review threads with **thread IDs and untruncated comment bodies**—addressing workflows that need full text for replies and `resolveReviewThread`.
> 
> The script paginates GitHub GraphQL `reviewThreads`, defaults to **unresolved** threads, and supports **`--all`** and **`--json`** (`{ id, author, isResolved, body }`). It reuses the same **`gh` resolution** (`REMNIC_GH_BIN`, mise shim bypass) and **stdout sanitization** (mise banner / leading non-JSON) as `pr-wait-settled.sh`.
> 
> **AGENTS.md** now points the review-loop “batch fixes” step at this command for re-scanning comments. **Tests** cover parsing, filtering, pagination guards, and end-to-end output via a stubbed `gh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f06ddc33998399466cbc00466ef195d3ccc714b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->