### PR TITLE
chore(plugin-openclaw): remove dead MIN_OBSERVE_CHUNK_BYTES constant

### DIFF
--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -39,8 +39,6 @@ import { postJsonWithStatus } from "./delegate-http.js";
  * `maxBodyBytes` (131072) so the JSON envelope around the notes still fits.
  */
 const MAX_OBSERVE_CHUNK_BYTES = 96 * 1024;
-/** The floor the adaptive halving stops at — below this a single note. */
-const MIN_OBSERVE_CHUNK_BYTES = 4 * 1024;
 /** Bounded wait for the flush-plan lock; a contended flush declines instead. */
 const LOCK_MAX_WAIT_MS = 5_000;
 const LOCK_STALE_MS = 60_000;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -3803,9 +3803,8 @@ test("a symlinked snapshot sidecar is refused before it is read", async () => {
 });
 
 test("a daemon limit below the chunk floor splits instead of quarantining good notes", async () => {
-  // With maxBodyBytes under MIN_OBSERVE_CHUNK_BYTES, reaching the floor does
-  // NOT mean the chunk is one line — it can still be a multi-line batch. The
-  // trigger for quarantine is the chunk's shape, not a byte floor (#2303).
+  // A daemon limit under the chunk floor still yields a multi-line batch — the
+  // quarantine trigger is the chunk's shape, not a byte floor (#2303).
   const delivered: string[] = [];
   const limit = 200;
   const overLimit = (body: Record<string, unknown>): boolean =>


### PR DESCRIPTION
Fixes #2395.

Remove the dead `MIN_OBSERVE_CHUNK_BYTES` constant (and its comment) from `delegate-flush-plan-ingest.ts`. The adaptive 413 path uses `Math.max(1, Math.floor(chunkBytes / 2))`, so the constant's "floor the adaptive halving stops at" contract is no longer enforced anywhere.

Also update the one test comment that referenced the constant name so it no longer points at the removed identifier.

- `packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts`: remove the constant + comment
- `packages/plugin-openclaw/src/delegate-runtime.test.ts`: reword the stale comment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of flush-plan batches when daemon chunk limits are smaller than expected, ensuring multi-line batches are still split and quarantined based on their structure.
* **Tests**
  * Updated test coverage descriptions to reflect the current chunking and quarantine behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->