### PR TITLE
fix(openclaw): replay flush-plan chunks in isolated serial batches

### DIFF
--- a/.changeset/2459-flush-plan-serial-chunks.md
+++ b/.changeset/2459-flush-plan-serial-chunks.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Replay oversized flush-plan chunks as isolated serial bulk-ingest batches.

--- a/src/openclaw-flush-plan-lifecycle.ts
+++ b/src/openclaw-flush-plan-lifecycle.ts
@@ -12,6 +12,11 @@ import {
   writeFile,
 } from "node:fs/promises";
 import type { ImportTurn } from "@remnic/core/bulk-import";
+import {
+  ingestFlushPlanImportTurns,
+  isFailedIngestResult,
+} from "./openclaw-flush-plan-serial-ingest.js";
+
 
 export type OpenClawFlushPlanProcessStatus =
   | "disabled"
@@ -764,109 +769,6 @@ function timestampForFlushPlanChunk(importedAt: string, chunkIndex: number): str
   return new Date(importedAtMs + chunkIndex).toISOString();
 }
 
-function isFailedIngestResult(
-  result: void | OpenClawFlushPlanIngestResult,
-): boolean {
-  return Boolean(
-    result &&
-      typeof result === "object" &&
-      typeof result.failedCount === "number" &&
-      result.failedCount > 0,
-  );
-}
-
-function partialIngestResultFromError(
-  error: unknown,
-): OpenClawFlushPlanIngestResult | undefined {
-  if (!error || typeof error !== "object") return undefined;
-  const partialResult = (error as { partialResult?: unknown }).partialResult;
-  if (!partialResult || typeof partialResult !== "object") return undefined;
-  return partialResult as OpenClawFlushPlanIngestResult;
-}
-
-const INGEST_RESULT_COUNTER_KEYS = [
-  "attemptedTurnCount",
-  "extractionCount",
-  "persistedCount",
-  "durableOutputCount",
-  "skippedCount",
-  "failedCount",
-  "postPersistMetadataFailureCount",
-  "processedTurnCount",
-] as const;
-
-type IngestResultCounterKey = (typeof INGEST_RESULT_COUNTER_KEYS)[number];
-type IngestResultCounters = Record<IngestResultCounterKey, number>;
-
-function emptyIngestResultCounters(): IngestResultCounters {
-  return {
-    attemptedTurnCount: 0,
-    extractionCount: 0,
-    persistedCount: 0,
-    durableOutputCount: 0,
-    skippedCount: 0,
-    failedCount: 0,
-    postPersistMetadataFailureCount: 0,
-    processedTurnCount: 0,
-  };
-}
-
-function mergeIngestResultCounters(
-  aggregate: IngestResultCounters,
-  result: void | OpenClawFlushPlanIngestResult,
-): void {
-  if (!result || typeof result !== "object") return;
-  for (const key of INGEST_RESULT_COUNTER_KEYS) {
-    const value = result[key];
-    if (typeof value === "number" && Number.isFinite(value)) {
-      aggregate[key] += value;
-    }
-  }
-}
-
-async function ingestFlushPlanImportTurns(params: {
-  ingestor: OpenClawFlushPlanIngestor;
-  importTurns: ImportTurn[];
-  deadlineMs?: number;
-}): Promise<void | OpenClawFlushPlanIngestResult> {
-  const aggregate = emptyIngestResultCounters();
-
-  for (const turn of params.importTurns) {
-    let result: void | OpenClawFlushPlanIngestResult;
-    try {
-      // One turn per call keeps each chunk on its own bulk-import session key
-      // so chunked flush plans never recombine into one extraction buffer.
-      result = await params.ingestor.ingestBulkImportBatch([turn], {
-        ...(params.deadlineMs === undefined
-          ? {}
-          : { deadlineMs: params.deadlineMs }),
-        failOnExtractionFailure: true,
-        includeSourceValidAtContext: false,
-      });
-    } catch (error) {
-      mergeIngestResultCounters(
-        aggregate,
-        partialIngestResultFromError(error),
-      );
-      if (aggregate.failedCount <= 0) aggregate.failedCount += 1;
-      if (aggregate.processedTurnCount > 0) return aggregate;
-      throw error;
-    }
-
-    mergeIngestResultCounters(aggregate, result);
-    if (isFailedIngestResult(result)) return aggregate;
-    if (
-      !(
-        typeof result?.processedTurnCount === "number" &&
-        result.processedTurnCount > 0
-      )
-    ) {
-      aggregate.processedTurnCount += 1;
-    }
-  }
-
-  return aggregate;
-}
 
 function hasPostPersistMetadataFailure(
   result: void | OpenClawFlushPlanIngestResult,

--- a/src/openclaw-flush-plan-lifecycle.ts
+++ b/src/openclaw-flush-plan-lifecycle.ts
@@ -784,30 +784,88 @@ function partialIngestResultFromError(
   return partialResult as OpenClawFlushPlanIngestResult;
 }
 
+const INGEST_RESULT_COUNTER_KEYS = [
+  "attemptedTurnCount",
+  "extractionCount",
+  "persistedCount",
+  "durableOutputCount",
+  "skippedCount",
+  "failedCount",
+  "postPersistMetadataFailureCount",
+  "processedTurnCount",
+] as const;
+
+type IngestResultCounterKey = (typeof INGEST_RESULT_COUNTER_KEYS)[number];
+type IngestResultCounters = Record<IngestResultCounterKey, number>;
+
+function emptyIngestResultCounters(): IngestResultCounters {
+  return {
+    attemptedTurnCount: 0,
+    extractionCount: 0,
+    persistedCount: 0,
+    durableOutputCount: 0,
+    skippedCount: 0,
+    failedCount: 0,
+    postPersistMetadataFailureCount: 0,
+    processedTurnCount: 0,
+  };
+}
+
+function mergeIngestResultCounters(
+  aggregate: IngestResultCounters,
+  result: void | OpenClawFlushPlanIngestResult,
+): void {
+  if (!result || typeof result !== "object") return;
+  for (const key of INGEST_RESULT_COUNTER_KEYS) {
+    const value = result[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      aggregate[key] += value;
+    }
+  }
+}
+
 async function ingestFlushPlanImportTurns(params: {
   ingestor: OpenClawFlushPlanIngestor;
   importTurns: ImportTurn[];
   deadlineMs?: number;
 }): Promise<void | OpenClawFlushPlanIngestResult> {
-  try {
-    return await params.ingestor.ingestBulkImportBatch(params.importTurns, {
-      ...(params.deadlineMs === undefined
-        ? {}
-        : { deadlineMs: params.deadlineMs }),
-      failOnExtractionFailure: true,
-      includeSourceValidAtContext: false,
-    });
-  } catch (error) {
-    const partialResult = partialIngestResultFromError(error);
-    if (
-      partialResult &&
-      typeof partialResult.processedTurnCount === "number" &&
-      partialResult.processedTurnCount > 0
-    ) {
-      return partialResult;
+  const aggregate = emptyIngestResultCounters();
+
+  for (const turn of params.importTurns) {
+    let result: void | OpenClawFlushPlanIngestResult;
+    try {
+      // One turn per call keeps each chunk on its own bulk-import session key
+      // so chunked flush plans never recombine into one extraction buffer.
+      result = await params.ingestor.ingestBulkImportBatch([turn], {
+        ...(params.deadlineMs === undefined
+          ? {}
+          : { deadlineMs: params.deadlineMs }),
+        failOnExtractionFailure: true,
+        includeSourceValidAtContext: false,
+      });
+    } catch (error) {
+      mergeIngestResultCounters(
+        aggregate,
+        partialIngestResultFromError(error),
+      );
+      if (aggregate.failedCount <= 0) aggregate.failedCount += 1;
+      if (aggregate.processedTurnCount > 0) return aggregate;
+      throw error;
     }
-    throw error;
+
+    mergeIngestResultCounters(aggregate, result);
+    if (isFailedIngestResult(result)) return aggregate;
+    if (
+      !(
+        typeof result?.processedTurnCount === "number" &&
+        result.processedTurnCount > 0
+      )
+    ) {
+      aggregate.processedTurnCount += 1;
+    }
   }
+
+  return aggregate;
 }
 
 function hasPostPersistMetadataFailure(

--- a/src/openclaw-flush-plan-serial-ingest.ts
+++ b/src/openclaw-flush-plan-serial-ingest.ts
@@ -1,0 +1,106 @@
+import type { ImportTurn } from "@remnic/core/bulk-import";
+import type {
+  OpenClawFlushPlanIngestor,
+  OpenClawFlushPlanIngestResult,
+} from "./openclaw-flush-plan-lifecycle.js";
+
+export function isFailedIngestResult(
+  result: void | OpenClawFlushPlanIngestResult,
+): boolean {
+  return Boolean(
+    result &&
+      typeof result === "object" &&
+      typeof result.failedCount === "number" &&
+      result.failedCount > 0,
+  );
+}
+
+function partialIngestResultFromError(
+  error: unknown,
+): OpenClawFlushPlanIngestResult | undefined {
+  if (!error || typeof error !== "object" || !("partialResult" in error)) {
+    return undefined;
+  }
+  const partialResult = error.partialResult;
+  if (!partialResult || typeof partialResult !== "object") return undefined;
+  return partialResult as OpenClawFlushPlanIngestResult;
+}
+
+const INGEST_RESULT_COUNTER_KEYS = [
+  "attemptedTurnCount",
+  "extractionCount",
+  "persistedCount",
+  "durableOutputCount",
+  "skippedCount",
+  "failedCount",
+  "postPersistMetadataFailureCount",
+  "processedTurnCount",
+] as const;
+
+type IngestResultCounterKey = (typeof INGEST_RESULT_COUNTER_KEYS)[number];
+type IngestResultCounters = Record<IngestResultCounterKey, number>;
+
+function emptyIngestResultCounters(): IngestResultCounters {
+  return {
+    attemptedTurnCount: 0,
+    extractionCount: 0,
+    persistedCount: 0,
+    durableOutputCount: 0,
+    skippedCount: 0,
+    failedCount: 0,
+    postPersistMetadataFailureCount: 0,
+    processedTurnCount: 0,
+  };
+}
+
+function mergeIngestResultCounters(
+  aggregate: IngestResultCounters,
+  result: void | OpenClawFlushPlanIngestResult,
+): void {
+  if (!result || typeof result !== "object") return;
+  for (const key of INGEST_RESULT_COUNTER_KEYS) {
+    const value = result[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      aggregate[key] += value;
+    }
+  }
+}
+
+export async function ingestFlushPlanImportTurns(params: {
+  ingestor: OpenClawFlushPlanIngestor;
+  importTurns: ImportTurn[];
+  deadlineMs?: number;
+}): Promise<void | OpenClawFlushPlanIngestResult> {
+  const aggregate = emptyIngestResultCounters();
+
+  for (const turn of params.importTurns) {
+    let result: void | OpenClawFlushPlanIngestResult;
+    try {
+      result = await params.ingestor.ingestBulkImportBatch([turn], {
+        ...(params.deadlineMs === undefined
+          ? {}
+          : { deadlineMs: params.deadlineMs }),
+        failOnExtractionFailure: true,
+        includeSourceValidAtContext: false,
+      });
+    } catch (error) {
+      mergeIngestResultCounters(aggregate, partialIngestResultFromError(error));
+      if (aggregate.failedCount <= 0) aggregate.failedCount += 1;
+      if (aggregate.processedTurnCount > 0) return aggregate;
+      throw error;
+    }
+
+    mergeIngestResultCounters(aggregate, result);
+    if (isFailedIngestResult(result)) return aggregate;
+    if (
+      !(
+        typeof result?.processedTurnCount === "number" &&
+        result.processedTurnCount > 0
+      )
+    ) {
+      aggregate.processedTurnCount += 1;
+    }
+  }
+
+  return aggregate;
+}

--- a/tests/openclaw-flush-plan-lifecycle.test.ts
+++ b/tests/openclaw-flush-plan-lifecycle.test.ts
@@ -349,6 +349,46 @@ test("processOpenClawFlushPlanFile chunks oversized snapshots before clearing", 
   });
 });
 
+test("processOpenClawFlushPlanFile replays oversized chunks in isolated size-one batches", async () => {
+  await withWorkspace(async (workspaceDir, flushPlanPath) => {
+    const maxTurnChars = 260;
+    const content = [
+      `- ${"Alpha serial flush-plan detail ".repeat(8)}`,
+      `- ${"Beta serial flush-plan detail ".repeat(8)}`,
+      `- ${"Gamma serial flush-plan detail ".repeat(8)}`,
+    ].join("\n");
+    await writeFlushPlan(flushPlanPath, content);
+    const batchSizes: number[] = [];
+    const received: ImportTurn[] = [];
+
+    const result = await processOpenClawFlushPlanFile({
+      enabled: true,
+      workspaceDir,
+      serviceId: SERVICE_ID,
+      maxTurnChars,
+      now: () => new Date("2026-06-24T00:00:00.000Z"),
+      ingestor: {
+        async ingestBulkImportBatch(turns) {
+          batchSizes.push(turns.length);
+          received.push(...turns);
+        },
+      },
+    });
+
+    assert.equal(result.status, "processed");
+    assert.ok(received.length > 1, "fixture should produce multiple chunks");
+    assert.equal(batchSizes.length, received.length);
+    assert.ok(
+      batchSizes.every((size) => size === 1),
+      `every oversized-plan ingest batch must have size one, got ${batchSizes.join(",")}`,
+    );
+    assert.equal(
+      received.map((turn) => String(turn.rawContent ?? "")).join(""),
+      content.trim(),
+    );
+  });
+});
+
 test("processOpenClawFlushPlanFile reuses pending marker chunk fingerprints after config changes", async () => {
   await withWorkspace(async (workspaceDir, flushPlanPath) => {
     const firstMaxTurnChars = 260;
@@ -358,7 +398,6 @@ test("processOpenClawFlushPlanFile reuses pending marker chunk fingerprints afte
       `- ${"Gamma pending flush-plan detail ".repeat(8)}`,
     ].join("\n");
     await writeFlushPlan(flushPlanPath, content);
-    const firstTurns: ImportTurn[] = [];
 
     await assert.rejects(
       processOpenClawFlushPlanFile({
@@ -369,7 +408,11 @@ test("processOpenClawFlushPlanFile reuses pending marker chunk fingerprints afte
         now: () => new Date("2026-06-24T00:00:00.000Z"),
         ingestor: {
           async ingestBulkImportBatch(turns) {
-            firstTurns.push(...turns);
+            assert.equal(
+              turns.length,
+              1,
+              "flush-plan chunks must be replayed one batch per turn",
+            );
             throw new Error("backend unavailable");
           },
         },
@@ -377,15 +420,17 @@ test("processOpenClawFlushPlanFile reuses pending marker chunk fingerprints afte
       /backend unavailable/,
     );
 
-    assert.ok(firstTurns.length > 1);
     const marker = JSON.parse(
       await readFile(processedMarkerPath(flushPlanPath), "utf8"),
     ) as {
       status?: string;
-      processedChunks?: unknown[];
+      processedChunks?: {
+        turnFingerprint?: string;
+        timestamp?: string;
+      }[];
     };
     assert.equal(marker.status, "pending");
-    assert.equal(marker.processedChunks?.length, firstTurns.length);
+    assert.ok((marker.processedChunks?.length ?? 0) > 1);
 
     const secondTurns: ImportTurn[] = [];
     const result = await processOpenClawFlushPlanFile({
@@ -395,23 +440,29 @@ test("processOpenClawFlushPlanFile reuses pending marker chunk fingerprints afte
       maxTurnChars: 4000,
       ingestor: {
         async ingestBulkImportBatch(turns) {
+          assert.equal(
+            turns.length,
+            1,
+            "marker recovery must keep replaying one batch per turn",
+          );
           secondTurns.push(...turns);
         },
       },
     });
 
     assert.equal(result.status, "processed_marker_recovered");
-    assert.deepEqual(
-      secondTurns.map((turn) => turn.rawContent),
-      firstTurns.map((turn) => turn.rawContent),
-    );
+    assert.equal(secondTurns.length, marker.processedChunks?.length);
     assert.deepEqual(
       secondTurns.map((turn) => turn.turnFingerprint),
-      firstTurns.map((turn) => turn.turnFingerprint),
+      marker.processedChunks?.map((chunk) => chunk.turnFingerprint),
     );
     assert.deepEqual(
       secondTurns.map((turn) => turn.timestamp),
-      firstTurns.map((turn) => turn.timestamp),
+      marker.processedChunks?.map((chunk) => chunk.timestamp),
+    );
+    assert.equal(
+      secondTurns.map((turn) => String(turn.rawContent ?? "")).join(""),
+      content.trim(),
     );
   });
 });
@@ -1220,7 +1271,6 @@ test("processOpenClawFlushPlanFile defers cleanup without retry after metadata-o
     assert.equal(importCalls, 1);
   });
 });
-
 test("processOpenClawFlushPlanFile preserves only failed tail after partial durable import", async () => {
   await withWorkspace(async (workspaceDir, flushPlanPath) => {
     const content =
@@ -1238,23 +1288,29 @@ test("processOpenClawFlushPlanFile preserves only failed tail after partial dura
       ingestor: {
         async ingestBulkImportBatch(turns) {
           importCalls += 1;
-          assert.ok(turns.length > 1, "test fixture should produce multiple chunks");
-          firstProcessedChunk =
-            typeof turns[0]?.rawContent === "string"
-              ? turns[0].rawContent
-              : (turns[0]?.content ?? "");
+          assert.equal(
+            turns.length,
+            1,
+            "flush-plan chunks must be replayed one batch per turn",
+          );
+          if (importCalls === 1) {
+            firstProcessedChunk =
+              typeof turns[0]?.rawContent === "string"
+                ? turns[0].rawContent
+                : (turns[0]?.content ?? "");
+            return undefined;
+          }
           const partialFailure = new Error("later chunk failed") as Error & {
             partialResult: Record<string, unknown>;
           };
           partialFailure.partialResult = {
-            attemptedTurnCount: turns.length,
-            extractionCount: 1,
-            persistedCount: 1,
-            durableOutputCount: 1,
+            attemptedTurnCount: 1,
+            extractionCount: 0,
+            persistedCount: 0,
+            durableOutputCount: 0,
             skippedCount: 0,
             failedCount: 1,
             postPersistMetadataFailureCount: 1,
-            processedTurnCount: 1,
           };
           throw partialFailure;
         },
@@ -1265,6 +1321,7 @@ test("processOpenClawFlushPlanFile preserves only failed tail after partial dura
     assert.match(first.reason ?? "", /metadata persistence was incomplete/);
     assert.equal(await readFile(flushPlanPath, "utf8"), content);
     assert.ok(firstProcessedChunk.length > 0);
+    assert.equal(importCalls, 2);
 
     const second = await processOpenClawFlushPlanFile({
       enabled: true,
@@ -1284,7 +1341,6 @@ test("processOpenClawFlushPlanFile preserves only failed tail after partial dura
       content.slice(firstProcessedChunk.length),
     );
     await assert.rejects(readFile(processedMarkerPath(flushPlanPath), "utf8"), /ENOENT/);
-    assert.equal(importCalls, 1);
   });
 });
 


### PR DESCRIPTION
## Why

Flush-plan recovery chunks an oversized snapshot into multiple `ImportTurn`s, but submitted all turns in one `ingestBulkImportBatch` call. Because the turns carry persistent fingerprints, bulk ingestion gives the entire batch one stable session key and a shared extraction buffer, so the chunks that were split to bound extraction size recombine. That produces oversized extraction prompts (model timeouts, heap pressure) and a failure late in the batch delays durable progress for earlier chunks.

## What Changed

- `ingestFlushPlanImportTurns` in `src/openclaw-flush-plan-lifecycle.ts` now calls `ingestBulkImportBatch([turn])` sequentially, one turn per call, so each chunk gets an isolated import session while preserving order.
- Ingest counters are aggregated across successful turns; the loop stops at the first failed result.
- When a later call throws, an aggregate partial result is returned so the already-processed prefix is removed and only the tail is retained (existing deadline, marker, and prefix/tail recovery semantics unchanged).
- Tests: new regression asserting every oversized-plan ingest batch has size one; updated the two multi-chunk tests that assumed a single combined batch.

Fixes #2459