### PR TITLE
docs(plugin-openclaw): fix stale delegate-runtime header contract

### DIFF
--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -11,12 +11,11 @@
  *   - compaction/reset    → POST /engram/v1/lcm/compaction/flush
  *
  * Deliberately out of scope for delegate v1 (still embedded-only): tool and
- * CLI registration, heartbeat/dreams surfaces, hourly summary crons, public
- * artifacts, and the memory-capability object. The daemon already exposes the
- * tool surface over HTTP/MCP to any client that needs it. This keeps a
- * co-located gateway from running a second orchestrator over the daemon's
- * memory corpus (double maintenance crons, duplicate extraction load, shared
- * SQLite contention).
+ * CLI registration, heartbeat/dreams surfaces, and hourly summary crons. The
+ * daemon already exposes the tool surface over HTTP/MCP to any client that
+ * needs it. This keeps a co-located gateway from running a second orchestrator
+ * over the daemon's memory corpus (double maintenance crons, duplicate
+ * extraction load, shared SQLite contention).
  */
 
 import path from "node:path";


### PR DESCRIPTION
Fixes #2394.

The module header of `delegate-runtime.ts` still listed "public artifacts" and "the memory-capability object" as out of scope for delegate v1, but PR #2375 made this same file import and register `registerDelegateMemoryCapability` and `createDelegateSupportPassportModelService`.

Update the header so its out-of-scope list matches what the module actually ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated delegate v1 scope documentation to clarify that public artifacts and the memory-capability object are included.
  * Clarified that the daemon-backed tool surface remains available through HTTP/MCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->