### PR TITLE
fix(qmd): kill subprocess descendants on timeout and abort

### DIFF
--- a/.changeset/2456-qmd-kill-process-group.md
+++ b/.changeset/2456-qmd-kill-process-group.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Kill bounded QMD subprocess descendants on timeout and abort by signaling the POSIX process group.

--- a/packages/remnic-core/src/qmd-process-group.test.ts
+++ b/packages/remnic-core/src/qmd-process-group.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runCommandWithTimeoutForTest } from "./qmd.js";
+
+// Regression for issue #2456: on timeout/abort the bounded qmd subprocess
+// launcher must be killed together with its descendants. The launcher runs
+// detached (own process group) so a negative-pid signal reaches grandchildren
+// the old child.kill("SIGKILL") left behind. POSIX only — Windows falls back
+// to a direct child kill by design.
+//
+// Real timers by design: this suite kills real OS processes, so the timeout
+// trigger and the exit polls run against the platform clock. Fake timers
+// cannot deliver signals to a spawned `sleep`. Every poll awaits a condition
+// (pid file exists, process gone), never a fixed sleep.
+const isPosix = process.platform !== "win32";
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitForExit(pid: number, deadlineMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !isAlive(pid);
+}
+
+async function setupFakeLauncher(): Promise<{ script: string; pidFile: string; dir: string }> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remnic-qmd-kill-"));
+  const script = path.join(dir, "fake-qmd");
+  const pidFile = path.join(dir, "grandchild.pid");
+  // Launcher spawns a grandchild that outlives it, then hangs until killed.
+  await fs.promises.writeFile(
+    script,
+    `#!/bin/sh\nsleep 30 &\necho $! > "${pidFile}"\nsleep 30\n`,
+    { mode: 0o755 },
+  );
+  return { script, pidFile, dir };
+}
+
+async function readPidFile(pidFile: string, deadlineMs = 5_000): Promise<number> {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    try {
+      const text = await fs.promises.readFile(pidFile, "utf8");
+      const pid = Number.parseInt(text.trim(), 10);
+      assert.ok(Number.isInteger(pid) && pid > 0, `bad grandchild pid: ${text}`);
+      return pid;
+    } catch (err) {
+      if (Date.now() >= deadline) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
+async function cleanupSurvivors(pids: Array<number | undefined>, dir?: string): Promise<void> {
+  for (const pid of pids) {
+    if (pid === undefined || !isAlive(pid)) continue;
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+  if (dir) await fs.promises.rm(dir, { recursive: true, force: true });
+}
+
+test(
+  "timeout kills qmd launcher process group including grandchildren",
+  { skip: isPosix ? false : "POSIX process groups do not exist on Windows" },
+  async () => {
+    const { script, pidFile, dir } = await setupFakeLauncher();
+    let grandchildPid: number | undefined;
+    try {
+      await assert.rejects(
+        runCommandWithTimeoutForTest(script, [], { timeoutMs: 500, label: "qmd fake" }),
+        (err: Error & { timedOut?: boolean }) => err.timedOut === true,
+      );
+      grandchildPid = await readPidFile(pidFile);
+      assert.ok(
+        await waitForExit(grandchildPid),
+        `grandchild ${grandchildPid} survived the group kill`,
+      );
+    } finally {
+      await cleanupSurvivors([grandchildPid], dir);
+    }
+  },
+);
+
+test(
+  "abort kills qmd launcher process group including grandchildren",
+  { skip: isPosix ? false : "POSIX process groups do not exist on Windows" },
+  async () => {
+    const { script, pidFile, dir } = await setupFakeLauncher();
+    let grandchildPid: number | undefined;
+    const controller = new AbortController();
+    try {
+      const run = runCommandWithTimeoutForTest(script, [], {
+        timeoutMs: 60_000,
+        signal: controller.signal,
+        label: "qmd fake",
+      });
+      setTimeout(() => controller.abort(), 300);
+      await assert.rejects(run, /aborted/);
+      grandchildPid = await readPidFile(pidFile);
+      assert.ok(
+        await waitForExit(grandchildPid),
+        `grandchild ${grandchildPid} survived the group kill`,
+      );
+    } finally {
+      await cleanupSurvivors([grandchildPid], dir);
+    }
+  },
+);

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -562,6 +562,11 @@ function runCommandWithTimeout(
     const child = launchProcess(command, args, {
       env: mergeEnv({ NO_COLOR: "1", ...options.env }),
       stdio: ["ignore", "pipe", "pipe"],
+      // POSIX: own process group so a timeout/abort kill can take down qmd's
+      // grandchildren too (launcher scripts spawn workers that outlive the
+      // launcher itself). Issue #2456. Windows ignores this option here —
+      // kill falls back to a direct child.kill.
+      detached: process.platform !== "win32",
     });
     if (!child.stdout || !child.stderr) {
       reject(new Error(`${label} failed to open stdio pipes`));
@@ -575,7 +580,7 @@ function runCommandWithTimeout(
     const timer = setTimeout(() => {
       settled = true;
       cleanup();
-      child.kill("SIGKILL");
+      killBoundedChild(child);
       // Flag the deadline breach so classifyProbeFailure can tell a genuine
       // timeout from a non-zero-exit error whose message merely embeds stderr.
       reject(
@@ -589,7 +594,7 @@ function runCommandWithTimeout(
       settled = true;
       clearTimeout(timer);
       cleanup();
-      child.kill("SIGKILL");
+      killBoundedChild(child);
       reject(abortError(`${label} aborted`));
     };
     const cleanup = () => {
@@ -635,6 +640,29 @@ function runProcessCommand(
     signal,
   });
 }
+
+// Kill a bounded subprocess and its descendants. On POSIX the child runs
+// detached (own process group), so a negative-pid signal reaches the whole
+// tree. Fall back to a direct kill on Windows, missing pid, or when the
+// group is already gone. Never throws — callers use it on best-effort paths.
+function killBoundedChild(child: CommandChildProcess): void {
+  const pid = child.pid;
+  if (pid !== undefined && process.platform !== "win32") {
+    try {
+      process.kill(-pid, "SIGKILL");
+      return;
+    } catch {
+      // Group already reaped or never became a leader — fall through.
+    }
+  }
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // Already exited between the check and the kill.
+  }
+}
+
+export { runCommandWithTimeout as runCommandWithTimeoutForTest };
 
 // ---------------------------------------------------------------------------
 // QMD Stdio Daemon Session (MCP over stdio child process)


### PR DESCRIPTION
## Why

Bounded QMD subprocess commands (version probes, query/update/embed runs) killed only the launcher process on timeout or abort. A qmd launcher script that spawns worker processes leaves those grandchildren running after the deadline — they hold no timeout of their own and survive until the machine reaps them.

## What Changed

- `runCommandWithTimeout` now spawns bounded commands with `detached: true` on POSIX, so the command leads its own process group.
- On timeout and on abort, it signals the negative pid (`process.kill(-pid, "SIGKILL")`), reaching the launcher and all descendants.
- Falls back to a direct `child.kill()` on Windows, missing pid, or when the group kill fails (already reaped, never became a leader).
- The long-lived MCP daemon session lifecycle is unchanged — only bounded subprocess commands are affected.
- New regression test (`qmd-process-group.test.ts`, POSIX-skipped on Windows): a fake launcher spawns a grandchild, the command times out / aborts, and the test asserts the grandchild is gone. Verified as a true regression test: with `detached` disabled, both cases fail.

Fixes #2456