### PR TITLE
feat(devx): enforce review-round budget ledger (warn at 3, cap backlog issue at 4)

### DIFF
--- a/.changeset/review-round-budget-2442.md
+++ b/.changeset/review-round-budget-2442.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Enforce the review-round budget ledger (issue #2442): the per-PR round comment counts fix rounds, posts a one-time warning reply at fix round 3, and at fix round 4 automatically files ONE backlog issue listing every still-open non-critical thread with permalinks, labels the PR `review-round:cap`, and links the issue from the ledger. Never fails a check or blocks merge — zero-unresolved-threads stays the merge gate.

--- a/.github/workflows/review-round-dispatch.yml
+++ b/.github/workflows/review-round-dispatch.yml
@@ -1,11 +1,13 @@
 name: Review Round Dispatch
 
 # Transactional review rounds (issue #1992, umbrella #1988 decision E).
-#
 # Maintains a per-PR round ledger and decides when the next bot review round may
-# be dispatched. v1 is visibility-first (umbrella decision C): the ledger comment
-# is always written, but reviewer dispatch stays a no-op unless
-# REVIEW_ROUND_ENFORCE=true. This workflow NEVER fails a check and NEVER hides an
+# be dispatched. Reviewer dispatch stays a no-op unless
+# REVIEW_ROUND_ENFORCE=true, but the round-BUDGET ledger is enforcing
+# (issue #2442): a one-time warning reply posts at fix round 3, and at fix
+# round 4 ONE backlog issue is filed listing every still-open non-critical
+# thread, the PR is labeled review-round:cap, and the issue is linked from the
+# ledger. This workflow NEVER fails a check and NEVER blocks merge or hides an
 # unresolved thread — the review-thread-guard remains the merge gate on threads.
 #
 # This is a SEPARATE workflow so it never adds concurrency to review-thread-guard
@@ -80,8 +82,10 @@ jobs:
       - name: Evaluate transactional review round
         uses: actions/github-script@v7
         env:
-          # Shadow by default (decision D): enforcement flip is PR3, after
-          # shadow data lands. Set to 'true' only after the sandbox check.
+          # Gates REVIEWER DISPATCH only (shadow by default, decision D: the
+          # dispatch flip is PR3, after shadow data lands). The round-budget
+          # ledger (warn at 3, cap backlog issue at 4, issue #2442) enforces
+          # regardless of this flag — it never fails a check or blocks merge.
           REVIEW_ROUND_ENFORCE: 'false'
           # Detection aliases MUST cover every bot the round dispatches
           # (@coderabbitai + @codex) plus Cursor's check-run, or their responses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ remain. Work with this, not against it:
    audit-then-hold — commit incrementally so a killed worker leaves recoverable
    state on the branch.
 
-### Transactional review rounds (shadow — issue #1992)
+### Transactional review rounds (issues #1992, #2442)
 
 The `Review Round Dispatch` workflow (`review-round-dispatch.yml`) makes the
 "batch fixes, push once per round" rule mechanical instead of prose. It keeps a
@@ -297,13 +297,21 @@ decision core in `scripts/review-rounds.mjs` + `scripts/review-round-gate.mjs`):
   round exceeds its max age (default 24 h, auto-closed and labeled), or when a
   maintainer applies the `review-round:force-dispatch` label.
 - The ledger comment tracks `pushes this round: N` and warns at N>3.
+- The ledger also counts **fix rounds** per PR (the first push landing in an
+  open round is that round's batched fix; later micro-pushes coalesce into it).
 
-This is **shadow-only in v1** (`REVIEW_ROUND_ENFORCE: 'false'`): it never fails a
-check, never blocks merge, and never hides an unresolved thread — the
-`unresolved-review-threads` guard stays the thread merge gate untouched, and its
-missing concurrency group (that `check-unsticker` depends on) is preserved. The
-enforcement flip and the guard's round-scoped pending state are a later step,
-gated on shadow data (umbrella #1988 decision D).
+The **round-budget ledger is enforcing** (issue #2442): at fix round 3 it posts
+a one-time warning reply citing the decline policy above, and at fix round 4 it
+automatically files ONE GitHub issue listing every still-open non-critical
+thread with permalinks (the decline rule's required backlog artifact), labels
+the PR `review-round:cap`, and links the issue from the ledger comment. These
+actions never fail a check, never block merge, and never resolve or hide a
+thread — the `unresolved-review-threads` guard stays the merge gate (a reasoned
+decline satisfies it exactly as much as a fix). Reviewer *dispatch* remains
+shadow (`REVIEW_ROUND_ENFORCE: 'false'`): the dispatch flip and the guard's
+round-scoped pending state are a later step, gated on shadow data (umbrella
+#1988 decision D), and the guard's missing concurrency group (that
+`check-unsticker` depends on) is preserved.
 
 ## Why Stateful PRs Churn (Read Before Touching Lifecycle Logic)
 

--- a/scripts/review-round-gate.mjs
+++ b/scripts/review-round-gate.mjs
@@ -52,7 +52,7 @@ export const CAP_LABEL = "review-round:cap";
 // and perf/capacity/reliability regressions are never declined). Over-matching
 // errs safe: the thread stays on the PR instead of the backlog.
 const CRITICAL_THREAD_PATTERN =
-  /\b(security|vulnerab(?:le|ility)|exploit|injection|remote code execution|data[ -]integrity|correctness|unbounded|memory leak|n\+1)\b/i;
+  /\b(security|vulnerab(?:le|ility)|exploit|injection|remote code execution|data[ -]integrity|correctness|unbounded|memory leak|n\+1|performance|capacity|reliability|regression)\b/i;
 export const DEFAULT_REQUIRED_AI_REVIEWER_GROUPS =
   "cursor-bugbot[bot]|cursor[bot]|cursor-bugbot|cursor|" +
   "coderabbitai[bot]|coderabbitai|chatgpt-codex-connector[bot]|chatgpt-codex-connector";
@@ -529,12 +529,14 @@ function renderCapIssueBody({ prNumber, threads, fixRounds }) {
   );
   lines.push("");
   lines.push(
-    'Per AGENTS.md ("Budget the review loop, then decline"), the still-open ',
-    "non-critical thread(s) below are declined in-thread with a reason and ",
-    "resolved; this issue is the required backlog artifact for those declines. ",
-    "**Critical findings (correctness, security, data integrity) and ",
-    "performance/capacity/reliability regressions are NOT declined** — they ",
-    "stay actionable on the PR and take precedence over the cap.",
+    'Per AGENTS.md ("Budget the review loop, then decline"), each still-open ',
+    "non-critical thread listed below must be declined in-thread with a reason ",
+    "and resolved by a maintainer before merge; this issue is the backlog ",
+    "artifact tracking those declines — the workflow itself never resolves or ",
+    "hides a thread. **Critical findings (correctness, security, data ",
+    "integrity) and performance/capacity/reliability regressions are NOT ",
+    "declinable** — they stay actionable on the PR and take precedence over ",
+    "the cap.",
   );
   lines.push("");
   lines.push(`## Still-open non-critical threads (${threads.length})`);
@@ -580,26 +582,30 @@ async function enforceRoundBudget({ github, core, owner, repo, prNumber, prTitle
 
   if (fixRounds >= FIX_ROUND_CAP && !state.capIssueUrl) {
     const declined = openNonCriticalThreads(threads);
-    if (declined.length === 0) return; // nothing still-open to backlog; re-evaluates next event
-    try {
-      const issue = await github.rest.issues.create({
-        owner,
-        repo,
-        title: `review-round cap reached on PR #${prNumber}: ${prTitle}`,
-        body: renderCapIssueBody({ prNumber, threads: declined, fixRounds }),
-      });
-      const url = issue?.data?.html_url ?? null;
-      if (url) {
-        state.capIssueUrl = url;
-        result.telemetry.capIssueUrl = url;
-        await addLabelSafely(github, owner, repo, prNumber, CAP_LABEL, core);
-        core.notice(`review-round gate PR #${prNumber}: cap backlog issue filed (${url}).`);
+    // Nothing still-open to backlog: skip only the FILING (the cap re-evaluates
+    // next event) — never return early, or a warning stamp written above would
+    // be dropped from the persisted commentBody and re-post every event (cursor).
+    if (declined.length > 0) {
+      try {
+        const issue = await github.rest.issues.create({
+          owner,
+          repo,
+          title: `review-round cap reached on PR #${prNumber}: ${prTitle}`,
+          body: renderCapIssueBody({ prNumber, threads: declined, fixRounds }),
+        });
+        const url = issue?.data?.html_url ?? null;
+        if (url) {
+          state.capIssueUrl = url;
+          result.telemetry.capIssueUrl = url;
+          await addLabelSafely(github, owner, repo, prNumber, CAP_LABEL, core);
+          core.notice(`review-round gate PR #${prNumber}: cap backlog issue filed (${url}).`);
+        }
+      } catch (error) {
+        core.info(
+          `review-round gate PR #${prNumber}: cap backlog issue failed ` +
+            `(${error?.message ?? error}); will retry on the next event.`,
+        );
       }
-    } catch (error) {
-      core.info(
-        `review-round gate PR #${prNumber}: cap backlog issue failed ` +
-          `(${error?.message ?? error}); will retry on the next event.`,
-      );
     }
   }
 

--- a/scripts/review-round-gate.mjs
+++ b/scripts/review-round-gate.mjs
@@ -41,6 +41,18 @@ export const FORCE_DISPATCH_LABEL = "review-round:force-dispatch";
 export const AUTO_CLOSED_LABEL = "review-round:auto-closed";
 /** Micro-push telemetry warns once the round crosses this many pushes (issue #1992 §4). */
 export const PUSH_WARN_THRESHOLD = 3;
+/** Round-budget ledger (issue #2442): a one-time warning reply posts at this many fix rounds. */
+export const FIX_ROUND_WARN_THRESHOLD = 3;
+/** At the cap, ONE backlog issue is filed listing still-open non-critical threads. */
+export const FIX_ROUND_CAP = 4;
+/** Label stamped on the PR when the cap backlog issue is filed (issue #2442). */
+export const CAP_LABEL = "review-round:cap";
+// Threads matching this stay actionable at the cap (AGENTS.md "Budget the
+// review loop, then decline": correctness, security, data-integrity defects
+// and perf/capacity/reliability regressions are never declined). Over-matching
+// errs safe: the thread stays on the PR instead of the backlog.
+const CRITICAL_THREAD_PATTERN =
+  /\b(security|vulnerab(?:le|ility)|exploit|injection|remote code execution|data[ -]integrity|correctness|unbounded|memory leak|n\+1)\b/i;
 export const DEFAULT_REQUIRED_AI_REVIEWER_GROUPS =
   "cursor-bugbot[bot]|cursor[bot]|cursor-bugbot|cursor|" +
   "coderabbitai[bot]|coderabbitai|chatgpt-codex-connector[bot]|chatgpt-codex-connector";
@@ -132,6 +144,8 @@ export function computeRoundGateDecision({
   const telemetry = {
     round: state?.round ?? 0,
     status: state?.status ?? "none",
+    fixRounds: state?.fixRounds ?? 0,
+    capIssueUrl: state?.capIssueUrl ?? null,
     action: decision.action,
     reason: decision.reason,
     pushes,
@@ -169,6 +183,16 @@ function renderRoundSummary({ telemetry, unresolved }) {
       `- ⚠️ ${telemetry.pushes} pushes this round exceeds the batch rule ` +
         "(batch review fixes by subsystem, push once per round). " +
         "Telemetry only in v1 — no failure (issue #1992 §4).",
+    );
+  }
+  lines.push(
+    `- Fix rounds: **${telemetry.fixRounds ?? 0}** (warn ${FIX_ROUND_WARN_THRESHOLD}, cap ${FIX_ROUND_CAP}; issue #2442)`,
+  );
+  if (telemetry.capIssueUrl) {
+    lines.push(`- Cap backlog issue: ${telemetry.capIssueUrl}`);
+  } else if ((telemetry.fixRounds ?? 0) >= FIX_ROUND_WARN_THRESHOLD) {
+    lines.push(
+      `- ⚠️ Fix-round budget at ${telemetry.fixRounds}: from round ${FIX_ROUND_WARN_THRESHOLD} on, only critical/regression/required-check findings are actionable (AGENTS.md); at the cap the decline backlog is filed automatically.`,
     );
   }
   const verb = telemetry.dispatch ? "DISPATCH" : "WAIT";
@@ -228,7 +252,7 @@ async function fetchReviewThreads(github, owner, repo, prNumber) {
               isResolved
               isOutdated
               comments(first: 100) {
-                nodes { path author { login } }
+                nodes { path author { login } url body }
               }
             }
           }
@@ -388,6 +412,23 @@ async function runRoundGateForPr({ github, core, env, owner, repo, prNumber }) {
     );
   }
 
+  // Round-budget enforcement (issue #2442) runs BEFORE the ledger persist so
+  // the one-shot warning/cap stamps land in the same single ledger write; a
+  // failed side effect leaves the stamp unset and retries on the next event.
+  // It is independent of REVIEW_ROUND_ENFORCE (which gates reviewer dispatch
+  // only) and, like dispatch, is non-blocking by contract.
+  if (persist) {
+    await enforceRoundBudget({
+      github,
+      core,
+      owner,
+      repo,
+      prNumber,
+      prTitle: pull.data.title ?? "",
+      result,
+      threads,
+    });
+  }
   // The ledger comment is the visibility mechanism in v1: upsert it (even in
   // shadow mode) unless an enforced dispatch failed above. Writes can fail on
   // fork PRs (read-only token) — that degrades to a log line, never a failed
@@ -441,6 +482,133 @@ async function runRoundGateForPr({ github, core, env, owner, repo, prNumber }) {
   return result;
 }
 
+
+function firstThreadComment(thread) {
+  return thread?.comments?.nodes?.[0] ?? thread?.comments?.[0] ?? null;
+}
+
+function threadPermalink(thread) {
+  const url = firstThreadComment(thread)?.url;
+  return typeof url === "string" && url.length > 0 ? url : null;
+}
+
+function threadIsCritical(thread) {
+  return CRITICAL_THREAD_PATTERN.test(firstThreadComment(thread)?.body ?? "");
+}
+
+/** Still-open, non-critical threads with a permalink — the cap decline backlog. */
+function openNonCriticalThreads(threads) {
+  return (Array.isArray(threads) ? threads : []).filter(
+    (thread) => thread?.isResolved === false && !threadIsCritical(thread) && threadPermalink(thread) !== null,
+  );
+}
+
+function renderBudgetWarning(fixRounds) {
+  return [
+    `⚠️ **Review-round budget: fix round ${fixRounds} of ${FIX_ROUND_CAP}.**`,
+    "",
+    "From round three on, only these review findings are actionable (AGENTS.md, ",
+    '"Budget the review loop, then decline"): a correctness, security, or ',
+    "data-integrity defect; a performance, capacity, or reliability regression; ",
+    "a failing required check; a factually wrong claim; or a mandated rule the ",
+    "PR violates. Everything else is **declined in-thread with the reason and ",
+    "the thread resolved** — a reasoned decline satisfies the ",
+    "zero-unresolved-threads bar exactly as much as a fix.",
+    "",
+    `At fix round ${FIX_ROUND_CAP} the cap fires: every still-open non-critical `,
+    "thread is declined and filed as ONE backlog issue, and the PR is labeled ",
+    `\`${CAP_LABEL}\`. Critical findings and regressions stay actionable at any `,
+    "round. This ledger never fails a check and never blocks merge (issue #2442).",
+  ].join("\n");
+}
+
+function renderCapIssueBody({ prNumber, threads, fixRounds }) {
+  const lines = [];
+  lines.push(
+    `The per-PR review-round budget ledger reached its cap (**${fixRounds} fix rounds**) on PR #${prNumber}.`,
+  );
+  lines.push("");
+  lines.push(
+    'Per AGENTS.md ("Budget the review loop, then decline"), the still-open ',
+    "non-critical thread(s) below are declined in-thread with a reason and ",
+    "resolved; this issue is the required backlog artifact for those declines. ",
+    "**Critical findings (correctness, security, data integrity) and ",
+    "performance/capacity/reliability regressions are NOT declined** — they ",
+    "stay actionable on the PR and take precedence over the cap.",
+  );
+  lines.push("");
+  lines.push(`## Still-open non-critical threads (${threads.length})`);
+  for (const thread of threads) {
+    lines.push(`- ${threadPermalink(thread)} — ${threadLabel(thread)}`);
+  }
+  lines.push("");
+  lines.push(
+    "Filed automatically by the Review Round Dispatch workflow (issue #2442). ",
+    "The ledger never blocks merge; zero-unresolved-threads remains the merge gate.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Round-budget ledger enforcement (issue #2442): one-time warning reply at
+ * FIX_ROUND_WARN_THRESHOLD, ONE cap backlog issue at FIX_ROUND_CAP. Every side
+ * effect is stamped into the ledger state so it never re-fires; every failure
+ * degrades to a log line (the gate never fails a check).
+ */
+async function enforceRoundBudget({ github, core, owner, repo, prNumber, prTitle, result, threads }) {
+  const state = result.state;
+  if (!state) return;
+  const fixRounds = state.fixRounds ?? 0;
+
+  if (fixRounds >= FIX_ROUND_WARN_THRESHOLD && !state.fixRoundWarnedAt) {
+    try {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: prNumber,
+        body: renderBudgetWarning(fixRounds),
+      });
+      state.fixRoundWarnedAt = new Date().toISOString();
+      core.notice(`review-round gate PR #${prNumber}: budget warning posted at fix round ${fixRounds}.`);
+    } catch (error) {
+      core.info(
+        `review-round gate PR #${prNumber}: budget warning comment failed ` +
+          `(${error?.message ?? error}); will retry on the next event.`,
+      );
+    }
+  }
+
+  if (fixRounds >= FIX_ROUND_CAP && !state.capIssueUrl) {
+    const declined = openNonCriticalThreads(threads);
+    if (declined.length === 0) return; // nothing still-open to backlog; re-evaluates next event
+    try {
+      const issue = await github.rest.issues.create({
+        owner,
+        repo,
+        title: `review-round cap reached on PR #${prNumber}: ${prTitle}`,
+        body: renderCapIssueBody({ prNumber, threads: declined, fixRounds }),
+      });
+      const url = issue?.data?.html_url ?? null;
+      if (url) {
+        state.capIssueUrl = url;
+        result.telemetry.capIssueUrl = url;
+        await addLabelSafely(github, owner, repo, prNumber, CAP_LABEL, core);
+        core.notice(`review-round gate PR #${prNumber}: cap backlog issue filed (${url}).`);
+      }
+    } catch (error) {
+      core.info(
+        `review-round gate PR #${prNumber}: cap backlog issue failed ` +
+          `(${error?.message ?? error}); will retry on the next event.`,
+      );
+    }
+  }
+
+  result.commentBody = renderRoundComment({
+    state: result.state,
+    telemetry: result.telemetry,
+    unresolved: result.unresolved,
+  });
+}
 async function dispatchReviewers({ github, owner, repo, prNumber, core }) {
   // Request a fresh bot round against the settled head. Returns true only when
   // the trigger comment is posted, so the caller can withhold the dispatched

--- a/scripts/review-rounds.mjs
+++ b/scripts/review-rounds.mjs
@@ -91,6 +91,11 @@ function openRound({ state, headSha, now, threads, botActivity }) {
     headSha,
     lastHeadChangedAt: now,
     pushes: 0,
+    // Round-budget ledger (issue #2442): cumulative per-PR fix-round count and
+    // one-shot stamps, carried forward across rounds.
+    fixRounds: state?.fixRounds ?? 0,
+    fixRoundWarnedAt: state?.fixRoundWarnedAt ?? null,
+    capIssueUrl: state?.capIssueUrl ?? null,
     threadIds: eligibleThreadIds(threads),
     dispatchIssuedAt: null,
     closeReason: null,
@@ -210,6 +215,13 @@ export function decideRound({
       state: closeForDispatch(next, now, "force-label"),
     };
   }
+  // Round-budget ledger (issue #2442): one fix round per open round — the
+  // FIRST push after the round's bot findings is that round's batched fix;
+  // later micro-pushes coalesce into the same fix round. Post-dispatch pushes
+  // (closed branch above) never count.
+  if (state.pushes === 0 && next.pushes === 1) {
+    next.fixRounds = (next.fixRounds ?? 0) + 1;
+  }
 
   // Nothing to act on yet (round opened with no threads and no pushes): a clean
   // bot review has nothing to auto-close or debounce-dispatch, so wait rather
@@ -279,6 +291,20 @@ function isValidRoundState(state) {
   if (!state || state.version !== 1 || !["open", "closed"].includes(state.status)) return false;
   if (!Number.isInteger(state.round) || state.round < 1) return false;
   if (!Number.isInteger(state.pushes) || state.pushes < 0) return false;
+  // Round-budget fields (issue #2442) are optional so pre-budget ledgers
+  // deployed during shadow v1 still parse (missing counts read as 0).
+  if (state.fixRounds !== undefined && (!Number.isInteger(state.fixRounds) || state.fixRounds < 0)) {
+    return false;
+  }
+  if (
+    state.fixRoundWarnedAt !== undefined && state.fixRoundWarnedAt !== null &&
+    (typeof state.fixRoundWarnedAt !== "string" || parseTime(state.fixRoundWarnedAt) === 0)
+  ) {
+    return false;
+  }
+  if (state.capIssueUrl !== undefined && state.capIssueUrl !== null && typeof state.capIssueUrl !== "string") {
+    return false;
+  }
   if (!Array.isArray(state.threadIds) || state.threadIds.some((id) => typeof id !== "string" || id.length === 0)) return false;
   if (new Set(state.threadIds).size !== state.threadIds.length) return false;
   if (typeof state.openedAt !== "string" || parseTime(state.openedAt) === 0) return false;

--- a/tests/review-round-gate.test.mjs
+++ b/tests/review-round-gate.test.mjs
@@ -572,7 +572,7 @@ test("shadow persists a dry-run dispatch as an OPEN round; enforce persists it c
 // ONE cap backlog issue at fix round 4 — never blocking, never re-firing.
 // ===========================================================================
 
-function budgetThread(id, { critical = false, resolved = false } = {}) {
+function budgetThread(id, { critical = false, resolved = false, body } = {}) {
   return {
     id,
     isResolved: resolved,
@@ -582,7 +582,7 @@ function budgetThread(id, { critical = false, resolved = false } = {}) {
           author: { login: "cursor" },
           path: `src/file-${id}.ts`,
           url: `https://github.com/o/r/pull/7/files#discussion_r_${id}`,
-          body: critical ? "Security: this leaks a bearer token." : "Consider a more descriptive name here.",
+          body: body ?? (critical ? "Security: this leaks a bearer token." : "Consider a more descriptive name here."),
         },
       ],
     },
@@ -646,6 +646,7 @@ test("at the cap the ledger files ONE backlog issue of still-open non-critical t
   const threads = [
     budgetThread("t1"),
     budgetThread("t2", { critical: true }),
+    budgetThread("t5", { critical: true, body: "Performance regression: latency doubles under load." }),
     budgetThread("t3", { resolved: true }),
     budgetThread("t4"),
   ];
@@ -660,7 +661,7 @@ test("at the cap the ledger files ONE backlog issue of still-open non-critical t
   assert.match(issue.title, /review-round cap reached on PR #7/);
   assert.match(issue.body, /discussion_r_t1\b/);
   assert.match(issue.body, /discussion_r_t4\b/);
-  assert.doesNotMatch(issue.body, /discussion_r_t2/, "critical threads stay on the PR, not the backlog");
+  assert.doesNotMatch(issue.body, /discussion_r_t5/, "perf-regression threads stay actionable, not backlogged");
   assert.doesNotMatch(issue.body, /discussion_r_t3/, "resolved threads are not listed");
   assert.ok(
     first.calls.labelsAdded.some((added) => added.labels.includes(CAP_LABEL)),
@@ -684,7 +685,17 @@ test("a cap with no still-open non-critical threads files nothing", async () => 
   const { github, calls } = fakeGithub({ existingComments: [{ id: 7, body: seed }], threads });
   await runRoundGate({ github, context, core, env: {} });
   assert.equal(calls.issuesCreated.length, 0, "an empty decline backlog is not filed as an issue");
-  assert.equal(parseRoundLedger(calls.updated[0].body).capIssueUrl, null);
+  // Regression (cursor, round 1): the empty-backlog path must still persist the
+  // warn stamp written in the same run, or the one-shot warning re-posts forever.
+  const persisted = parseRoundLedger(calls.updated[0].body);
+  assert.equal(persisted.capIssueUrl, null);
+  assert.ok(persisted.fixRoundWarnedAt, "the warn stamp survives the empty-backlog skip");
+  const second = fakeGithub({ existingComments: [{ id: 7, body: calls.updated[0].body }], threads });
+  await runRoundGate({ github: second.github, context, core, env: {} });
+  assert.ok(
+    !second.calls.created.some((comment) => /fix round 4 of 4/.test(comment.body)),
+    "the warning does not re-post after the empty-backlog run",
+  );
 });
 
 test("cap filing failures degrade to a log line and never fail the check", async () => {

--- a/tests/review-round-gate.test.mjs
+++ b/tests/review-round-gate.test.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import { ROUND_COMMENT_MARKER, parseRoundLedger, renderRoundLedger } from "../scripts/review-rounds.mjs";
 import {
   AUTO_CLOSED_LABEL,
+  CAP_LABEL,
+  FIX_ROUND_CAP,
   DEFAULT_REQUIRED_AI_REVIEWER_GROUPS,
   FORCE_DISPATCH_LABEL,
   PUSH_WARN_THRESHOLD,
@@ -246,9 +248,9 @@ for (const name of ["pr-1852.json", "pr-1923.json"]) {
 
 function fakeGithub({
   existingComments = [], threads = [], labels = [], draft = false,
-  failDispatch = false, failLedgerWrite = false,
+  failDispatch = false, failLedgerWrite = false, failCapIssue = false,
 } = {}) {
-  const calls = { created: [], updated: [], graphql: 0, labelsAdded: [], labelsRemoved: [] };
+  const calls = { created: [], updated: [], graphql: 0, labelsAdded: [], labelsRemoved: [], issuesCreated: [] };
   const listComments = () => {};
   const listReviews = () => {};
   const listReviewComments = () => {};
@@ -293,6 +295,14 @@ function fakeGithub({
         },
         addLabels: async (args) => calls.labelsAdded.push(args),
         removeLabel: async (args) => calls.labelsRemoved.push(args),
+        // issues.create files the round-4 cap backlog issue (issue #2442);
+        // failCapIssue simulates a transient failure so tests can assert the
+        // gate degrades to a log line and retries on the next event.
+        create: async (args) => {
+          if (failCapIssue) throw new Error("simulated cap issue failure");
+          calls.issuesCreated.push(args);
+          return { data: { html_url: "https://github.com/o/r/issues/555" } };
+        },
       },
       repos: {
         getCommit: async () => ({ data: { commit: { committer: { date: "2026-07-18T11:59:00.000Z" } } } }),
@@ -555,4 +565,141 @@ test("shadow persists a dry-run dispatch as an OPEN round; enforce persists it c
   assert.equal(enforced.state.status, "closed", "enforcement records the real dispatch");
   assert.equal(typeof enforced.state.dispatchIssuedAt, "string");
   assert.equal(parseRoundLedger(enforced.commentBody).status, "closed");
+});
+
+// ===========================================================================
+// Round-budget ledger enforcement (issue #2442): warn at fix round 3, file the
+// ONE cap backlog issue at fix round 4 — never blocking, never re-firing.
+// ===========================================================================
+
+function budgetThread(id, { critical = false, resolved = false } = {}) {
+  return {
+    id,
+    isResolved: resolved,
+    comments: {
+      nodes: [
+        {
+          author: { login: "cursor" },
+          path: `src/file-${id}.ts`,
+          url: `https://github.com/o/r/pull/7/files#discussion_r_${id}`,
+          body: critical ? "Security: this leaks a bearer token." : "Consider a more descriptive name here.",
+        },
+      ],
+    },
+  };
+}
+
+const budgetThreads = (count) => Array.from({ length: count }, (_, index) => budgetThread(`t${index + 1}`));
+
+function openBudgetState({ round, fixRounds, fixRoundWarnedAt = null, capIssueUrl = null }) {
+  return {
+    version: 1,
+    status: "open",
+    round,
+    openedAt: "2026-07-18T11:00:00.000Z",
+    openedHeadSha: "head-1",
+    headSha: "head-1",
+    lastHeadChangedAt: "2026-07-18T11:00:00.000Z",
+    pushes: 0,
+    fixRounds,
+    fixRoundWarnedAt,
+    capIssueUrl,
+    threadIds: ["thread-1", "thread-2"],
+    dispatchIssuedAt: null,
+    closeReason: null,
+    autoClosed: false,
+    lastBotActivity: { id: "review-1", at: "2026-07-18T12:00:00.000Z" },
+  };
+}
+
+test("budget telemetry and summary surface the fix-round count", () => {
+  const seeded = renderRoundLedger(openBudgetState({ round: 3, fixRounds: 3 }));
+  const result = decide({ ledgerBody: seeded });
+  assert.equal(result.telemetry.fixRounds, 3);
+  assert.match(result.commentBody, /Fix rounds: \*\*3\*\*/);
+  assert.match(result.commentBody, /Fix-round budget at 3/);
+});
+
+test("the budget ledger posts a one-time warning reply at fix round 3", async () => {
+  const seed = renderRoundLedger(openBudgetState({ round: 3, fixRounds: 3 }));
+  const first = fakeGithub({ existingComments: [{ id: 7, body: seed }], threads: budgetThreads(2) });
+  await runRoundGate({ github: first.github, context, core, env: {} });
+  const warning = first.calls.created.find((comment) => /fix round 3 of 4/.test(comment.body));
+  assert.ok(warning, "warning reply posted on the PR");
+  assert.match(warning.body, /declined in-thread/);
+  const persisted = parseRoundLedger(first.calls.updated[0].body);
+  assert.ok(persisted.fixRoundWarnedAt, "warn stamp persisted in the ledger");
+  assert.equal(persisted.capIssueUrl, null, "no cap issue at round 3");
+
+  const second = fakeGithub({
+    existingComments: [{ id: 7, body: first.calls.updated[0].body }],
+    threads: budgetThreads(2),
+  });
+  await runRoundGate({ github: second.github, context, core, env: {} });
+  assert.ok(
+    !second.calls.created.some((comment) => /fix round 3 of 4/.test(comment.body)),
+    "the warning is one-shot across events",
+  );
+});
+
+test("at the cap the ledger files ONE backlog issue of still-open non-critical threads", async () => {
+  const threads = [
+    budgetThread("t1"),
+    budgetThread("t2", { critical: true }),
+    budgetThread("t3", { resolved: true }),
+    budgetThread("t4"),
+  ];
+  const seed = renderRoundLedger(
+    openBudgetState({ round: 4, fixRounds: 4, fixRoundWarnedAt: "2026-07-18T12:10:00.000Z" }),
+  );
+  const first = fakeGithub({ existingComments: [{ id: 7, body: seed }], threads });
+  await runRoundGate({ github: first.github, context, core, env: {} });
+
+  assert.equal(first.calls.issuesCreated.length, 1, "exactly one backlog issue is filed");
+  const issue = first.calls.issuesCreated[0];
+  assert.match(issue.title, /review-round cap reached on PR #7/);
+  assert.match(issue.body, /discussion_r_t1\b/);
+  assert.match(issue.body, /discussion_r_t4\b/);
+  assert.doesNotMatch(issue.body, /discussion_r_t2/, "critical threads stay on the PR, not the backlog");
+  assert.doesNotMatch(issue.body, /discussion_r_t3/, "resolved threads are not listed");
+  assert.ok(
+    first.calls.labelsAdded.some((added) => added.labels.includes(CAP_LABEL)),
+    "the PR is labeled review-round:cap",
+  );
+  const persisted = parseRoundLedger(first.calls.updated[0].body);
+  assert.equal(persisted.capIssueUrl, "https://github.com/o/r/issues/555", "issue link persisted in the ledger");
+  assert.match(first.calls.updated[0].body, /Cap backlog issue: https:\/\/github\.com\/o\/r\/issues\/555/);
+
+  const second = fakeGithub({
+    existingComments: [{ id: 7, body: first.calls.updated[0].body }],
+    threads,
+  });
+  await runRoundGate({ github: second.github, context, core, env: {} });
+  assert.equal(second.calls.issuesCreated.length, 0, "the cap issue is one-shot across events");
+});
+
+test("a cap with no still-open non-critical threads files nothing", async () => {
+  const threads = [budgetThread("t1", { critical: true }), budgetThread("t2", { resolved: true })];
+  const seed = renderRoundLedger(openBudgetState({ round: 4, fixRounds: 4 }));
+  const { github, calls } = fakeGithub({ existingComments: [{ id: 7, body: seed }], threads });
+  await runRoundGate({ github, context, core, env: {} });
+  assert.equal(calls.issuesCreated.length, 0, "an empty decline backlog is not filed as an issue");
+  assert.equal(parseRoundLedger(calls.updated[0].body).capIssueUrl, null);
+});
+
+test("cap filing failures degrade to a log line and never fail the check", async () => {
+  let failed = false;
+  const spyCore = { notice() {}, info() {}, warning() {}, setFailed() { failed = true; } };
+  const seed = renderRoundLedger(openBudgetState({ round: 4, fixRounds: 4 }));
+  const { github, calls } = fakeGithub({
+    existingComments: [{ id: 7, body: seed }],
+    threads: budgetThreads(1),
+    failCapIssue: true,
+  });
+  const result = await runRoundGate({ github, context, core: spyCore, env: {} });
+  assert.ok(result, "the gate completes");
+  assert.equal(failed, false, "a cap failure never fails the check");
+  const persisted = parseRoundLedger(calls.updated[0].body);
+  assert.equal(persisted.capIssueUrl, null, "no stamp without a filed issue (retries next event)");
+  assert.ok(persisted.fixRoundWarnedAt, "the round-3 warning still fired on the way to the cap");
 });

--- a/tests/review-rounds.test.mjs
+++ b/tests/review-rounds.test.mjs
@@ -105,6 +105,68 @@ test("a push during an open round increments telemetry but cannot dispatch", () 
   assert.equal(result.state.lastHeadChangedAt, "2026-07-18T12:01:00.000Z");
 });
 
+test("the first push in an open round counts one fix round; micro-pushes coalesce", () => {
+  const state = openRound();
+  const pushed = decideRound({ ...base, state, headSha: "head-2", botActivity: null }).state;
+  assert.equal(pushed.pushes, 1);
+  assert.equal(pushed.fixRounds, 1);
+  const again = decideRound({ ...base, state: pushed, headSha: "head-3", botActivity: null }).state;
+  assert.equal(again.pushes, 2);
+  assert.equal(again.fixRounds, 1, "a second push in the same round is not a new fix round");
+});
+
+test("fix rounds accumulate across bot rounds, not across post-dispatch pushes", () => {
+  const later = "2026-07-18T12:20:00.000Z";
+  const later2 = "2026-07-18T12:25:00.000Z";
+  const resolved = base.threads.map((thread) => ({ ...thread, isResolved: true }));
+  const fixed = decideRound({ ...base, state: openRound(), headSha: "head-2", botActivity: null }).state;
+  assert.equal(fixed.fixRounds, 1);
+
+  const dispatched = decideRound({
+    ...base,
+    state: fixed,
+    headSha: "head-2",
+    now: later,
+    threads: resolved,
+    botActivity: null,
+  });
+  assert.equal(dispatched.action, "dispatch");
+
+  const midPush = decideRound({ ...base, state: dispatched.state, headSha: "head-3", botActivity: null });
+  assert.equal(midPush.action, "wait");
+  assert.equal(midPush.state.fixRounds, 1, "a push after dispatch, before the next bot round, is not a fix round");
+
+  const reopened = decideRound({
+    ...base,
+    state: midPush.state,
+    headSha: "head-3",
+    now: later2,
+    botActivity: { id: "review-2", at: later2 },
+  });
+  assert.equal(reopened.action, "open");
+  assert.equal(reopened.state.round, 2);
+  assert.equal(reopened.state.fixRounds, 1, "the cumulative fix-round count carries into the next round");
+
+  const fix2 = decideRound({ ...base, state: reopened.state, headSha: "head-4", botActivity: null }).state;
+  assert.equal(fix2.pushes, 1);
+  assert.equal(fix2.fixRounds, 2);
+});
+
+test("the ledger round-trips the budget fields", () => {
+  const state = openRound();
+  state.fixRounds = 3;
+  state.fixRoundWarnedAt = "2026-07-18T12:10:00.000Z";
+  state.capIssueUrl = "https://github.com/o/r/issues/555";
+  assert.deepEqual(parseRoundLedger(renderRoundLedger(state)), state);
+});
+
+test("a legacy ledger without budget fields still parses", () => {
+  const { fixRounds: _f, fixRoundWarnedAt: _w, capIssueUrl: _c, ...legacy } = openRound();
+  const parsed = parseRoundLedger(renderRoundLedger(legacy));
+  assert.ok(parsed, "pre-budget shadow ledgers must keep parsing (count reads as 0)");
+  assert.equal(parsed.fixRounds, undefined);
+});
+
 test("resolving every round thread dispatches only after the head debounce", () => {
   const state = openRound();
   const addressed = base.threads.map((thread) => ({ ...thread, isResolved: true }));


### PR DESCRIPTION
Fixes #2442

## What

Promotes the per-PR review-round ledger (`remnic-review-round:v1`, from #1992) from shadow telemetry to budget enforcement, within its existing design:

- **Fix-round counting**: the ledger state gains a cumulative per-PR `fixRounds` — one per open round that receives its batched fix push (the first push after the round's bot findings); micro-pushes coalesce; post-dispatch pushes don't count. Legacy shadow ledgers without the field still parse (count reads as 0).
- **Warn at 3**: a one-time warning reply posts on the PR citing the AGENTS.md decline policy (`fixRoundWarnedAt` stamp makes it one-shot across events).
- **Cap at 4**: ONE backlog issue is filed (gh-token `issues.create`) titled per-PR, listing every still-open non-critical thread with permalinks (critical = correctness/security/data-integrity heuristic; those stay actionable on the PR), the PR is labeled `review-round:cap`, and the issue link is persisted in the ledger (`capIssueUrl` stamp → exactly one issue, ever). No still-open non-critical threads → nothing filed.
- **Guarantees unchanged**: independent of `REVIEW_ROUND_ENFORCE` (which still gates reviewer *dispatch* only, still `'false'`); every budget side effect is try/catch-degraded to a log line; never fails a check, never blocks merge, never resolves or hides a thread — zero-unresolved-threads stays the merge gate.

## Where

- `scripts/review-rounds.mjs` — state fields + reducer increment + validator (backward-compatible).
- `scripts/review-round-gate.mjs` — constants, telemetry/summary lines, `enforceRoundBudget` (runs before the single ledger persist so stamps land atomically), GraphQL thread query now fetches comment `url`/`body` for permalinks + criticality.
- `.github/workflows/review-round-dispatch.yml` — comment updates only (no behavior/permission changes; `issues:write` already present).
- `AGENTS.md` — section updated from "shadow-only in v1" to describe budget enforcement while preserving the no-block guarantees.
- Changeset: `.changeset/review-round-budget-2442.md`.

## Tests

76/76 across the three review-round suites (67 pre-existing, 9 new):

- reducer: first-push-counts-once / micro-push coalescing / accumulation across bot rounds / post-dispatch push exclusion / ledger round-trip / legacy-ledger parse.
- driver (stubbed GitHub client, existing `fakeGithub` style): one-time warning at 3, ONE cap issue at 4 with permalink list excluding critical+resolved threads, `review-round:cap` label, ledger link + idempotency across runs, empty-backlog no-op, and cap-failure degradation (no `setFailed`, retry next event).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated GitHub issue creation and PR labeling from Actions with heuristic “critical” classification; mistakes could mis-route threads to backlog, but merge gates and thread resolution are unchanged and errors are non-blocking.
> 
> **Overview**
> **Enforces the per-PR review-round budget** (issue #2442) on top of the existing transactional ledger: cumulative **fix rounds** (first batched push per open bot round; micro-pushes coalesce; post-dispatch pushes do not count), carried in ledger state with backward-compatible parsing.
> 
> At **fix round 3**, `enforceRoundBudget` posts a **one-time** PR comment citing the AGENTS.md decline policy (`fixRoundWarnedAt` stamp). At **fix round 4**, it files **one** backlog GitHub issue listing still-open **non-critical** threads (heuristic on comment body; security/perf/regression-style threads stay off the list), applies `review-round:cap`, and persists `capIssueUrl`. Side effects run **before** the single ledger write so stamps stay atomic; failures log and retry without failing checks or blocking merge. Reviewer dispatch remains gated by `REVIEW_ROUND_ENFORCE` (still shadow).
> 
> The GraphQL thread fetch now includes comment `url` and `body` for permalinks and criticality. Docs/workflow comments and tests cover counting, idempotency, empty backlog, and cap failure degradation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04d799cd3cc08d58cca351136593df7e3e8adf50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->