### PR TITLE
fix(test): spawn tsx JS entry on win32 without a shell

### DIFF
--- a/scripts/test-file.mjs
+++ b/scripts/test-file.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import { isAnySourceNewerThan } from "./build-staleness.mjs";
 import { appendNodeOption } from "./root-test-runner-env.mjs";
+import { buildTestSpawnPlan, resolveTsxCliPath } from "./test-spawn-plan.mjs";
 import {
   loadNativeManifest,
   partitionNativeDependent,
@@ -121,10 +122,16 @@ for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
   });
 }
 
-const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
+const spawnPlan = buildTestSpawnPlan({
+  platform: process.platform,
+  execPath: process.execPath,
+  tsxCliPath: process.platform === "win32" ? resolveTsxCliPath(repoRoot) : undefined,
+  runnerArgs,
+  files: filesToRun,
+});
 const result = await new Promise((resolve) => {
-  testProcess = spawn(tsxBin, ["--test", ...runnerArgs, ...filesToRun], {
+  testProcess = spawn(spawnPlan.command, spawnPlan.args, {
     cwd: repoRoot,
     env: {
       ...process.env,
@@ -135,14 +142,13 @@ const result = await new Promise((resolve) => {
       TEMP: testRunScratchDir,
     },
     stdio: "inherit",
-    shell: process.platform === "win32",
+    shell: spawnPlan.shell,
   });
-  testProcess.on("error", (error) => resolve({ error }));
   testProcess.on("close", (status, signal) => resolve({ status, signal }));
 });
 
 if (result.error) {
-  console.error(`Failed to launch ${tsxBin}: ${result.error.message}`);
+  console.error(`Failed to launch ${spawnPlan.command}: ${result.error.message}`);
   process.exit(1);
 }
 

--- a/scripts/test-spawn-plan.mjs
+++ b/scripts/test-spawn-plan.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+
+/**
+ * Resolve the tsx CLI JS entry inside the workspace's installed tsx package.
+ * Reading the `bin` field keeps this stable across tsx layout changes and
+ * avoids the `.cmd` shim, which requires a shell to execute on Windows.
+ */
+export function resolveTsxCliPath(repoRoot) {
+  const requireFromRoot = createRequire(join(repoRoot, "package.json"));
+  const pkgPath = requireFromRoot.resolve("tsx/package.json");
+  const bin = JSON.parse(readFileSync(pkgPath, "utf8")).bin;
+  const binPath = typeof bin === "string" ? bin : bin?.tsx;
+  if (!binPath) {
+    throw new Error(`tsx package at ${dirname(pkgPath)} declares no bin entry`);
+  }
+  return resolve(dirname(pkgPath), binPath);
+}
+
+/**
+ * Build the spawn plan for the root test runner.
+ *
+ * win32: spawn node directly against the tsx JS entry with `shell: false` —
+ * a shell would wrap the `.cmd` shim, break `testProcess.kill` signal
+ * forwarding, and concatenate args unquoted.
+ * POSIX: keep spawning the `tsx` bin (resolved from the workspace `.bin`
+ * via PATH), also without a shell.
+ */
+export function buildTestSpawnPlan({ platform, execPath, tsxCliPath, runnerArgs, files }) {
+  const args = ["--test", ...runnerArgs, ...files];
+  if (platform === "win32") {
+    return {
+      command: execPath,
+      args: [tsxCliPath, ...args],
+      shell: false,
+    };
+  }
+  return {
+    command: "tsx",
+    args,
+    shell: false,
+  };
+}

--- a/tests/test-spawn-plan.test.mjs
+++ b/tests/test-spawn-plan.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { buildTestSpawnPlan, resolveTsxCliPath } from "../scripts/test-spawn-plan.mjs";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("win32 plan spawns node with the tsx JS entry and no shell", () => {
+  const plan = buildTestSpawnPlan({
+    platform: "win32",
+    execPath: "C:\\Program Files\\nodejs\\node.exe",
+    tsxCliPath: "C:\\repo\\node_modules\\tsx\\dist\\cli.mjs",
+    runnerArgs: ["--test-name-pattern", "foo bar"],
+    files: ["tests/a.test.mjs", "tests/b.test.mjs"],
+  });
+
+  assert.equal(plan.command, "C:\\Program Files\\nodejs\\node.exe");
+  assert.deepEqual(plan.args, [
+    "C:\\repo\\node_modules\\tsx\\dist\\cli.mjs",
+    "--test",
+    "--test-name-pattern",
+    "foo bar",
+    "tests/a.test.mjs",
+    "tests/b.test.mjs",
+  ]);
+  assert.equal(plan.shell, false);
+});
+
+test("posix plan spawns the tsx bin without a shell", () => {
+  const plan = buildTestSpawnPlan({
+    platform: "linux",
+    execPath: "/usr/bin/node",
+    tsxCliPath: undefined,
+    runnerArgs: [],
+    files: ["tests/a.test.mjs"],
+  });
+
+  assert.equal(plan.command, "tsx");
+  assert.deepEqual(plan.args, ["--test", "tests/a.test.mjs"]);
+  assert.equal(plan.shell, false);
+});
+
+test("darwin plan matches the posix plan", () => {
+  const plan = buildTestSpawnPlan({
+    platform: "darwin",
+    execPath: "/usr/local/bin/node",
+    tsxCliPath: undefined,
+    runnerArgs: [],
+    files: ["tests/a.test.mjs"],
+  });
+
+  assert.equal(plan.command, "tsx");
+  assert.equal(plan.shell, false);
+});
+
+test("resolveTsxCliPath resolves the installed tsx bin entry", () => {
+  const tsxCliPath = resolveTsxCliPath(repoRoot);
+
+  const expectedSegment = ["node_modules", "tsx"].join(sep);
+  assert.ok(
+    tsxCliPath.includes(expectedSegment),
+    `expected ${tsxCliPath} to contain ${expectedSegment}`,
+  );
+  assert.ok(existsSync(tsxCliPath), `expected ${tsxCliPath} to exist`);
+});


### PR DESCRIPTION
## Summary

On Windows, `npm run test:file` spawned `tsx.cmd` with `shell: true`. That wraps the runner in `cmd.exe`, so `testProcess.kill` can orphan the child and args are concatenated unquoted.

This change spawns `process.execPath` plus the `tsx` JS entry on win32, with `shell: false`. POSIX still uses the `tsx` bin, also without a shell.

Fixes #2433

## Test

`npm run test:file -- tests/test-spawn-plan.test.mjs` — 4/4 pass.