### PR TITLE
devx: ReDoS-shape regex precheck in preflight:quick + CI

### DIFF
--- a/.changeset/regex-safety-precheck-2439.md
+++ b/.changeset/regex-safety-precheck-2439.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `npm run check:regex-safety` (wired into `preflight:quick`): flags changed `.ts`/`.mts` lines whose regex literals match the ReDoS shapes CodeQL repeatedly flagged — `[\s\S]*?`/lazy `.*?`, unbounded `[^>]*` with an alternation, `\s*` chains adjacent to captures, and nested quantifiers like `(a+)+` (issue #2439).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,14 @@ jobs:
 
       - name: Docs-code parity
         run: node scripts/check-docs-parity.mjs
+      # ReDoS-shape pre-check (issue #2439): scans changed .ts/.mts lines for
+      # the regex shapes CodeQL redos flagged across PR rounds. Relies on the
+      # base-ref fetch performed by the ratchet scoping step above; on non-PR
+      # events (shallow checkout, no base) the script self-skips.
+      - name: Regex safety pre-check (issue #2439)
+        run: node scripts/check-regex-safety.mjs
+        env:
+          REMNIC_REGEX_SAFETY_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || 'origin/main' }}
 
   # The root/misc suite runs on a hosted runner. Package tests use two
   # deterministic file shards on the self-hosted pool when it is safe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ These rules are the default workflow for all agents and contributors.
    - If you touch `orchestrator.ts`, `storage.ts`, `intent.ts`, `memory-cache.ts`,
      `entity-retrieval.ts`, `config.ts`, or any file under `storage/` or `orchestration/`
      in `src/` or `packages/remnic-core/src/`, also run `npm run test:entity-hardening`.
+   - `npm run check:regex-safety` (also part of `preflight:quick`) flags new regex literals on changed `.ts`/`.mts` lines that match the ReDoS shapes CodeQL repeatedly flagged — `[\s\S]*?`/lazy `.*?`, unbounded `[^>]*` with an alternative branch, `\s*` chains around captures, nested quantifiers like `(a+)+`. Prefer bounded quantifiers or `indexOf`/loop scans (issue #2439).
    - If Cursor CLI is available, run `npm run review:cursor` before requesting external AI review.
 
 5. Treat external AI review as stale unless it matches the current head.

--- a/package.json
+++ b/package.json
@@ -991,6 +991,7 @@
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
     "check:ratchets": "node scripts/check-ratchets.mjs",
     "check:docs-parity": "node scripts/check-docs-parity.mjs",
+    "check:regex-safety": "node scripts/check-regex-safety.mjs",
     "release:bump-changed-packages": "node scripts/bump-changed-packages.mjs",
     "build": "node scripts/pnpm.mjs --filter @remnic/core build && node scripts/pnpm.mjs --filter @remnic/plugin-openclaw build && node scripts/pnpm.mjs run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "node scripts/pnpm.mjs --filter @remnic/plugin-openclaw build && node scripts/pnpm.mjs --parallel --filter remnic-workspace --filter @remnic/plugin-openclaw run dev:watch",

--- a/scripts/check-regex-safety.mjs
+++ b/scripts/check-regex-safety.mjs
@@ -56,9 +56,10 @@ export const REDOS_SHAPES = Object.freeze([
   {
     id: "lazy-any",
     codeql: "js/polynomial-redos",
-    // [\s\S]* / [\s\S]+ (greedy or lazy) or a lazy .*/.+ — an unbounded
+    // [\s\S]* / [\S\s]+ / [\w\W]*? / [\d\D]+ … any complementary pair in
+    // either order (greedy or lazy), or a lazy .*/.+ — an unbounded
     // quantifier over a class that matches everything.
-    detector: /\[\\s\\S\][*+]\??|\.[*+]\?/,
+    detector: /\[(?:\\s\\S|\\S\\s|\\w\\W|\\W\\w|\\d\\D|\\D\\d)\][*+]\??|\.[*+]\?/,
     fix: "bound the quantifier (e.g. {0,256}) or replace with an indexOf/loop scan",
   },
   {
@@ -180,13 +181,16 @@ const PRE_REGEX_CHARS = new Set([
 // bait (CodeQL flagged exactly that on this file's first PR run).
 
 /**
- * Track string spans and a line-comment start on one source line so
- * candidates inside strings or after `//` are skipped. Best-effort:
- * regex literals containing quote characters can confuse the tracker,
- * which at worst suppresses a later candidate on the same line.
+ * Track string spans, same-line block-comment spans, and a trailing
+ * comment start on one source line so candidates inside strings or
+ * comments are skipped. A `/* ... *​/` pair that closes on the same
+ * line only masks its own span — code after `*​/` is still scanned.
+ * Best-effort: regex literals containing quote characters can confuse
+ * the tracker, which at worst suppresses a later candidate.
  */
 function lineRegions(line) {
   const strings = [];
+  const comments = [];
   let commentStart = -1;
   let quote = null;
   let spanStart = 0;
@@ -205,27 +209,38 @@ function lineRegions(line) {
       spanStart = i;
       continue;
     }
-    if (c === "/" && (line[i + 1] === "/" || line[i + 1] === "*")) {
+    if (c === "/" && line[i + 1] === "/") {
       commentStart = i;
       break;
     }
+    if (c === "/" && line[i + 1] === "*") {
+      const close = line.indexOf("*/", i + 2);
+      if (close === -1) {
+        commentStart = i;
+        break;
+      }
+      comments.push([i, close + 1]);
+      i = close + 1;
+      continue;
+    }
   }
   if (quote) strings.push([spanStart, line.length]);
-  return { strings, commentStart };
+  return { strings, comments, commentStart };
 }
 export function extractRegexLiterals(line) {
   // JSDoc/block-comment continuation lines start with `*` — code-looking
   // regexes there are prose, not literals. (A `/*` opener on this line is
   // handled by commentStart below.)
   if (/^\s*\*/.test(line)) return [];
-  const { strings, commentStart } = lineRegions(line);
+  const { strings, comments, commentStart } = lineRegions(line);
   const inString = (pos) => strings.some(([s, e]) => pos >= s && pos <= e);
+  const inComment = (pos) => comments.some(([s, e]) => pos >= s && pos <= e);
   const isFlag = (c) => c >= "a" && c <= "z";
   const out = [];
   for (let open = 0; open < line.length; open += 1) {
     if (line[open] !== "/") continue;
     if (commentStart >= 0 && open > commentStart) break;
-    if (inString(open)) continue;
+    if (inString(open) || inComment(open)) continue;
     const prev = open === 0 ? "" : line[open - 1];
     if (!PRE_REGEX_CHARS.has(prev)) continue;
     const after = line[open + 1];

--- a/scripts/check-regex-safety.mjs
+++ b/scripts/check-regex-safety.mjs
@@ -82,17 +82,37 @@ export const REDOS_SHAPES = Object.freeze([
     id: "nested-quantifier",
     codeql: "js/redos",
     // A quantified token inside a group that is itself quantified —
-    // (a+)+, (a*)+, (\d{2,})+ exponential backtracking.
-    detector: /\((?:\\.|[^()\\])+[*+}]\)[*+]/,
+    // (a+)+, (a*)+, (\d{2,})+ exponential backtracking. Detected with a
+    // string scan (not a regex): a regex detector for this shape is
+    // itself the nested-quantifier shape CodeQL flags.
+    detector: null,
     fix: "remove one quantifier level or rewrite the matching as a loop",
   },
 ]);
+
+/**
+ * One nesting level only: a `)` carrying `*`/`+` whose group body
+ * (no nested groups) ends with a quantifier (`*`, `+`, or `}`).
+ */
+function hasNestedQuantifier(src) {
+  for (let i = 0; i + 1 < src.length; i += 1) {
+    if (src[i] !== ")" || (src[i + 1] !== "*" && src[i + 1] !== "+")) continue;
+    const open = src.lastIndexOf("(", i);
+    if (open === -1) continue;
+    if (src.indexOf(")", open + 1) !== i) continue; // inner group — skip this level
+    const body = src.slice(open + 1, i);
+    const last = body[body.length - 1];
+    if (last === "*" || last === "+" || last === "}") return true;
+  }
+  return false;
+}
 
 function shapeMatches(shape, src) {
   if (shape.id === "ws-capture-chain") {
     const wsCount = (src.match(/\\s[*+]/g) ?? []).length;
     return wsCount >= 2 && (src.includes("(") || /\[[^\]]+\][*+]/.test(src));
   }
+  if (shape.id === "nested-quantifier") return hasNestedQuantifier(src);
   if (!shape.detector.test(src)) return false;
   if (shape.requiresAlternation && !src.includes("|")) return false;
   return true;
@@ -106,8 +126,10 @@ const PRE_REGEX_CHARS = new Set([
   ";", ">", "<", "+", "-", "*", "%", "~", "^", "\n",
 ]);
 
-const REGEX_LITERAL_RE =
-  /\/(?![/*])(?:\\.|\[(?:\\.|[^\]\\\n])*\]|[^/\\\n])+\/[a-z]*/g;
+// No regex-in-regex here: the scanner's own extraction runs as a linear
+// character scan (escapes and character classes respected), because a
+// nested-quantifier extraction pattern is itself js/polynomial-redos
+// bait (CodeQL flagged exactly that on this file's first PR run).
 
 /**
  * Track string spans and a line-comment start on one source line so
@@ -143,23 +165,42 @@ function lineRegions(line) {
   if (quote) strings.push([spanStart, line.length]);
   return { strings, commentStart };
 }
-
-/** Extract regex-literal candidates ({ literal, src, index }) from one line. */
 export function extractRegexLiterals(line) {
   const { strings, commentStart } = lineRegions(line);
   const inString = (pos) => strings.some(([s, e]) => pos >= s && pos <= e);
+  const isFlag = (c) => c >= "a" && c <= "z";
   const out = [];
-  REGEX_LITERAL_RE.lastIndex = 0;
-  for (const match of line.matchAll(REGEX_LITERAL_RE)) {
-    const open = match.index;
-    if (commentStart >= 0 && open > commentStart) continue;
+  for (let open = 0; open < line.length; open += 1) {
+    if (line[open] !== "/") continue;
+    if (commentStart >= 0 && open > commentStart) break;
     if (inString(open)) continue;
     const prev = open === 0 ? "" : line[open - 1];
     if (!PRE_REGEX_CHARS.has(prev)) continue;
-    const text = match[0];
-    const src = text.slice(1, text.lastIndexOf("/"));
-    if (src.length === 0) continue;
-    out.push({ literal: text, src, index: open });
+    const after = line[open + 1];
+    if (after === undefined || after === "/" || after === "*") continue;
+    // Walk to the closing slash, honoring escapes and [...] classes.
+    let i = open + 1;
+    let inClass = false;
+    let closed = -1;
+    while (i < line.length) {
+      const c = line[i];
+      if (c === "\\") i += 2;
+      else if (inClass) {
+        if (c === "]") inClass = false;
+        i += 1;
+      } else if (c === "[") {
+        inClass = true;
+        i += 1;
+      } else if (c === "/") {
+        closed = i;
+        break;
+      } else i += 1;
+    }
+    if (closed === -1 || closed === open + 1) continue;
+    let end = closed + 1;
+    while (end < line.length && isFlag(line[end])) end += 1;
+    out.push({ literal: line.slice(open, end), src: line.slice(open + 1, closed), index: open });
+    open = end - 1; // the for-loop increment moves past the literal
   }
   return out;
 }

--- a/scripts/check-regex-safety.mjs
+++ b/scripts/check-regex-safety.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * ReDoS-shape pre-check for changed regex literals (issue #2439).
+ *
+ * CodeQL flagged the same wrapper-strip regex three times in a row on
+ * PR #2438 — each fix traded one polynomial shape for another
+ * ([^>]* → bounded attr → bounded content → finally an indexOf scan),
+ * costing three full CI+review cycles. This gate is the local mirror of
+ * those findings: it scans CHANGED/ADDED lines in .ts/.mts files for
+ * regex literals matching the known-flagged shapes and fails with
+ * file:line + the literal before a push burns a CodeQL round.
+ *
+ * Heuristic, not a solver — catching the known-flagged shapes pre-push
+ * is the bar. A clean run does NOT prove CodeQL will pass.
+ *
+ * Usage:
+ *   node scripts/check-regex-safety.mjs             # changed lines vs origin/main
+ *                                                    # (falls back to HEAD~1 when no
+ *                                                    # origin/main; skips when neither)
+ *   node scripts/check-regex-safety.mjs <file>...   # full-file scan of the given
+ *                                                    # .ts/.mts files (tests, targeted runs)
+ *
+ * Env: REMNIC_REGEX_SAFETY_BASE_REF overrides the base ref (default
+ * origin/main). REMNIC_REGEX_SAFETY_ROOT is a test seam pointing the
+ * git mode at another repo root. Node stdlib only — no new deps.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = process.env.REMNIC_REGEX_SAFETY_ROOT
+  ? path.resolve(process.env.REMNIC_REGEX_SAFETY_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const SCANNED_EXTENSIONS = new Set([".ts", ".mts"]);
+
+/**
+ * Known ReDoS-flagged shapes. Each entry names the CodeQL finding class
+ * it mirrors, from the PR #2438 flag rounds:
+ *
+ *  - lazy-any                  → js/polynomial-redos (round: bounded-content fix
+ *                                still used [\s\S]*? / lazy .*? over any-matching input)
+ *  - negated-class-alternation → js/polynomial-redos (round 1: [^>]*-style class
+ *                                with a preceding literal alternative branch)
+ *  - ws-capture-chain          → js/polynomial-redos (round 2: \s* chains adjacent
+ *                                to [a-z]+-style captures inside longer patterns)
+ *  - nested-quantifier         → js/redos (classic (a+)+ exponential backtracking)
+ *
+ * Bounded quantifiers ({0,256}) and linear scans (indexOf/loop) are the
+ * sanctioned fixes and deliberately do NOT match these detectors.
+ */
+export const REDOS_SHAPES = Object.freeze([
+  {
+    id: "lazy-any",
+    codeql: "js/polynomial-redos",
+    // [\s\S]* / [\s\S]+ (greedy or lazy) or a lazy .*/.+ — an unbounded
+    // quantifier over a class that matches everything.
+    detector: /\[\\s\\S\][*+]\??|\.[*+]\?/,
+    fix: "bound the quantifier (e.g. {0,256}) or replace with an indexOf/loop scan",
+  },
+  {
+    id: "negated-class-alternation",
+    codeql: "js/polynomial-redos",
+    // [^>]*-style unbounded negated class combined with a literal
+    // alternative branch — the PR #2438 round-1 shape.
+    detector: /\[\^[^\]]+\][*+]/,
+    requiresAlternation: true,
+    fix: "bound the class (e.g. [^>]{0,256}) or drop the alternative and scan with indexOf",
+  },
+  {
+    id: "ws-capture-chain",
+    codeql: "js/polynomial-redos",
+    // Two or more \s*/\s+ adjacent to a capture group or quantified class
+    // inside one pattern — the round-2 shape.
+    detector: null,
+    fix: "collapse the \\s* chain (single \\s* or bounded \\s{0,8}) or trim before matching",
+  },
+  {
+    id: "nested-quantifier",
+    codeql: "js/redos",
+    // A quantified token inside a group that is itself quantified —
+    // (a+)+, (a*)+, (\d{2,})+ exponential backtracking.
+    detector: /\((?:\\.|[^()\\])+[*+}]\)[*+]/,
+    fix: "remove one quantifier level or rewrite the matching as a loop",
+  },
+]);
+
+function shapeMatches(shape, src) {
+  if (shape.id === "ws-capture-chain") {
+    const wsCount = (src.match(/\\s[*+]/g) ?? []).length;
+    return wsCount >= 2 && (src.includes("(") || /\[[^\]]+\][*+]/.test(src));
+  }
+  if (!shape.detector.test(src)) return false;
+  if (shape.requiresAlternation && !src.includes("|")) return false;
+  return true;
+}
+
+// ── Regex-literal extraction ────────────────────────────────────────────────
+
+/** Characters that may directly precede a regex literal's opening slash. */
+const PRE_REGEX_CHARS = new Set([
+  "", " ", "\t", "(", ",", "=", ":", "[", "!", "&", "|", "?", "{", "}",
+  ";", ">", "<", "+", "-", "*", "%", "~", "^", "\n",
+]);
+
+const REGEX_LITERAL_RE =
+  /\/(?![/*])(?:\\.|\[(?:\\.|[^\]\\\n])*\]|[^/\\\n])+\/[a-z]*/g;
+
+/**
+ * Track string spans and a line-comment start on one source line so
+ * candidates inside strings or after `//` are skipped. Best-effort:
+ * regex literals containing quote characters can confuse the tracker,
+ * which at worst suppresses a later candidate on the same line.
+ */
+function lineRegions(line) {
+  const strings = [];
+  let commentStart = -1;
+  let quote = null;
+  let spanStart = 0;
+  for (let i = 0; i < line.length; i += 1) {
+    const c = line[i];
+    if (quote) {
+      if (c === "\\") i += 1;
+      else if (c === quote) {
+        strings.push([spanStart, i]);
+        quote = null;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      spanStart = i;
+      continue;
+    }
+    if (c === "/" && line[i + 1] === "/") {
+      commentStart = i;
+      break;
+    }
+  }
+  if (quote) strings.push([spanStart, line.length]);
+  return { strings, commentStart };
+}
+
+/** Extract regex-literal candidates ({ literal, src, index }) from one line. */
+export function extractRegexLiterals(line) {
+  const { strings, commentStart } = lineRegions(line);
+  const inString = (pos) => strings.some(([s, e]) => pos >= s && pos <= e);
+  const out = [];
+  REGEX_LITERAL_RE.lastIndex = 0;
+  for (const match of line.matchAll(REGEX_LITERAL_RE)) {
+    const open = match.index;
+    if (commentStart >= 0 && open > commentStart) continue;
+    if (inString(open)) continue;
+    const prev = open === 0 ? "" : line[open - 1];
+    if (!PRE_REGEX_CHARS.has(prev)) continue;
+    const text = match[0];
+    const src = text.slice(1, text.lastIndexOf("/"));
+    if (src.length === 0) continue;
+    out.push({ literal: text, src, index: open });
+  }
+  return out;
+}
+
+/** Scan one line's text; returns findings for the line. */
+export function scanLine(text) {
+  const findings = [];
+  for (const { literal, src } of extractRegexLiterals(text)) {
+    for (const shape of REDOS_SHAPES) {
+      if (shapeMatches(shape, src)) {
+        findings.push({ id: shape.id, codeql: shape.codeql, literal, fix: shape.fix });
+      }
+    }
+  }
+  return findings;
+}
+
+// ── Input modes ─────────────────────────────────────────────────────────────
+
+function tryGit(args, cwd = ROOT) {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function resolveBase() {
+  const ref = process.env.REMNIC_REGEX_SAFETY_BASE_REF || "origin/main";
+  if (tryGit(["rev-parse", "--verify", `${ref}^{commit}`])) {
+    const mergeBase = tryGit(["merge-base", "HEAD", ref]);
+    if (mergeBase) return { base: mergeBase.trim(), ref };
+  }
+  if (tryGit(["rev-parse", "--verify", "HEAD~1"])) {
+    return { base: "HEAD~1", ref: "HEAD~1" };
+  }
+  return null;
+}
+export function parseAddedLines(diff) {
+  const added = [];
+  let file = null;
+  let newLine = 0;
+  for (const raw of diff.split("\n")) {
+    if (raw.startsWith("+++ b/") || raw.startsWith("+++ w/")) {
+      file = raw.slice(6);
+      continue;
+    }
+    if (raw.startsWith("+++ ")) {
+      file = null;
+      continue;
+    }
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)/.exec(raw);
+    if (hunk) {
+      newLine = Number.parseInt(hunk[1], 10);
+      continue;
+    }
+    if (file === null) continue;
+    if (raw.startsWith("+")) {
+      added.push({ file, line: newLine, text: raw.slice(1) });
+      newLine += 1;
+    } else if (raw.startsWith(" ")) {
+      newLine += 1;
+    }
+  }
+  return added;
+}
+
+function collectGitModeLines() {
+  const resolved = resolveBase();
+  if (!resolved) return { skipped: true };
+  const diff = tryGit([
+    "diff",
+    "--no-color",
+    "--unified=0",
+    "--diff-filter=ACMR",
+    resolved.base,
+    "--",
+    "*.ts",
+    "*.mts",
+  ]);
+  if (diff === null) return { error: `git diff against ${resolved.ref} failed` };
+  return { added: parseAddedLines(diff), base: resolved.ref };
+}
+
+function collectArgvModeLines(files) {
+  const added = [];
+  for (const filePath of files) {
+    if (!SCANNED_EXTENSIONS.has(path.extname(filePath))) continue;
+    let source;
+    try {
+      source = readFileSync(filePath, "utf8");
+    } catch (error) {
+      return { error: `cannot read ${filePath}: ${error.message}` };
+    }
+    const lines = source.split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      added.push({ file: filePath, line: i + 1, text: lines[i] });
+    }
+  }
+  return { added };
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+function main() {
+  const argvFiles = process.argv.slice(2);
+  const collected = argvFiles.length > 0 ? collectArgvModeLines(argvFiles) : collectGitModeLines();
+
+  if (collected.error) {
+    console.error(`[regex-safety] ERROR: ${collected.error}`);
+    process.exit(2);
+  }
+  if (collected.skipped) {
+    console.log(
+      "[regex-safety] no base ref (origin/main and HEAD~1 unavailable) — nothing to scan, passing.",
+    );
+    process.exit(0);
+  }
+
+  const findings = [];
+  for (const { file, line, text } of collected.added) {
+    for (const finding of scanLine(text)) {
+      findings.push({ file, line, ...finding });
+    }
+  }
+
+  findings.sort((a, b) => {
+    const fileCmp = a.file.localeCompare(b.file);
+    if (fileCmp !== 0) return fileCmp;
+    if (a.line !== b.line) return a.line - b.line;
+    return a.id.localeCompare(b.id);
+  });
+
+  if (findings.length > 0) {
+    for (const f of findings) {
+      console.error(
+        `${f.file}:${f.line}: [${f.id}] ${f.literal} mirrors CodeQL ${f.codeql} — ${f.fix}`,
+      );
+    }
+    console.error(
+      `[regex-safety] ${findings.length} ReDoS-shaped regex literal(s) on changed lines. ` +
+        "Fix before pushing (issue #2439).",
+    );
+    process.exit(1);
+  }
+
+  const fileCount = new Set(collected.added.map((e) => e.file)).size;
+  const baseNote = collected.base ? ` (base ${collected.base})` : "";
+  console.log(
+    `Regex safety check passed: ${collected.added.length} changed line(s) across ` +
+      `${fileCount} file(s), 0 findings${baseNote}.`,
+  );
+  process.exit(0);
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
+  main();
+}

--- a/scripts/check-regex-safety.mjs
+++ b/scripts/check-regex-safety.mjs
@@ -91,8 +91,52 @@ export const REDOS_SHAPES = Object.freeze([
 ]);
 
 /**
+ * Replace escape-targeted punctuation and character-class contents with
+ * spaces so shape detectors see only STRUCTURAL regex syntax: `\)` or
+ * `[()]` are literals, not group syntax; `\s` / `\d` shorthands survive
+ * (their leading backslash targets a letter, not punctuation).
+ */
+function maskLiterals(src) {
+  let out = "";
+  let inClass = false;
+  for (let i = 0; i < src.length; i += 1) {
+    const c = src[i];
+    if (c === "\\") {
+      const next = src[i + 1] ?? "";
+      const isShorthand = /[a-zA-Z0-9]/.test(next);
+      out += isShorthand ? c + next : "  ";
+      i += 1;
+      continue;
+    }
+    if (inClass) {
+      out += c === "]" ? "]" : " ";
+      if (c === "]") inClass = false;
+      continue;
+    }
+    if (c === "[") {
+      inClass = true;
+      out += "[";
+      if (src[i + 1] === "^") {
+        out += "^"; // negation marker is structural, not content
+        i += 1;
+      }
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+/** True when a `{...}` quantifier body has no upper bound ({2,}). */
+function unboundedBrace(braceBody) {
+  return /^\d+,$/.test(braceBody);
+}
+
+/**
  * One nesting level only: a `)` carrying `*`/`+` whose group body
- * (no nested groups) ends with a quantifier (`*`, `+`, or `}`).
+ * (no nested groups) ends with an UNBOUNDED quantifier (`*`, `+`, or
+ * `{n,}`). Bounded repetitions like `(\d{2})+` are linear and pass.
+ * Operates on masked source (escapes/classes already neutralized).
  */
 function hasNestedQuantifier(src) {
   for (let i = 0; i + 1 < src.length; i += 1) {
@@ -102,7 +146,11 @@ function hasNestedQuantifier(src) {
     if (src.indexOf(")", open + 1) !== i) continue; // inner group — skip this level
     const body = src.slice(open + 1, i);
     const last = body[body.length - 1];
-    if (last === "*" || last === "+" || last === "}") return true;
+    if (last === "*" || last === "+") return true;
+    if (last === "}") {
+      const openBrace = body.lastIndexOf("{");
+      if (openBrace !== -1 && unboundedBrace(body.slice(openBrace + 1, -1))) return true;
+    }
   }
   return false;
 }
@@ -157,7 +205,7 @@ function lineRegions(line) {
       spanStart = i;
       continue;
     }
-    if (c === "/" && line[i + 1] === "/") {
+    if (c === "/" && (line[i + 1] === "/" || line[i + 1] === "*")) {
       commentStart = i;
       break;
     }
@@ -166,6 +214,10 @@ function lineRegions(line) {
   return { strings, commentStart };
 }
 export function extractRegexLiterals(line) {
+  // JSDoc/block-comment continuation lines start with `*` — code-looking
+  // regexes there are prose, not literals. (A `/*` opener on this line is
+  // handled by commentStart below.)
+  if (/^\s*\*/.test(line)) return [];
   const { strings, commentStart } = lineRegions(line);
   const inString = (pos) => strings.some(([s, e]) => pos >= s && pos <= e);
   const isFlag = (c) => c >= "a" && c <= "z";
@@ -209,8 +261,9 @@ export function extractRegexLiterals(line) {
 export function scanLine(text) {
   const findings = [];
   for (const { literal, src } of extractRegexLiterals(text)) {
+    const masked = maskLiterals(src);
     for (const shape of REDOS_SHAPES) {
-      if (shapeMatches(shape, src)) {
+      if (shapeMatches(shape, masked)) {
         findings.push({ id: shape.id, codeql: shape.codeql, literal, fix: shape.fix });
       }
     }
@@ -234,9 +287,14 @@ function tryGit(args, cwd = ROOT) {
 
 function resolveBase() {
   const ref = process.env.REMNIC_REGEX_SAFETY_BASE_REF || "origin/main";
+  const head = tryGit(["rev-parse", "HEAD"]);
   if (tryGit(["rev-parse", "--verify", `${ref}^{commit}`])) {
     const mergeBase = tryGit(["merge-base", "HEAD", ref]);
-    if (mergeBase) return { base: mergeBase.trim(), ref };
+    // On push events (CI on main) origin/main == HEAD and the diff is
+    // empty; fall through to HEAD~1 so the last commit is still scanned.
+    if (mergeBase && mergeBase.trim() !== (head ?? "").trim()) {
+      return { base: mergeBase.trim(), ref };
+    }
   }
   if (tryGit(["rev-parse", "--verify", "HEAD~1"])) {
     return { base: "HEAD~1", ref: "HEAD~1" };
@@ -286,7 +344,25 @@ function collectGitModeLines() {
     "*.mts",
   ]);
   if (diff === null) return { error: `git diff against ${resolved.ref} failed` };
-  return { added: parseAddedLines(diff), base: resolved.ref };
+  const added = parseAddedLines(diff);
+  // `git diff` never reports untracked files — a brand-new .ts file is
+  // entirely "added lines", so scan it whole (pre-commit runs before
+  // the first `git add` is guaranteed).
+  const untracked = tryGit(["ls-files", "--others", "--exclude-standard", "--", "*.ts", "*.mts"]);
+  if (untracked) {
+    for (const relPath of untracked.split("\n")) {
+      if (!relPath) continue;
+      try {
+        const lines = readFileSync(path.join(ROOT, relPath), "utf8").split("\n");
+        for (let i = 0; i < lines.length; i += 1) {
+          added.push({ file: relPath, line: i + 1, text: lines[i] });
+        }
+      } catch {
+        // unreadable untracked file — the diff scan will surface tracked problems
+      }
+    }
+  }
+  return { added, base: resolved.ref };
 }
 
 function collectArgvModeLines(files) {

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -300,6 +300,7 @@ run bash scripts/check-review-patterns.sh
 run node scripts/check-ratchets.mjs
 run node scripts/check-docs-parity.mjs
 run node scripts/check-dataset-hygiene.mjs
+run npm run check:regex-safety
 run pnpm exec turbo --version
 run_quiet pnpm exec turbo run check-types --dry=json
 

--- a/tests/check-regex-safety.test.mjs
+++ b/tests/check-regex-safety.test.mjs
@@ -130,6 +130,35 @@ test("nested-quantifier distinguishes bounded from unbounded brace repetition", 
   });
 });
 
+test("a closed same-line block comment masks only its own span; swapped any-pairs still fire", () => {
+  withTempDir("regex-safety-block-", (dir) => {
+    // Regex after the closing */ on the same line must be scanned.
+    const blinded = path.join(dir, "after-close.ts");
+    writeFileSync(blinded, "const a = 1; /* note */ const bad = /[\\s\\S]*?y/;\n");
+    const res = runScript([blinded]);
+    assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`);
+    assert.match(res.stderr, /after-close\.ts:1: \[lazy-any\]/);
+
+    // Regex inside the comment span is ignored; code after it is clean.
+    const masked = path.join(dir, "inside-comment.ts");
+    writeFileSync(masked, "const a = 1; /* /fake[\\s\\S]*?x/ */ const ok = /\\d+/;\n");
+    assert.equal(runScript([masked]).status, 0);
+
+    // Complementary pairs in either spelling are flagged.
+    for (const [name, re] of [
+      ["swapped", "[\\S\\s]*?"],
+      ["wordpair", "[\\w\\W]*"],
+      ["digitpair", "[\\d\\D]+"],
+    ]) {
+      const f = path.join(dir, `${name}.ts`);
+      writeFileSync(f, `export const v = /${re}x/;\n`);
+      const hit = runScript([f]);
+      assert.equal(hit.status, 1, `${name}: ${hit.stdout}\n${hit.stderr}`);
+      assert.match(hit.stderr, new RegExp(`${name}\\.ts:1: \\[lazy-any\\]`));
+    }
+  });
+});
+
 test("scans only lines added since the base commit, including uncommitted edits", () => {
   withTempDir("regex-safety-git-", (dir) => {
     const repo = path.join(dir, "repo");

--- a/tests/check-regex-safety.test.mjs
+++ b/tests/check-regex-safety.test.mjs
@@ -1,0 +1,155 @@
+// Regex-safety pre-check tests (issue #2439).
+//
+// Mirrors check-dataset-hygiene.test.mjs conventions: spawnSync the script
+// against fixture files built at runtime in a temp dir (so known-bad regex
+// literals never land in committed source), assert exit codes + output.
+// The git-diff mode test builds a throwaway git repo to pin changed-line
+// scoping (only lines added since the base commit are scanned).
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { REDOS_SHAPES } from "../scripts/check-regex-safety.mjs";
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "scripts",
+  "check-regex-safety.mjs",
+);
+
+function runScript(args, cwd = process.cwd(), env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+function withTempDir(prefix, fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function git(cwd, args) {
+  execFileSync("git", ["-c", "user.email=dev@example.com", "-c", "user.name=Dev", ...args], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+// One line per flagged shape class, plus a second lazy-any shape.
+const BAD_FIXTURE = [
+  "// Known-bad ReDoS shapes (issue #2439 fixtures).",
+  "export const wrapper = /<supermemory-context[^>]*>[\\s\\S]*?<\\/supermemory-context>/;",
+  "export const lazyAny = /^start(.*?)end(.*?)$/;",
+  "export const altClass = /<tag(?:b|strong)[^>]*>/;",
+  "export const wsChain = /^(\\s*)([a-z]+)(\\s*)(\\d+)$/;",
+  "export const nested = /(a+)+b/;",
+  "",
+].join("\n");
+
+const GOOD_FIXTURE = [
+  "// Benign regexes — bounded or unambiguous shapes must pass.",
+  "export const isoDate = /^\\d{4}-\\d{2}-\\d{2}$/;",
+  "export const words = /[a-z]+/g;",
+  "export const split = /\\s+/;",
+  "export const boundedTag = /<supermemory-context[^>]{0,256}>/;",
+  "export const proto = /^https?:\\/\\/\\S+$/;",
+  "const ratio = total / count / scale;",
+  'const note = "contains [a-z]* and .*? inside a string";',
+  "// comment with /fake.*?regex/ never scanned",
+  "",
+].join("\n");
+
+test("flags every known ReDoS shape class from the issue body", () => {
+  withTempDir("regex-safety-bad-", (dir) => {
+    const bad = path.join(dir, "bad.ts");
+    writeFileSync(bad, BAD_FIXTURE);
+
+    const res = runScript([bad]);
+    const output = `${res.stdout}\n${res.stderr}`;
+    assert.equal(res.status, 1, output);
+    assert.match(res.stderr, /bad\.ts:2: \[lazy-any\]/);
+    assert.match(res.stderr, /\[\\s\\S\]\*\?/);
+    assert.match(res.stderr, /bad\.ts:3: \[lazy-any\]/);
+    assert.match(res.stderr, /bad\.ts:4: \[negated-class-alternation\]/);
+    assert.match(res.stderr, /mirrors CodeQL js\/polynomial-redos/);
+    assert.match(res.stderr, /bad\.ts:5: \[ws-capture-chain\]/);
+    assert.match(res.stderr, /bad\.ts:6: \[nested-quantifier\]/);
+    assert.match(res.stderr, /mirrors CodeQL js\/redos/);
+  });
+});
+
+test("passes on benign regexes, division, strings, and comments", () => {
+  withTempDir("regex-safety-good-", (dir) => {
+    const good = path.join(dir, "good.ts");
+    writeFileSync(good, GOOD_FIXTURE);
+
+    const res = runScript([good]);
+    assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
+    assert.match(res.stdout, /Regex safety check passed/);
+  });
+});
+
+test("ignores files that are not .ts/.mts", () => {
+  withTempDir("regex-safety-ext-", (dir) => {
+    const js = path.join(dir, "notscanned.js");
+    writeFileSync(js, 'export const x = /[\\s\\S]*?y/;\n');
+
+    const res = runScript([js]);
+    assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
+  });
+});
+
+test("scans only lines added since the base commit, including uncommitted edits", () => {
+  withTempDir("regex-safety-git-", (dir) => {
+    const repo = path.join(dir, "repo");
+    mkdirSync(repo, { recursive: true });
+    git(repo, ["init", "-q"]);
+    const target = path.join(repo, "scan.ts");
+    // Commit 1: a ReDoS shape that predates the scan base.
+    writeFileSync(target, "export const stale = /[\\s\\S]*?x/;\n");
+    git(repo, ["add", "scan.ts"]);
+    git(repo, ["commit", "-q", "-m", "base with a stale bad shape"]);
+    // Commit 2: benign addition only.
+    appendFileSync(target, "export const fresh = /abc/;\n");
+    git(repo, ["add", "scan.ts"]);
+    git(repo, ["commit", "-q", "-m", "benign addition"]);
+
+    // The committed bad line predates HEAD~1, so the changed-line scan passes.
+    const clean = runScript([], repo, { REMNIC_REGEX_SAFETY_ROOT: repo });
+    assert.equal(clean.status, 0, `${clean.stdout}\n${clean.stderr}`);
+
+    // An uncommitted bad line IS in the worktree diff and must fail with
+    // its exact file:line.
+    appendFileSync(target, "export const freshBad = /[\\s\\S]*?y/;\n");
+    const dirty = runScript([], repo, { REMNIC_REGEX_SAFETY_ROOT: repo });
+    assert.equal(dirty.status, 1, `${dirty.stdout}\n${dirty.stderr}`);
+    assert.match(dirty.stderr, /scan\.ts:3: \[lazy-any\]/);
+    assert.doesNotMatch(dirty.stderr, /scan\.ts:1/);
+  });
+});
+
+test("shape table keeps the four issue-body classes with CodeQL mappings", () => {
+  assert.deepEqual(
+    REDOS_SHAPES.map((s) => `${s.id}→${s.codeql}`),
+    [
+      "lazy-any→js/polynomial-redos",
+      "negated-class-alternation→js/polynomial-redos",
+      "ws-capture-chain→js/polynomial-redos",
+      "nested-quantifier→js/redos",
+    ],
+  );
+});

--- a/tests/check-regex-safety.test.mjs
+++ b/tests/check-regex-safety.test.mjs
@@ -69,6 +69,10 @@ const GOOD_FIXTURE = [
   "export const proto = /^https?:\\/\\/\\S+$/;",
   "const ratio = total / count / scale;",
   'const note = "contains [a-z]* and .*? inside a string";',
+  "export const boundedRep = /(\\d{2})+/;",
+  "export const literalStar = /(\\*)+/;",
+  "const afterBlock = 1; /* note /fake[\\s\\S]*?re/ here */",
+  " * const jsdoc = /[\\s\\S]*?x/;",
   "// comment with /fake.*?regex/ never scanned",
   "",
 ].join("\n");
@@ -107,9 +111,22 @@ test("ignores files that are not .ts/.mts", () => {
   withTempDir("regex-safety-ext-", (dir) => {
     const js = path.join(dir, "notscanned.js");
     writeFileSync(js, 'export const x = /[\\s\\S]*?y/;\n');
-
     const res = runScript([js]);
     assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
+  });
+});
+
+test("nested-quantifier distinguishes bounded from unbounded brace repetition", () => {
+  withTempDir("regex-safety-brace-", (dir) => {
+    const safe = path.join(dir, "safe.ts");
+    writeFileSync(safe, "export const pairs = /(\\d{2})+/;\n");
+    assert.equal(runScript([safe]).status, 0);
+
+    const risky = path.join(dir, "risky.ts");
+    writeFileSync(risky, "export const unbounded = /(\\d{2,})+/;\n");
+    const res = runScript([risky]);
+    assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`);
+    assert.match(res.stderr, /risky\.ts:1: \[nested-quantifier\]/);
   });
 });
 
@@ -139,6 +156,20 @@ test("scans only lines added since the base commit, including uncommitted edits"
     assert.equal(dirty.status, 1, `${dirty.stdout}\n${dirty.stderr}`);
     assert.match(dirty.stderr, /scan\.ts:3: \[lazy-any\]/);
     assert.doesNotMatch(dirty.stderr, /scan\.ts:1/);
+
+    // Committing the bad line keeps it in the HEAD~1..worktree diff: a
+    // push event with a clean tree still scans the last commit.
+    git(repo, ["add", "scan.ts"]);
+    git(repo, ["commit", "-q", "-m", "add bad shape"]);
+    const committed = runScript([], repo, { REMNIC_REGEX_SAFETY_ROOT: repo });
+    assert.equal(committed.status, 1, `${committed.stdout}\n${committed.stderr}`);
+    assert.match(committed.stderr, /scan\.ts:3: \[lazy-any\]/);
+
+    // An untracked brand-new .ts file is fully "added" and must be scanned.
+    writeFileSync(path.join(repo, "untracked.ts"), "export const u = /[\\s\\S]*?z/;\n");
+    const withUntracked = runScript([], repo, { REMNIC_REGEX_SAFETY_ROOT: repo });
+    assert.equal(withUntracked.status, 1, `${withUntracked.stdout}\n${withUntracked.stderr}`);
+    assert.match(withUntracked.stderr, /untracked\.ts:1: \[lazy-any\]/);
   });
 });
 


### PR DESCRIPTION
Fixes #2439

## Summary

Adds `scripts/check-regex-safety.mjs` (node, zero new deps): scans changed/added lines in `.ts`/`.mts` files for regex literals matching the ReDoS shapes CodeQL flagged across the PR #2438 rounds, and fails with `file:line` + the literal + the mirrored CodeQL class. Heuristic table (`REDOS_SHAPES`) maps each shape to its finding class:

- `lazy-any` → `js/polynomial-redos` — `[\s\S]*?` / lazy `.*?` unbounded over any-matching input
- `negated-class-alternation` → `js/polynomial-redos` — `[^>]*`-style unbounded class with a literal alternative branch (round 1)
- `ws-capture-chain` → `js/polynomial-redos` — `\\s*` chains adjacent to `[a-z]+`-style captures (round 2)
- `nested-quantifier` → `js/redos` — `(a+)+`-style exponential backtracking

Bounded quantifiers (`{0,256}`) and indexOf/loop scans are the sanctioned fixes and deliberately pass.

Input modes: bare invocation diffs changed lines against `origin/main` (worktree-aware: staged + unstaged covered; falls back to `HEAD~1`); explicit file arguments scan full files (tests/targeted runs). Wired as `npm run check:regex-safety` into `preflight:quick` (common section of `scripts/pr-preflight.sh`, so full preflight runs it too) and as a CI step after docs-parity, reusing the base-ref fetch from ratchet scoping.

## Type of change

- [x] Security / hardening

## Validation

- [x] `tests/check-regex-safety.test.mjs` — 5 tests: each shape class flagged with file:line on runtime-built fixtures; benign regexes/division/strings/comments pass; non-`.ts/.mts` ignored; changed-line scoping pinned via a throwaway git repo (stale bad line predating base NOT flagged, uncommitted bad line flagged at exact line); shape-table contract.
- [x] `npm run test:file -- tests/check-regex-safety.test.mjs` green via the repo runner.
- [x] `npm run check:regex-safety` green standalone; `npm run lint` green; `bash -n scripts/pr-preflight.sh` green.
- [ ] `npm run preflight:quick` — blocked locally by PRE-EXISTING main ratchet debt (config.ts 4559→4561, recall-internal.ts 5329→5344 — grown by merged #2438, zero diff from this branch). All preflight steps through review-patterns pass; CI scopes ratchets to changed files (this PR touches none of them). Filed for main separately if not already tracked.
- [x] Added/updated tests for behavior changes

## Changelog

- [x] Added changeset `regex-safety-precheck-2439.md`

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered (additive gate; self-skips when no base ref exists)
- [x] New CI step self-skips on shallow non-PR checkouts rather than failing vacuously

## Notes for reviewers

- The scanner only sees CHANGED lines (issue scope: pre-push bar); committed history is not rescanned.
- Known-bad fixtures are built at runtime in `os.tmpdir()` so flagged literals never land in committed source (same convention as dataset-hygiene API-key fixtures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive dev/CI tooling only; no runtime behavior change, and the check self-skips when no git base is available.
> 
> **Overview**
> Adds a **ReDoS-shape pre-push gate** so new regex literals on changed TypeScript lines are caught before CodeQL burns another review round (issue #2439).
> 
> **`scripts/check-regex-safety.mjs`** diffs added/changed lines in `.ts`/`.mts` (or full files when passed as args), extracts regex literals with a linear scanner, and flags four heuristic shapes tied to prior CodeQL classes: lazy `[\s\S]*?` / `.*?`, unbounded negated classes with `|`, `\s*` chains near captures, and nested quantifiers like `(a+)+`. Failures print `file:line`, the literal, and a fix hint; bounded quantifiers and `indexOf`-style patterns are meant to pass.
> 
> **Wiring:** `npm run check:regex-safety` is added and run from **`preflight:quick`** (`scripts/pr-preflight.sh`) and **CI** after docs-parity, with `REMNIC_REGEX_SAFETY_BASE_REF` on PRs. **`AGENTS.md`** documents the check. **`tests/check-regex-safety.test.mjs`** covers shapes, false positives, git scoping, and untracked files. Patch **changeset** for `@remnic/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 581d044b2e5c95dce60414731a572340a0b2f500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated regex safety checks for changed TypeScript files.
  * Reports vulnerable patterns with affected lines, risk categories, and remediation guidance.
  * Integrated checks into required preflight and continuous integration validation.

* **Documentation**
  * Added guidance for avoiding regex patterns associated with denial-of-service risks.

* **Tests**
  * Added coverage for vulnerable and safe patterns, supported file types, and change-based scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->