### PR TITLE
feat: add Factory Droid connector

### DIFF
--- a/.changeset/droid-connector.md
+++ b/.changeset/droid-connector.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/connector-droid": patch
+---
+
+Add Factory Droid connector (`remnic connectors install droid`). Mints a host token, records connector state, and writes a `remnic` MCP server entry (HTTP + bearer auth) to the user-level `~/.factory/mcp.json`. Never writes tokens to the project-level `.factory/mcp.json`. `remnic connectors doctor droid` and `remnic connectors remove droid` are supported. Built by Droid.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Open-source, local-first memory and context for AI agents. One memory store, eve
 Website: **[remnic.ai](https://remnic.ai)** - guide library, comparisons, benchmarks, and changelog.
 
 - **Your files, your machine.** Every memory is a plain markdown file with YAML frontmatter on your disk. No database, no cloud dependency, no subscription. `cat`, `grep`, edit, and version-control your memory with the tools you already use.
-- **One memory across every tool.** OpenClaw, Claude Code, Codex CLI, Cursor, ChatGPT (developer mode), Hermes, Replit, Pi, omp, and any MCP client read and write the same store. Tell one agent a preference; every agent knows it.
+- **One memory across every tool.** OpenClaw, Claude Code, Codex CLI, Cursor, ChatGPT (developer mode), Hermes, Replit, Pi, omp, Factory Droid, and any MCP client read and write the same store. Tell one agent a preference; every agent knows it.
 - **Automatic extraction and recall.** Remnic watches conversations, distills durable knowledge, and injects the right context back when it is needed.
 - **Sharp retrieval.** Hybrid search (BM25 + vector + reranking) over rebuildable indexes, with graph recall, memory-worth scoring, and per-result provenance you can inspect.
 - **MIT licensed.** Free, open, and built to be forked.
@@ -320,6 +320,7 @@ One store, many front doors. Each integration reads and writes the same memory o
 | Replit | MCP | On demand | [docs/plugins/replit.md](docs/plugins/replit.md) |
 | Pi Coding Agent | Native extension + MCP + compaction | Every turn / every turn | [docs/integration/pi.md](docs/integration/pi.md) |
 | Oh My Pi (omp) | Native extension + MCP | Every turn / every turn | [docs/integration/omp.md](docs/integration/omp.md) |
+| Factory Droid | HTTP MCP + bearer auth | On demand | [docs/integration/droid.md](docs/integration/droid.md) |
 | Any MCP client | HTTP or stdio MCP | On demand | [docs/integration/connector-setup.md](docs/integration/connector-setup.md) |
 
 Once the daemon is running, register each tool with a single command:
@@ -330,6 +331,7 @@ remnic connectors install claude-code   # token + connector state
 remnic connectors install pi            # token + connector state
 remnic connectors install omp           # token + connector state
 remnic connectors install replit        # token + connector state
+remnic connectors install droid         # token + connector state + ~/.factory/mcp.json
 ```
 
 Each install mints a host-specific auth token and records Remnic-side connector state; for some hosts (such as Codex CLI) it also materializes the memory extension. How much of the host itself gets configured varies — Claude Code and Hermes, for example, need a few manual wiring steps documented in their plugin guides. See the [connector setup guide](docs/integration/connector-setup.md) for every tool, exactly what its install automates, its config snippet, and multi-tenant setups.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -20,7 +20,7 @@ For the live-connector framework contract (how to write one) see
 
 | Command | Family | What it does |
 |---|---|---|
-| `remnic connectors list` | Agent-tool | List the 14 marketplace agent-tool connectors and their install state |
+| `remnic connectors list` | Agent-tool | List the 15 marketplace agent-tool connectors and their install state |
 | `remnic connectors install <id>` | Agent-tool | Install a connector and publish its memory extension |
 | `remnic connectors remove <id>` | Agent-tool | Remove a connector and unpublish its extension |
 | `remnic connectors doctor <id>` | Agent-tool | Health-check one connector and its publisher |

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -49,10 +49,10 @@ Available connectors:
   ...
 ```
 
-`✓` marks an installed connector, `○` an available one. The 14 built-ins are
+`✓` marks an installed connector, `○` an available one. The 15 built-ins are
 `claude-code`, `codex-cli`, `cursor`, `cline`, `github-copilot`, `roo-code`,
-`windsurf`, `amp`, `pi`, `omp`, `replit`, `generic-mcp`, `weclone`, and
-`hermes`. Add `--json` for machine-readable `{ installed, available }`.
+`windsurf`, `amp`, `pi`, `omp`, `replit`, `generic-mcp`, `weclone`, `hermes`,
+and `droid`. Add `--json` for machine-readable `{ installed, available }`.
 
 ### Install, remove, doctor
 

--- a/docs/integration/connector-setup.md
+++ b/docs/integration/connector-setup.md
@@ -349,6 +349,32 @@ for the full config reference and architecture diagram.
 
 ---
 
+---
+
+## Factory Droid
+
+[Factory Droid](https://factory.ai) is an AI software engineering agent. Install the connector to give Droid persistent memory:
+
+```bash
+remnic connectors install droid
+```
+
+This mints a host token, records connector state, and writes a `remnic` entry to the **user-level** `~/.factory/mcp.json` (HTTP MCP + Authorization bearer). Existing MCP server entries are preserved. The project-level `.factory/mcp.json` is never touched.
+
+Optional configuration:
+
+```bash
+remnic connectors install droid \
+  --config mcpServerUrl=http://127.0.0.1:4318/mcp \
+  --config namespace=my-project
+```
+
+See the [full Droid integration guide](droid.md) for doctor, remove, and troubleshooting.
+
+**Capabilities:** observe, recall, store, search, entities, real-time sync, batch
+
+---
+
 ## Generic MCP Client
 
 Any tool that supports the [Model Context Protocol](https://modelcontextprotocol.io/) can connect to Remnic. Point your client at:

--- a/docs/integration/droid.md
+++ b/docs/integration/droid.md
@@ -1,0 +1,160 @@
+# Factory Droid Integration
+
+> **Built by Droid.** This connector was implemented by Factory Droid itself —
+> Droid wrote the code, tests, and this document. See the PR description for
+> the full walkthrough of Droid commands, commit SHAs, and before/after output.
+
+[Factory Droid](https://factory.ai) is an AI software engineering agent that
+works in your environment. With the Remnic Droid connector, Droid gets
+persistent memory across sessions: every conversation can recall relevant
+context and store new knowledge into your shared Remnic memory store.
+
+## Quickstart
+
+```bash
+# 1. Start the Remnic daemon
+remnic daemon start
+
+# 2. Install the Droid connector
+remnic connectors install droid
+
+# 3. Verify the install
+remnic connectors doctor droid
+
+# 4. Confirm Droid can see the remnic MCP server
+#    (restart Droid or open a new session)
+```
+
+That's it. Droid reads MCP server config from `~/.factory/mcp.json` at startup.
+The install writes a `remnic` entry with HTTP transport and a bearer token so
+Droid authenticates to your local Remnic daemon automatically.
+
+## What `install` does
+
+`remnic connectors install droid` performs three actions:
+
+1. **Mints a host token.** A per-connector bearer token is generated and stored
+   in `~/.remnic/tokens.json` (the authoritative token store, permissions
+   `0600`). The token is never written into the connector registry file.
+
+2. **Records connector state.** A `droid.json` file is written to the Remnic
+   connectors directory (`~/.config/remnic/.remnic-connectors/connectors/droid.json`).
+   This tracks the install time, the resolved MCP server URL, and the path to
+   `~/.factory/mcp.json` so `remove` can find it later.
+
+3. **Writes `~/.factory/mcp.json`.** The install upserts a `remnic` entry under
+   `mcpServers` with HTTP transport and the `Authorization: Bearer <token>`
+   header. Existing MCP server entries are preserved — only the `remnic` key
+   is added or updated.
+
+### User-level vs project-level
+
+The install writes to the **user-level** `~/.factory/mcp.json` only. It never
+touches the project-level `.factory/mcp.json`, which may be committed to git
+and would expose the bearer token to anyone with repository access.
+
+## Configuration
+
+Optional overrides via `--config`:
+
+```bash
+remnic connectors install droid \
+  --config mcpServerUrl=http://127.0.0.1:4318/mcp \
+  --config namespace=my-project
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mcpServerUrl` | `http://127.0.0.1:4318/mcp` | URL of the Remnic MCP server |
+| `namespace` | _(none)_ | Optional memory namespace for project/team isolation |
+
+## Doctor
+
+```bash
+remnic connectors doctor droid
+```
+
+Checks:
+
+- **Config file** — the `droid.json` registry file exists and is valid JSON
+- **Config valid** — parses without errors
+- **Droid MCP config** — `~/.factory/mcp.json` contains a `remnic` entry under
+  `mcpServers`
+
+## Remove
+
+```bash
+remnic connectors remove droid
+```
+
+This removes the `remnic` entry from `~/.factory/mcp.json` (preserving all
+other MCP server entries), deletes the `droid.json` registry file, and revokes
+the bearer token from `~/.remnic/tokens.json`.
+
+## Manual setup (without `remnic connectors install`)
+
+If you prefer to configure Droid manually, add this to `~/.factory/mcp.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "remnic": {
+      "type": "http",
+      "url": "http://localhost:4318/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-remnic-token>"
+      }
+    }
+  }
+}
+```
+
+Generate a token with `remnic token generate droid` and use the returned value
+in place of `<your-remnic-token>`.
+
+## Capabilities
+
+| Capability | Supported |
+|------------|-----------|
+| Observe | Yes |
+| Recall | Yes |
+| Store | Yes |
+| Search | Yes |
+| Entities | Yes |
+| Real-time sync | Yes |
+| Batch | Yes |
+
+## Troubleshooting
+
+### Droid doesn't see the remnic MCP tools
+
+Restart Droid or open a new session — it reads `~/.factory/mcp.json` at
+startup. Verify the entry exists:
+
+```bash
+remnic connectors doctor droid
+```
+
+### 401 Unauthorized
+
+The token in `~/.factory/mcp.json` doesn't match what the daemon expects.
+Reinstall to mint a fresh token:
+
+```bash
+remnic connectors install droid --force
+```
+
+### Connection refused
+
+The Remnic daemon isn't running:
+
+```bash
+remnic daemon start
+```
+
+Verify with:
+
+```bash
+curl -H "Authorization: Bearer $(remnic token list --json | jq -r '.tokens[] | select(.connector=="droid") | .token')" \
+  http://localhost:4318/engram/v1/health
+```

--- a/docs/integration/droid.md
+++ b/docs/integration/droid.md
@@ -100,7 +100,7 @@ If you prefer to configure Droid manually, add this to `~/.factory/mcp.json`:
   "mcpServers": {
     "remnic": {
       "type": "http",
-      "url": "http://localhost:4318/mcp",
+      "url": "http://127.0.0.1:4318/mcp",
       "headers": {
         "Authorization": "Bearer <your-remnic-token>"
       }

--- a/packages/connector-droid/README.md
+++ b/packages/connector-droid/README.md
@@ -1,0 +1,32 @@
+# @remnic/connector-droid
+
+> **Built by Droid.** This connector was implemented by Factory Droid itself.
+
+Factory Droid connector for Remnic — connect [Droid](https://factory.ai) to
+your shared memory store via HTTP MCP.
+
+## Install
+
+```bash
+remnic connectors install droid
+```
+
+This mints a host token, records Remnic-side connector state, and writes a
+`remnic` entry to the **user-level** `~/.factory/mcp.json` with HTTP transport
+and an `Authorization: Bearer <token>` header. The project-level
+`.factory/mcp.json` is never touched.
+
+## Verify
+
+```bash
+remnic connectors doctor droid
+```
+
+## Remove
+
+```bash
+remnic connectors remove droid
+```
+
+See [docs/integration/droid.md](../../docs/integration/droid.md) for the full
+guide.

--- a/packages/connector-droid/package.json
+++ b/packages/connector-droid/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@remnic/connector-droid",
+  "version": "9.63.0",
+  "description": "Factory Droid connector for Remnic — connect Droid to your shared memory store via HTTP MCP",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/index.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.63.0"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-droid"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "droid",
+    "factory",
+    "ai",
+    "agent",
+    "mcp"
+  ]
+}

--- a/packages/connector-droid/package.json
+++ b/packages/connector-droid/package.json
@@ -28,6 +28,11 @@
   "peerDependencies": {
     "@remnic/core": "^9.63.0"
   },
+  "peerDependenciesMeta": {
+    "@remnic/core": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@remnic/core": "workspace:*",
     "tsup": "^8.0.0",

--- a/packages/connector-droid/src/index.test.ts
+++ b/packages/connector-droid/src/index.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the Factory Droid connector package.
+ *
+ * Verifies the package exports the expected connector ID and MCP helper
+ * functions, and that the helper functions round-trip correctly.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CONNECTOR_ID,
+  REMNIC_MCP_SERVER_KEY,
+  resolveFactoryMcpPath,
+  upsertFactoryMcpRemnicEntry,
+  removeFactoryMcpRemnicEntry,
+} from "./index.js";
+
+test("CONNECTOR_ID is 'droid'", () => {
+  assert.equal(CONNECTOR_ID, "droid");
+});
+
+test("REMNIC_MCP_SERVER_KEY is 'remnic'", () => {
+  assert.equal(REMNIC_MCP_SERVER_KEY, "remnic");
+});
+
+test("resolveFactoryMcpPath returns an absolute path ending in .factory/mcp.json", () => {
+  const p = resolveFactoryMcpPath();
+  assert.ok(p.endsWith(".factory/mcp.json"), `expected path ending in .factory/mcp.json, got ${p}`);
+  // Must be absolute
+  assert.ok(p.startsWith("/"), `expected absolute path, got ${p}`);
+});
+
+test("upsertFactoryMcpRemnicEntry creates a new config with remnic entry", () => {
+  const config = upsertFactoryMcpRemnicEntry(null, "test-token-123", {});
+  const servers = config.mcpServers as Record<string, unknown>;
+  assert.ok("remnic" in servers, "remnic entry must exist");
+  const remnic = servers.remnic as Record<string, unknown>;
+  assert.equal(remnic.type, "http");
+  assert.equal(remnic.url, "http://127.0.0.1:4318/mcp");
+  const headers = remnic.headers as Record<string, string>;
+  assert.equal(headers["Authorization"], "Bearer test-token-123");
+});
+
+test("upsertFactoryMcpRemnicEntry preserves existing mcpServers entries", () => {
+  const prior = JSON.stringify({
+    mcpServers: {
+      "other-tool": { type: "stdio", command: "npx" },
+    },
+  });
+  const config = upsertFactoryMcpRemnicEntry(prior, "test-token-456", {});
+  const servers = config.mcpServers as Record<string, unknown>;
+  assert.ok("other-tool" in servers, "existing entry must be preserved");
+  assert.ok("remnic" in servers, "remnic entry must be added");
+});
+
+test("upsertFactoryMcpRemnicEntry updates remnic entry on re-install", () => {
+  const prior = JSON.stringify({
+    mcpServers: {
+      remnic: { type: "http", url: "http://old-url:4318/mcp", headers: { Authorization: "Bearer old-token" } },
+    },
+  });
+  const config = upsertFactoryMcpRemnicEntry(prior, "new-token-789", {});
+  const servers = config.mcpServers as Record<string, unknown>;
+  const remnic = servers.remnic as Record<string, unknown>;
+  assert.equal(remnic.url, "http://127.0.0.1:4318/mcp");
+  const headers = remnic.headers as Record<string, string>;
+  assert.equal(headers["Authorization"], "Bearer new-token-789");
+});
+
+test("upsertFactoryMcpRemnicEntry adds namespace header when configured", () => {
+  const config = upsertFactoryMcpRemnicEntry(null, "tok", { namespace: "my-project" });
+  const remnic = (config.mcpServers as Record<string, Record<string, unknown>>).remnic;
+  const headers = remnic.headers as Record<string, string>;
+  assert.equal(headers["X-Engram-Namespace"], "my-project");
+});
+
+test("upsertFactoryMcpRemnicEntry uses custom mcpServerUrl when provided", () => {
+  const config = upsertFactoryMcpRemnicEntry(null, "tok", { mcpServerUrl: "http://custom:9999/mcp" });
+  const remnic = (config.mcpServers as Record<string, Record<string, unknown>>).remnic;
+  assert.equal(remnic.url, "http://custom:9999/mcp");
+});
+
+test("upsertFactoryMcpRemnicEntry handles malformed prior JSON gracefully", () => {
+  const config = upsertFactoryMcpRemnicEntry("not valid json", "tok", {});
+  const servers = config.mcpServers as Record<string, unknown>;
+  assert.ok("remnic" in servers);
+});
+
+test("removeFactoryMcpRemnicEntry removes the remnic entry and preserves others", () => {
+  const prior = JSON.stringify({
+    mcpServers: {
+      remnic: { type: "http", url: "http://localhost:4318/mcp" },
+      "other-tool": { type: "stdio", command: "npx" },
+    },
+  });
+  const result = removeFactoryMcpRemnicEntry(prior);
+  assert.ok(result !== null, "should return updated config");
+  const servers = result.mcpServers as Record<string, unknown>;
+  assert.ok(!("remnic" in servers), "remnic entry must be removed");
+  assert.ok("other-tool" in servers, "other entries must be preserved");
+});
+
+test("removeFactoryMcpRemnicEntry returns null when remnic is absent", () => {
+  const prior = JSON.stringify({
+    mcpServers: {
+      "other-tool": { type: "stdio", command: "npx" },
+    },
+  });
+  const result = removeFactoryMcpRemnicEntry(prior);
+  assert.equal(result, null);
+});
+
+test("removeFactoryMcpRemnicEntry returns null for malformed JSON", () => {
+  const result = removeFactoryMcpRemnicEntry("not valid json");
+  assert.equal(result, null);
+});
+
+test("removeFactoryMcpRemnicEntry returns null when mcpServers is missing", () => {
+  const prior = JSON.stringify({ otherKey: "value" });
+  const result = removeFactoryMcpRemnicEntry(prior);
+  assert.equal(result, null);
+});

--- a/packages/connector-droid/src/index.test.ts
+++ b/packages/connector-droid/src/index.test.ts
@@ -68,6 +68,32 @@ test("upsertFactoryMcpRemnicEntry updates remnic entry on re-install", () => {
   assert.equal(headers["Authorization"], "Bearer new-token-789");
 });
 
+test("upsertFactoryMcpRemnicEntry does not preserve stale X-Engram-Namespace on reinstall", () => {
+  const prior = JSON.stringify({
+    mcpServers: {
+      remnic: { type: "http", url: "http://localhost:4318/mcp", headers: { Authorization: "Bearer old", "X-Engram-Namespace": "old-ns" } },
+    },
+  });
+  // Reinstall without namespace — should NOT preserve the old namespace.
+  const config = upsertFactoryMcpRemnicEntry(prior, "new-tok", {});
+  const remnic = (config.mcpServers as Record<string, Record<string, unknown>>).remnic;
+  const headers = remnic.headers as Record<string, string>;
+  assert.equal(headers["Authorization"], "Bearer new-tok");
+  assert.ok(!("X-Engram-Namespace" in headers), "stale X-Engram-Namespace must not be preserved");
+});
+
+test("upsertFactoryMcpRemnicEntry preserves user-managed headers on reinstall", () => {
+  const prior = JSON.stringify({
+    mcpServers: {
+      remnic: { type: "http", url: "http://localhost:4318/mcp", headers: { Authorization: "Bearer old", "X-Custom-Header": "my-value" } },
+    },
+  });
+  const config = upsertFactoryMcpRemnicEntry(prior, "new-tok", {});
+  const remnic = (config.mcpServers as Record<string, Record<string, unknown>>).remnic;
+  const headers = remnic.headers as Record<string, string>;
+  assert.equal(headers["X-Custom-Header"], "my-value");
+});
+
 test("upsertFactoryMcpRemnicEntry adds namespace header when configured", () => {
   const config = upsertFactoryMcpRemnicEntry(null, "tok", { namespace: "my-project" });
   const remnic = (config.mcpServers as Record<string, Record<string, unknown>>).remnic;
@@ -81,10 +107,11 @@ test("upsertFactoryMcpRemnicEntry uses custom mcpServerUrl when provided", () =>
   assert.equal(remnic.url, "http://custom:9999/mcp");
 });
 
-test("upsertFactoryMcpRemnicEntry handles malformed prior JSON gracefully", () => {
-  const config = upsertFactoryMcpRemnicEntry("not valid json", "tok", {});
-  const servers = config.mcpServers as Record<string, unknown>;
-  assert.ok("remnic" in servers);
+test("upsertFactoryMcpRemnicEntry throws on malformed prior JSON instead of silently discarding entries", () => {
+  assert.throws(
+    () => upsertFactoryMcpRemnicEntry("not valid json", "tok", {}),
+    /malformed JSON/,
+  );
 });
 
 test("removeFactoryMcpRemnicEntry removes the remnic entry and preserves others", () => {

--- a/packages/connector-droid/src/index.ts
+++ b/packages/connector-droid/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @remnic/connector-droid — Factory Droid connector for Remnic
+ *
+ * Connects Factory Droid to your shared Remnic memory store via HTTP MCP.
+ *
+ * Install with:
+ *   remnic connectors install droid
+ *
+ * This mints a host token, records Remnic-side connector state, and writes
+ * the remnic MCP server entry (HTTP transport + Authorization bearer) into
+ * the user-level ~/.factory/mcp.json — never the project-level
+ * .factory/mcp.json.
+ *
+ * Built by Droid. See docs/integration/droid.md for the full walkthrough.
+ */
+
+export {
+  resolveFactoryMcpPath,
+  upsertFactoryMcpRemnicEntry,
+  removeFactoryMcpRemnicEntry,
+} from "@remnic/core/connectors";
+
+export const CONNECTOR_ID = "droid" as const;
+export const REMNIC_MCP_SERVER_KEY = "remnic" as const;

--- a/packages/connector-droid/tsconfig.json
+++ b/packages/connector-droid/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-core/src/connectors/droid-mcp.ts
+++ b/packages/remnic-core/src/connectors/droid-mcp.ts
@@ -1,0 +1,412 @@
+/**
+ * @remnic/core — Droid connector helpers
+ *
+ * Factory Droid reads MCP server config from the user-level ~/.factory/mcp.json.
+ * `remnic connectors install droid` writes a "remnic" entry under mcpServers
+ * with HTTP transport and a bearer token so Droid can authenticate to the
+ * Remnic daemon. The token is NEVER written into the project-level
+ * .factory/mcp.json — only the user-level file at ~/.factory/mcp.json.
+ *
+ * Extracted from connectors/index.ts to keep the main file under its
+ * ratchet ceiling (issue #1995).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { readEnvVar } from "../runtime/env.js";
+import type { ConnectorManifest } from "./index.js";
+
+// ── Manifest ────────────────────────────────────────────────────────────────
+
+/**
+ * The droid connector manifest entry. Imported into BUILTIN_CONNECTORS
+ * in connectors/index.ts.
+ */
+export const DROID_CONNECTOR_MANIFEST: ConnectorManifest = {
+  id: "droid",
+  name: "Factory Droid",
+  version: "1.0.0",
+  description:
+    "Factory Droid — AI software engineering agent; memory via HTTP MCP with bearer auth",
+  capabilities: {
+    observe: true,
+    recall: true,
+    store: true,
+    search: true,
+    entities: true,
+    realtimeSync: true,
+    batch: true,
+    maxBudgetChars: 32000,
+    connectionType: "mcp",
+  },
+  configSchema: {
+    mcpServerUrl: "URL of the MCP Remnic: server (default: http://127.0.0.1:4318/mcp)",
+    namespace: "Optional namespace",
+  },
+  homepage: "https://factory.ai",
+  author: "Remnic",
+  tags: ["official", "ai", "droid", "factory"],
+  requiresToken: true,
+};
+
+// ── Provenance reading for removeConnector ─────────────────────────────────
+
+/**
+ * Result of reading the droid MCP provenance from the saved connector JSON.
+ */
+export interface DroidMcpProvenance {
+  /** Resolved MCP config path, or null if none found. */
+  mcpConfigPath: string | null;
+  /** True if the connector JSON was malformed (abort removal). */
+  registryParseFailed: boolean;
+}
+
+// ── Install step (called from installConnector) ────────────────────────────
+
+/**
+ * Result of the droid install step — either success with rollback/mcpPath,
+ * or an error result that installConnector should return directly.
+ */
+export type DroidInstallStepResult =
+  | { ok: true; rollback: (() => void) | null; mcpPath: string }
+  | { ok: false; errorMessage: string };
+
+/**
+ * Write the remnic MCP entry to ~/.factory/mcp.json, with token rollback on failure.
+ *
+ * `saveTokenStore` is passed as a callback to avoid a circular dependency
+ * back into the main connectors module.
+ */
+export function droidInstallStep(
+  authToken: string | undefined,
+  resolvedConfig: Record<string, unknown>,
+  requiresToken: boolean,
+  tokenEntry: { token: string } | null,
+  priorTokenStore: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+saveTokenStoreFn: (store: any) => void,
+): DroidInstallStepResult {
+  try {
+    const result = writeDroidMcpEntry(authToken, resolvedConfig);
+    return { ok: true, rollback: result.rollback, mcpPath: result.mcpPath };
+  } catch (droidErr) {
+    const errMsg = droidErr instanceof Error ? droidErr.message : String(droidErr);
+    let tokenSuffix = "";
+    if (requiresToken && tokenEntry !== null && priorTokenStore !== null) {
+      try {
+        saveTokenStoreFn(priorTokenStore);
+        tokenSuffix = " Token has been rolled back.";
+      } catch (e) {
+        tokenSuffix = ` Token rollback FAILED (${e instanceof Error ? e.message : String(e)}) — manually inspect ~/.remnic/tokens.json and reinstall.`;
+      }
+    }
+    return {
+      ok: false,
+      errorMessage: `Droid install aborted: ~/.factory/mcp.json write failed — ${errMsg}.${tokenSuffix} Resolve the write permission issue on ~/.factory/, then reinstall.`,
+    };
+  }
+}
+
+/**
+ * Called from `removeConnector` when `connectorId === "droid"`. Falls back to
+ * env resolution if the path is missing (legacy install pre-dating
+ * factoryMcpPath provenance).
+ */
+export function readDroidMcpProvenance(configPath: string): DroidMcpProvenance {
+  let mcpConfigPath: string | null = null;
+  let registryParseFailed = false;
+  try {
+    const stored = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    if (typeof stored.factoryMcpPath === "string" && stored.factoryMcpPath.length > 0) {
+      mcpConfigPath = stored.factoryMcpPath;
+    }
+  } catch {
+    registryParseFailed = true;
+  }
+  if (mcpConfigPath === null && !registryParseFailed) {
+    try {
+      mcpConfigPath = resolveFactoryMcpPath();
+    } catch {
+      // Resolution failed — leave null; cleanup block skips.
+    }
+  }
+  return { mcpConfigPath, registryParseFailed };
+}
+
+/**
+ * Atomic write with owner-only (0o600) permissions. Mirrors the
+ * `writeSecretFileSync` in connectors/index.ts — kept local so this module
+ * has no dependency back into the main file.
+ */
+function writeSecretFileSync(filePath: string, data: string): void {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = path.join(
+    dir,
+    `.${base}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  let wroteTemp = false;
+  try {
+    fs.writeFileSync(tmpPath, data, { mode: 0o600, flag: "wx" });
+    wroteTemp = true;
+    try { fs.chmodSync(tmpPath, 0o600); } catch { /* best-effort */ }
+    fs.renameSync(tmpPath, filePath);
+    try { fs.chmodSync(filePath, 0o600); } catch { /* best-effort */ }
+  } catch (err) {
+    if (wroteTemp) { try { fs.unlinkSync(tmpPath); } catch { /* best-effort */ } }
+    throw err;
+  }
+}
+
+// ── Install ─────────────────────────────────────────────────────────────────
+
+/**
+ * Result of the droid MCP install step.
+ */
+export interface DroidMcpInstallResult {
+  /** Absolute path to ~/.factory/mcp.json that was written. */
+  mcpPath: string;
+  /** Rollback closure: restores prior content (or deletes if newly created). */
+  rollback: () => void;
+}
+
+/**
+ * Write the remnic MCP server entry to ~/.factory/mcp.json.
+ *
+ * Called from `installConnector` when `connectorId === "droid"`. Upserts only
+ * the `remnic` key under `mcpServers`, preserving all other entries. Returns
+ * the resolved path and a rollback closure. Throws on write failure (after
+ * attempting rollback).
+ */
+export function writeDroidMcpEntry(
+  authToken: string | undefined,
+  resolvedConfig: Record<string, unknown>,
+): DroidMcpInstallResult {
+  const mcpPath = resolveFactoryMcpPath();
+  const priorContent = readFactoryMcpIfExists(mcpPath);
+  const mcpConfig = upsertFactoryMcpRemnicEntry(priorContent, authToken, resolvedConfig);
+  fs.mkdirSync(path.dirname(mcpPath), { recursive: true });
+  const rollback = (): void => {
+    try {
+      if (priorContent === null) {
+        if (fs.existsSync(mcpPath)) fs.unlinkSync(mcpPath);
+      } else {
+        writeSecretFileSync(mcpPath, priorContent);
+      }
+    } catch { /* best-effort */ }
+  };
+  try {
+    writeSecretFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2));
+  } catch (writeErr) {
+    try { rollback(); } catch { /* best-effort */ }
+    throw writeErr;
+  }
+  return { mcpPath, rollback };
+}
+
+// ── Remove ──────────────────────────────────────────────────────────────────
+
+/**
+ * Remove the remnic entry from ~/.factory/mcp.json at the given path.
+ *
+ * Validates the path is absolute and ends with `.factory/mcp.json` before
+ * modifying. Returns a note string on success, or null if no modification
+ * was needed. Throws on write failure or if the path fails safety validation.
+ */
+export function removeDroidMcpEntry(mcpPath: string): string | null {
+  const expectedSuffix = path.join(".factory", "mcp.json");
+  if (!path.isAbsolute(mcpPath) || !mcpPath.endsWith(expectedSuffix)) {
+    throw new Error(
+      `MCP config path ${JSON.stringify(mcpPath)} failed safety validation ` +
+      `(must be absolute and end with "${expectedSuffix}"). ` +
+      `Refusing to modify — remove the "remnic" entry manually if it exists.`,
+    );
+  }
+  const priorContent = readFactoryMcpIfExists(mcpPath);
+  if (priorContent === null) return null;
+  const updated = removeFactoryMcpRemnicEntry(priorContent);
+  if (updated === null) return null;
+  writeSecretFileSync(mcpPath, JSON.stringify(updated, null, 2));
+  return `Removed remnic entry from Droid MCP config: ${mcpPath}`;
+}
+
+// ── Doctor ──────────────────────────────────────────────────────────────────
+
+export interface DroidDoctorCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+/**
+ * Check that ~/.factory/mcp.json contains a remnic entry.
+ *
+ * Called from `doctorConnector` when `connectorId === "droid"`.
+ */
+export function droidMcpDoctorCheck(savedPath: string | undefined): DroidDoctorCheck {
+  const mcpPath = savedPath ?? resolveFactoryMcpPath();
+  try {
+    const raw = fs.readFileSync(mcpPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const servers = parsed.mcpServers;
+    const hasRemnic =
+      typeof servers === "object" && servers !== null &&
+      "remnic" in (servers as Record<string, unknown>);
+    return {
+      name: "Droid MCP config",
+      ok: hasRemnic,
+      detail: hasRemnic
+        ? `remnic entry present in ${mcpPath}`
+        : `remnic entry missing in ${mcpPath} — run \`remnic connectors install droid\``,
+    };
+  } catch {
+    return {
+      name: "Droid MCP config",
+      ok: false,
+      detail: `Cannot read ${mcpPath} — run \`remnic connectors install droid\``,
+    };
+  }
+}
+
+// ── Path resolution and low-level helpers ───────────────────────────────────
+
+/**
+ * Resolve the path to ~/.factory/mcp.json. Honours HOME / USERPROFILE env
+ * overrides so tests can point the install at a temp dir without leaking
+ * into the real home directory. Always returns an absolute path.
+ */
+export function resolveFactoryMcpPath(): string {
+  const envHome = readEnvVar("HOME");
+  const home = envHome && envHome.length > 0 ? envHome : os.homedir();
+  return path.resolve(home, ".factory", "mcp.json");
+}
+
+/**
+ * Read the existing ~/.factory/mcp.json, if any. Returns raw string contents
+ * so the caller can parse, modify, and restore on rollback.
+ */
+export function readFactoryMcpIfExists(mcpPath: string): string | null {
+  try {
+    if (!fs.existsSync(mcpPath)) return null;
+    return fs.readFileSync(mcpPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default MCP server URL for the Remnic daemon.
+ */
+const REMNIC_DEFAULT_MCP_URL = "http://127.0.0.1:4318/mcp";
+
+/**
+ * Upsert the "remnic" entry in a ~/.factory/mcp.json config object.
+ *
+ * Parses the prior content (if any), preserves all existing mcpServers entries,
+ * and sets the "remnic" entry with HTTP transport, the bearer token, and an
+ * optional namespace header. Returns the full config object ready to serialize.
+ *
+ * If no token is available, the entry is still written but without the
+ * Authorization header — the caller will see an auth error from the daemon,
+ * which is more informative than a missing entry.
+ */
+export function upsertFactoryMcpRemnicEntry(
+  priorContent: string | null,
+  authToken: string | undefined,
+  resolvedConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  let config: Record<string, unknown>;
+  if (priorContent !== null) {
+    try {
+      const parsed = JSON.parse(priorContent);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        config = parsed as Record<string, unknown>;
+      } else {
+        config = {};
+      }
+    } catch {
+      config = {};
+    }
+  } else {
+    config = {};
+  }
+
+  if (typeof config.mcpServers !== "object" || config.mcpServers === null || Array.isArray(config.mcpServers)) {
+    config.mcpServers = {};
+  }
+  const servers = config.mcpServers as Record<string, unknown>;
+
+  const mcpUrl =
+    typeof resolvedConfig.mcpServerUrl === "string" && resolvedConfig.mcpServerUrl.length > 0
+      ? resolvedConfig.mcpServerUrl
+      : REMNIC_DEFAULT_MCP_URL;
+
+  const remnicEntry: Record<string, unknown> = { type: "http", url: mcpUrl };
+
+  const headers: Record<string, string> = {};
+  if (
+    typeof servers.remnic === "object" && servers.remnic !== null &&
+    typeof (servers.remnic as Record<string, unknown>).headers === "object" &&
+    (servers.remnic as Record<string, unknown>).headers !== null
+  ) {
+    const priorHeaders = (servers.remnic as Record<string, Record<string, unknown>>).headers as Record<string, unknown>;
+    for (const [key, value] of Object.entries(priorHeaders)) {
+      if (key !== "Authorization" && typeof value === "string") {
+        headers[key] = value;
+      }
+    }
+  }
+
+  if (authToken && authToken.length > 0) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  const namespace =
+    typeof resolvedConfig.namespace === "string" && resolvedConfig.namespace.length > 0
+      ? resolvedConfig.namespace
+      : undefined;
+  if (namespace) {
+    headers["X-Engram-Namespace"] = namespace;
+  }
+
+  if (Object.keys(headers).length > 0) {
+    remnicEntry.headers = headers;
+  }
+
+  servers.remnic = remnicEntry;
+  return config;
+}
+
+/**
+ * Remove the "remnic" entry from a ~/.factory/mcp.json config object.
+ *
+ * Returns the updated config object (with remnic removed) or null if the
+ * entry was not present (no modification needed).
+ */
+export function removeFactoryMcpRemnicEntry(
+  priorContent: string,
+): Record<string, unknown> | null {
+  let config: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(priorContent);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    config = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (typeof config.mcpServers !== "object" || config.mcpServers === null) {
+    return null;
+  }
+  const servers = config.mcpServers as Record<string, unknown>;
+  if (!("remnic" in servers)) {
+    return null;
+  }
+
+  delete servers.remnic;
+  return config;
+}

--- a/packages/remnic-core/src/connectors/droid-mcp.ts
+++ b/packages/remnic-core/src/connectors/droid-mcp.ts
@@ -117,6 +117,9 @@ saveTokenStoreFn: (store: any) => void,
 export function readDroidMcpProvenance(configPath: string): DroidMcpProvenance {
   let mcpConfigPath: string | null = null;
   let registryParseFailed = false;
+  if (!fs.existsSync(configPath)) {
+    return { mcpConfigPath: null, registryParseFailed: false };
+  }
   try {
     const stored = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
     if (typeof stored.factoryMcpPath === "string" && stored.factoryMcpPath.length > 0) {
@@ -247,35 +250,43 @@ export interface DroidDoctorCheck {
  */
 export function droidMcpDoctorCheck(savedPath: string | undefined): DroidDoctorCheck {
   const mcpPath = savedPath ?? resolveFactoryMcpPath();
+  // Safety gate: validate persisted path before reading (mirrors removeConnector).
+  if (savedPath !== undefined) {
+    const expectedSuffix = path.join(".factory", "mcp.json");
+    if (!path.isAbsolute(savedPath) || !savedPath.endsWith(expectedSuffix)) {
+      return { name: "Droid MCP config", ok: false, detail: `Unsafe path in droid.json: ${savedPath}` };
+    }
+  }
   try {
     const raw = fs.readFileSync(mcpPath, "utf8");
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     const servers = parsed.mcpServers;
-    const hasRemnic =
-      typeof servers === "object" && servers !== null &&
-      "remnic" in (servers as Record<string, unknown>);
+    if (typeof servers !== "object" || servers === null || !("remnic" in (servers as Record<string, unknown>))) {
+      return { name: "Droid MCP config", ok: false, detail: `remnic entry missing in ${mcpPath} — run \`remnic connectors install droid\`` };
+    }
+    const remnic = (servers as Record<string, Record<string, unknown>>).remnic;
+    // Validate the entry has the expected shape (type + url + Authorization).
+    if (remnic.type !== "http" || typeof remnic.url !== "string") {
+      return { name: "Droid MCP config", ok: false, detail: `remnic entry malformed in ${mcpPath}` };
+    }
+    const headers = remnic.headers as Record<string, unknown> | undefined;
+    const hasAuth = headers && typeof headers["Authorization"] === "string" && (headers["Authorization"] as string).startsWith("Bearer ");
     return {
       name: "Droid MCP config",
-      ok: hasRemnic,
-      detail: hasRemnic
-        ? `remnic entry present in ${mcpPath}`
-        : `remnic entry missing in ${mcpPath} — run \`remnic connectors install droid\``,
+      ok: !!hasAuth,
+      detail: hasAuth ? `remnic entry present in ${mcpPath}` : `remnic entry missing Authorization header in ${mcpPath} — run \`remnic connectors install droid\``,
     };
   } catch {
-    return {
-      name: "Droid MCP config",
-      ok: false,
-      detail: `Cannot read ${mcpPath} — run \`remnic connectors install droid\``,
-    };
+    return { name: "Droid MCP config", ok: false, detail: `Cannot read ${mcpPath} — run \`remnic connectors install droid\`` };
   }
 }
 
 // ── Path resolution and low-level helpers ───────────────────────────────────
 
 /**
- * Resolve the path to ~/.factory/mcp.json. Honours HOME / USERPROFILE env
- * overrides so tests can point the install at a temp dir without leaking
- * into the real home directory. Always returns an absolute path.
+ * Resolve the path to ~/.factory/mcp.json. Honours the HOME env override
+ * so tests can point the install at a temp dir without leaking into the
+ * real home directory. Falls back to os.homedir() when HOME is unset.
  */
 export function resolveFactoryMcpPath(): string {
   const envHome = readEnvVar("HOME");
@@ -324,10 +335,17 @@ export function upsertFactoryMcpRemnicEntry(
       if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
         config = parsed as Record<string, unknown>;
       } else {
+        // Non-object JSON — start fresh but warn in console.
+        console.warn("[remnic/connectors] ~/.factory/mcp.json contained non-object JSON; starting fresh.");
         config = {};
       }
     } catch {
-      config = {};
+      // Malformed JSON — do NOT silently discard other MCP server entries.
+      // Throw so the caller can surface the error instead of overwriting the file.
+      throw new Error(
+        "~/.factory/mcp.json contains malformed JSON and cannot be parsed. " +
+        "Fix the file manually before reinstalling, or use --force to overwrite (this will lose existing MCP server entries).",
+      );
     }
   } else {
     config = {};
@@ -345,6 +363,10 @@ export function upsertFactoryMcpRemnicEntry(
 
   const remnicEntry: Record<string, unknown> = { type: "http", url: mcpUrl };
 
+  // Preserve prior headers EXCEPT Remnic-managed ones (Authorization,
+  // X-Engram-Namespace). These are always replaced from the current install
+  // config so a reinstall that clears namespace does not leave a stale header.
+  const REMNIC_MANAGED_HEADERS = new Set(["Authorization", "X-Engram-Namespace"]);
   const headers: Record<string, string> = {};
   if (
     typeof servers.remnic === "object" && servers.remnic !== null &&
@@ -353,7 +375,7 @@ export function upsertFactoryMcpRemnicEntry(
   ) {
     const priorHeaders = (servers.remnic as Record<string, Record<string, unknown>>).headers as Record<string, unknown>;
     for (const [key, value] of Object.entries(priorHeaders)) {
-      if (key !== "Authorization" && typeof value === "string") {
+      if (!REMNIC_MANAGED_HEADERS.has(key) && typeof value === "string") {
         headers[key] = value;
       }
     }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -29,6 +29,15 @@ import {
 } from "./hermes-shim.js";
 import { getConnectorsDir, getRegistryPath } from "./paths.js";
 export { getConnectorsDir, getRegistryPath } from "./paths.js";
+export { resolveFactoryMcpPath, upsertFactoryMcpRemnicEntry, removeFactoryMcpRemnicEntry } from "./droid-mcp.js";
+export { DROID_CONNECTOR_MANIFEST } from "./droid-mcp.js";
+import {
+  DROID_CONNECTOR_MANIFEST,
+  droidInstallStep,
+  removeDroidMcpEntry as removeDroidMcpEntryImpl,
+  droidMcpDoctorCheck as droidMcpDoctorCheckImpl,
+  readDroidMcpProvenance,
+} from "./droid-mcp.js";
 
 // Native memory artifact materialization for Codex CLI (#378). Surfaced here
 // so downstream callers can `import { materializeForNamespace } from "@remnic/core/connectors"`.
@@ -565,32 +574,7 @@ export const BUILTIN_CONNECTORS: ConnectorManifest[] = [
     tags: ["official", "python", "hermes"],
     requiresToken: true,
   },
-  {
-    id: "droid",
-    name: "Factory Droid",
-    version: "1.0.0",
-    description:
-      "Factory Droid — AI software engineering agent; memory via HTTP MCP with bearer auth",
-    capabilities: {
-      observe: true,
-      recall: true,
-      store: true,
-      search: true,
-      entities: true,
-      realtimeSync: true,
-      batch: true,
-      maxBudgetChars: 32000,
-      connectionType: "mcp",
-    },
-    configSchema: {
-      mcpServerUrl: "URL of the MCP Remnic server (default: http://127.0.0.1:4318/mcp)",
-      namespace: "Optional namespace",
-    },
-    homepage: "https://factory.ai",
-    author: "Remnic",
-    tags: ["official", "ai", "droid", "factory"],
-    requiresToken: true,
-  },
+  DROID_CONNECTOR_MANIFEST,
 ];
 
 // ── Registry management ───────────────────────────────────────────────────
@@ -2055,76 +2039,21 @@ export function installConnector(options: InstallOptions): InstallResult {
   }
 
   // ── Droid: write remnic MCP server entry to ~/.factory/mcp.json ──────────
-  //
-  // Factory Droid reads MCP server config from the USER-level ~/.factory/mcp.json
-  // (never the project-level .factory/mcp.json, which may be committed to git).
-  // installConnector writes a "remnic" entry under mcpServers with HTTP transport
-  // and the freshly minted bearer token so Droid can authenticate to the Remnic
-  // daemon. Existing entries are preserved; only the "remnic" key is upserted.
-  //
-  // The token is NOT written into the connector.json registry file (same rule
-  // as all other connectors). It lives only in ~/.factory/mcp.json (which Droid
-  // reads) and ~/.remnic/tokens.json (the authoritative store). The registry
-  // JSON persists the resolved factoryMcpPath so removeConnector can locate the
-  // exact file later even if HOME or the env changes.
   let droidMcpRollback: (() => void) | null = null;
   if (options.connectorId === "droid") {
-    try {
-      const mcpPath = resolveFactoryMcpPath();
-      const priorContent = readFactoryMcpIfExists(mcpPath);
-      const mcpConfig = upsertFactoryMcpRemnicEntry(
-        priorContent,
-        tokenEntry?.token,
-        resolvedConfig,
-      );
-      fs.mkdirSync(path.dirname(mcpPath), { recursive: true });
-      droidMcpRollback = () => {
-        try {
-          if (priorContent === null) {
-            if (fs.existsSync(mcpPath)) fs.unlinkSync(mcpPath);
-          } else {
-            writeSecretFileSync(mcpPath, priorContent);
-          }
-        } catch {
-          // Best-effort rollback.
-        }
-      };
-      try {
-        writeSecretFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2));
-      } catch (writeErr) {
-        try { droidMcpRollback(); } catch { /* best-effort */ }
-        droidMcpRollback = null;
-        throw writeErr;
-      }
-      resolvedConfig.factoryMcpPath = mcpPath;
-    } catch (droidErr) {
-      let tokenRolledBack = false;
-      let tokenRollbackMsg = "";
-      if (tokenEntry !== null && nonHermesPriorTokenStore !== null) {
-        try {
-          saveTokenStore(nonHermesPriorTokenStore);
-          tokenRolledBack = true;
-        } catch (tokenRestoreErr) {
-          tokenRolledBack = false;
-          tokenRollbackMsg =
-            tokenRestoreErr instanceof Error ? tokenRestoreErr.message : String(tokenRestoreErr);
-        }
-      }
-      const tokenSuffix = manifest.requiresToken && tokenEntry !== null
-        ? tokenRolledBack
-          ? " Token has been rolled back."
-          : ` Token rollback FAILED (${tokenRollbackMsg}) — tokens.json may contain an orphaned entry. ` +
-            `Manually inspect ~/.remnic/tokens.json and reinstall.`
-        : "";
-      return {
-        connectorId: options.connectorId,
-        status: "error",
-        message:
-          `Droid install aborted: ~/.factory/mcp.json write failed — ` +
-          `${droidErr instanceof Error ? droidErr.message : String(droidErr)}.` +
-          `${tokenSuffix} Resolve the write permission issue on ~/.factory/, then reinstall.`,
-      };
+    const stepResult = droidInstallStep(
+      tokenEntry?.token,
+      resolvedConfig,
+      manifest.requiresToken ?? false,
+      tokenEntry,
+      nonHermesPriorTokenStore,
+      saveTokenStore,
+    );
+    if (!stepResult.ok) {
+      return { connectorId: options.connectorId, status: "error", message: stepResult.errorMessage };
     }
+    droidMcpRollback = stepResult.rollback;
+    resolvedConfig.factoryMcpPath = stepResult.mcpPath;
   }
 
   // Finding 5: strip internal/test-only keys that must never be persisted to
@@ -2424,47 +2353,17 @@ export function removeConnector(connectorId: string): RemoveResult {
     }
   }
 
-  // For droid, read the persisted factoryMcpPath from the saved registry
-  // config BEFORE deleting it. Using the persisted absolute path (rather
-  // than recomputing from current HOME) guarantees that a remove still
-  // targets the original file even if HOME has changed between install
-  // and remove. If the path is missing (legacy install pre-dating
-  // factoryMcpPath provenance), fall back to env resolution.
+  // For droid, read the persisted factoryMcpPath before deleting the config.
   let droidMcpConfigPath: string | null = null;
   let droidRegistryParseFailed = false;
   if (connectorId === "droid") {
-    try {
-      const stored = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
-      if (typeof stored.factoryMcpPath === "string" && stored.factoryMcpPath.length > 0) {
-        droidMcpConfigPath = stored.factoryMcpPath;
-      }
-    } catch {
-      droidRegistryParseFailed = true;
-    }
-    if (droidMcpConfigPath === null && !droidRegistryParseFailed) {
-      try {
-        droidMcpConfigPath = resolveFactoryMcpPath();
-      } catch {
-        // Resolution failed — leave null; cleanup block skips.
-      }
-    }
+    const prov = readDroidMcpProvenance(configPath);
+    droidMcpConfigPath = prov.mcpConfigPath;
+    droidRegistryParseFailed = prov.registryParseFailed;
   }
   if (connectorId === "droid" && droidRegistryParseFailed) {
-    console.warn(
-      "[remnic/connectors] removeConnector: droid.json is malformed — " +
-        "aborting removal to preserve provenance. Fix or delete " +
-        configPath +
-        " manually and retry.",
-    );
-    return {
-      connectorId,
-      configPath,
-      message:
-        "Removal aborted: droid.json is malformed. Registry config left in place for inspection; " +
-        "~/.factory/mcp.json NOT modified.",
-      status: "skipped",
-      reason: "config-parse-failed",
-    };
+    console.warn(`[remnic/connectors] removeConnector: droid.json malformed — aborting. Fix or delete ${configPath} manually and retry.`);
+    return { connectorId, configPath, message: "Removal aborted: droid.json is malformed. Registry config left in place.", status: "skipped", reason: "config-parse-failed" };
   }
 
   if (connectorId === "weclone" && weCloneRegistryParseFailed) {
@@ -2716,63 +2615,18 @@ export function removeConnector(connectorId: string): RemoveResult {
   }
 
   // Droid-specific: remove the "remnic" entry from ~/.factory/mcp.json.
-  // Using the persisted absolute path (read above before the registry file
-  // was deleted) — not a re-derivation from the current environment — so a
-  // HOME change between install and remove cannot leave the old mcp.json
-  // with a stale "remnic" entry (and its live bearer token) behind.
   let droidMcpDeleteFailed: string | null = null;
   if (connectorId === "droid") {
     if (droidMcpConfigPath === null) {
-      notes.push(
-        "Droid MCP config cleanup skipped: no persisted path found in saved config " +
-          "(likely a legacy install predating factoryMcpPath provenance).",
-      );
+      notes.push("Droid MCP config cleanup skipped: no persisted path found (legacy install).");
     } else {
-      // Safety gate: validate the persisted path before modifying. The path
-      // is loaded from user-controlled JSON, so restrict to paths that are:
-      //   1. Absolute (relative paths are CWD-dependent).
-      //   2. End with ".factory/mcp.json" — the only filename the installer
-      //      ever writes.
-      const expectedSuffix = path.join(".factory", "mcp.json");
-      const isSafePath =
-        path.isAbsolute(droidMcpConfigPath) &&
-        droidMcpConfigPath.endsWith(expectedSuffix);
-      if (!isSafePath) {
-        droidMcpDeleteFailed =
-          `MCP config path ${JSON.stringify(droidMcpConfigPath)} failed safety validation ` +
-          `(must be absolute and end with "${expectedSuffix}"). ` +
-          `Refusing to modify — remove the "remnic" entry manually if it exists.`;
-      } else {
-        try {
-          const priorContent = readFactoryMcpIfExists(droidMcpConfigPath);
-          if (priorContent !== null) {
-            const updated = removeFactoryMcpRemnicEntry(priorContent);
-            if (updated !== null) {
-              writeSecretFileSync(droidMcpConfigPath, JSON.stringify(updated, null, 2));
-              notes.push(`Removed remnic entry from Droid MCP config: ${droidMcpConfigPath}`);
-            }
-          }
-        } catch (err) {
-          droidMcpDeleteFailed = err instanceof Error ? err.message : String(err);
-        }
-      }
+      try { const note = removeDroidMcpEntryImpl(droidMcpConfigPath); if (note) notes.push(note); }
+      catch (err) { droidMcpDeleteFailed = err instanceof Error ? err.message : String(err); }
     }
   }
   if (droidMcpDeleteFailed !== null && droidMcpConfigPath !== null) {
-    const tokenStatus = tokenRevoked
-      ? "the registry config was deleted and the token was revoked"
-      : "the registry config was deleted but TOKEN REVOCATION ALSO FAILED — " +
-        "inspect ~/.remnic/tokens.json and revoke manually";
-    return {
-      connectorId,
-      configPath,
-      status: "error",
-      message:
-        `Droid remove partially succeeded: ${tokenStatus}, ` +
-        `but the MCP config at ${droidMcpConfigPath} could not be updated ` +
-        `(${droidMcpDeleteFailed}). Manually remove the "remnic" entry from that file — ` +
-        `it may still contain a Remnic daemon bearer token.`,
-    };
+    const ts = tokenRevoked ? "token was revoked" : "TOKEN REVOCATION ALSO FAILED — inspect ~/.remnic/tokens.json and revoke manually";
+    return { connectorId, configPath, status: "error", message: `Droid remove partially succeeded: registry config deleted, ${ts}, but the MCP config at ${droidMcpConfigPath} could not be updated (${droidMcpDeleteFailed}). Manually remove the "remnic" entry.` };
   }
 
   // Hermes-specific: strip the remnic: block from config.yaml (the writability
@@ -3514,29 +3368,7 @@ export async function doctorConnector(connectorId: string): Promise<DoctorResult
 
   // Droid-specific: check ~/.factory/mcp.json has the remnic entry
   if (connectorId === "droid") {
-    const savedPath = instance.config.factoryMcpPath as string | undefined;
-    const mcpPath = savedPath ?? resolveFactoryMcpPath();
-    try {
-      const raw = fs.readFileSync(mcpPath, "utf8");
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      const servers = parsed.mcpServers;
-      const hasRemnic =
-        typeof servers === "object" && servers !== null &&
-        "remnic" in (servers as Record<string, unknown>);
-      checks.push({
-        name: "Droid MCP config",
-        ok: hasRemnic,
-        detail: hasRemnic
-          ? `remnic entry present in ${mcpPath}`
-          : `remnic entry missing in ${mcpPath} — run \`remnic connectors install droid\``,
-      });
-    } catch {
-      checks.push({
-        name: "Droid MCP config",
-        ok: false,
-        detail: `Cannot read ${mcpPath} — run \`remnic connectors install droid\``,
-      });
-    }
+    checks.push(droidMcpDoctorCheckImpl(instance.config.factoryMcpPath as string | undefined));
   }
 
   const healthy = checks.every((c) => c.ok);
@@ -4223,161 +4055,5 @@ export function buildWeCloneProxyConfig(args: {
     config.remnicAuthToken = priorConfig.remnicAuthToken;
   }
 
-  return config;
-}
-
-// ── Droid ~/.factory/mcp.json helpers ─────────────────────────────────────
-//
-// Factory Droid reads MCP server config from the user-level ~/.factory/mcp.json.
-// `remnic connectors install droid` writes a "remnic" entry under mcpServers
-// with HTTP transport and a bearer token so Droid can authenticate to the
-// Remnic daemon. The token is NEVER written into the project-level
-// .factory/mcp.json — only the user-level file at ~/.factory/mcp.json.
-
-/**
- * Resolve the path to ~/.factory/mcp.json. Honours HOME / USERPROFILE env
- * overrides so tests can point the install at a temp dir without leaking
- * into the real home directory. Always returns an absolute path.
- */
-export function resolveFactoryMcpPath(): string {
-  const envHome = readEnvVar("HOME");
-  const home = envHome && envHome.length > 0 ? envHome : os.homedir();
-  return path.resolve(home, ".factory", "mcp.json");
-}
-
-/**
- * Read the existing ~/.factory/mcp.json, if any. Returns raw string contents
- * so the caller can parse, modify, and restore on rollback.
- */
-function readFactoryMcpIfExists(mcpPath: string): string | null {
-  try {
-    if (!fs.existsSync(mcpPath)) return null;
-    return fs.readFileSync(mcpPath, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Default MCP server URL for the Remnic daemon.
- */
-const REMNIC_DEFAULT_MCP_URL = "http://127.0.0.1:4318/mcp";
-
-/**
- * Upsert the "remnic" entry in a ~/.factory/mcp.json config object.
- *
- * Parses the prior content (if any), preserves all existing mcpServers entries,
- * and sets the "remnic" entry with HTTP transport, the bearer token, and an
- * optional namespace header. Returns the full config object ready to serialize.
- *
- * If no token is available, the entry is still written but without the
- * Authorization header — the caller will see an auth error from the daemon,
- * which is more informative than a missing entry.
- */
-export function upsertFactoryMcpRemnicEntry(
-  priorContent: string | null,
-  authToken: string | undefined,
-  resolvedConfig: Record<string, unknown>,
-): Record<string, unknown> {
-  let config: Record<string, unknown>;
-  if (priorContent !== null) {
-    try {
-      const parsed = JSON.parse(priorContent);
-      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-        config = parsed as Record<string, unknown>;
-      } else {
-        config = {};
-      }
-    } catch {
-      // Prior content is not valid JSON — start fresh.
-      config = {};
-    }
-  } else {
-    config = {};
-  }
-
-  // Ensure mcpServers object exists
-  if (typeof config.mcpServers !== "object" || config.mcpServers === null || Array.isArray(config.mcpServers)) {
-    config.mcpServers = {};
-  }
-  const servers = config.mcpServers as Record<string, unknown>;
-
-  // Resolve the MCP URL from user config or default
-  const mcpUrl =
-    typeof resolvedConfig.mcpServerUrl === "string" && resolvedConfig.mcpServerUrl.length > 0
-      ? resolvedConfig.mcpServerUrl
-      : REMNIC_DEFAULT_MCP_URL;
-
-  // Build the remnic entry
-  const remnicEntry: Record<string, unknown> = {
-    type: "http",
-    url: mcpUrl,
-  };
-
-  // Build headers — preserve any non-remnic headers from the prior entry
-  const headers: Record<string, string> = {};
-  if (
-    typeof servers.remnic === "object" && servers.remnic !== null &&
-    typeof (servers.remnic as Record<string, unknown>).headers === "object" &&
-    (servers.remnic as Record<string, unknown>).headers !== null
-  ) {
-    const priorHeaders = (servers.remnic as Record<string, Record<string, unknown>>).headers as Record<string, unknown>;
-    for (const [key, value] of Object.entries(priorHeaders)) {
-      if (key !== "Authorization" && typeof value === "string") {
-        headers[key] = value;
-      }
-    }
-  }
-
-  if (authToken && authToken.length > 0) {
-    headers["Authorization"] = `Bearer ${authToken}`;
-  }
-
-  // Add optional namespace header
-  const namespace =
-    typeof resolvedConfig.namespace === "string" && resolvedConfig.namespace.length > 0
-      ? resolvedConfig.namespace
-      : undefined;
-  if (namespace) {
-    headers["X-Engram-Namespace"] = namespace;
-  }
-
-  if (Object.keys(headers).length > 0) {
-    remnicEntry.headers = headers;
-  }
-
-  servers.remnic = remnicEntry;
-  return config;
-}
-
-/**
- * Remove the "remnic" entry from a ~/.factory/mcp.json config object.
- *
- * Returns the updated config object (with remnic removed) or null if the
- * entry was not present (no modification needed).
- */
-export function removeFactoryMcpRemnicEntry(
-  priorContent: string,
-): Record<string, unknown> | null {
-  let config: Record<string, unknown>;
-  try {
-    const parsed = JSON.parse(priorContent);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return null;
-    }
-    config = parsed as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-
-  if (typeof config.mcpServers !== "object" || config.mcpServers === null) {
-    return null;
-  }
-  const servers = config.mcpServers as Record<string, unknown>;
-  if (!("remnic" in servers)) {
-    return null;
-  }
-
-  delete servers.remnic;
   return config;
 }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -565,6 +565,32 @@ export const BUILTIN_CONNECTORS: ConnectorManifest[] = [
     tags: ["official", "python", "hermes"],
     requiresToken: true,
   },
+  {
+    id: "droid",
+    name: "Factory Droid",
+    version: "1.0.0",
+    description:
+      "Factory Droid — AI software engineering agent; memory via HTTP MCP with bearer auth",
+    capabilities: {
+      observe: true,
+      recall: true,
+      store: true,
+      search: true,
+      entities: true,
+      realtimeSync: true,
+      batch: true,
+      maxBudgetChars: 32000,
+      connectionType: "mcp",
+    },
+    configSchema: {
+      mcpServerUrl: "URL of the MCP Remnic server (default: http://127.0.0.1:4318/mcp)",
+      namespace: "Optional namespace",
+    },
+    homepage: "https://factory.ai",
+    author: "Remnic",
+    tags: ["official", "ai", "droid", "factory"],
+    requiresToken: true,
+  },
 ];
 
 // ── Registry management ───────────────────────────────────────────────────
@@ -2028,6 +2054,79 @@ export function installConnector(options: InstallOptions): InstallResult {
     }
   }
 
+  // ── Droid: write remnic MCP server entry to ~/.factory/mcp.json ──────────
+  //
+  // Factory Droid reads MCP server config from the USER-level ~/.factory/mcp.json
+  // (never the project-level .factory/mcp.json, which may be committed to git).
+  // installConnector writes a "remnic" entry under mcpServers with HTTP transport
+  // and the freshly minted bearer token so Droid can authenticate to the Remnic
+  // daemon. Existing entries are preserved; only the "remnic" key is upserted.
+  //
+  // The token is NOT written into the connector.json registry file (same rule
+  // as all other connectors). It lives only in ~/.factory/mcp.json (which Droid
+  // reads) and ~/.remnic/tokens.json (the authoritative store). The registry
+  // JSON persists the resolved factoryMcpPath so removeConnector can locate the
+  // exact file later even if HOME or the env changes.
+  let droidMcpRollback: (() => void) | null = null;
+  if (options.connectorId === "droid") {
+    try {
+      const mcpPath = resolveFactoryMcpPath();
+      const priorContent = readFactoryMcpIfExists(mcpPath);
+      const mcpConfig = upsertFactoryMcpRemnicEntry(
+        priorContent,
+        tokenEntry?.token,
+        resolvedConfig,
+      );
+      fs.mkdirSync(path.dirname(mcpPath), { recursive: true });
+      droidMcpRollback = () => {
+        try {
+          if (priorContent === null) {
+            if (fs.existsSync(mcpPath)) fs.unlinkSync(mcpPath);
+          } else {
+            writeSecretFileSync(mcpPath, priorContent);
+          }
+        } catch {
+          // Best-effort rollback.
+        }
+      };
+      try {
+        writeSecretFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2));
+      } catch (writeErr) {
+        try { droidMcpRollback(); } catch { /* best-effort */ }
+        droidMcpRollback = null;
+        throw writeErr;
+      }
+      resolvedConfig.factoryMcpPath = mcpPath;
+    } catch (droidErr) {
+      let tokenRolledBack = false;
+      let tokenRollbackMsg = "";
+      if (tokenEntry !== null && nonHermesPriorTokenStore !== null) {
+        try {
+          saveTokenStore(nonHermesPriorTokenStore);
+          tokenRolledBack = true;
+        } catch (tokenRestoreErr) {
+          tokenRolledBack = false;
+          tokenRollbackMsg =
+            tokenRestoreErr instanceof Error ? tokenRestoreErr.message : String(tokenRestoreErr);
+        }
+      }
+      const tokenSuffix = manifest.requiresToken && tokenEntry !== null
+        ? tokenRolledBack
+          ? " Token has been rolled back."
+          : ` Token rollback FAILED (${tokenRollbackMsg}) — tokens.json may contain an orphaned entry. ` +
+            `Manually inspect ~/.remnic/tokens.json and reinstall.`
+        : "";
+      return {
+        connectorId: options.connectorId,
+        status: "error",
+        message:
+          `Droid install aborted: ~/.factory/mcp.json write failed — ` +
+          `${droidErr instanceof Error ? droidErr.message : String(droidErr)}.` +
+          `${tokenSuffix} Resolve the write permission issue on ~/.factory/, then reinstall.`,
+      };
+    }
+  }
+
   // Finding 5: strip internal/test-only keys that must never be persisted to
   // the config file. These keys are used at install time only (e.g. to inject
   // a synthetic extension source dir in tests) and have no meaning on disk.
@@ -2091,6 +2190,14 @@ export function installConnector(options: InstallOptions): InstallResult {
     if (weCloneProxyHandleRollback !== null) {
       try {
         weCloneProxyHandleRollback();
+      } catch {
+        // Best-effort rollback.
+      }
+    }
+    // Roll back the Droid ~/.factory/mcp.json if it was written.
+    if (droidMcpRollback !== null) {
+      try {
+        droidMcpRollback();
       } catch {
         // Best-effort rollback.
       }
@@ -2316,6 +2423,50 @@ export function removeConnector(connectorId: string): RemoveResult {
       }
     }
   }
+
+  // For droid, read the persisted factoryMcpPath from the saved registry
+  // config BEFORE deleting it. Using the persisted absolute path (rather
+  // than recomputing from current HOME) guarantees that a remove still
+  // targets the original file even if HOME has changed between install
+  // and remove. If the path is missing (legacy install pre-dating
+  // factoryMcpPath provenance), fall back to env resolution.
+  let droidMcpConfigPath: string | null = null;
+  let droidRegistryParseFailed = false;
+  if (connectorId === "droid") {
+    try {
+      const stored = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+      if (typeof stored.factoryMcpPath === "string" && stored.factoryMcpPath.length > 0) {
+        droidMcpConfigPath = stored.factoryMcpPath;
+      }
+    } catch {
+      droidRegistryParseFailed = true;
+    }
+    if (droidMcpConfigPath === null && !droidRegistryParseFailed) {
+      try {
+        droidMcpConfigPath = resolveFactoryMcpPath();
+      } catch {
+        // Resolution failed — leave null; cleanup block skips.
+      }
+    }
+  }
+  if (connectorId === "droid" && droidRegistryParseFailed) {
+    console.warn(
+      "[remnic/connectors] removeConnector: droid.json is malformed — " +
+        "aborting removal to preserve provenance. Fix or delete " +
+        configPath +
+        " manually and retry.",
+    );
+    return {
+      connectorId,
+      configPath,
+      message:
+        "Removal aborted: droid.json is malformed. Registry config left in place for inspection; " +
+        "~/.factory/mcp.json NOT modified.",
+      status: "skipped",
+      reason: "config-parse-failed",
+    };
+  }
+
   if (connectorId === "weclone" && weCloneRegistryParseFailed) {
     console.warn(
       "[remnic/connectors] removeConnector: weclone.json is malformed — " +
@@ -2561,6 +2712,66 @@ export function removeConnector(connectorId: string): RemoveResult {
         `but the proxy config at ${weCloneProxyConfigPath} could not be deleted ` +
         `(${weCloneProxyDeleteFailed}). Manually remove that file — it may still contain ` +
         `a Remnic daemon bearer token.`,
+    };
+  }
+
+  // Droid-specific: remove the "remnic" entry from ~/.factory/mcp.json.
+  // Using the persisted absolute path (read above before the registry file
+  // was deleted) — not a re-derivation from the current environment — so a
+  // HOME change between install and remove cannot leave the old mcp.json
+  // with a stale "remnic" entry (and its live bearer token) behind.
+  let droidMcpDeleteFailed: string | null = null;
+  if (connectorId === "droid") {
+    if (droidMcpConfigPath === null) {
+      notes.push(
+        "Droid MCP config cleanup skipped: no persisted path found in saved config " +
+          "(likely a legacy install predating factoryMcpPath provenance).",
+      );
+    } else {
+      // Safety gate: validate the persisted path before modifying. The path
+      // is loaded from user-controlled JSON, so restrict to paths that are:
+      //   1. Absolute (relative paths are CWD-dependent).
+      //   2. End with ".factory/mcp.json" — the only filename the installer
+      //      ever writes.
+      const expectedSuffix = path.join(".factory", "mcp.json");
+      const isSafePath =
+        path.isAbsolute(droidMcpConfigPath) &&
+        droidMcpConfigPath.endsWith(expectedSuffix);
+      if (!isSafePath) {
+        droidMcpDeleteFailed =
+          `MCP config path ${JSON.stringify(droidMcpConfigPath)} failed safety validation ` +
+          `(must be absolute and end with "${expectedSuffix}"). ` +
+          `Refusing to modify — remove the "remnic" entry manually if it exists.`;
+      } else {
+        try {
+          const priorContent = readFactoryMcpIfExists(droidMcpConfigPath);
+          if (priorContent !== null) {
+            const updated = removeFactoryMcpRemnicEntry(priorContent);
+            if (updated !== null) {
+              writeSecretFileSync(droidMcpConfigPath, JSON.stringify(updated, null, 2));
+              notes.push(`Removed remnic entry from Droid MCP config: ${droidMcpConfigPath}`);
+            }
+          }
+        } catch (err) {
+          droidMcpDeleteFailed = err instanceof Error ? err.message : String(err);
+        }
+      }
+    }
+  }
+  if (droidMcpDeleteFailed !== null && droidMcpConfigPath !== null) {
+    const tokenStatus = tokenRevoked
+      ? "the registry config was deleted and the token was revoked"
+      : "the registry config was deleted but TOKEN REVOCATION ALSO FAILED — " +
+        "inspect ~/.remnic/tokens.json and revoke manually";
+    return {
+      connectorId,
+      configPath,
+      status: "error",
+      message:
+        `Droid remove partially succeeded: ${tokenStatus}, ` +
+        `but the MCP config at ${droidMcpConfigPath} could not be updated ` +
+        `(${droidMcpDeleteFailed}). Manually remove the "remnic" entry from that file — ` +
+        `it may still contain a Remnic daemon bearer token.`,
     };
   }
 
@@ -3301,6 +3512,33 @@ export async function doctorConnector(connectorId: string): Promise<DoctorResult
     }
   }
 
+  // Droid-specific: check ~/.factory/mcp.json has the remnic entry
+  if (connectorId === "droid") {
+    const savedPath = instance.config.factoryMcpPath as string | undefined;
+    const mcpPath = savedPath ?? resolveFactoryMcpPath();
+    try {
+      const raw = fs.readFileSync(mcpPath, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const servers = parsed.mcpServers;
+      const hasRemnic =
+        typeof servers === "object" && servers !== null &&
+        "remnic" in (servers as Record<string, unknown>);
+      checks.push({
+        name: "Droid MCP config",
+        ok: hasRemnic,
+        detail: hasRemnic
+          ? `remnic entry present in ${mcpPath}`
+          : `remnic entry missing in ${mcpPath} — run \`remnic connectors install droid\``,
+      });
+    } catch {
+      checks.push({
+        name: "Droid MCP config",
+        ok: false,
+        detail: `Cannot read ${mcpPath} — run \`remnic connectors install droid\``,
+      });
+    }
+  }
+
   const healthy = checks.every((c) => c.ok);
   return { connectorId, checks, healthy };
 }
@@ -3985,5 +4223,161 @@ export function buildWeCloneProxyConfig(args: {
     config.remnicAuthToken = priorConfig.remnicAuthToken;
   }
 
+  return config;
+}
+
+// ── Droid ~/.factory/mcp.json helpers ─────────────────────────────────────
+//
+// Factory Droid reads MCP server config from the user-level ~/.factory/mcp.json.
+// `remnic connectors install droid` writes a "remnic" entry under mcpServers
+// with HTTP transport and a bearer token so Droid can authenticate to the
+// Remnic daemon. The token is NEVER written into the project-level
+// .factory/mcp.json — only the user-level file at ~/.factory/mcp.json.
+
+/**
+ * Resolve the path to ~/.factory/mcp.json. Honours HOME / USERPROFILE env
+ * overrides so tests can point the install at a temp dir without leaking
+ * into the real home directory. Always returns an absolute path.
+ */
+export function resolveFactoryMcpPath(): string {
+  const envHome = readEnvVar("HOME");
+  const home = envHome && envHome.length > 0 ? envHome : os.homedir();
+  return path.resolve(home, ".factory", "mcp.json");
+}
+
+/**
+ * Read the existing ~/.factory/mcp.json, if any. Returns raw string contents
+ * so the caller can parse, modify, and restore on rollback.
+ */
+function readFactoryMcpIfExists(mcpPath: string): string | null {
+  try {
+    if (!fs.existsSync(mcpPath)) return null;
+    return fs.readFileSync(mcpPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default MCP server URL for the Remnic daemon.
+ */
+const REMNIC_DEFAULT_MCP_URL = "http://127.0.0.1:4318/mcp";
+
+/**
+ * Upsert the "remnic" entry in a ~/.factory/mcp.json config object.
+ *
+ * Parses the prior content (if any), preserves all existing mcpServers entries,
+ * and sets the "remnic" entry with HTTP transport, the bearer token, and an
+ * optional namespace header. Returns the full config object ready to serialize.
+ *
+ * If no token is available, the entry is still written but without the
+ * Authorization header — the caller will see an auth error from the daemon,
+ * which is more informative than a missing entry.
+ */
+export function upsertFactoryMcpRemnicEntry(
+  priorContent: string | null,
+  authToken: string | undefined,
+  resolvedConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  let config: Record<string, unknown>;
+  if (priorContent !== null) {
+    try {
+      const parsed = JSON.parse(priorContent);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        config = parsed as Record<string, unknown>;
+      } else {
+        config = {};
+      }
+    } catch {
+      // Prior content is not valid JSON — start fresh.
+      config = {};
+    }
+  } else {
+    config = {};
+  }
+
+  // Ensure mcpServers object exists
+  if (typeof config.mcpServers !== "object" || config.mcpServers === null || Array.isArray(config.mcpServers)) {
+    config.mcpServers = {};
+  }
+  const servers = config.mcpServers as Record<string, unknown>;
+
+  // Resolve the MCP URL from user config or default
+  const mcpUrl =
+    typeof resolvedConfig.mcpServerUrl === "string" && resolvedConfig.mcpServerUrl.length > 0
+      ? resolvedConfig.mcpServerUrl
+      : REMNIC_DEFAULT_MCP_URL;
+
+  // Build the remnic entry
+  const remnicEntry: Record<string, unknown> = {
+    type: "http",
+    url: mcpUrl,
+  };
+
+  // Build headers — preserve any non-remnic headers from the prior entry
+  const headers: Record<string, string> = {};
+  if (
+    typeof servers.remnic === "object" && servers.remnic !== null &&
+    typeof (servers.remnic as Record<string, unknown>).headers === "object" &&
+    (servers.remnic as Record<string, unknown>).headers !== null
+  ) {
+    const priorHeaders = (servers.remnic as Record<string, Record<string, unknown>>).headers as Record<string, unknown>;
+    for (const [key, value] of Object.entries(priorHeaders)) {
+      if (key !== "Authorization" && typeof value === "string") {
+        headers[key] = value;
+      }
+    }
+  }
+
+  if (authToken && authToken.length > 0) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  // Add optional namespace header
+  const namespace =
+    typeof resolvedConfig.namespace === "string" && resolvedConfig.namespace.length > 0
+      ? resolvedConfig.namespace
+      : undefined;
+  if (namespace) {
+    headers["X-Engram-Namespace"] = namespace;
+  }
+
+  if (Object.keys(headers).length > 0) {
+    remnicEntry.headers = headers;
+  }
+
+  servers.remnic = remnicEntry;
+  return config;
+}
+
+/**
+ * Remove the "remnic" entry from a ~/.factory/mcp.json config object.
+ *
+ * Returns the updated config object (with remnic removed) or null if the
+ * entry was not present (no modification needed).
+ */
+export function removeFactoryMcpRemnicEntry(
+  priorContent: string,
+): Record<string, unknown> | null {
+  let config: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(priorContent);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    config = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (typeof config.mcpServers !== "object" || config.mcpServers === null) {
+    return null;
+  }
+  const servers = config.mcpServers as Record<string, unknown>;
+  if (!("remnic" in servers)) {
+    return null;
+  }
+
+  delete servers.remnic;
   return config;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connector-droid:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/connector-fireflies:
     devDependencies:
       '@remnic/core':
@@ -651,7 +666,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.0.0)
+        version: 1.29.0(zod@3.25.76)
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
@@ -2941,28 +2956,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.0.0)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.29
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.0.0
-      zod-to-json-schema: 3.25.2(zod@4.0.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@msgpack/msgpack@3.1.3': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -4406,10 +4399,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.0.0):
-    dependencies:
-      zod: 4.0.0
 
   zod@3.25.76: {}
 

--- a/tests/integration/connectors-droid.test.ts
+++ b/tests/integration/connectors-droid.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Integration tests for the Droid connector install/remove/doctor flow.
+ *
+ * Tests validate:
+ * - droid appears in BUILTIN_CONNECTORS with the expected manifest
+ * - installConnector writes ~/.factory/mcp.json with HTTP MCP + bearer token
+ * - the token is NOT written into the connector.json registry file
+ * - existing mcpServers entries in ~/.factory/mcp.json are preserved
+ * - removeConnector removes the remnic entry from ~/.factory/mcp.json
+ * - doctorConnector checks the ~/.factory/mcp.json remnic entry
+ *
+ * All tests use a temp HOME so no real user config is modified.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+const CONNECTORS_SRC = path.join(ROOT, "packages/remnic-core/src/connectors/index.ts");
+
+// ── Source-level checks ───────────────────────────────────────────────────
+
+test("droid is in BUILTIN_CONNECTORS", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  assert.ok(content.includes('id: "droid"'), "droid must be in BUILTIN_CONNECTORS");
+  assert.ok(content.includes('name: "Factory Droid"'), "Must have correct name");
+});
+
+test("droid connector has expected capabilities", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  const droidIdx = content.indexOf('id: "droid"');
+  assert.ok(droidIdx >= 0, "droid block must exist");
+  const window = content.slice(droidIdx, droidIdx + 600);
+  assert.ok(window.includes("observe: true"), "droid must support observe");
+  assert.ok(window.includes("recall: true"), "droid must support recall");
+  assert.ok(window.includes("store: true"), "droid must support store");
+  assert.ok(window.includes("search: true"), "droid must support search");
+  assert.ok(window.includes('connectionType: "mcp"'), "droid must use mcp connection type");
+});
+
+test("droid connector requires a token", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  const droidIdx = content.indexOf('id: "droid"');
+  const window = content.slice(droidIdx, droidIdx + 800);
+  assert.ok(window.includes("requiresToken: true"), "droid must require a token");
+});
+
+test("resolveFactoryMcpPath is exported", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  assert.ok(
+    content.includes("export function resolveFactoryMcpPath"),
+    "resolveFactoryMcpPath must be exported",
+  );
+});
+
+test("upsertFactoryMcpRemnicEntry is exported", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  assert.ok(
+    content.includes("export function upsertFactoryMcpRemnicEntry"),
+    "upsertFactoryMcpRemnicEntry must be exported",
+  );
+});
+
+test("removeFactoryMcpRemnicEntry is exported", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  assert.ok(
+    content.includes("export function removeFactoryMcpRemnicEntry"),
+    "removeFactoryMcpRemnicEntry must be exported",
+  );
+});
+
+test("installConnector has a droid-specific block that writes ~/.factory/mcp.json", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  assert.ok(
+    content.includes('options.connectorId === "droid"'),
+    "installConnector must have a droid-specific block",
+  );
+  assert.ok(
+    content.includes("resolveFactoryMcpPath"),
+    "droid install must resolve the factory MCP path",
+  );
+  assert.ok(
+    content.includes("upsertFactoryMcpRemnicEntry"),
+    "droid install must upsert the remnic entry",
+  );
+});
+
+test("removeConnector has a droid-specific block that removes the remnic entry", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  // Find the removeConnector section
+  const removeIdx = content.indexOf("export function removeConnector");
+  assert.ok(removeIdx >= 0, "removeConnector must exist");
+  const removeSection = content.slice(removeIdx);
+  assert.ok(
+    removeSection.includes('connectorId === "droid"'),
+    "removeConnector must have a droid-specific block",
+  );
+  assert.ok(
+    removeSection.includes("removeFactoryMcpRemnicEntry"),
+    "removeConnector must call removeFactoryMcpRemnicEntry for droid",
+  );
+});
+
+test("doctorConnector has a droid-specific check for ~/.factory/mcp.json", () => {
+  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  const doctorIdx = content.indexOf("export async function doctorConnector");
+  assert.ok(doctorIdx >= 0, "doctorConnector must exist");
+  const doctorSection = content.slice(doctorIdx);
+  assert.ok(
+    doctorSection.includes('connectorId === "droid"'),
+    "doctorConnector must have a droid-specific check",
+  );
+});
+
+// ── Functional tests (tsx import) ─────────────────────────────────────────
+
+test("droid install/remove/doctor flow with temp HOME", async () => {
+  // Set up a temp HOME so we don't touch the real ~/.factory or ~/.remnic
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-droid-test-"));
+  const origHome = process.env.HOME;
+  const origRemnicHome = process.env.REMNIC_HOME;
+  const origXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = tmpHome;
+  process.env.REMNIC_HOME = path.join(tmpHome, ".remnic");
+  // Clear XDG_CONFIG_HOME so the connectors dir resolves under tmpHome/.config
+  delete process.env.XDG_CONFIG_HOME;
+
+  try {
+    // Dynamic import so env vars take effect
+    const {
+      installConnector,
+      removeConnector,
+      listConnectors,
+      resolveFactoryMcpPath,
+      getConnectorsDir,
+    } = await import("../../packages/remnic-core/src/connectors/index.js");
+
+    // Verify droid appears in available connectors
+    const { available } = listConnectors();
+    const droidManifest = available.find((c) => c.id === "droid");
+    assert.ok(droidManifest, "droid must appear in available connectors");
+    assert.equal(droidManifest.name, "Factory Droid");
+
+    // ── Pre-existing mcp.json with other entries ──
+    const mcpPath = resolveFactoryMcpPath();
+    fs.mkdirSync(path.dirname(mcpPath), { recursive: true });
+    const existingConfig = {
+      mcpServers: {
+        "other-tool": { type: "stdio", command: "npx", args: ["-y", "other-tool"] },
+      },
+    };
+    fs.writeFileSync(mcpPath, JSON.stringify(existingConfig, null, 2));
+
+    // ── Install ──
+    const installResult = installConnector({ connectorId: "droid" });
+    assert.equal(installResult.status, "installed", `install should succeed: ${installResult.message}`);
+
+    // Verify droid is now listed as installed
+    const { installed } = listConnectors();
+    const droidInstalled = installed.find((c) => c.connectorId === "droid");
+    assert.ok(droidInstalled, "droid must appear in installed connectors");
+
+    // Verify ~/.factory/mcp.json has the remnic entry
+    assert.ok(fs.existsSync(mcpPath), "~/.factory/mcp.json must exist after install");
+    const mcpContent = JSON.parse(fs.readFileSync(mcpPath, "utf8")) as Record<string, unknown>;
+    const servers = mcpContent.mcpServers as Record<string, unknown>;
+    assert.ok("remnic" in servers, "remnic entry must be in mcpServers");
+    const remnicEntry = servers.remnic as Record<string, unknown>;
+    assert.equal(remnicEntry.type, "http");
+    assert.ok((remnicEntry.url as string).includes("/mcp"), "URL must point to MCP endpoint");
+    const headers = remnicEntry.headers as Record<string, string>;
+    assert.ok(headers["Authorization"], "Authorization header must be present");
+    assert.ok(headers["Authorization"].startsWith("Bearer "), "Authorization must be a Bearer token");
+
+    // Verify existing entries are preserved
+    assert.ok("other-tool" in servers, "existing mcpServers entries must be preserved");
+
+    // Verify token is NOT in the connector.json registry file
+    const connectorsDir = getConnectorsDir();
+    const droidJsonPath = path.join(connectorsDir, "droid.json");
+    assert.ok(fs.existsSync(droidJsonPath), `droid.json must exist at ${droidJsonPath}`);
+    const droidJson = JSON.parse(fs.readFileSync(droidJsonPath, "utf8")) as Record<string, unknown>;
+    assert.ok(!("token" in droidJson), "token must NOT be in connector.json");
+
+    // ── Doctor ──
+    const { doctorConnector } = await import("../../packages/remnic-core/src/connectors/index.js");
+    const doctorResult = await doctorConnector("droid");
+    // Config file and config valid should pass
+    const configCheck = doctorResult.checks.find((c) => c.name === "Config file");
+    assert.ok(configCheck?.ok, "Config file check should pass");
+    const droidMcpCheck = doctorResult.checks.find((c) => c.name === "Droid MCP config");
+    assert.ok(droidMcpCheck, "Droid MCP config check must exist");
+    assert.ok(droidMcpCheck?.ok, "Droid MCP config check should pass");
+
+    // ── Remove ──
+    const removeResult = removeConnector("droid");
+    assert.equal(removeResult.status, "removed", `remove should succeed: ${removeResult.message}`);
+
+    // Verify remnic entry is removed from ~/.factory/mcp.json but other-tool preserved
+    const mcpAfterRemove = JSON.parse(fs.readFileSync(mcpPath, "utf8")) as Record<string, unknown>;
+    const serversAfter = mcpAfterRemove.mcpServers as Record<string, unknown>;
+    assert.ok(!("remnic" in serversAfter), "remnic entry must be removed");
+    assert.ok("other-tool" in serversAfter, "other entries must be preserved");
+
+    // Verify droid.json is deleted
+    assert.ok(!fs.existsSync(droidJsonPath), "droid.json must be deleted after remove");
+  } finally {
+    process.env.HOME = origHome;
+    if (origRemnicHome !== undefined) {
+      process.env.REMNIC_HOME = origRemnicHome;
+    } else {
+      delete process.env.REMNIC_HOME;
+    }
+    if (origXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXdgConfigHome;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    // Clean up temp dir
+    try {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+test("droid install preserves user-level mcp.json and never touches project-level", async () => {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-droid-privacy-"));
+  const origHome = process.env.HOME;
+  const origRemnicHome = process.env.REMNIC_HOME;
+  const origXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  process.env.HOME = tmpHome;
+  process.env.REMNIC_HOME = path.join(tmpHome, ".remnic");
+  delete process.env.XDG_CONFIG_HOME;
+
+  try {
+    const { installConnector, resolveFactoryMcpPath } = await import(
+      "../../packages/remnic-core/src/connectors/index.js"
+    );
+
+    // Create a user-level mcp.json with existing config
+    const userMcpPath = resolveFactoryMcpPath();
+    fs.mkdirSync(path.dirname(userMcpPath), { recursive: true });
+    const userConfig = {
+      mcpServers: {
+        "my-existing-server": { type: "http", url: "http://localhost:3000/mcp" },
+      },
+    };
+    fs.writeFileSync(userMcpPath, JSON.stringify(userConfig, null, 2));
+
+    // Install droid
+    const result = installConnector({ connectorId: "droid" });
+    assert.equal(result.status, "installed");
+
+    // Verify user-level file still has the existing entry plus remnic
+    const after = JSON.parse(fs.readFileSync(userMcpPath, "utf8")) as Record<string, unknown>;
+    const servers = after.mcpServers as Record<string, unknown>;
+    assert.ok("my-existing-server" in servers, "user's existing server must be preserved");
+    assert.ok("remnic" in servers, "remnic must be added");
+
+    // Verify NO project-level .factory/mcp.json was created
+    const projectMcpPath = path.join(process.cwd(), ".factory", "mcp.json");
+    assert.ok(
+      !fs.existsSync(projectMcpPath),
+      "project-level .factory/mcp.json must NOT be created by install",
+    );
+  } finally {
+    process.env.HOME = origHome;
+    if (origRemnicHome !== undefined) {
+      process.env.REMNIC_HOME = origRemnicHome;
+    } else {
+      delete process.env.REMNIC_HOME;
+    }
+    if (origXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXdgConfigHome;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    try {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+});

--- a/tests/integration/connectors-droid.test.ts
+++ b/tests/integration/connectors-droid.test.ts
@@ -22,17 +22,20 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "../..");
 const CONNECTORS_SRC = path.join(ROOT, "packages/remnic-core/src/connectors/index.ts");
+const DROID_MCP_SRC = path.join(ROOT, "packages/remnic-core/src/connectors/droid-mcp.ts");
 
 // ── Source-level checks ───────────────────────────────────────────────────
 
 test("droid is in BUILTIN_CONNECTORS", () => {
   const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
-  assert.ok(content.includes('id: "droid"'), "droid must be in BUILTIN_CONNECTORS");
-  assert.ok(content.includes('name: "Factory Droid"'), "Must have correct name");
+  assert.ok(content.includes("DROID_CONNECTOR_MANIFEST"), "index.ts must reference DROID_CONNECTOR_MANIFEST");
+  const droidContent = fs.readFileSync(DROID_MCP_SRC, "utf-8");
+  assert.ok(droidContent.includes('id: "droid"'), "droid manifest must exist in droid-mcp.ts");
+  assert.ok(droidContent.includes('name: "Factory Droid"'), "Must have correct name");
 });
 
 test("droid connector has expected capabilities", () => {
-  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  const content = fs.readFileSync(DROID_MCP_SRC, "utf-8");
   const droidIdx = content.indexOf('id: "droid"');
   assert.ok(droidIdx >= 0, "droid block must exist");
   const window = content.slice(droidIdx, droidIdx + 600);
@@ -44,7 +47,7 @@ test("droid connector has expected capabilities", () => {
 });
 
 test("droid connector requires a token", () => {
-  const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
+  const content = fs.readFileSync(DROID_MCP_SRC, "utf-8");
   const droidIdx = content.indexOf('id: "droid"');
   const window = content.slice(droidIdx, droidIdx + 800);
   assert.ok(window.includes("requiresToken: true"), "droid must require a token");
@@ -53,24 +56,24 @@ test("droid connector requires a token", () => {
 test("resolveFactoryMcpPath is exported", () => {
   const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
   assert.ok(
-    content.includes("export function resolveFactoryMcpPath"),
-    "resolveFactoryMcpPath must be exported",
+    content.includes("resolveFactoryMcpPath"),
+    "resolveFactoryMcpPath must be exported from connectors/index.ts",
   );
 });
 
 test("upsertFactoryMcpRemnicEntry is exported", () => {
   const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
   assert.ok(
-    content.includes("export function upsertFactoryMcpRemnicEntry"),
-    "upsertFactoryMcpRemnicEntry must be exported",
+    content.includes("upsertFactoryMcpRemnicEntry"),
+    "upsertFactoryMcpRemnicEntry must be exported from connectors/index.ts",
   );
 });
 
 test("removeFactoryMcpRemnicEntry is exported", () => {
   const content = fs.readFileSync(CONNECTORS_SRC, "utf-8");
   assert.ok(
-    content.includes("export function removeFactoryMcpRemnicEntry"),
-    "removeFactoryMcpRemnicEntry must be exported",
+    content.includes("removeFactoryMcpRemnicEntry"),
+    "removeFactoryMcpRemnicEntry must be exported from connectors/index.ts",
   );
 });
 
@@ -81,12 +84,21 @@ test("installConnector has a droid-specific block that writes ~/.factory/mcp.jso
     "installConnector must have a droid-specific block",
   );
   assert.ok(
-    content.includes("resolveFactoryMcpPath"),
-    "droid install must resolve the factory MCP path",
+    content.includes("droidInstallStep"),
+    "installConnector must call droidInstallStep for droid",
+  );
+  // The actual implementation lives in droid-mcp.ts
+  const droidMcpSrc = fs.readFileSync(
+    path.join(ROOT, "packages/remnic-core/src/connectors/droid-mcp.ts"),
+    "utf-8",
   );
   assert.ok(
-    content.includes("upsertFactoryMcpRemnicEntry"),
-    "droid install must upsert the remnic entry",
+    droidMcpSrc.includes("resolveFactoryMcpPath"),
+    "droid-mcp.ts must resolve the factory MCP path",
+  );
+  assert.ok(
+    droidMcpSrc.includes("upsertFactoryMcpRemnicEntry"),
+    "droid-mcp.ts must upsert the remnic entry",
   );
 });
 
@@ -101,8 +113,17 @@ test("removeConnector has a droid-specific block that removes the remnic entry",
     "removeConnector must have a droid-specific block",
   );
   assert.ok(
-    removeSection.includes("removeFactoryMcpRemnicEntry"),
-    "removeConnector must call removeFactoryMcpRemnicEntry for droid",
+    removeSection.includes("removeDroidMcpEntry"),
+    "removeConnector must call removeDroidMcpEntry for droid",
+  );
+  // The actual implementation lives in droid-mcp.ts
+  const droidMcpSrc = fs.readFileSync(
+    path.join(ROOT, "packages/remnic-core/src/connectors/droid-mcp.ts"),
+    "utf-8",
+  );
+  assert.ok(
+    droidMcpSrc.includes("removeFactoryMcpRemnicEntry"),
+    "droid-mcp.ts must call removeFactoryMcpRemnicEntry",
   );
 });
 

--- a/tests/integration/connectors-droid.test.ts
+++ b/tests/integration/connectors-droid.test.ts
@@ -231,7 +231,7 @@ test("droid install/remove/doctor flow with temp HOME", async () => {
     // Verify droid.json is deleted
     assert.ok(!fs.existsSync(droidJsonPath), "droid.json must be deleted after remove");
   } finally {
-    process.env.HOME = origHome;
+    if (origHome !== undefined) process.env.HOME = origHome; else delete process.env.HOME;
     if (origRemnicHome !== undefined) {
       process.env.REMNIC_HOME = origRemnicHome;
     } else {
@@ -292,7 +292,7 @@ test("droid install preserves user-level mcp.json and never touches project-leve
       "project-level .factory/mcp.json must NOT be created by install",
     );
   } finally {
-    process.env.HOME = origHome;
+    if (origHome !== undefined) process.env.HOME = origHome; else delete process.env.HOME;
     if (origRemnicHome !== undefined) {
       process.env.REMNIC_HOME = origRemnicHome;
     } else {

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -28,6 +28,7 @@ const expectedPublishDirs = [
   "packages/connector-omi",
   "packages/connector-fireflies",
   "packages/connector-granola",
+  "packages/connector-droid",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
## What this PR adds

A `droid` connector so `remnic connectors install droid` gives Factory Droid persistent memory via HTTP MCP with bearer auth.

> **Built by Droid.** This entire connector, code, tests, docs, and this PR, was implemented by Factory Droid running on the stock `droid` CLI. No missions, no BYOK, no side repos. The walkthrough below documents every command Droid ran.

## Walkthrough: Droid building the Droid connector

### Setup

    cd ~/src && git clone https://github.com/joshuaswarren/remnic remnic-guild-pr && cd remnic-guild-pr && droid

### What Droid did

1. **Explored the connector architecture.** Read `packages/remnic-core/src/connectors/index.ts` to understand the `BUILTIN_CONNECTORS` registry, `installConnector`, `removeConnector`, and `doctorConnector` flows. Studied existing connectors (hermes, weclone, codex-cli) for install/rollback patterns. Checked `~/.factory/mcp.json` format to confirm the HTTP MCP + bearer entry shape.

2. **Added the droid manifest** to `BUILTIN_CONNECTORS` with `requiresToken: true`, `connectionType: "mcp"`, and full capabilities (observe, recall, store, search, entities, realtimeSync, batch).

3. **Implemented install logic.** In `installConnector`, added a droid-specific block that:
   - Resolves `~/.factory/mcp.json` via `resolveFactoryMcpPath()`
   - Reads existing content, upserts only the `remnic` entry (preserving all other MCP servers)
   - Writes with `writeSecretFileSync` (0600 permissions, atomic temp+rename)
   - Persists the resolved `factoryMcpPath` in `droid.json` for later removal
   - Rolls back on failure (token store + mcp.json)

4. **Implemented remove logic.** In `removeConnector`, added a droid-specific block that:
   - Reads the persisted `factoryMcpPath` from `droid.json` before deleting it
   - Validates the path is absolute and ends with `.factory/mcp.json` (safety gate against tampered JSON)
   - Removes only the `remnic` entry, preserving all other MCP servers
   - Revokes the bearer token from `tokens.json`

5. **Implemented doctor logic.** In `doctorConnector`, added a `Droid MCP config` check that verifies the `remnic` entry exists in `~/.factory/mcp.json`.

6. **Created the @remnic/connector-droid package** with re-exports of the helper functions, a `CONNECTOR_ID` constant, and unit tests (13 tests, all pass).

7. **Wrote integration tests** (`tests/integration/connectors-droid.test.ts`) covering:
   - Source-level checks (manifest exists, capabilities, exports, install/remove/doctor blocks)
   - Full install/remove/doctor flow with temp HOME (verifies mcp.json entry, token NOT in connector.json, existing entries preserved, remove cleans up)
   - User-level-only write verification (never touches project-level .factory/mcp.json)
   - All 11 tests pass

8. **Wrote docs**: `docs/integration/droid.md` with quickstart, config reference, troubleshooting. Updated `connector-setup.md`, `connectors.md` (14 to 15 built-ins), and the README tools table.

### Commit SHA

    fcd2913ad785990c50a2a6f5782ef2d067be7818

### Before/after: remnic connectors list

**Before (14 connectors, no droid):**

    ✓ claude-code            Claude Code v1.0.0
    ✓ codex-cli              Codex CLI v1.0.0
    ○ cursor                 Cursor IDE v1.0.0
    ○ cline                  Cline v1.0.0
    ○ github-copilot         GitHub Copilot v1.0.0
    ○ roo-code               Roo Code v1.0.0
    ○ windsurf               Windsurf v1.0.0
    ○ amp                    Amp v1.0.0
    ✓ pi                     Pi Coding Agent v1.0.0
    ○ omp                    Oh My Pi (omp) v1.0.0
    ○ replit                 Replit Agent v1.0.0
    ○ generic-mcp            Generic MCP Client v1.0.0
    ○ weclone                WeClone Avatar v1.0.0
    ✓ hermes                 Hermes Agent v1.0.0

    Total: 14 connectors

**After (15 connectors, droid added):**

    ✓ claude-code            Claude Code v1.0.0
    ✓ codex-cli              Codex CLI v1.0.0
    ○ cursor                 Cursor IDE v1.0.0
    ○ cline                  Cline v1.0.0
    ○ github-copilot         GitHub Copilot v1.0.0
    ○ roo-code               Roo Code v1.0.0
    ○ windsurf               Windsurf v1.0.0
    ○ amp                    Amp v1.0.0
    ✓ pi                     Pi Coding Agent v1.0.0
    ○ omp                    Oh My Pi (omp) v1.0.0
    ○ replit                 Replit Agent v1.0.0
    ○ generic-mcp            Generic MCP Client v1.0.0
    ○ weclone                WeClone Avatar v1.0.0
    ✓ hermes                 Hermes Agent v1.0.0
    ○ droid                  Factory Droid v1.0.0 — memory via HTTP MCP with bearer auth

    Total: 15 connectors

### Test results

    NODE_OPTIONS="--conditions=remnic-source" npx tsx --test       packages/connector-droid/src/index.test.ts       tests/integration/connectors-droid.test.ts

    tests 24
    pass 24
    fail 0

Existing connector tests still pass (42/42 in tests/cli/connectors.test.ts).

### Key design decisions

- **User-level ~/.factory/mcp.json only.** The install never writes to project-level .factory/mcp.json (which may be committed to git and would expose the bearer token). This is tested explicitly.
- **Token never in connector.json.** Same pattern as all other connectors. The bearer token lives only in ~/.remnic/tokens.json (0600) and ~/.factory/mcp.json (0600).
- **Preserves existing MCP entries.** The upsert only touches the remnic key under mcpServers; all other tools MCP config is untouched. Tested with a pre-existing other-tool entry.
- **Atomic rollback on failure.** If the connector.json write fails after the mcp.json write, the mcp.json is rolled back to its prior state (or deleted if it did not exist before).
- **Safety gate on remove.** The persisted factoryMcpPath is validated (must be absolute, must end with .factory/mcp.json) before any modification, preventing a tampered droid.json from causing arbitrary file writes.

### Files changed

- `packages/remnic-core/src/connectors/index.ts` — droid manifest + install/remove/doctor logic + helper functions
- `packages/connector-droid/` — new package (package.json, tsconfig, src/index.ts, src/index.test.ts, README.md)
- `tests/integration/connectors-droid.test.ts` — integration tests
- `docs/integration/droid.md` — full guide with quickstart
- `docs/integration/connector-setup.md` — added Droid section
- `docs/connectors.md` — updated built-in count (14 to 15)
- `README.md` — added Droid to tools table, install commands, and tool list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Factory Droid as a supported integration.
  * Added installation with bearer-token authentication and user-level MCP configuration.
  * Preserves existing MCP settings and avoids modifying project-level configuration.
  * Added verification, troubleshooting, and removal commands.
  * Added support for optional URL and namespace configuration.

* **Documentation**
  * Added Factory Droid setup guidance, supported capabilities, configuration options, and troubleshooting information.
  * Updated supported integrations and shared memory-store listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->