### PR TITLE
fix(ci): repair main gates broken by #2437/#2438

### DIFF
--- a/.changeset/main-ci-gate-repair.md
+++ b/.changeset/main-ci-gate-repair.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Repair CI gates broken on main by #2437/#2438: register `storage/tombstone-migration-sources.ts` in the lifecycle manifest (it was added to the coverage map but not the manifest), sync the ratchet baseline to the committed config.ts/recall-internal.ts sizes, and update the offline manifest test expectation for the new `identityResolutionVersion: 2` row field.

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -213,6 +213,7 @@ test("offline manifest streams body-free active, archived, old, bad, and encrypt
       id: "active-memory",
       category: "fact",
       contentHash: activeContentHash,
+      identityResolutionVersion: 2,
       normalizerVersion: 4,
       status: "active",
     });

--- a/scripts/lifecycle-matrix/coverage.json
+++ b/scripts/lifecycle-matrix/coverage.json
@@ -128,6 +128,7 @@
     "packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts",
     "packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts",
     "packages/remnic-core/src/storage/tombstone-blocked-capture-mutation.ts",
+    "packages/remnic-core/src/storage/tombstone-migration-sources.ts",
     "packages/remnic-core/src/storage/entity-store.ts",
     "packages/remnic-core/src/storage/entity-timeline.ts",
     "packages/remnic-core/src/storage/identity-continuity-store.ts",

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -8,7 +8,7 @@
       "packages/remnic-core/src/cli.ts": 9428,
       "packages/remnic-core/src/access-service.ts": 5910,
       "packages/remnic-core/src/storage.ts": 7315,
-      "packages/remnic-core/src/config.ts": 4559
+      "packages/remnic-core/src/config.ts": 4561
     },
     "oversizedFileCount": 12,
     "fileSizeGrandfather": {
@@ -36,7 +36,7 @@
       "packages/remnic-core/src/cli.ts": 9428,
       "packages/remnic-core/src/coding/codegraph-runtime.ts": 1311,
       "packages/remnic-core/src/compounding/engine.ts": 1722,
-      "packages/remnic-core/src/config.ts": 4559,
+      "packages/remnic-core/src/config.ts": 4561,
       "packages/remnic-core/src/connectors/index.ts": 4061,
       "packages/remnic-core/src/connectors/live/gmail.ts": 1303,
       "packages/remnic-core/src/evals.ts": 1321,
@@ -53,7 +53,7 @@
       "packages/remnic-core/src/offline-sync.ts": 2646,
       "packages/remnic-core/src/operator-toolkit.ts": 2501,
       "packages/remnic-core/src/orchestration/extraction-persist.ts": 3031,
-      "packages/remnic-core/src/orchestration/recall-internal.ts": 5329,
+      "packages/remnic-core/src/orchestration/recall-internal.ts": 5344,
       "packages/remnic-core/src/orchestration/recall-search-pipeline.ts": 1719,
       "packages/remnic-core/src/orchestrator.ts": 3979,
       "packages/remnic-core/src/peers/storage.ts": 1435,


### PR DESCRIPTION
Main has been red since 65b6c203 (#2437, 23:21Z): every PR (and push) fails `checks`, `lifecycle-matrix`, `tests (root)`, and `tests (packages-2)`. Three mechanical fallouts:

1. **Lifecycle manifest** — `storage/tombstone-migration-sources.ts` was added to the coverage map (subject `tombstone-blocked-capture`) but not to `lifecycleManifest`, so `loadCoverageManifest` throws on every gate run and the coverage test suite. Added to the manifest array next to its siblings.
2. **Ratchet baseline** — #2437 grew `config.ts` 4559→4561 and #2438 grew `recall-internal.ts` 5329→5344 without syncing `ratchet-baseline.json`. Hand-edited (the sanctioned loud-exception path — `--update` refuses ceiling raises and scope-limited updates skip out-of-scope files). Both merges were reviewed and deliberate; the baseline now records reality. Shrinking those files instead belongs to the debt-reduction track (#1520/#1995), not a gate-repair PR.
3. **Offline manifest test** — #2437 added `identityResolutionVersion: IDENTITY_RESOLUTION_VERSION` (2) to reconcile manifest rows; `access-service-offline-file-content.test.ts` still expects the pre-#2437 row shape. Updated the single `deepEqual` expectation.

## Validation

- [x] `node scripts/check-ratchets.mjs` → OK
- [x] `node scripts/lifecycle-matrix/check-coverage.mjs` → OK (2 covered, 3 grandfathered, 0 violations)
- [x] `npm run test:file -- tests/lifecycle-matrix-coverage.test.mjs` → green
- [x] `npm run test:file -- packages/remnic-core/src/access-service-offline-file-content.test.ts` → 10/10 green

## Type of change

- [x] Bug fix

## Changelog

- [x] Added changeset

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest, ratchet baseline, and test-only updates with no production logic changes in this diff.
> 
> **Overview**
> **Restores green CI on main** after fallout from #2437/#2438: lifecycle manifest validation, structural ratchets, and one offline manifest assertion.
> 
> Adds `packages/remnic-core/src/storage/tombstone-migration-sources.ts` to **`lifecycleManifest`** in `scripts/lifecycle-matrix/coverage.json`. That path was already in the `coverage` map (`tombstone-blocked-capture`) but missing from the manifest, so `loadCoverageManifest` threw on every lifecycle-matrix run.
> 
> Bumps **`scripts/ratchet-baseline.json`** to match current LOC for `config.ts` (4561) and `recall-internal.ts` (5344) after those files grew in the prior merges without updating the baseline.
> 
> Updates **`access-service-offline-file-content.test.ts`** so the reconcile manifest row expectation includes **`identityResolutionVersion: 2`**, aligning with the row shape introduced in #2437.
> 
> Includes a **`@remnic/core` patch** changeset documenting the gate repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5520439cf6951dea2c4ccb3616a50b075162b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->