### PR TITLE
fix(recall): language-agnostic planner heuristics

### DIFF
--- a/.changeset/2191-recall-planner-i18n.md
+++ b/.changeset/2191-recall-planner-i18n.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Make recall planner heuristics script-agnostic: multilingual acknowledgements and timeline cues, Thai/Khmer/Lao/Myanmar n-grams, and a Unicode direct-fact agent gate so non-English prompts no longer silently degrade.

--- a/packages/remnic-core/src/direct-answer.ts
+++ b/packages/remnic-core/src/direct-answer.ts
@@ -18,7 +18,11 @@
  * Not wired into retrieval yet — see slice 3.
  */
 
-import { normalizeRecallTokenSet, normalizeRecallTokens } from "./recall-tokenization.js";
+import {
+  isUnsegmentableRecallChar as isUnsegmentableRecallCodepoint,
+  normalizeRecallTokenSet,
+  normalizeRecallTokens,
+} from "./recall-tokenization.js";
 import type { TrustZoneName } from "./trust-zones.js";
 import type { MemoryFile, MemoryStatus } from "./types.js";
 
@@ -154,8 +158,7 @@ interface ScoredCandidate {
 }
 
 function hasUnsegmentableRecallChar(token: string): boolean {
-  if (token.includes("ー") || token.includes("ｰ")) return true;
-  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(token);
+  return [...token].some((ch) => isUnsegmentableRecallCodepoint(ch));
 }
 
 function requiredCjkPhraseTokens(query: string): string[] {

--- a/packages/remnic-core/src/event-order-query.ts
+++ b/packages/remnic-core/src/event-order-query.ts
@@ -1,0 +1,78 @@
+import { EVENT_ORDER_CUES, containsRecallCue } from "./recall-planner-i18n.js";
+
+function isTimelineSummaryQuery(normalized: string): boolean {
+  return (
+    /\b(?:summarize|summary|major progress|what happened|develop(?:ed|ment)?|approached)\b/.test(
+      normalized,
+    ) &&
+    (/\b(?:over time|throughout|between|project|progress|timeline|journey|sessions?|along the way)\b/.test(
+      normalized,
+    ) ||
+      /\bfrom\b.+\bthrough\b/.test(normalized))
+  );
+}
+
+export function shouldRecallEventOrderEvidence(query: string): boolean {
+  const normalized = query.toLowerCase();
+
+  if (containsRecallCue(normalized, EVENT_ORDER_CUES)) {
+    return true;
+  }
+
+  if (
+    /\border in which\b/.test(normalized) ||
+    /\bsequence in which\b/.test(normalized) ||
+    /\breconstruct\b.*\btimeline\b/.test(normalized) ||
+    /\btimeline\b.*\bin order\b/.test(normalized) ||
+    /\bsequence\b.*\bin order\b/.test(normalized) ||
+    /\bintroduced\b.*\bin order\b/.test(normalized) ||
+    (/\bwalk me through\b/.test(normalized) && /\bin order\b/.test(normalized)) ||
+    (/\bin order\b/.test(normalized) &&
+      /\b(?:develop(?:ed|ment)?|evolv(?:e|ed|ing)?|progress|throughout|conversations?|sessions?)\b/.test(
+        normalized,
+      )) ||
+    /\bprogress\b.*\bin order\b/.test(normalized) ||
+    /\bchronological(?:ly| order)?\b/.test(normalized) ||
+    isTimelineSummaryQuery(normalized)
+  ) {
+    return true;
+  }
+
+  if (/\bwhich\b.*\bfirst\b/.test(normalized) || /\bwhat was the first\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bhappened first\b/.test(normalized) || /\bwhich\b.*\bhappened\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bhow many days\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bwhen did\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bwhich\b.*\blast\b/.test(normalized) || /\bthe last\b.*\bi\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bwho\b.*\bfirst\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bmost recent(?:ly)?\b/.test(normalized)) {
+    return true;
+  }
+  if (/\border of\b/.test(normalized) || /\bfrom earliest to latest\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bhow long\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bhow many (months|weeks|years)\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bhow many\b.*\bbefore\b/.test(normalized)) {
+    return true;
+  }
+  if (/\bhow old\b.*\bwhen\b/.test(normalized)) {
+    return true;
+  }
+  return false;
+}

--- a/packages/remnic-core/src/event-order-recall.ts
+++ b/packages/remnic-core/src/event-order-recall.ts
@@ -7,6 +7,10 @@ import {
   type RankedEvidenceItem,
 } from "./recall-pipeline-stages.js";
 
+import { shouldRecallEventOrderEvidence } from "./event-order-query.js";
+export { shouldRecallEventOrderEvidence };
+
+
 export interface EventOrderRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   // event-order reads a SINGLE LCM session key. Unlike the relevance-ranked
@@ -28,87 +32,6 @@ const DEFAULT_SCAN_WINDOW_TURNS = 12;
 const DEFAULT_SCAN_WINDOW_TOKENS = 24_000;
 const DEFAULT_MAX_ITEMS = 24;
 
-export function shouldRecallEventOrderEvidence(query: string): boolean {
-  const normalized = query.toLowerCase();
-
-  // --- Existing event-order patterns (LongMemEval order-reconstruction phrasing) ---
-  if (
-    /\border in which\b/.test(normalized) ||
-    /\bsequence in which\b/.test(normalized) ||
-    /\breconstruct\b.*\btimeline\b/.test(normalized) ||
-    /\btimeline\b.*\bin order\b/.test(normalized) ||
-    /\bsequence\b.*\bin order\b/.test(normalized) ||
-    /\bintroduced\b.*\bin order\b/.test(normalized) ||
-    (/\bwalk me through\b/.test(normalized) && /\bin order\b/.test(normalized)) ||
-    (/\bin order\b/.test(normalized) &&
-      /\b(?:develop(?:ed|ment)?|evolv(?:e|ed|ing)?|progress|throughout|conversations?|sessions?)\b/.test(normalized)) ||
-    /\bprogress\b.*\bin order\b/.test(normalized) ||
-    /\bchronological(?:ly| order)?\b/.test(normalized) ||
-    isTimelineSummaryQuery(normalized)
-  ) {
-    return true;
-  }
-
-  // --- Temporal-reasoning patterns (LongMemEval temporal-reasoning question type) ---
-  // These question shapes need chronological evidence to answer correctly:
-  // ordering ("which happened first"), relative time ("how many days
-  // between"), and recency ("which did I [verb] last"). The event-order tier
-  // surfaces a chronologically sorted evidence pack so the responder can
-  // reconstruct the answer from an ordered timeline rather than fragments.
-  // Verified against the LongMemEval-oracle dataset: 0% of the 133
-  // temporal-reasoning questions matched the original heuristic above.
-
-  // "Which X did I Y first, A or B?" / "What was the first X ...?"
-  if (/\bwhich\b.*\bfirst\b/.test(normalized) || /\bwhat was the first\b/.test(normalized)) {
-    return true;
-  }
-  // "Which event happened first, A or B?" / "Which happened first"
-  if (/\bhappened first\b/.test(normalized) || /\bwhich\b.*\bhappened\b/.test(normalized)) {
-    return true;
-  }
-  // "How many days before/between/after/did it take"
-  if (/\bhow many days\b/.test(normalized)) {
-    return true;
-  }
-  // "When did I ..." (date-shaped)
-  if (/\bwhen did\b/.test(normalized)) {
-    return true;
-  }
-  // "Which X did I Y last?" / "the last X I ..."
-  if (/\bwhich\b.*\blast\b/.test(normalized) || /\bthe last\b.*\bi\b/.test(normalized)) {
-    return true;
-  }
-  // "Who did I meet/become first, X or Y?" (person ordering)
-  if (/\bwho\b.*\bfirst\b/.test(normalized)) {
-    return true;
-  }
-  // "most recently" / "most recent" (recency)
-  if (/\bmost recent(?:ly)?\b/.test(normalized)) {
-    return true;
-  }
-  // "What is the order of..." / "...from earliest to latest"
-  if (/\border of\b/.test(normalized) || /\bfrom earliest to latest\b/.test(normalized)) {
-    return true;
-  }
-
-  // "How long have/did/had I been..." (duration)
-  if (/\bhow long\b/.test(normalized)) {
-    return true;
-  }
-  // "How many months/weeks/years ago/before" (relative time)
-  if (/\bhow many (months|weeks|years)\b/.test(normalized)) {
-    return true;
-  }
-  // "How many X did I [verb] before Y" (temporal comparison)
-  if (/\bhow many\b.*\bbefore\b/.test(normalized)) {
-    return true;
-  }
-  // "How old was I when..." (age-at-time)
-  if (/\bhow old\b.*\bwhen\b/.test(normalized)) {
-    return true;
-  }
-  return false;
-}
 
 export async function buildEventOrderRecallSection(
   options: EventOrderRecallOptions,
@@ -1693,15 +1616,6 @@ function deriveChronologicalCueLabels(content: string, query: string): string[] 
   return [...labels].slice(0, 5);
 }
 
-function isTimelineSummaryQuery(normalized: string): boolean {
-  return /\b(?:summarize|summary|major progress|what happened|develop(?:ed|ment)?|approached)\b/.test(
-    normalized,
-  ) &&
-    (/\b(?:over time|throughout|between|project|progress|timeline|journey|sessions?|along the way)\b/.test(
-      normalized,
-    ) ||
-      /\bfrom\b.+\bthrough\b/.test(normalized));
-}
 
 function addLabelIf(
   labels: Set<string>,

--- a/packages/remnic-core/src/intent.ts
+++ b/packages/remnic-core/src/intent.ts
@@ -1,3 +1,11 @@
+import {
+  CAUSAL_CHAIN_CUES,
+  GRAPH_MODE_CUES,
+  containsRecallCue,
+  endsWithQuestionMark,
+  isMultilingualAck,
+  stripTrailingRecallNoise,
+} from "./recall-planner-i18n.js";
 import type { MemoryIntent, RecallPlanMode } from "./types.js";
 
 const GOAL_PATTERNS: Array<{ re: RegExp; goal: string }> = [
@@ -100,35 +108,26 @@ export function intentCompatibilityScore(queryIntent: MemoryIntent, memoryIntent
 
 export function planRecallMode(prompt: string): RecallPlanMode {
   const p = normalizeTextInput(prompt).trim();
-  let ackCandidate = p;
-  while (ackCandidate.length > 0) {
-    const ch = ackCandidate.charCodeAt(ackCandidate.length - 1);
-    const isDigit = ch >= 48 && ch <= 57;
-    const isUpper = ch >= 65 && ch <= 90;
-    const isLower = ch >= 97 && ch <= 122;
-    // Strip any trailing non-alphanumeric noise (punctuation/emojis/symbols).
-    if (isDigit || isUpper || isLower) break;
-    ackCandidate = ackCandidate.slice(0, -1);
-  }
-  ackCandidate = ackCandidate.trim();
   if (p.length === 0) return "no_recall";
 
-  if (/\b(timeline|sequence|history|what happened|chain of events|root cause)\b/i.test(p)) {
+  if (
+    /\b(timeline|sequence|history|what happened|chain of events|root cause)\b/i.test(p) ||
+    containsRecallCue(p, GRAPH_MODE_CUES)
+  ) {
     return "graph_mode";
   }
 
   // Reserve no_recall for low-information acknowledgements; avoid broad regressions.
-  if (
-    p.length <= 18 &&
-    /^(ok|okay|kk|thanks|thx|got it|sounds good|yep|yes|nope|no|done|cool|works)$/i.test(ackCandidate)
-  ) {
+  // Multilingual table (issue #2191): Japanese/Chinese/Korean/Russian/etc acks
+  // route the same way; the exact-match set cannot match longer English prompts.
+  if (p.length <= 18 && isMultilingualAck(stripTrailingRecallNoise(p))) {
     return "no_recall";
   }
 
   // Full recall for prompts that are explicitly memory-seeking or analytical questions.
   if (
     /\b(previous|earlier|remember|last time|did we|what did we decide|context|summarize|summary|recap|key points|decision)\b/i.test(p) ||
-    /\?$/.test(p) ||
+    endsWithQuestionMark(p) ||
     /^(what|why|how|when|where|who|which)\b/i.test(p.toLowerCase())
   ) {
     return "full";
@@ -148,7 +147,8 @@ export function planRecallMode(prompt: string): RecallPlanMode {
 export function hasBroadGraphIntent(prompt: string): boolean {
   const p = normalizeTextInput(prompt).trim().toLowerCase();
   if (!p) return false;
-  return /\b(what changed|how did we get here|why did this happen|what led to|cause chain|dependency chain|regression chain|failure chain)\b/i.test(
-    p,
+  return (
+    /\b(what changed|how did we get here|why did this happen|what led to|cause chain|dependency chain|regression chain|failure chain)\b/i.test(p) ||
+    containsRecallCue(p, CAUSAL_CHAIN_CUES)
   );
 }

--- a/packages/remnic-core/src/recall-planner-i18n.ts
+++ b/packages/remnic-core/src/recall-planner-i18n.ts
@@ -1,0 +1,193 @@
+/**
+ * Per-script closed-class cue tables and script-agnostic signal helpers
+ * shared by the recall planner heuristics (issue #2191).
+ *
+ * English keyword regexes stay in their consumers. These tables seed the
+ * top ~10 languages so non-English prompts route to the same recall modes
+ * as their English equivalents. Substring cues are curated so pure-ASCII
+ * entries are multi-word phrases (or non-English single words) that cannot
+ * occur in English text — the English corpus behavior is unchanged.
+ */
+
+const ASCII_CHARS = /[\u0000-\u007f]/g;
+const LETTER_RE = /\p{L}/u;
+const WORDISH_RE = /[\p{L}\p{N}]/u;
+const QUESTION_MARK_END_RE = /[?？؟]$/u;
+const COLON_TERMINATED_RE = /[:：]\s*$/u;
+
+/** True when the text contains a letter outside ASCII — the English keyword
+ * tables cannot be assumed to apply. */
+export function hasNonAsciiLetter(text: string): boolean {
+  return LETTER_RE.test(text.replace(ASCII_CHARS, ""));
+}
+
+/** Strip trailing punctuation/symbols/emojis (Unicode-aware) so exact-match
+ * ack detection works for "はい。", "merci !", "شكرا" etc. */
+export function stripTrailingRecallNoise(text: string): string {
+  let candidate = text;
+  while (candidate.length > 0) {
+    const last = candidate.at(-1) ?? "";
+    if (WORDISH_RE.test(last)) break;
+    candidate = candidate.slice(0, -1);
+  }
+  return candidate.trim();
+}
+
+/** True when the text ends with an ASCII, fullwidth, or Arabic question mark. */
+export function endsWithQuestionMark(text: string): boolean {
+  return QUESTION_MARK_END_RE.test(text.trimEnd());
+}
+
+export function containsRecallCue(text: string, cues: readonly string[]): boolean {
+  const normalized = text.toLowerCase();
+  return cues.some((cue) => normalized.includes(cue));
+}
+
+// Exact-match acknowledgements (lowercased, trailing noise stripped).
+const ACK_CANDIDATES = new Set([
+  // English (membership identical to the previous regex alternation)
+  "ok", "okay", "kk", "thanks", "thx", "got it", "sounds good", "yep", "yes",
+  "nope", "no", "done", "cool", "works",
+  // Japanese
+  "はい", "うん", "わかった", "わかりました", "了解", "承知", "ありがとう",
+  "どうも", "おけー", "オッケー", "りょうかい",
+  // Chinese
+  "好", "好的", "嗯", "对", "行", "可以", "收到", "明白", "明白了", "知道了",
+  "谢谢", "没问题",
+  // Korean
+  "네", "응", "알겠어", "알겠습니다", "고마워", "감사합니다", "좋아",
+  // Spanish
+  "sí", "si", "gracias", "vale", "de acuerdo", "perfecto", "claro", "listo",
+  // French
+  "oui", "merci", "d'accord", "bien", "parfait", "compris", "ça marche",
+  // German
+  "ja", "danke", "gut", "verstanden", "alles klar", "passt", "einverstanden",
+  // Portuguese
+  "sim", "obrigado", "obrigada", "certo", "combinado", "beleza",
+  // Russian
+  "да", "спасибо", "ок", "хорошо", "понял", "поняла", "ясно", "угу", "принято",
+  // Arabic
+  "نعم", "شكرا", "حسنا", "تمام", "طيب", "موافق", "أوكي",
+  // Hindi
+  "हाँ", "ठीक", "अच्छा", "धन्यवाद", "समझ गया", "मंज़ूर",
+]);
+
+export function isMultilingualAck(candidate: string): boolean {
+  return ACK_CANDIDATES.has(candidate.trim().toLowerCase());
+}
+
+// Timeline / sequence / what-happened cues → graph_mode parity.
+export const GRAPH_MODE_CUES: readonly string[] = [
+  // Japanese
+  "タイムライン", "時系列", "時の流れ", "順序", "経緯", "変遷", "何があった", "どうなった",
+  // Chinese
+  "时间线", "时间轴", "时间顺序", "先后顺序", "来龙去脉", "变迁", "发生了什么", "怎么演变",
+  // Korean
+  "타임라인", "시간순", "경위", "변천", "무슨 일이 있었", "어떻게 됐", "어떻게 변했",
+  // Spanish
+  "línea de tiempo", "cronología", "cronologia", "qué pasó", "qué ocurrió", "historial",
+  // French
+  "chronologie", "frise chronologique", "qu'est-il passé", "historique",
+  // German
+  "zeitleiste", "abfolge", "ereignisfolge", "was ist passiert", "verlauf",
+  // Portuguese
+  "linha do tempo", "sequência de eventos", "o que aconteceu",
+  // Russian
+  "хронология", "последовательность событий", "что произошло", "таймлайн",
+  // Arabic
+  "الجدول الزمني", "التسلسل الزمني", "تسلسل الأحداث", "ماذا حدث",
+  // Hindi
+  "टाइमलाइन", "कालक्रम", "घटनाक्रम", "क्या हुआ",
+];
+
+// Causal-chain cues (broad graph intent).
+export const CAUSAL_CHAIN_CUES: readonly string[] = [
+  "原因", "因果", "根本原因", "怎么会",
+  "原因は", "なぜそうなった", "因果関係",
+  "원인이", "왜 이렇게", "인과",
+  "por qué pasó", "causa raíz", "cadena de causas",
+  "pourquoi c'est arrivé", "cause racine",
+  "wieso ist das passiert", "ursachenkette",
+  "por que aconteceu", "cadeia de causas",
+  "почему это произошло", "первопричина", "причинно",
+  "لماذا حدث هذا", "سلسلة الأسباب",
+  "ऐसा क्यों हुआ", "मूल कारण",
+];
+
+// Temporal-ordering markers → chronological evidence tier parity.
+export const EVENT_ORDER_CUES: readonly string[] = [
+  // Japanese
+  "最初", "初めて", "いつ", "何日", "何ヶ月", "何か月", "前に", "後で", "以降",
+  "順番", "順に", "前回", "さかのぼ", "最近",
+  // Chinese
+  "第一", "最早", "最后一次", "上次", "什么时候", "几月", "几天", "几个月",
+  "之前", "之后", "顺序", "按时间", "最近",
+  // Korean
+  "처음", "언제", "며칠", "몇 달", "몇 개월", "전에", "후에", "순서대로", "지난번",
+  // Spanish
+  "cuándo", "cuando fue", "cuántos días", "cuántos meses", "primero", "última vez",
+  "por orden", "orden cronológico",
+  // French
+  "quand ", "combien de jours", "combien de mois", "la première fois",
+  "la dernière fois", "dans l'ordre",
+  // German
+  "wann ", "wie viele tage", "wie viele monate", "zum ersten", "das letzte mal",
+  // Portuguese
+  "quando foi", "quantos dias", "quantos meses", "primeira vez", "última vez",
+  // Russian
+  "когда", "сколько дней", "сколько месяцев", "впервые", "последний раз", "по порядку",
+  // Arabic
+  "متى", "كم يوم", "كم شهر", "أول مرة", "آخر مرة", "بالترتيب",
+  // Hindi
+  "कब", "कितने दिन", "कितने महीने", "पहली बार", "आख़िरी बार",
+];
+
+// Timing/detail question cues for the response-guidance dates intent.
+export const TIMING_DETAIL_CUES: readonly string[] = [
+  "いつ", "日時", "期日", "締め切り", "締切",
+  "什么时候", "几点", "日期", "截止",
+  "언제", "날짜", "마감",
+  "qué día", "qué fecha", "fecha límite", "cuándo",
+  "quelle date", "date limite",
+  "welches datum", "frist",
+  "que dia", "que data", "prazo",
+  "какого числа", "дедлайн",
+  "تاريخ الموعد", "متى الموعد",
+  "तारीख",
+];
+
+// Contradiction-resolution cues for the response-guidance tier.
+export const CONTRADICTION_CUES: readonly string[] = [
+  "矛盾", "食い違", "前と違う", "一貫して",
+  "不一致", "之前说的", "前后矛盾",
+  "모순", "일관되",
+  "contradice", "inconsistente", "antes dijiste",
+  "contredit", "incohérent", "tu avais dit",
+  "widerspricht", "widersprüchlich",
+  "contradiz",
+  "противореч", "непоследовательн",
+  "يناقض", "تعارض",
+  "विरोधाभास",
+];
+
+// Prompt-filler words (recall verbs in other languages) that must not count
+// as content discriminators in the direct-answer gate.
+export const MULTILINGUAL_PROMPT_RECALL_WORDS: readonly string[] = [
+  "教えて", "見せて", "探して", "一覧",
+  "告诉我", "显示", "查找",
+  "보여줘", "알려줘", "찾아줘",
+  "muestra", "busca", "encuentra",
+  "montre", "cherche",
+  "zeige", "suche",
+  "покажи",
+  "أظهر", "ابحث",
+  "दिखाओ", "खोजो",
+];
+
+/** Structural heading line for non-Latin scripts: colon-terminated, short,
+ * and containing a non-ASCII letter. English prompts are unaffected. */
+export function isNonLatinHeadingLine(line: string): boolean {
+  if (line.length > 80) return false;
+  if (!COLON_TERMINATED_RE.test(line)) return false;
+  return hasNonAsciiLetter(line);
+}

--- a/packages/remnic-core/src/recall-tokenization.ts
+++ b/packages/remnic-core/src/recall-tokenization.ts
@@ -6,7 +6,9 @@ const DEFAULT_RECALL_STOP_WORDS = ["the", "and", "for", "with", "from", "into", 
 
 export function isUnsegmentableRecallChar(char: string): boolean {
   if (char === "ー" || char === "ｰ") return true;
-  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(char);
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Thai}\p{Script=Khmer}\p{Script=Lao}\p{Script=Myanmar}]/u.test(
+    char,
+  );
 }
 
 function isRecallCombiningMark(char: string): boolean {

--- a/packages/remnic-core/src/retrieval-agents.ts
+++ b/packages/remnic-core/src/retrieval-agents.ts
@@ -24,6 +24,8 @@ import type { QmdSearchResult } from "./types.js";
 import type { QmdClient } from "./qmd.js";
 import { isTemporalQuery, recencyWindowBoundsFromPrompt } from "./temporal-index.js";
 import { isAbortError } from "./abort-error.js";
+import { normalizeRecallTokens } from "./recall-tokenization.js";
+
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -56,10 +58,9 @@ export function shouldRunAgent(
 ): boolean {
   switch (agent) {
     case "direct":
-      // Skip only if query has no word-like tokens at all. Both capitalized and
-      // lowercase entity names are stored (normalizeEntityName lowercases them),
-      // so gating on capitalization would silently skip most real entity lookups.
-      return knownEntityCount > 0 || /\b\w{2,}/.test(query);
+      // Skip only if the query has no letter/number tokens. `\w` and `\b` are
+      // ASCII-only, so CJK entity names would never start the direct agent.
+      return knownEntityCount > 0 || /[\p{L}\p{N}]{2,}/u.test(query);
     case "temporal":
       // Only run temporal agent when the query actually asks about a time window.
       // Running it for every query injects recency bias into semantic searches.
@@ -74,12 +75,7 @@ export function shouldRunAgent(
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function tokenize(value: string): string[] {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim()
-    .split(/\s+/)
-    .filter((t) => t.length >= 2);
+  return normalizeRecallTokens(value).filter((t) => t.length >= 2);
 }
 
 function overlapScore(queryTokens: string[], candidateTokens: string[]): number {

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -21,6 +21,16 @@ test("planRecallMode uses graph_mode for timeline/history prompts", () => {
   assert.equal(planRecallMode("what happened in the timeline"), "graph_mode");
 });
 
+test("planRecallMode treats Japanese acknowledgements as no_recall", () => {
+  assert.equal(planRecallMode("はい"), "no_recall");
+  assert.equal(planRecallMode("わかった"), "no_recall");
+});
+
+test("planRecallMode matches Japanese timeline prompts to the English mode", () => {
+  assert.equal(planRecallMode("what happened in the timeline"), "graph_mode");
+  assert.equal(planRecallMode("タイムラインで何があった"), "graph_mode");
+});
+
 test("hasBroadGraphIntent matches expanded causal phrasing", () => {
   assert.equal(hasBroadGraphIntent("What changed in our recall pipeline?"), true);
   assert.equal(hasBroadGraphIntent("How did we get here with QMD failures?"), true);

--- a/tests/recall-planner-i18n.test.ts
+++ b/tests/recall-planner-i18n.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { shouldRecallEventOrderEvidence } from "../packages/remnic-core/src/event-order-recall.ts";
+import {
+  expandUnsegmentableRecallNGrams,
+  isUnsegmentableRecallChar,
+  normalizeRecallTokens,
+} from "../packages/remnic-core/src/recall-tokenization.ts";
+test("Thai characters are unsegmentable and expand to n-grams", () => {
+  assert.equal(isUnsegmentableRecallChar("ก"), true);
+  const tokens = expandUnsegmentableRecallNGrams("กรุง");
+  assert.equal(tokens.includes("ก"), true);
+  assert.equal(tokens.includes("กรุง"), true);
+  assert.ok(normalizeRecallTokens("กรุงเทพ").length > 1);
+});
+
+test("Khmer Lao and Myanmar scripts are unsegmentable", () => {
+  assert.equal(isUnsegmentableRecallChar("ក"), true);
+  assert.equal(isUnsegmentableRecallChar("ກ"), true);
+  assert.equal(isUnsegmentableRecallChar("က"), true);
+});
+
+test("shouldRecallEventOrderEvidence matches Japanese temporal cues", () => {
+  assert.equal(shouldRecallEventOrderEvidence("最初に何があった"), true);
+  assert.equal(shouldRecallEventOrderEvidence("What was my espresso code?"), false);
+});

--- a/tests/retrieval-agents.test.ts
+++ b/tests/retrieval-agents.test.ts
@@ -38,6 +38,10 @@ test("shouldRunAgent: direct runs when knownEntityCount > 0", () => {
   assert.equal(shouldRunAgent("direct", "what happened", 3), true);
 });
 
+test("shouldRunAgent: direct runs for a pure-CJK query naming an entity", () => {
+  assert.equal(shouldRunAgent("direct", "東京プロジェクト", 0), true);
+});
+
 test("shouldRunAgent: contextual always runs", () => {
   assert.equal(shouldRunAgent("contextual", "anything", 0), true);
 });


### PR DESCRIPTION
## Summary

Recall planner heuristics were English/ASCII-gated. Non-English acknowledgements paid full recall, timeline/event-order tiers were unreachable, Thai queries collapsed to one token, and the direct-fact agent skipped CJK entity names.

This change:

- Routes Japanese/Chinese/Korean and other acknowledgements to no_recall
- Matches Japanese timeline questions to the same graph_mode as English
- Extracts event-order query detection (fileSizeGrandfather shrink) and honors multilingual temporal cues
- Treats Thai/Khmer/Lao/Myanmar as unsegmentable n-gram scripts
- Starts the direct-fact agent for letter/number tokens, not ASCII word classes

Fixes #2191

## Test

NODE_OPTIONS=--conditions=remnic-source npx tsx --test tests/intent.test.ts tests/retrieval-agents.test.ts tests/recall-planner-i18n.test.ts — 64/64 pass.