### PR TITLE
fix(ci): drop duplicate identityResolutionVersion from #2446 merge

### DIFF
--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -215,7 +215,6 @@ test("offline manifest streams body-free active, archived, old, bad, and encrypt
       contentHash: activeContentHash,
       identityResolutionVersion: 2,
       normalizerVersion: 4,
-      identityResolutionVersion: 2,
       status: "active",
     });
     assert.notEqual(rowsByPath.get("facts/active.md")?.sha256, activeContentHash);


### PR DESCRIPTION
The #2446 merge re-applied the offline manifest test expectation already landed in #2450, leaving a duplicate `identityResolutionVersion: 2` property that fails `tsc` (TS1117) repo-wide. One-line deletion; `npm run test:file -- packages/remnic-core/src/access-service-offline-file-content.test.ts` 10/10 green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only one-line fix with no production code impact.
> 
> **Overview**
> Fixes a **TypeScript compile failure** (`TS1117` duplicate object property) in `access-service-offline-file-content.test.ts` by removing a second `identityResolutionVersion: 2` entry from the `assert.deepEqual` expectation for `facts/active.md` manifest memory metadata.
> 
> No runtime or production behavior changes—only the test object literal is corrected after a merge duplicated a field that was already present alongside `normalizerVersion` and `status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4492abc0bb0c0ff59187a64ce0acefc4b196b3a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->