### PR TITLE
fix(extraction): salvage valid items from mixed-invalid model output

### DIFF
--- a/.changeset/2455-extraction-salvage-mixed-invalid.md
+++ b/.changeset/2455-extraction-salvage-mixed-invalid.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Salvage valid items from mixed-invalid extraction model output: one malformed fact, entity, question, relationship, or profile update no longer discards the whole extraction result. A non-empty array with zero valid items still fails so bounded retry stays effective.

--- a/packages/remnic-core/src/schemas.test.ts
+++ b/packages/remnic-core/src/schemas.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ConsolidationResultSchema, ExtractionResultSchema } from "./schemas.js";
+
+// Synthetic fixtures only — no real memory content (public repo).
+const validFact = {
+  category: "fact",
+  content: "The API rate limit is 1000 requests per minute.",
+  confidence: 0.8,
+  tags: ["api"],
+};
+
+const validEntity = {
+  name: "acme-corp",
+  type: "company",
+  facts: ["Uses PostgreSQL for the main database."],
+};
+
+const validQuestion = {
+  question: "Which service enforces the rate limit?",
+  context: "The limit shape suggests an upstream gateway.",
+  priority: 0.4,
+};
+
+const validRelationship = {
+  source: "person-jane-doe",
+  target: "acme-corp",
+  label: "works at",
+};
+
+function baseResult() {
+  return {
+    facts: [validFact],
+    profileUpdates: ["Prefers concise status updates."],
+    entities: [validEntity],
+    questions: [validQuestion],
+    relationships: [validRelationship],
+  };
+}
+
+test("ExtractionResultSchema salvages valid facts from a mixed-invalid array (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    ...baseResult(),
+    facts: [
+      validFact,
+      { category: "not-a-category", content: "x", confidence: 0.5, tags: [] },
+      { category: "fact", content: "missing confidence", tags: [] },
+      // procedure facts without steps fail the superRefine — salvage must
+      // respect refinement issues, not just base-shape issues
+      { category: "procedure", content: "Deploy the service.", confidence: 0.9, tags: ["deploy"] },
+      "bare string is not a fact",
+    ],
+  });
+
+  assert.equal(parsed.success, true);
+  assert.deepEqual(parsed.data?.facts, [validFact]);
+});
+
+test("ExtractionResultSchema fails when a non-empty facts array is wholly invalid (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    ...baseResult(),
+    facts: [
+      { category: "not-a-category", content: "x", confidence: 0.5, tags: [] },
+      42,
+    ],
+  });
+
+  assert.equal(parsed.success, false);
+  assert.ok(
+    parsed.error.issues.some((issue) => issue.message.includes("no items matching the schema")),
+  );
+});
+
+test("ExtractionResultSchema keeps explicitly empty arrays valid (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    facts: [],
+    profileUpdates: [],
+    entities: [],
+    questions: [],
+    relationships: [],
+  });
+
+  assert.equal(parsed.success, true);
+  assert.deepEqual(parsed.data?.facts, []);
+  assert.deepEqual(parsed.data?.questions, []);
+});
+
+test("ExtractionResultSchema salvages valid entities from a mixed-invalid array (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    ...baseResult(),
+    entities: [
+      validEntity,
+      { name: "bad-type", type: "organization", facts: ["nope"] },
+      { name: "bad-facts", type: "person", facts: [17] },
+      null,
+    ],
+  });
+
+  assert.equal(parsed.success, true);
+  assert.deepEqual(parsed.data?.entities, [validEntity]);
+});
+
+test("ExtractionResultSchema fails when a non-empty entities array is wholly invalid (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    ...baseResult(),
+    entities: [{ name: "bad-type", type: "organization", facts: ["nope"] }],
+  });
+
+  assert.equal(parsed.success, false);
+});
+
+test("ExtractionResultSchema salvages valid questions from a mixed-invalid array (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    ...baseResult(),
+    questions: [
+      validQuestion,
+      { question: "no context", priority: 0.3 },
+      { question: "bad priority", context: "out of range", priority: 5 },
+    ],
+  });
+
+  assert.equal(parsed.success, true);
+  assert.deepEqual(parsed.data?.questions, [validQuestion]);
+});
+
+test("ExtractionResultSchema salvages valid profileUpdates and relationships (#2455)", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    ...baseResult(),
+    profileUpdates: ["Prefers concise status updates.", 42, null],
+    relationships: [validRelationship, { source: "jane-doe", label: "missing target" }],
+  });
+
+  assert.equal(parsed.success, true);
+  assert.deepEqual(parsed.data?.profileUpdates, ["Prefers concise status updates."]);
+  assert.deepEqual(parsed.data?.relationships, [validRelationship]);
+});
+
+test("ExtractionResultSchema still accepts null/omitted relationships (#2455)", () => {
+  const nullParsed = ExtractionResultSchema.safeParse({ ...baseResult(), relationships: null });
+  assert.equal(nullParsed.success, true);
+
+  const omitted: Record<string, unknown> = { ...baseResult() };
+  delete omitted.relationships;
+  const omittedParsed = ExtractionResultSchema.safeParse(omitted);
+  assert.equal(omittedParsed.success, true);
+});
+
+test("ConsolidationResultSchema stays strict on mixed-invalid arrays (#2455)", () => {
+  const validItem = { existingId: "fact-1", action: "SKIP", reason: "still accurate" };
+  const parsed = ConsolidationResultSchema.safeParse({
+    items: [validItem, { existingId: "fact-2", action: "DESTROY", reason: "bad enum" }],
+    profileUpdates: [],
+    entityUpdates: [],
+  });
+
+  assert.equal(parsed.success, false);
+});

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -278,27 +278,51 @@ export const ProactiveExtractionResultSchema = z.object({
     ),
 });
 
+/**
+ * Salvage array for model-produced extraction output (issue #2455).
+ *
+ * Mixed valid+invalid items parse to the valid subset so one malformed
+ * element no longer discards the whole extraction. A non-empty array with
+ * zero valid items still fails, so bounded retry stays effective and wholly
+ * malformed output is never silently accepted as empty. Empty arrays stay
+ * valid. Consolidation schemas intentionally stay strict — do not use this
+ * for them.
+ */
+function salvageArray<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z
+    .array(z.unknown())
+    .transform((items, ctx) => {
+      const valid: z.infer<T>[] = [];
+      for (const raw of items) {
+        const parsed = itemSchema.safeParse(raw);
+        if (parsed.success) {
+          valid.push(parsed.data);
+        }
+      }
+      if (items.length > 0 && valid.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "array contains no items matching the schema",
+        });
+        return z.NEVER;
+      }
+      return valid;
+    });
+}
+
 export const ExtractionResultSchema = z.object({
-  facts: z
-    .array(ExtractedFactSchema)
-    .describe(
-      "Extracted memories from the conversation. Include facts, preferences, corrections, and decisions. Only extract genuinely new, durable information — skip transient task state.",
-    ),
-  profileUpdates: z
-    .array(z.string())
-    .describe(
-      "Updates to the user's behavioral profile. Each string is a standalone statement about the user's preferences, habits, or personality. Only include genuinely new insights.",
-    ),
-  entities: z
-    .array(EntityMentionSchema)
-    .describe(
-      "Entities mentioned in the conversation with new facts about them.",
-    ),
-  questions: z
-    .array(ExtractedQuestionSchema)
-    .describe(
-      "Zero to three source-grounded questions useful in future sessions. Return an empty array when the conversation supports none.",
-    ),
+  facts: salvageArray(ExtractedFactSchema).describe(
+    "Extracted memories from the conversation. Include facts, preferences, corrections, and decisions. Only extract genuinely new, durable information — skip transient task state.",
+  ),
+  profileUpdates: salvageArray(z.string()).describe(
+    "Updates to the user's behavioral profile. Each string is a standalone statement about the user's preferences, habits, or personality. Only include genuinely new insights.",
+  ),
+  entities: salvageArray(EntityMentionSchema).describe(
+    "Entities mentioned in the conversation with new facts about them.",
+  ),
+  questions: salvageArray(ExtractedQuestionSchema).describe(
+    "Zero to three source-grounded questions useful in future sessions. Return an empty array when the conversation supports none.",
+  ),
   identityReflection: z
     .string()
     .optional()
@@ -311,8 +335,7 @@ export const ExtractionResultSchema = z.object({
     .optional()
     .nullable()
     .describe("A six-to-eight word title for this conversation segment."),
-  relationships: z
-    .array(ExtractedRelationshipSchema)
+  relationships: salvageArray(ExtractedRelationshipSchema)
     .optional()
     .nullable()
     .describe(


### PR DESCRIPTION
## Why

`ExtractionResultSchema` validated each model-produced array as one strict unit (#2455). One malformed fact, entity, question, relationship, or profile update rejected the whole extraction result. Valid memories in the same model response were lost and the run degraded to `fallback_no_parsed_output`; bounded retries could not fix deterministic schema deviations.

## What Changed

- Added a `salvageArray` helper in `packages/remnic-core/src/schemas.ts`:
  - mixed valid+invalid items parse to the valid subset;
  - a non-empty array with zero valid items still fails, so bounded retry stays effective and wholly malformed output is never accepted as empty;
  - empty arrays stay valid.
- Applied it to the five arrays owned by `ExtractionResultSchema` (`facts`, `profileUpdates`, `entities`, `questions`, `relationships`). Field descriptions and the `relationships` optional/nullable shape are unchanged.
- `ConsolidationResultSchema` and the other consolidation schemas stay strict, per the issue contract.
- Added focused schema tests (`packages/remnic-core/src/schemas.test.ts`) proving the three cases for facts, entities, questions, profileUpdates, and relationships, plus the consolidation strictness guard.

Fixes #2455