### PR TITLE
feat(devx): add pr-merge-ready helper

### DIFF
--- a/.changeset/pr-merge-ready-2440.md
+++ b/.changeset/pr-merge-ready-2440.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `scripts/pr-merge-ready.sh <pr>` to finish a review-settled PR in one command: verify head-SHA check-run gates and the GraphQL unresolved-thread count with a printed evidence block, dismiss stale CHANGES_REQUESTED reviews (superseded commits) with a reason, merge `--squash` with one logged `--admin` retry when every verified precondition held, and delete the remote branch only after polling confirms `MERGED` (issue #2440).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,19 @@ Merge with `gh pr merge <number> --squash`. Do not add `--delete-branch` when
 git push origin --delete <branch>
 ```
 
+For the whole end-of-review sequence in one command, run
+`scripts/pr-merge-ready.sh <pr-number>` (issue #2440): it verifies the head
+SHA's check-run conclusions and the GraphQL unresolved-thread count, prints an
+evidence block (head SHA, per-gate conclusion, thread count), dismisses
+`CHANGES_REQUESTED` reviews that target a superseded head with a reason string,
+merges `--squash` — retrying once with `--admin` only when every verified
+precondition held and the head is unchanged (GitHub can leave mergeStateStatus
+BLOCKED after a dismissal even with head checks green) — and deletes the remote
+branch only after polling confirms `state=MERGED`, because deleting before the
+merge confirms auto-closes the PR (hit on #2434). `--check` prints the plan
+without acting. A `CHANGES_REQUESTED` verdict on the current head blocks the
+merge rather than being dismissed.
+
 When review threads remain, resolve every thread, including outdated threads.
 If `unresolved-review-threads` stays red, dispatch the check-unsticker workflow:
 

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -214,6 +214,7 @@ test("offline manifest streams body-free active, archived, old, bad, and encrypt
       category: "fact",
       contentHash: activeContentHash,
       normalizerVersion: 4,
+      identityResolutionVersion: 2,
       status: "active",
     });
     assert.notEqual(rowsByPath.get("facts/active.md")?.sha256, activeContentHash);

--- a/scripts/lifecycle-matrix/coverage.json
+++ b/scripts/lifecycle-matrix/coverage.json
@@ -35,6 +35,7 @@
     "packages/remnic-core/src/storage/deletion-revision-store.ts",
     "packages/remnic-core/src/storage/committed-invalidation.ts",
     "packages/remnic-core/src/storage/supersession-audit.ts",
+    "packages/remnic-core/src/storage/tombstone-migration-sources.ts",
     "packages/remnic-core/src/session-toggles.ts",
     "packages/remnic-core/src/session-namespace-bindings.ts",
     "packages/remnic-core/src/memory-cache.ts",

--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -68,7 +68,17 @@ strip_gh_banner() {
 
 GH_BIN="$(resolve_gh)"
 gh() {
-  "$GH_BIN" "$@" 2> >(strip_gh_banner >&2) | strip_gh_banner
+  # Synchronous stderr filtering (round-1 review): an async process
+  # substitution `2> >(strip_gh_banner >&2)` can outlive the command
+  # substitution capturing this function's output, racing away failure text
+  # the merge path matches on ("already merged"). Capture stderr to a temp
+  # file, strip after gh exits, and preserve its status via pipefail.
+  local err_file status=0
+  err_file="$(mktemp)"
+  "$GH_BIN" "$@" 2>"$err_file" | strip_gh_banner || status=$?
+  strip_gh_banner <"$err_file" >&2
+  rm -f "$err_file"
+  return "$status"
 }
 
 resolve_git() {
@@ -95,6 +105,7 @@ if [[ $# -lt 1 ]]; then
   exit 2
 fi
 PR_NUMBER="$1"
+[[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { usage; exit 2; }
 shift
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -102,10 +113,20 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN=true
       shift
       ;;
-    --interval|--timeout)
+    --interval)
+      # Fractional OK: only `sleep` consumes it.
       [[ $# -ge 2 ]] || { usage; exit 2; }
-      [[ "$2" =~ ^[0-9]+([.][0-9]+)?$ ]] || { printf 'Invalid %s value: %s\n' "$1" "$2" >&2; exit 2; }
-      if [[ "$1" == "--timeout" ]]; then TIMEOUT="$2"; else INTERVAL="$2"; fi
+      [[ "$2" =~ ^[0-9]+([.][0-9]+)?$ ]] || { printf 'Invalid --interval value: %s\n' "$2" >&2; exit 2; }
+      INTERVAL="$2"
+      shift 2
+      ;;
+    --timeout)
+      # Integer only (round-1 review): the merge-poll deadline uses bash
+      # integer arithmetic; a fractional value would abort after a
+      # successful merge and skip the branch delete.
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      [[ "$2" =~ ^[0-9]+$ ]] || { printf 'Invalid --timeout value (integer seconds): %s\n' "$2" >&2; exit 2; }
+      TIMEOUT="$2"
       shift 2
       ;;
     *)
@@ -172,23 +193,41 @@ fi
 IFS=$'\t' read -r HEAD_SHA BRANCH PR_STATE MERGE_STATE <<< "$pr_meta"
 GATE_FAILURES=()
 GATE_LINES=""
-GATE_COUNT=0
+GATE_NAMES=0
 if ! check_runs_raw=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs[] | [.name, (.status // "-"), (.conclusion // "-"), (.head_sha // "-")] | @tsv' 2>/dev/null); then
   GATE_FAILURES+=("api:check-runs")
 else
+  # Per-name aggregation (round-1 review): a re-run leaves superseded rows on
+  # the same SHA, and branch protection honors the latest run per check name.
+  # A name is green when ANY of its runs completed green — the same semantics
+  # as scripts/pr-wait-settled.sh. Display shows the first (non-green) state
+  # only when no run for that name is green.
+  declare -A CHECK_STATE_LINES=()
   while IFS=$'\t' read -r gate_name run_status conclusion run_sha; do
     [[ -n "$gate_name" ]] || continue
     [[ "$run_sha" == "$HEAD_SHA" ]] || continue
-    GATE_COUNT=$((GATE_COUNT + 1))
-    if [[ "$run_status" == "completed" && "$conclusion" =~ ^(success|neutral|skipped)$ ]]; then
-      GATE_LINES+="  ${gate_name}: ${conclusion}"$'\n'
-    else
-      GATE_FAILURES+=("check:${gate_name}(${run_status}/${conclusion})")
-      GATE_LINES+="  ${gate_name}: ${run_status}/${conclusion:-pending} (RED)"$'\n'
-    fi
+    CHECK_STATE_LINES["$gate_name"]+="${run_status}/${conclusion}"$'\n'
   done <<< "$check_runs_raw"
+  for gate_name in "${!CHECK_STATE_LINES[@]}"; do
+    GATE_NAMES=$((GATE_NAMES + 1))
+    gate_green=""
+    gate_first=""
+    while IFS= read -r state_line; do
+      [[ -n "$state_line" ]] || continue
+      [[ -n "$gate_first" ]] || gate_first="$state_line"
+      case "$state_line" in
+        completed/success|completed/neutral|completed/skipped) gate_green="${state_line#completed/}" ;;
+      esac
+    done <<< "${CHECK_STATE_LINES[$gate_name]}"
+    if [[ -n "$gate_green" ]]; then
+      GATE_LINES+="  ${gate_name}: ${gate_green}"$'\n'
+    else
+      GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")
+      GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (RED)"$'\n'
+    fi
+  done
 fi
-if [[ "$GATE_COUNT" -eq 0 && ${#GATE_FAILURES[@]} -eq 0 ]]; then
+if [[ "$GATE_NAMES" -eq 0 && ${#GATE_FAILURES[@]} -eq 0 ]]; then
   GATE_FAILURES+=("check-runs:none-reported-on-head")
 fi
 
@@ -233,7 +272,7 @@ if [[ "$THREADS_READ_FAILED" == true ]]; then
 else
   printf 'threads:         %s unresolved / %s total\n' "$THREAD_UNRESOLVED" "$THREAD_TOTAL"
 fi
-printf 'gates (%s check runs on head):\n' "$GATE_COUNT"
+printf 'gates (%s distinct check names on head):\n' "$GATE_NAMES"
 if [[ -n "$GATE_LINES" ]]; then
   printf '%s' "$GATE_LINES"
 else
@@ -303,9 +342,26 @@ if [[ "$merge_ok" != true && "$already_merged" != true ]]; then
       "${current_head:-unreadable}" "${HEAD_SHA:0:7}" >&2
     exit 1
   fi
+  # Round-1 review: a CHANGES_REQUESTED posted on this same head AFTER the
+  # initial gate pass is a live rejection -- re-check before --admin so the
+  # fallback can never bulldoze a standing verdict.
+  late_blockers=0
+  if ! late_reviews_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --jq '.[] | select(.state == "CHANGES_REQUESTED") | [(.node_id // "-"), (.commit_id // "-")] | @tsv' 2>/dev/null); then
+    printf '[pr-merge] FAIL: cannot re-read reviews before --admin retry; refusing.\n' >&2
+    exit 1
+  fi
+  while IFS=$'\t' read -r late_node late_commit; do
+    [[ -n "$late_node" ]] || continue
+    [[ "$late_commit" == "$HEAD_SHA" ]] && late_blockers=$((late_blockers + 1))
+  done <<< "$late_reviews_raw"
+  if [[ "$late_blockers" -gt 0 ]]; then
+    printf '[pr-merge] FAIL: %s CHANGES_REQUESTED review(s) now target the current head; refusing --admin retry.\n' \
+      "$late_blockers" >&2
+    exit 1
+  fi
   printf '[pr-merge] plain merge refused: %s\n' "$merge_out"
   printf '[pr-merge] retrying ONCE with --admin. WHY: every verified precondition held (head %s check runs green, %s unresolved threads, %s stale verdict(s) dismissed, head unchanged at %s) and GitHub still refuses — known mergeStateStatus BLOCKED-after-dismissal behavior (issue #2440).\n' \
-    "$GATE_COUNT" "$THREAD_UNRESOLVED" "${#STALE_REVIEWS[@]}" "$HEAD_SHA"
+    "$GATE_NAMES" "$THREAD_UNRESOLVED" "${#STALE_REVIEWS[@]}" "$HEAD_SHA"
   if ! merge_out=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --admin --match-head-commit "$HEAD_SHA" 2>&1); then
     printf '[pr-merge] FAIL: --admin merge also refused: %s\n' "$merge_out" >&2
     exit 1

--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Merge a review-settled PR end to end, then delete its branch (issue #2440).
+#
+# Usage: scripts/pr-merge-ready.sh <pr-number> [--check] [--interval S] [--timeout S]
+#
+# 1. Verify gates on the head SHA: every check run on the head completed with a
+#    green conclusion (success/neutral/skipped), no CHANGES_REQUESTED review
+#    targets the current head, and the GraphQL unresolved-thread count is 0.
+#    Prints an evidence block (head SHA, per-gate conclusion, thread count).
+# 2. Dismiss CHANGES_REQUESTED reviews whose commit is not the head SHA, with
+#    a reason string, via the GraphQL dismissPullRequestReview mutation.
+# 3. Attempt `gh pr merge <n> --squash`. If GitHub refuses while every verified
+#    precondition still held (head unchanged), retry once with `--admin` and
+#    log why: GitHub can leave mergeStateStatus BLOCKED after a dismissal even
+#    with head checks green and threads at zero.
+# 4. Poll the PR state until MERGED, and only then run
+#    `git push origin --delete <branch>` — deleting before the merge confirms
+#    auto-closes the PR (hit on #2434).
+#
+# `--check` prints the plan (evidence + intended actions) without acting.
+# Exit 0 on success, 1 when a gate or merge step blocks, 2 on usage errors.
+
+# Resolve the real gh binary when a tool-manager wrapper appears first on PATH.
+resolve_mise_gh() {
+  local candidate
+  command -v mise >/dev/null 2>&1 || return 1
+  candidate="$(mise which gh 2>/dev/null || true)"
+  [[ -x "$candidate" ]] || return 1
+  printf '%s\n' "$candidate"
+}
+
+resolve_gh() {
+  if [[ -n "${REMNIC_GH_BIN:-}" ]]; then
+    printf '%s\n' "$REMNIC_GH_BIN"
+    return
+  fi
+  local candidate kind source
+  while IFS= read -r candidate; do
+    [[ -x "$candidate" ]] || continue
+    case "$candidate" in
+      */shims/gh)
+        resolve_mise_gh && return
+        continue
+        ;;
+    esac
+    kind="$(file -b "$candidate" 2>/dev/null || true)"
+    if [[ "$kind" == *script* || "$kind" == *text* ]]; then
+      source="$(sed -n '1,8p' "$candidate" 2>/dev/null || true)"
+      if [[ "$source" == *mise* ]]; then
+        resolve_mise_gh && return
+        continue
+      fi
+    fi
+    printf '%s\n' "$candidate"
+    return
+  done < <(type -P -a gh 2>/dev/null | awk '!seen[$0]++')
+  command -v gh
+}
+
+strip_gh_banner() {
+  awk '
+    !started && $0 ~ /^[[:space:]]*mise[[:space:]].*config[.]toml[[:space:]]+tools:[[:space:]]+gh@[^[:space:]]+[[:space:]]*$/ { next }
+    { started = 1; print }
+  '
+}
+
+GH_BIN="$(resolve_gh)"
+gh() {
+  "$GH_BIN" "$@" 2> >(strip_gh_banner >&2) | strip_gh_banner
+}
+
+resolve_git() {
+  if [[ -n "${REMNIC_GIT_BIN:-}" ]]; then
+    printf '%s\n' "$REMNIC_GIT_BIN"
+    return
+  fi
+  command -v git
+}
+GIT_BIN="$(resolve_git)"
+
+PR_NUMBER=""
+DRY_RUN=false
+INTERVAL=5
+TIMEOUT=300
+REPO="${REMNIC_REPO:-joshuaswarren/remnic}"
+
+usage() {
+  printf 'Usage: scripts/pr-merge-ready.sh <pr-number> [--check] [--interval S] [--timeout S]\n' >&2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+PR_NUMBER="$1"
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      DRY_RUN=true
+      shift
+      ;;
+    --interval|--timeout)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      [[ "$2" =~ ^[0-9]+([.][0-9]+)?$ ]] || { printf 'Invalid %s value: %s\n' "$1" "$2" >&2; exit 2; }
+      if [[ "$1" == "--timeout" ]]; then TIMEOUT="$2"; else INTERVAL="$2"; fi
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+REVIEW_THREADS_QUERY='query($owner: String!, $name: String!, $pr: Int!, $after: String = null) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved }
+      }
+    }
+  }
+}'
+
+DISMISS_MUTATION='mutation($id: ID!, $message: String!) {
+  dismissPullRequestReview(input: {pullRequestReviewId: $id, message: $message}) {
+    pullRequestReview { state }
+  }
+}'
+
+DISMISS_REASON="Stale CHANGES_REQUESTED on a superseded commit (does not target the current head); head checks are green and review threads are resolved. Dismissed by scripts/pr-merge-ready.sh (issue #2440)."
+
+fetch_threads() {
+  local after="" page total unresolved has_next end_cursor
+  THREAD_TOTAL=0
+  THREAD_UNRESOLVED=0
+  while true; do
+    local args=(api graphql -f query="$REVIEW_THREADS_QUERY" -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER")
+    [[ -n "$after" ]] && args+=(-f after="$after")
+    if ! page=$(gh "${args[@]}" --jq '.data.repository.pullRequest.reviewThreads as $threads | [($threads.totalCount // 0), ([($threads.nodes // [])[] | select(.isResolved == false)] | length), ($threads.pageInfo.hasNextPage // false), ($threads.pageInfo.endCursor // "")] | @tsv' 2>/dev/null); then
+      return 1
+    fi
+    if [[ "$page" != *$'\n'* ]]; then
+      IFS=$'\t' read -r total unresolved has_next end_cursor <<< "$page"
+      if [[ "$total" =~ ^[0-9]+$ && "$unresolved" =~ ^[0-9]+$ && "$has_next" =~ ^(true|false)$ ]]; then
+        [[ "$THREAD_TOTAL" -gt 0 ]] || THREAD_TOTAL="$total"
+        THREAD_UNRESOLVED=$((THREAD_UNRESOLVED + unresolved))
+        [[ "$has_next" == "true" ]] || return 0
+        [[ -n "$end_cursor" && "$end_cursor" != "$after" ]] || return 1
+        after="$end_cursor"
+        continue
+      fi
+    fi
+    return 1
+  done
+}
+
+# ---- step 1: verify gates on the head SHA and print the evidence block ----
+
+if ! pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid,headRefName,state,mergeStateStatus --jq '[.headRefOid, .headRefName, .state, (.mergeStateStatus // "")] | @tsv' 2>/dev/null); then
+  printf '[pr-merge] FAIL: cannot read PR #%s metadata from %s.\n' "$PR_NUMBER" "$REPO" >&2
+  exit 1
+fi
+IFS=$'\t' read -r HEAD_SHA BRANCH PR_STATE MERGE_STATE <<< "$pr_meta"
+GATE_FAILURES=()
+GATE_LINES=""
+GATE_COUNT=0
+if ! check_runs_raw=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs[] | [.name, (.status // "-"), (.conclusion // "-"), (.head_sha // "-")] | @tsv' 2>/dev/null); then
+  GATE_FAILURES+=("api:check-runs")
+else
+  while IFS=$'\t' read -r gate_name run_status conclusion run_sha; do
+    [[ -n "$gate_name" ]] || continue
+    [[ "$run_sha" == "$HEAD_SHA" ]] || continue
+    GATE_COUNT=$((GATE_COUNT + 1))
+    if [[ "$run_status" == "completed" && "$conclusion" =~ ^(success|neutral|skipped)$ ]]; then
+      GATE_LINES+="  ${gate_name}: ${conclusion}"$'\n'
+    else
+      GATE_FAILURES+=("check:${gate_name}(${run_status}/${conclusion})")
+      GATE_LINES+="  ${gate_name}: ${run_status}/${conclusion:-pending} (RED)"$'\n'
+    fi
+  done <<< "$check_runs_raw"
+fi
+if [[ "$GATE_COUNT" -eq 0 && ${#GATE_FAILURES[@]} -eq 0 ]]; then
+  GATE_FAILURES+=("check-runs:none-reported-on-head")
+fi
+
+THREAD_TOTAL=0
+THREAD_UNRESOLVED=0
+THREADS_READ_FAILED=false
+if ! fetch_threads; then
+  THREADS_READ_FAILED=true
+  GATE_FAILURES+=("api:review-threads")
+fi
+
+# CHANGES_REQUESTED verdicts: stale ones (commit != head) are dismissable; a
+# verdict on the CURRENT head is a live rejection and must block the merge —
+# otherwise the --admin fallback could bulldoze a standing review verdict.
+CURRENT_HEAD_BLOCKING=0
+STALE_REVIEWS=()
+if ! reviews_raw=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --jq '.[] | select(.state == "CHANGES_REQUESTED") | [(.node_id // "-"), (.user.login // "-"), (.commit_id // "-")] | @tsv' 2>/dev/null); then
+  GATE_FAILURES+=("api:reviews")
+  reviews_raw=""
+else
+  while IFS=$'\t' read -r node_id login commit; do
+    [[ -n "$node_id" ]] || continue
+    if [[ "$commit" == "$HEAD_SHA" ]]; then
+      CURRENT_HEAD_BLOCKING=$((CURRENT_HEAD_BLOCKING + 1))
+    else
+      STALE_REVIEWS+=("${node_id}"$'\t'"${login}"$'\t'"${commit}")
+    fi
+  done <<< "$reviews_raw"
+fi
+[[ "$CURRENT_HEAD_BLOCKING" -eq 0 ]] || GATE_FAILURES+=("review-verdicts:${CURRENT_HEAD_BLOCKING}-current-head-CHANGES_REQUESTED")
+[[ "$PR_STATE" == "OPEN" ]] || GATE_FAILURES+=("state:${PR_STATE}")
+
+GATES_OK=true
+[[ ${#GATE_FAILURES[@]} -eq 0 && "$THREAD_UNRESOLVED" -eq 0 && "$THREADS_READ_FAILED" == false ]] || GATES_OK=false
+
+printf '== pr-merge-ready #%s (%s) ==\n' "$PR_NUMBER" "$REPO"
+printf 'head:            %s\n' "$HEAD_SHA"
+printf 'branch:          %s\n' "$BRANCH"
+printf 'state:           %s (mergeStateStatus: %s)\n' "$PR_STATE" "${MERGE_STATE:-unknown}"
+if [[ "$THREADS_READ_FAILED" == true ]]; then
+  printf 'threads:         READ FAILED\n'
+else
+  printf 'threads:         %s unresolved / %s total\n' "$THREAD_UNRESOLVED" "$THREAD_TOTAL"
+fi
+printf 'gates (%s check runs on head):\n' "$GATE_COUNT"
+if [[ -n "$GATE_LINES" ]]; then
+  printf '%s' "$GATE_LINES"
+else
+  printf '  (none)\n'
+fi
+printf 'review verdicts: %s current-head CHANGES_REQUESTED (blocking), %s stale (dismissable)\n' \
+  "$CURRENT_HEAD_BLOCKING" "${#STALE_REVIEWS[@]}"
+if [[ ${#GATE_FAILURES[@]} -gt 0 ]]; then
+  printf 'failures:\n'
+  for failure in "${GATE_FAILURES[@]}"; do
+    printf '  - %s\n' "$failure"
+  done
+fi
+if [[ "$GATES_OK" == true ]]; then
+  printf 'verdict:         READY\n'
+else
+  printf 'verdict:         BLOCKED\n'
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+  printf 'plan (--check, no actions taken):\n'
+  printf '  1. dismiss %s stale CHANGES_REQUESTED review(s) via GraphQL with reason:\n' "${#STALE_REVIEWS[@]}"
+  for stale in "${STALE_REVIEWS[@]}"; do
+    IFS=$'\t' read -r node_id login commit <<< "$stale"
+    printf '     - %s (%s, commit %s != head %s)\n' "$node_id" "$login" "${commit:0:7}" "${HEAD_SHA:0:7}"
+  done
+  printf '  2. gh pr merge %s --repo %s --squash --match-head-commit %s\n' "$PR_NUMBER" "$REPO" "$HEAD_SHA"
+  printf '     (retry once with --admin ONLY if refused while every verified precondition held and the head is unchanged)\n'
+  printf '  3. poll state until MERGED, then git push origin --delete %s\n' "$BRANCH"
+  if [[ "$GATES_OK" == true ]]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [[ "$GATES_OK" != true ]]; then
+  printf '[pr-merge] FAIL: gates not satisfied; refusing to dismiss, merge, or delete.\n' >&2
+  exit 1
+fi
+
+# ---- step 2: dismiss stale CHANGES_REQUESTED reviews ----
+
+for stale in "${STALE_REVIEWS[@]}"; do
+  IFS=$'\t' read -r node_id login commit <<< "$stale"
+  printf '[pr-merge] dismissing stale CHANGES_REQUESTED from %s (commit %s != head %s)...\n' \
+    "$login" "${commit:0:7}" "${HEAD_SHA:0:7}"
+  if ! dismiss_out=$(gh api graphql -f query="$DISMISS_MUTATION" -f id="$node_id" -f message="$DISMISS_REASON" 2>&1); then
+    printf '[pr-merge] FAIL: dismissal of %s failed: %s\n' "$node_id" "$dismiss_out" >&2
+    exit 1
+  fi
+done
+
+# ---- step 3: merge (squash), one logged --admin retry ----
+
+printf '[pr-merge] merging PR #%s (squash)...\n' "$PR_NUMBER"
+merge_ok=false
+already_merged=false
+if merge_out=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --match-head-commit "$HEAD_SHA" 2>&1); then
+  merge_ok=true
+elif [[ "$merge_out" == *"already been merged"* || "$merge_out" == *"already merged"* ]]; then
+  already_merged=true
+fi
+if [[ "$merge_ok" != true && "$already_merged" != true ]]; then
+  current_head="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+  if [[ "$current_head" != "$HEAD_SHA" ]]; then
+    printf '[pr-merge] FAIL: head moved after verification (%s != %s); refusing --admin retry.\n' \
+      "${current_head:-unreadable}" "${HEAD_SHA:0:7}" >&2
+    exit 1
+  fi
+  printf '[pr-merge] plain merge refused: %s\n' "$merge_out"
+  printf '[pr-merge] retrying ONCE with --admin. WHY: every verified precondition held (head %s check runs green, %s unresolved threads, %s stale verdict(s) dismissed, head unchanged at %s) and GitHub still refuses — known mergeStateStatus BLOCKED-after-dismissal behavior (issue #2440).\n' \
+    "$GATE_COUNT" "$THREAD_UNRESOLVED" "${#STALE_REVIEWS[@]}" "$HEAD_SHA"
+  if ! merge_out=$(gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --admin --match-head-commit "$HEAD_SHA" 2>&1); then
+    printf '[pr-merge] FAIL: --admin merge also refused: %s\n' "$merge_out" >&2
+    exit 1
+  fi
+fi
+
+# ---- step 4: poll until MERGED, only then delete the branch ----
+
+printf '[pr-merge] waiting for PR #%s to reach MERGED (timeout %ss)...\n' "$PR_NUMBER" "$TIMEOUT"
+deadline=$(( $(date +%s) + TIMEOUT ))
+while true; do
+  state="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq .state 2>/dev/null || true)"
+  if [[ "$state" == "MERGED" ]]; then
+    break
+  fi
+  if [[ "$(date +%s)" -ge "$deadline" ]]; then
+    printf '[pr-merge] FAIL: PR #%s did not reach MERGED within %ss (last state: %s). Branch %s NOT deleted — deleting before merge confirmation auto-closes the PR (#2434).\n' \
+      "$PR_NUMBER" "$TIMEOUT" "${state:-unreadable}" "$BRANCH" >&2
+    exit 1
+  fi
+  sleep "$INTERVAL"
+done
+
+printf '[pr-merge] PR #%s is MERGED; deleting remote branch %s.\n' "$PR_NUMBER" "$BRANCH"
+if ! delete_out=$("$GIT_BIN" push origin --delete "$BRANCH" 2>&1); then
+  printf '[pr-merge] FAIL: branch deletion failed: %s\n' "$delete_out" >&2
+  exit 1
+fi
+printf '[pr-merge] done: merged and branch deleted.\n'

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -8,7 +8,7 @@
       "packages/remnic-core/src/cli.ts": 9428,
       "packages/remnic-core/src/access-service.ts": 5910,
       "packages/remnic-core/src/storage.ts": 7315,
-      "packages/remnic-core/src/config.ts": 4559
+      "packages/remnic-core/src/config.ts": 4561
     },
     "oversizedFileCount": 12,
     "fileSizeGrandfather": {
@@ -36,7 +36,7 @@
       "packages/remnic-core/src/cli.ts": 9428,
       "packages/remnic-core/src/coding/codegraph-runtime.ts": 1311,
       "packages/remnic-core/src/compounding/engine.ts": 1722,
-      "packages/remnic-core/src/config.ts": 4559,
+      "packages/remnic-core/src/config.ts": 4561,
       "packages/remnic-core/src/connectors/index.ts": 4061,
       "packages/remnic-core/src/connectors/live/gmail.ts": 1303,
       "packages/remnic-core/src/evals.ts": 1321,
@@ -53,7 +53,7 @@
       "packages/remnic-core/src/offline-sync.ts": 2646,
       "packages/remnic-core/src/operator-toolkit.ts": 2501,
       "packages/remnic-core/src/orchestration/extraction-persist.ts": 3031,
-      "packages/remnic-core/src/orchestration/recall-internal.ts": 5329,
+      "packages/remnic-core/src/orchestration/recall-internal.ts": 5344,
       "packages/remnic-core/src/orchestration/recall-search-pipeline.ts": 1719,
       "packages/remnic-core/src/orchestrator.ts": 3979,
       "packages/remnic-core/src/peers/storage.ts": 1435,

--- a/tests/pr-merge-ready.test.mjs
+++ b/tests/pr-merge-ready.test.mjs
@@ -60,6 +60,12 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/${headSha}/check-runs
       printf 'ci\\tin_progress\\t-\\t${headSha}\\n'
       printf 'ai-reviewers\\tcompleted\\tsuccess\\t${headSha}\\n'
       ;;
+    rerun_green)
+      printf 'ci\\tcompleted\\tfailure\\t${headSha}\\n'
+      printf 'ci\\tcompleted\\tsuccess\\t${headSha}\\n'
+      printf 'ai-reviewers\\tcompleted\\tsuccess\\t${headSha}\\n'
+      printf 'unresolved-review-threads\\tcompleted\\tsuccess\\t${headSha}\\n'
+      ;;
     *)
       printf 'ci\\tcompleted\\tsuccess\\t${headSha}\\n'
       printf 'ai-reviewers\\tcompleted\\tsuccess\\t${headSha}\\n'
@@ -70,16 +76,23 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/${headSha}/check-runs
 fi
 
 if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
-  case "$GH_STUB_SCENARIO" in
-    stale_review)
-      printf 'R_STALE\\tcoderabbitai[bot]\\t${staleSha}\\n'
-      ;;
-    current_head_changes)
-      printf 'R_FRESH\\tcoderabbitai[bot]\\t${headSha}\\n'
-      ;;
-    *)
-      ;;
-  esac
+  review_calls=$(( $(cat "$GH_STUB_REVIEWS_COUNT" 2>/dev/null || echo 0) + 1 ))
+  printf '%s\\n' "$review_calls" > "$GH_STUB_REVIEWS_COUNT"
+  # The gate-time query reads 3 columns (its jq mentions .user.login); the
+  # pre-admin recheck reads 2 (node_id, commit_id). Branch on the jq shape so
+  # each caller gets the column layout it parses.
+  if [[ "$*" == *"user.login"* ]]; then
+    case "$GH_STUB_SCENARIO" in
+      stale_review)
+        printf 'R_STALE\\tcoderabbitai[bot]\\t${staleSha}\\n'
+        ;;
+      current_head_changes)
+        printf 'R_FRESH\\tcoderabbitai[bot]\\t${headSha}\\n'
+        ;;
+    esac
+  elif [[ "$GH_STUB_SCENARIO" == "late_changes_requested" && "$review_calls" -ge 2 ]]; then
+    printf 'R_LATE\\t${headSha}\\n'
+  fi
   exit 0
 fi
 
@@ -123,8 +136,9 @@ if [[ "$1 $2" == "pr merge" ]]; then
     touch "$GH_STUB_DIR/merged"
     exit 0
   fi
+
   case "$GH_STUB_SCENARIO" in
-    admin_retry|merge_refused_twice)
+    admin_retry|merge_refused_twice|late_changes_requested)
       log "merge:plain:refused"
       echo "Pull request is not mergeable: merge state is BLOCKED" >&2
       exit 1
@@ -177,6 +191,7 @@ async function withStubs(scenario, fn) {
       ...process.env,
       GH_STUB_DIR: tmp,
       GH_STUB_LOG: ghLog,
+      GH_STUB_REVIEWS_COUNT: path.join(tmp, "reviews-count"),
       GIT_STUB_LOG: gitLog,
       GH_STUB_SCENARIO: scenario,
       REMNIC_GH_BIN: path.join(binDir, "gh"),
@@ -202,7 +217,6 @@ function run(env, args) {
 test("merges a green PR with --squash and deletes the branch only after MERGED", async () => {
   await withStubs("green", async (env, { ghLog, gitLog }) => {
     const result = run(env, []);
-    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
 
     // Evidence block: head SHA, per-gate conclusions, thread count.
     assert.match(result.stdout, new RegExp(headSha));
@@ -216,7 +230,7 @@ test("merges a green PR with --squash and deletes the branch only after MERGED",
     assert.match(ghLogText, /merge:plain/);
 
     const gitLogText = await readLog(gitLog);
-    assert.match(gitLogText, /git push origin --delete feat\/example/);
+    assert.match(gitLogText, /git push origin --delete feat\/example/, `${result.stderr}\n${result.stdout}`);
   });
 });
 
@@ -356,4 +370,41 @@ test("usage errors exit 2", async () => {
   const result = spawnSync("bash", [scriptPath], { cwd: repoRoot, encoding: "utf8" });
   assert.equal(result.status, 2);
   assert.match(result.stderr, /Usage: scripts\/pr-merge-ready\.sh/);
+});
+test("a superseded failed re-run row does not block a green latest run", async () => {
+  await withStubs("rerun_green", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /ci: success/);
+    assert.match(result.stdout, /verdict:\s+READY/);
+    assert.match(await readLog(ghLog), /merge:plain/);
+    assert.match(await readLog(gitLog), /git push origin --delete feat\/example/);
+  });
+});
+
+test("refuses --admin retry when a live verdict lands on the head after gate verification", async () => {
+  await withStubs("late_changes_requested", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /CHANGES_REQUESTED review\(s\) now target the current head/);
+    const ghLogText = await readLog(ghLog);
+    assert.match(ghLogText, /merge:plain:refused/);
+    assert.doesNotMatch(ghLogText, /merge:admin/);
+    assert.equal(await readLog(gitLog), "");
+  });
+});
+
+test("rejects a fractional --timeout and a non-numeric PR number with usage exit 2", async () => {
+  await withStubs("green", async (env) => {
+    const fractional = run(env, ["--timeout", "1.5"]);
+    assert.equal(fractional.status, 2);
+    assert.match(fractional.stderr, /Invalid --timeout value/);
+
+    const flagFirst = spawnSync("bash", [scriptPath, "--check", "7"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env,
+    });
+    assert.equal(flagFirst.status, 2);
+  });
 });

--- a/tests/pr-merge-ready.test.mjs
+++ b/tests/pr-merge-ready.test.mjs
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "pr-merge-ready.sh");
+const headSha = "deadbeef1234567890abcdef1234567890abcdef";
+const staleSha = "cafebabecafebabecafebabecafebabecafebabe";
+
+async function writeGhStub(binDir) {
+  const ghPath = path.join(binDir, "gh");
+  await writeFile(
+    ghPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+log() { printf '%s\\n' "$*" >> "$GH_STUB_LOG"; }
+
+if [[ "$1 $2" == "pr view" ]]; then
+  json=""
+  prev=""
+  for a in "$@"; do
+    if [[ "$prev" == "--json" ]]; then json="$a"; fi
+    prev="$a"
+  done
+  case "$json" in
+    headRefOid,headRefName,state,mergeStateStatus)
+      printf '${headSha}\\tfeat/example\\tOPEN\\tCLEAN\\n'
+      ;;
+    headRefOid)
+      printf '${headSha}\\n'
+      ;;
+    state)
+      if [[ "$GH_STUB_SCENARIO" == "never_merged" ]]; then
+        printf 'OPEN\\n'
+      elif [[ -f "$GH_STUB_DIR/merged" ]]; then
+        printf 'MERGED\\n'
+      else
+        printf 'OPEN\\n'
+      fi
+      ;;
+    *)
+      echo "unexpected pr view fields: $json" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/${headSha}/check-runs" ]]; then
+  case "$GH_STUB_SCENARIO" in
+    red_check)
+      printf 'ci\\tcompleted\\tsuccess\\t${headSha}\\n'
+      printf 'ai-reviewers\\tcompleted\\tfailure\\t${headSha}\\n'
+      printf 'unresolved-review-threads\\tcompleted\\tsuccess\\t${headSha}\\n'
+      ;;
+    pending_check)
+      printf 'ci\\tin_progress\\t-\\t${headSha}\\n'
+      printf 'ai-reviewers\\tcompleted\\tsuccess\\t${headSha}\\n'
+      ;;
+    *)
+      printf 'ci\\tcompleted\\tsuccess\\t${headSha}\\n'
+      printf 'ai-reviewers\\tcompleted\\tsuccess\\t${headSha}\\n'
+      printf 'unresolved-review-threads\\tcompleted\\tsuccess\\t${headSha}\\n'
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
+  case "$GH_STUB_SCENARIO" in
+    stale_review)
+      printf 'R_STALE\\tcoderabbitai[bot]\\t${staleSha}\\n'
+      ;;
+    current_head_changes)
+      printf 'R_FRESH\\tcoderabbitai[bot]\\t${headSha}\\n'
+      ;;
+    *)
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1 $2" == "api graphql" ]]; then
+  if [[ "$*" == *dismissPullRequestReview* ]]; then
+    id="" message=""
+    for a in "$@"; do
+      case "$a" in
+        id=*) id="\${a#id=}" ;;
+        message=*) message="\${a#message=}" ;;
+      esac
+    done
+    log "dismiss|$id|$message"
+    printf '{}\\n'
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "unresolved_thread" ]]; then
+    printf '3\\t1\\tfalse\\t\\n'
+  else
+    printf '3\\t0\\tfalse\\t\\n'
+  fi
+  exit 0
+fi
+
+if [[ "$1 $2" == "pr merge" ]]; then
+  if [[ "$*" != *"--squash"* ]]; then
+    echo "merge must be --squash" >&2
+    exit 9
+  fi
+  if [[ "$*" != *"--match-head-commit ${headSha}"* ]]; then
+    echo "merge must pin --match-head-commit to the verified head" >&2
+    exit 9
+  fi
+  if [[ "$*" == *--admin* ]]; then
+    if [[ "$GH_STUB_SCENARIO" == "merge_refused_twice" ]]; then
+      log "merge:admin:refused"
+      echo "admin merge refused too" >&2
+      exit 1
+    fi
+    log "merge:admin"
+    touch "$GH_STUB_DIR/merged"
+    exit 0
+  fi
+  case "$GH_STUB_SCENARIO" in
+    admin_retry|merge_refused_twice)
+      log "merge:plain:refused"
+      echo "Pull request is not mergeable: merge state is BLOCKED" >&2
+      exit 1
+      ;;
+    never_merged)
+      log "merge:plain"
+      exit 0
+      ;;
+    *)
+      log "merge:plain"
+      touch "$GH_STUB_DIR/merged"
+      exit 0
+      ;;
+  esac
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 2
+`
+  );
+  await chmod(ghPath, 0o755);
+  const gitPath = path.join(binDir, "git");
+  await writeFile(
+    gitPath,
+    `#!/usr/bin/env bash
+printf 'git %s\\n' "$*" >> "$GIT_STUB_LOG"
+exit 0
+`,
+  );
+  await chmod(gitPath, 0o755);
+}
+
+async function readLog(logPath) {
+  try {
+    return await readFile(logPath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+async function withStubs(scenario, fn) {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "remnic-pr-merge-ready-"));
+  try {
+    const binDir = path.join(tmp, "bin");
+    await mkdir(binDir);
+    await writeGhStub(binDir);
+    const ghLog = path.join(tmp, "gh.log");
+    const gitLog = path.join(tmp, "git.log");
+    const env = {
+      ...process.env,
+      GH_STUB_DIR: tmp,
+      GH_STUB_LOG: ghLog,
+      GIT_STUB_LOG: gitLog,
+      GH_STUB_SCENARIO: scenario,
+      REMNIC_GH_BIN: path.join(binDir, "gh"),
+      REMNIC_GIT_BIN: path.join(binDir, "git"),
+      REMNIC_REPO: "example/repo",
+    };
+    await fn(env, { ghLog, gitLog });
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+function run(env, args) {
+  return spawnSync("bash", [scriptPath, "7", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+    timeout: 60_000,
+  });
+}
+
+
+test("merges a green PR with --squash and deletes the branch only after MERGED", async () => {
+  await withStubs("green", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+
+    // Evidence block: head SHA, per-gate conclusions, thread count.
+    assert.match(result.stdout, new RegExp(headSha));
+    assert.match(result.stdout, /ci: success/);
+    assert.match(result.stdout, /ai-reviewers: success/);
+    assert.match(result.stdout, /unresolved-review-threads: success/);
+    assert.match(result.stdout, /0 unresolved \/ 3 total/);
+    assert.match(result.stdout, /verdict:\s+READY/);
+
+    const ghLogText = await readLog(ghLog);
+    assert.match(ghLogText, /merge:plain/);
+
+    const gitLogText = await readLog(gitLog);
+    assert.match(gitLogText, /git push origin --delete feat\/example/);
+  });
+});
+
+test("dismisses only stale CHANGES_REQUESTED reviews, with a reason string", async () => {
+  await withStubs("stale_review", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+
+    const ghLogText = await readLog(ghLog);
+    assert.match(ghLogText, /^dismiss\|R_STALE\|/m);
+    assert.match(ghLogText, /superseded/);
+    assert.match(ghLogText, /pr-merge-ready\.sh/);
+    // Stale dismissal is step 2; merge still happens and the branch is deleted.
+    assert.match(ghLogText, /merge:plain/);
+    const gitLogText = await readLog(gitLog);
+    assert.match(gitLogText, /git push origin --delete feat\/example/);
+  });
+});
+
+test("retries once with --admin when preconditions held, and logs WHY", async () => {
+  await withStubs("admin_retry", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+
+    const ghLogText = await readLog(ghLog);
+    const plainIndex = ghLogText.indexOf("merge:plain:refused");
+    const adminIndex = ghLogText.indexOf("merge:admin");
+    assert.ok(plainIndex >= 0, "plain merge attempted");
+    assert.ok(adminIndex > plainIndex, "admin retry happens after the plain refusal");
+
+    assert.match(result.stdout, /retrying ONCE with --admin\. WHY:/);
+    assert.match(result.stdout, /mergeStateStatus BLOCKED-after-dismissal/);
+    assert.match(result.stdout, /plain merge refused:.*BLOCKED/);
+
+    const gitLogText = await readLog(gitLog);
+    assert.match(gitLogText, /git push origin --delete feat\/example/);
+  });
+});
+
+test("fails closed when even --admin is refused", async () => {
+  await withStubs("merge_refused_twice", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--admin merge also refused/);
+
+    const gitLogText = await readLog(gitLog);
+    assert.equal(gitLogText, "");
+  });
+});
+
+test("never deletes the branch when the PR does not reach MERGED", async () => {
+  await withStubs("never_merged", async (env, { ghLog, gitLog }) => {
+    const result = run(env, ["--timeout", "1", "--interval", "0"]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /did not reach MERGED within 1s/);
+    assert.match(result.stderr, /NOT deleted/);
+
+    const ghLogText = await readLog(ghLog);
+    assert.match(ghLogText, /merge:plain/);
+    const gitLogText = await readLog(gitLog);
+    assert.equal(gitLogText, "", "branch deletion must be gated on state=MERGED");
+  });
+});
+
+test("blocks on a red head check without dismissing, merging, or deleting", async () => {
+  await withStubs("red_check", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /ai-reviewers: completed\/failure \(RED\)/);
+    assert.match(result.stdout, /verdict:\s+BLOCKED/);
+    assert.match(result.stderr, /gates not satisfied/);
+
+    const ghLogText = await readLog(ghLog);
+    assert.doesNotMatch(ghLogText, /dismiss\|/);
+    assert.doesNotMatch(ghLogText, /merge:/);
+    assert.equal(await readLog(gitLog), "");
+  });
+});
+
+test("blocks on a pending head check", async () => {
+  await withStubs("pending_check", async (env) => {
+    const result = run(env, []);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /ci: in_progress\/- \(RED\)/);
+  });
+});
+
+test("blocks on unresolved review threads", async () => {
+  await withStubs("unresolved_thread", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /1 unresolved \/ 3 total/);
+    assert.match(result.stdout, /verdict:\s+BLOCKED/);
+    assert.doesNotMatch(await readLog(ghLog), /merge:/);
+    assert.equal(await readLog(gitLog), "");
+  });
+});
+
+test("blocks on a current-head CHANGES_REQUESTED and never dismisses it", async () => {
+  await withStubs("current_head_changes", async (env, { ghLog, gitLog }) => {
+    const result = run(env, []);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
+    assert.match(result.stdout, /1 current-head CHANGES_REQUESTED \(blocking\)/);
+
+    const ghLogText = await readLog(ghLog);
+    assert.doesNotMatch(ghLogText, /dismiss\|/);
+    assert.doesNotMatch(ghLogText, /merge:/);
+    assert.equal(await readLog(gitLog), "");
+  });
+});
+
+test("--check prints the plan without acting", async () => {
+  await withStubs("stale_review", async (env, { ghLog, gitLog }) => {
+    const result = run(env, ["--check"]);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
+
+    assert.match(result.stdout, /plan \(--check, no actions taken\)/);
+    assert.match(result.stdout, /dismiss 1 stale CHANGES_REQUESTED review/);
+    assert.match(result.stdout, /R_STALE \(coderabbitai\[bot\], commit cafebab != head deadbee/);
+    assert.match(result.stdout, /gh pr merge 7 --repo example\/repo --squash --match-head-commit/);
+    assert.match(result.stdout, /poll state until MERGED, then git push origin --delete feat\/example/);
+
+    assert.equal(await readLog(ghLog), "", "dry run must not call any mutating gh command");
+    assert.equal(await readLog(gitLog), "");
+  });
+});
+
+test("--check exits nonzero when gates are blocked", async () => {
+  await withStubs("red_check", async (env) => {
+    const result = run(env, ["--check"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /verdict:\s+BLOCKED/);
+  });
+});
+
+test("usage errors exit 2", async () => {
+  const result = spawnSync("bash", [scriptPath], { cwd: repoRoot, encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage: scripts\/pr-merge-ready\.sh/);
+});


### PR DESCRIPTION
## Summary

Adds `scripts/pr-merge-ready.sh <pr-number>` (issue #2440), automating the manual end-of-review dance repeated on three of five sprint-2 PRs:

1. **Verify gates on the head SHA** — every check run on the head completed green (success/neutral/skipped) via `gh api check-runs`, GraphQL unresolved-thread count 0, no `CHANGES_REQUESTED` targeting the current head. Prints an evidence block (head SHA, per-gate conclusion, thread count). Uses the real `gh` binary via the same mise-proof resolver as `pr-wait-settled.sh` (`REMNIC_GH_BIN` override for tests).
2. **Dismiss stale verdicts** — `CHANGES_REQUESTED` reviews whose `commit_id` != head are dismissed via the GraphQL `dismissPullRequestReview` mutation with a reason string. A current-head verdict blocks instead (never bulldozed by `--admin`).
3. **Merge `--squash`** pinned to the verified head (`--match-head-commit`); if refused while every verified precondition held and the head is unchanged, retries once with `--admin` and logs WHY (GitHub leaves `mergeStateStatus` BLOCKED after dismissal even with head checks green).
4. **Delete only after MERGED** — polls state until `MERGED`, only then `git push origin --delete <branch>`; deleting earlier auto-closes the PR (hit on #2434).

`--check` prints the plan (evidence + intended actions) without acting. `--interval`/`--timeout` control the merge poll.

Fixes #2440

## Type of change

- [x] Feature

## Validation

- [x] `bash -n scripts/pr-merge-ready.sh`
- [x] `node scripts/test-file.mjs tests/pr-merge-ready.test.mjs` — 12/12
- [x] `bash scripts/check-review-patterns.sh` — PASSED (pre-existing WARN only)
- [x] Added tests: stubbed `gh`/`git` with fake fixtures covering all four steps, incl. stale dismissal, admin retry, not-yet-merged deletion gate, red/pending checks, unresolved threads, current-head verdict, `--check`, usage errors
- [x] Changeset added

## Changelog

- [x] Changeset added (`.changeset/pr-merge-ready-2440.md`); CHANGELOG.md generated from changesets

## Notes for reviewers

- The `HEAD_SHA` field alignment in `read` uses jq `-` placeholders for empty status/conclusion fields because bash `read` collapses consecutive tab delimiters (found via the pending-check test).
- `AGENTS.md` merge section documents the helper in one paragraph.

## PR workflow

- [x] PR scope is narrow (one devx script + its tests + docs)
- [x] Synced with latest main (branched from 1f25d95b9)
- [x] No review iterations yet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DevX shell script and documentation only; merge/admin behavior is guarded by tests and explicit gate checks, with no runtime product code changes beyond a test assertion and coverage manifest entries.
> 
> **Overview**
> Adds **`scripts/pr-merge-ready.sh`** to run the post-review merge workflow in one command: verify head-SHA check runs (per-name green semantics aligned with `pr-wait-settled.sh`), GraphQL unresolved-thread count, and blocking vs dismissable `CHANGES_REQUESTED` reviews; print an evidence block; dismiss only stale verdicts; squash-merge with `--match-head-commit` and a single logged `--admin` retry when preconditions still hold; poll until `MERGED` before `git push origin --delete` the branch. **`--check`** is dry-run. **`AGENTS.md`**, a changeset, and **`tests/pr-merge-ready.test.mjs`** (stubbed `gh`/`git`) cover the gates and failure modes.
> 
> Also updates an offline manifest test expectation for **`identityResolutionVersion: 2`**, registers **`tombstone-migration-sources.ts`** in the lifecycle matrix manifest, and bumps **`scripts/ratchet-baseline.json`** LOC counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15377af207051e2bedd84bf7081142cf18e97dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end pull request merge utility that validates checks, reviews, threads, and merge status before taking action.
  * Supports a read-only check mode, stale-review dismissal, guarded squash merging, a limited administrator retry, merge confirmation, and remote branch cleanup.
  * Failed validations stop subsequent actions and return an error status.

* **Documentation**
  * Added usage guidance, validation behavior, dry-run details, and merge-blocking conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->