### PR TITLE
fix(capture-audio): overlap-aware release and poisoned-chunk quarantine

### DIFF
--- a/.changeset/2379-capture-audio-buffer-policy.md
+++ b/.changeset/2379-capture-audio-buffer-policy.md
@@ -1,0 +1,5 @@
+---
+"@remnic/capture-audio": patch
+---
+
+Release overlapping chunks together, quarantine a poisoned chunk, and replay orphaned WAV files at startup.

--- a/packages/capture-audio/package.json
+++ b/packages/capture-audio/package.json
@@ -21,7 +21,7 @@
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts src/dedup.test.ts src/assembly.test.ts src/diarization.test.ts src/connector.test.ts src/e2e.test.ts src/native.test.ts src/processor.test.ts src/capture.test.ts src/service.test.ts src/enroll.test.ts",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/validate.test.ts src/token.test.ts src/spool.test.ts src/replay.test.ts src/daemon.test.ts src/cli.test.ts src/stt.test.ts src/model.test.ts src/janitor.test.ts src/vad.test.ts src/dedup.test.ts src/assembly.test.ts src/diarization.test.ts src/connector.test.ts src/e2e.test.ts src/native.test.ts src/processor.test.ts src/processor-policy.test.ts src/capture.test.ts src/service.test.ts src/enroll.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-audio/src/buffer-policy.ts
+++ b/packages/capture-audio/src/buffer-policy.ts
@@ -1,0 +1,60 @@
+import type { ChunkEvent } from "./native.js";
+
+/** Ceiling on chunks held in the reorder buffer. */
+export const MAX_BUFFERED_CHUNKS = 512;
+
+/** Consecutive apply failures before a chunk is parked. */
+export const QUARANTINE_AFTER_FAILURES = 3;
+
+/** Oldest quarantined rows are dropped once this many are stored. */
+export const MAX_QUARANTINED_CHUNKS = 64;
+
+export type PendingChunkReason = "evicted" | "quarantined";
+
+export interface PendingChunkInput {
+  id: string;
+  wavPath: string;
+  startedAtUtc: string;
+  endedAtUtc: string;
+  channel: ChunkEvent["channel"];
+  device: string | null;
+  reason: PendingChunkReason;
+}
+
+export interface PendingChunkRecord extends PendingChunkInput {
+  createdAtUtc: string;
+}
+
+export class ChunkApplyError extends Error {
+  readonly chunkId: string;
+
+  constructor(chunkId: string, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "ChunkApplyError";
+    this.chunkId = chunkId;
+    if (cause instanceof Error) this.cause = cause;
+  }
+}
+
+export function spansOverlap(
+  left: { startMs: number; endMs: number },
+  right: { startMs: number; endMs: number },
+): boolean {
+  return left.startMs < right.endMs && right.startMs < left.endMs;
+}
+
+/**
+ * A chunk may leave the buffer only when the watermark has passed its end
+ * and no still-held chunk overlaps it (issue #2379).
+ */
+export function isReleaseEligible(
+  candidate: { startMs: number; endMs: number },
+  threshold: number,
+  held: readonly { startMs: number; endMs: number }[],
+): boolean {
+  if (candidate.endMs > threshold) return false;
+  for (const other of held) {
+    if (spansOverlap(candidate, other)) return false;
+  }
+  return true;
+}

--- a/packages/capture-audio/src/capture.ts
+++ b/packages/capture-audio/src/capture.ts
@@ -27,6 +27,7 @@ import {
   type ResolveHelperDeps,
   type RestartTimer,
 } from "./native.js";
+import { scanOrphanedChunks } from "./orphan-scan.js";
 import { createChunkProcessor, type ChunkProcessor, type ChunkTranscribeInput } from "./processor.js";
 import type { Spool } from "./spool.js";
 import { resolveModelPath, runWhisperCli, transcribeWithWhisper, type TranscribedSegment } from "./stt.js";
@@ -180,6 +181,9 @@ export function createLiveCapture(options: LiveCaptureOptions): LiveCapture {
       // Pre-flight the STT model once so a missing/unreadable model fails fast
       // (actionable) here instead of throwing on every captured chunk.
       resolveModel();
+      for (const event of scanOrphanedChunks({ rawDirectory: outDir, spool })) {
+        processor.enqueue(event);
+      }
       runner.start();
     },
     async stop(): Promise<number> {

--- a/packages/capture-audio/src/constants.ts
+++ b/packages/capture-audio/src/constants.ts
@@ -12,7 +12,7 @@ export const DEFAULT_HOST = "127.0.0.1";
 export const DEFAULT_PORT = 4340;
 
 /** Spool schema version, persisted in the `meta` table. */
-export const SPOOL_SCHEMA_VERSION = 2;
+export const SPOOL_SCHEMA_VERSION = 3;
 
 /** Upper bound for the conversations `limit` query parameter. */
 export const MAX_CONVERSATIONS_LIMIT = 500;

--- a/packages/capture-audio/src/index.ts
+++ b/packages/capture-audio/src/index.ts
@@ -106,7 +106,8 @@ export type {
   NativeRunnerOptions,
   ResolveHelperDeps,
 } from "./native.js";
-export { chunkStableId, createChunkProcessor } from "./processor.js";
+export { chunkStableId, createChunkProcessor, MAX_BUFFERED_CHUNKS, QUARANTINE_AFTER_FAILURES } from "./processor.js";
+export { scanOrphanedChunks } from "./orphan-scan.js";
 export type { ChunkProcessor, ChunkProcessorDeps, ChunkTranscribeInput } from "./processor.js";
 export { createLiveCapture } from "./capture.js";
 export type { LiveCapture, LiveCaptureOptions } from "./capture.js";

--- a/packages/capture-audio/src/orphan-scan.ts
+++ b/packages/capture-audio/src/orphan-scan.ts
@@ -1,0 +1,77 @@
+import { existsSync, lstatSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { chunkStableId } from "./processor.js";
+import type { ChunkEvent } from "./native.js";
+import type { Spool } from "./spool.js";
+
+const DEFAULT_CHUNK_MS = 30_000;
+
+export interface OrphanScanInput {
+  rawDirectory: string;
+  spool: Spool;
+}
+
+/**
+ * Rebuild chunk events from durable pending rows and leftover WAVs so a
+ * restart can feed them through the live processor (issue #2379).
+ */
+export function scanOrphanedChunks(input: OrphanScanInput): ChunkEvent[] {
+  const recovered = new Map<string, ChunkEvent>();
+  const quarantined = new Set(input.spool.listPendingChunks("quarantined").map((row) => row.id));
+
+  for (const row of input.spool.listPendingChunks("evicted")) {
+    if (quarantined.has(row.id)) continue;
+    if (input.spool.isChunkApplied(`${row.id}:done`)) continue;
+    if (!existsSync(row.wavPath)) continue;
+    recovered.set(row.id, {
+      path: row.wavPath,
+      channel: row.channel,
+      startedAtUtc: row.startedAtUtc,
+      endedAtUtc: row.endedAtUtc,
+      device: row.device,
+    });
+  }
+
+  let root;
+  try {
+    root = lstatSync(input.rawDirectory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [...recovered.values()].sort(byStart);
+    }
+    throw error;
+  }
+  if (root.isSymbolicLink() || !root.isDirectory()) return [...recovered.values()].sort(byStart);
+
+  for (const name of readdirSync(input.rawDirectory)) {
+    if (!name.endsWith(".wav")) continue;
+    const location = path.join(input.rawDirectory, name);
+    let stat;
+    try {
+      stat = lstatSync(location);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+    if (!stat.isFile()) continue;
+    const event: ChunkEvent = {
+      path: location,
+      channel: "mic",
+      startedAtUtc: new Date(stat.mtimeMs - DEFAULT_CHUNK_MS).toISOString(),
+      endedAtUtc: new Date(stat.mtimeMs).toISOString(),
+      device: null,
+    };
+    const id = chunkStableId(event);
+    if (quarantined.has(id) || recovered.has(id)) continue;
+    if (input.spool.isChunkApplied(`${id}:done`)) continue;
+    recovered.set(id, event);
+  }
+
+  return [...recovered.values()].sort(byStart);
+}
+
+function byStart(left: ChunkEvent, right: ChunkEvent): number {
+  if (left.startedAtUtc !== right.startedAtUtc) return left.startedAtUtc < right.startedAtUtc ? -1 : 1;
+  return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+}

--- a/packages/capture-audio/src/processor-policy.test.ts
+++ b/packages/capture-audio/src/processor-policy.test.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ConversationAssembler } from "./assembly.js";
+import { scanOrphanedChunks } from "./orphan-scan.js";
+import type { ChunkEvent } from "./native.js";
+import {
+  chunkStableId,
+  createChunkProcessor,
+  MAX_BUFFERED_CHUNKS,
+  QUARANTINE_AFTER_FAILURES,
+  type ChunkProcessorDeps,
+} from "./processor.js";
+import { Spool } from "./spool.js";
+import type { TranscribedSegment } from "./stt.js";
+
+const t = (s: number): string => `2026-07-24T00:00:${String(s).padStart(2, "0")}.000Z`;
+
+const chunk = (over: Partial<ChunkEvent> = {}): ChunkEvent => ({
+  path: "/tmp/raw/a.wav",
+  channel: "mic",
+  startedAtUtc: "2026-07-24T00:00:00.000Z",
+  endedAtUtc: "2026-07-24T00:00:30.000Z",
+  device: "mic",
+  ...over,
+});
+
+function deps(spool: Spool, over: Partial<ChunkProcessorDeps> = {}): ChunkProcessorDeps {
+  return {
+    spool,
+    assembler: new ConversationAssembler({ gapMinutes: 10 }),
+    resolveModel: () => "/model.bin",
+    transcribe: async (): Promise<TranscribedSegment[]> => [
+      { text: "hello", startUtc: t(1), endUtc: t(2) },
+    ],
+    cleanupRawAudio: async () => undefined,
+    ...over,
+  };
+}
+
+test("overlap eligibility holds an earlier-ending chunk while a later overlapping peer is still held", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const byPath: Record<string, TranscribedSegment[]> = {
+      "/tmp/raw/early-end.wav": [{ text: "early", startUtc: t(0), endUtc: t(1) }],
+      "/tmp/raw/late-end.wav": [{ text: "overlap", startUtc: t(20), endUtc: t(21) }],
+      "/tmp/raw/watermark.wav": [{ text: "later", startUtc: "2026-07-24T00:04:00.000Z", endUtc: "2026-07-24T00:04:01.000Z" }],
+    };
+    const proc = createChunkProcessor(
+      deps(spool, {
+        reorderWindowMs: 60_000,
+        transcribe: async ({ wavPath }) => byPath[wavPath] ?? [],
+      }),
+    );
+    proc.enqueue(
+      chunk({
+        path: "/tmp/raw/early-end.wav",
+        startedAtUtc: "2026-07-24T00:00:00.000Z",
+        endedAtUtc: "2026-07-24T00:00:30.000Z",
+      }),
+    );
+    proc.enqueue(
+      chunk({
+        path: "/tmp/raw/late-end.wav",
+        channel: "system",
+        startedAtUtc: "2026-07-24T00:00:20.000Z",
+        endedAtUtc: "2026-07-24T00:01:30.000Z",
+      }),
+    );
+    await proc.drain();
+    assert.equal(spool.stats().segments, 0, "the overlapping earlier-ending chunk stays held");
+
+    proc.enqueue(
+      chunk({
+        path: "/tmp/raw/watermark.wav",
+        startedAtUtc: "2026-07-24T00:04:00.000Z",
+        endedAtUtc: "2026-07-24T00:04:40.000Z",
+      }),
+    );
+    await proc.drain();
+    assert.equal(spool.stats().segments, 2, "both overlapping chunks release together once the peer is eligible");
+    const texts = spool
+      .capturingConversationIds()
+      .flatMap((id) => spool.conversationSegmentsForDedup(id).map((seg) => seg.text));
+    assert.deepEqual(texts, ["early", "overlap"]);
+  } finally {
+    spool.close();
+  }
+});
+
+test("a persistently failing chunk is quarantined so later audio can release", async () => {
+  const spool = new Spool(":memory:");
+  const errors: Error[] = [];
+  try {
+    const poison = chunk({ path: "/tmp/raw/poison.wav" });
+    const proc = createChunkProcessor(
+      deps(spool, {
+        onError: (error) => errors.push(error),
+        embed: async (event) => {
+          if (event.path.endsWith("poison.wav")) throw new Error("embed boom");
+          return [1, 0, 0, 0];
+        },
+        transcribe: async (input) => [
+          {
+            text: input.wavPath.endsWith("poison.wav") ? "poison" : input.wavPath,
+            startUtc: input.chunkStartedAtUtc,
+            endUtc: input.chunkStartedAtUtc,
+          },
+        ],
+      }),
+    );
+    proc.enqueue(poison);
+    for (let i = 0; i < QUARANTINE_AFTER_FAILURES; i++) {
+      proc.enqueue(
+        chunk({
+          path: `/tmp/raw/later-${i}.wav`,
+          startedAtUtc: `2026-07-24T00:0${i + 2}:00.000Z`,
+          endedAtUtc: `2026-07-24T00:0${i + 2}:30.000Z`,
+        }),
+      );
+    }
+    await proc.drain();
+
+    const quarantined = spool.listPendingChunks("quarantined");
+    assert.equal(quarantined.length, 1, "the poisoned chunk is parked");
+    assert.equal(quarantined[0]?.id, chunkStableId(poison));
+    assert.equal(quarantined[0]?.wavPath, poison.path, "its WAV path is retained for replay");
+    const texts = spool
+      .capturingConversationIds()
+      .flatMap((id) => spool.conversationSegmentsForDedup(id).map((seg) => seg.text));
+    assert.ok(
+      texts.some((text) => text.includes("later-")),
+      "later audio released after quarantine",
+    );
+    assert.equal(
+      texts.includes("poison"),
+      false,
+      "the poisoned transcript is not appended",
+    );
+    assert.ok(errors.length >= QUARANTINE_AFTER_FAILURES);
+  } finally {
+    spool.close();
+  }
+});
+
+test("a partial persist reseeds the assembler from durable spool rows", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    let appends = 0;
+    let failSecond = true;
+    const guarded = new Proxy(spool, {
+      get(target, prop, receiver) {
+        if (prop === "appendAssembledSegments") {
+          return (input: Parameters<Spool["appendAssembledSegments"]>[0]) => {
+            appends += 1;
+            if (appends === 2 && failSecond) {
+              failSecond = false;
+              throw new Error("sqlite busy");
+            }
+            return target.appendAssembledSegments(input);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Spool;
+
+    let minted = 0;
+    const assembler = new ConversationAssembler({ gapMinutes: 0, makeId: () => `conv_${++minted}` });
+    const proc = createChunkProcessor(
+      deps(guarded, {
+        assembler,
+        transcribe: async () => [
+          { text: "A", startUtc: t(1), endUtc: t(2) },
+          { text: "B", startUtc: t(20), endUtc: t(21) },
+          { text: "C", startUtc: t(40), endUtc: t(41) },
+        ],
+      }),
+    );
+    proc.enqueue(chunk());
+    await proc.drain();
+    assert.equal(spool.stats().segments, 1, "only the durable prefix landed");
+
+    await proc.finalize();
+    assert.equal(spool.stats().segments, 3, "the unpersisted suffix landed on retry");
+    const page = spool.queryFinalConversations({ date: "2026-07-24", timezone: "UTC", limit: 10 });
+    assert.deepEqual(
+      page.conversations.map((conversation) => conversation.segments.map((seg) => seg.textRaw)),
+      [["A"], ["B"], ["C"]],
+      "each gap-separated segment kept its own conversation",
+    );
+  } finally {
+    spool.close();
+  }
+});
+
+test("startup scanner replays a pending record and an orphaned WAV", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "capture-orphan-"));
+  const pendingPath = path.join(root, "pending.wav");
+  const orphanPath = path.join(root, "orphan.wav");
+  await writeFile(pendingPath, "pending");
+  await writeFile(orphanPath, "orphan");
+
+  const spool = new Spool(":memory:");
+  try {
+    const pendingEvent = chunk({
+      path: pendingPath,
+      channel: "system",
+      startedAtUtc: "2026-07-24T00:00:00.000Z",
+      endedAtUtc: "2026-07-24T00:00:30.000Z",
+      device: "loopback",
+    });
+    spool.recordPendingChunk({
+      id: chunkStableId(pendingEvent),
+      wavPath: pendingEvent.path,
+      startedAtUtc: pendingEvent.startedAtUtc,
+      endedAtUtc: pendingEvent.endedAtUtc,
+      channel: pendingEvent.channel,
+      device: pendingEvent.device,
+      reason: "evicted",
+    });
+
+    const recovered = scanOrphanedChunks({ rawDirectory: root, spool });
+    assert.equal(recovered.length, 2, "pending row and leftover WAV both recover");
+    const pending = recovered.find((event) => event.path === pendingPath);
+    assert.ok(pending, "the pending record is present");
+    assert.equal(pending.channel, "system");
+    assert.equal(pending.startedAtUtc, pendingEvent.startedAtUtc);
+    assert.ok(
+      recovered.some((event) => event.path === orphanPath),
+      "the orphaned WAV is present",
+    );
+
+    const proc = createChunkProcessor(
+      deps(spool, {
+        transcribe: async (input) => [
+          {
+            text: path.basename(input.wavPath, ".wav"),
+            startUtc: input.chunkStartedAtUtc,
+            endUtc: input.chunkStartedAtUtc,
+          },
+        ],
+      }),
+    );
+    for (const event of recovered) proc.enqueue(event);
+    await proc.finalize();
+    assert.equal(spool.stats().segments, 2, "both recovered files produced segments");
+    const days = ["2026-07-24", new Date().toISOString().slice(0, 10)];
+    const texts = days.flatMap((date) =>
+      spool
+        .queryFinalConversations({ date, timezone: "UTC", limit: 10 })
+        .conversations.flatMap((conversation) => conversation.segments.map((seg) => seg.textRaw)),
+    );
+    assert.ok(texts.includes("pending"));
+    assert.ok(texts.includes("orphan"));
+  } finally {
+    spool.close();
+  }
+});
+
+test("reorder-buffer eviction writes a durable pending-chunk record", async () => {
+  const spool = new Spool(":memory:");
+  try {
+    const proc = createChunkProcessor(
+      deps(spool, {
+        reorderWindowMs: 24 * 60 * 60 * 1000,
+        transcribe: async () => [],
+      }),
+    );
+    const first = chunk({ path: "/tmp/raw/evict-0.wav" });
+    proc.enqueue(first);
+    for (let i = 1; i <= MAX_BUFFERED_CHUNKS; i++) {
+      proc.enqueue(
+        chunk({
+          path: `/tmp/raw/evict-${i}.wav`,
+          startedAtUtc: `2026-07-24T01:00:${String(i % 60).padStart(2, "0")}.000Z`,
+          endedAtUtc: `2026-07-24T01:01:${String(i % 60).padStart(2, "0")}.000Z`,
+        }),
+      );
+    }
+    await proc.drain();
+    const pending = spool.listPendingChunks("evicted");
+    assert.ok(pending.length >= 1, "eviction persisted a pending row");
+    assert.equal(pending[0]?.id, chunkStableId(first));
+    assert.equal(pending[0]?.wavPath, first.path);
+    assert.equal(pending[0]?.channel, first.channel);
+  } finally {
+    spool.close();
+  }
+});

--- a/packages/capture-audio/src/processor.ts
+++ b/packages/capture-audio/src/processor.ts
@@ -19,6 +19,12 @@ import { createHash } from "node:crypto";
 
 import { log } from "@remnic/core/logger";
 
+import {
+  ChunkApplyError,
+  isReleaseEligible,
+  MAX_BUFFERED_CHUNKS,
+  QUARANTINE_AFTER_FAILURES,
+} from "./buffer-policy.js";
 import type { AssemblySegment, ConversationAssembler } from "./assembly.js";
 import { dedupeCrossChannel } from "./dedup.js";
 import { CaptureInputError } from "./errors.js";
@@ -81,6 +87,8 @@ export interface ChunkProcessor {
   finalize(): Promise<number>;
 }
 
+export { MAX_BUFFERED_CHUNKS, QUARANTINE_AFTER_FAILURES } from "./buffer-policy.js";
+
 /**
  * Stable chunk identity derived purely from the WAV path. Because it never
  * depends on a freshly-generated conversation id, the same chunk yields the
@@ -130,14 +138,6 @@ export function chunkStableId(event: ChunkEvent): string {
   return `chk_${createHash("sha1").update(event.path).digest("hex")}`;
 }
 
-/**
- * Ceiling on chunks held in the reorder buffer.
- *
- * At the default 30-second chunks this is over four hours of audio per
- * channel, so it is only reachable when persistence has been failing for a
- * long time. Bounding it keeps memory and the per-release scan finite.
- */
-const MAX_BUFFERED_CHUNKS = 512;
 
 /** One transcribed chunk waiting in the reorder buffer (issue #2145). */
 interface BufferedChunk {
@@ -187,7 +187,7 @@ function lastEndMs(event: ChunkEvent, raw: readonly TranscribedSegment[]): numbe
 
 export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   let tail: Promise<void> = Promise.resolve();
-  let recovered = false;
+  const failCounts = new Map<string, number>();
   let openConversationId: string | null = null;
   // Set when a chunk is deliberately left unapplied for a later replay: its
   // conversation must stay `capturing` so that replay can resume it.
@@ -355,6 +355,18 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     }
   };
 
+  function persistPending(entry: BufferedChunk, reason: "evicted" | "quarantined"): void {
+    deps.spool.recordPendingChunk({
+      id: entry.chunkId,
+      wavPath: entry.event.path,
+      startedAtUtc: entry.event.startedAtUtc,
+      endedAtUtc: entry.event.endedAtUtc,
+      channel: entry.event.channel,
+      device: entry.event.device,
+      reason,
+    });
+  }
+
   async function process(event: ChunkEvent): Promise<void> {
     const chunkId = chunkStableId(event);
     // In-run replay: already applied, or already transcribed and waiting in
@@ -424,6 +436,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       const evicted = buffer.shift();
       if (evicted !== undefined) {
         bufferedIds.delete(evicted.chunkId);
+        persistPending(evicted, "evicted");
         report(
           new Error(
             `reorder buffer is full (${MAX_BUFFERED_CHUNKS}); chunk ${evicted.chunkId} was dropped with its raw audio retained`,
@@ -476,36 +489,24 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     batch: readonly BufferedChunk[],
     progress: { persisted: boolean },
   ): Promise<void> {
-    // Recover the newest still-open conversation once (any chunk, incl. silent)
-    // so a post-restart chunk continues it; then finalize a stale open
-    // conversation when this batch is released a gap past it. Pure-silence runs
-    // never call assembler.add, so closeIfIdle is what closes them.
-    if (!recovered) {
-      recovered = true;
-      // Prefer the conversation this batch's own chunks already contributed
-      // to: a replay of an OLDER chunk must resume its own prefix, or its
-      // missing tail predates the newest capturing conversation and lands in a
-      // new one instead (issue #2145).
-      const ownPrefix = batch
-        .flatMap((entry) => deps.spool.conversationIdsForChunk(entry.chunkId))
-        .map((id) => deps.spool.capturingConversationById(id))
-        .find((conversation) => conversation !== null);
-      const prior = ownPrefix ?? deps.spool.latestCapturingConversation();
-      if (prior) {
-        deps.assembler.resume(prior);
-        openConversationId = prior.id;
-      }
-      // A restart loses which chunks are still awaiting a replay, so rebuild
-      // the holds from the durable markers: a manifest without a `:done` is a
-      // chunk whose WAV is retained, and the conversations capturing right now
-      // are the prefixes its replay could still resume (issue #2145).
-      const capturingAtStartup = new Set(deps.spool.capturingConversationIds());
-      for (const chunkId of deps.spool.incompleteChunkIds()) {
-        // Each hold is scoped to that chunk's own conversation, so a completed
-        // one finalizes even while another chunk still awaits replay.
-        const held = heldFor(chunkId, capturingAtStartup);
-        if (held.size > 0) retainedChunks.set(chunkId, held);
-      }
+    // Reconstruct assembler position from durable rows on every apply
+    // (issue #2379). A partial persist then retry must resume the capturing
+    // conversation and its segment bounds, not keep an advanced assembler.
+    deps.assembler.rewind([]);
+    openConversationId = null;
+    const ownPrefix = batch
+      .flatMap((entry) => deps.spool.conversationIdsForChunk(entry.chunkId))
+      .map((id) => deps.spool.capturingConversationById(id))
+      .find((conversation) => conversation !== null);
+    const prior = ownPrefix ?? deps.spool.latestCapturingConversation();
+    if (prior) {
+      deps.assembler.resume(prior);
+      openConversationId = prior.id;
+    }
+    const capturingNow = new Set(deps.spool.capturingConversationIds());
+    for (const chunkId of deps.spool.incompleteChunkIds()) {
+      const held = heldFor(chunkId, capturingNow);
+      if (held.size > 0) retainedChunks.set(chunkId, held);
     }
     // Decide retention BEFORE anything can close a conversation: a chunk kept
     // for a later replay must keep its durable prefix resumable, and both the
@@ -562,7 +563,11 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     // after it had consumed segments would leave it advanced.
     if (deps.embed) {
       for (const { entry, item } of fresh) {
-        item.seg.embedding = await deps.embed(entry.event, item.raw);
+        try {
+          item.seg.embedding = await deps.embed(entry.event, item.raw);
+        } catch (error) {
+          throw new ChunkApplyError(entry.chunkId, error);
+        }
       }
     }
 
@@ -606,16 +611,20 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           // and the batch must still be able to rewind.
           if (finalizeConv(openConversationId)) progress.persisted = true;
         }
-        deps.spool.appendAssembledSegments({
-          idempotencyKey: key,
-          chunkId: key,
-          conversationId: run.id,
-          startedAtUtc: run.startedAtUtc,
-          state: "capturing",
-          device: event.device,
-          wavPath: event.path,
-          segments: [item.seg],
-        });
+        try {
+          deps.spool.appendAssembledSegments({
+            idempotencyKey: key,
+            chunkId: key,
+            conversationId: run.id,
+            startedAtUtc: run.startedAtUtc,
+            state: "capturing",
+            device: event.device,
+            wavPath: event.path,
+            segments: [item.seg],
+          });
+        } catch (error) {
+          throw new ChunkApplyError(chunkId, error);
+        }
         progress.persisted = true;
         openConversationId = run.id;
       }
@@ -653,6 +662,8 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       // transcribe the missing tail. Cleanup is best-effort; the janitor is
       // the backstop.
       deps.spool.markChunkComplete(entry.chunkId, openConversationId ?? "-");
+      deps.spool.deletePendingChunk(entry.chunkId);
+      failCounts.delete(entry.chunkId);
       try {
         await deps.cleanupRawAudio(entry.event);
       } catch (err) {
@@ -715,13 +726,10 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
   }
 
   /**
-   * Release every buffered chunk the watermark has passed, as one batch.
-   *
    * A chunk becomes releasable when the newest observed chunk end is
-   * `reorderWindowMs` past its own end. Releasing the whole releasable set
-   * together is what lets `applyBatch` interleave overlapping cross-channel
-   * windows; holding until the END clears the watermark is what bounds how far
-   * out of order an arrival can be.
+   * `reorderWindowMs` past its own end AND no still-held chunk overlaps it
+   * (issue #2379). Releasing the whole releasable set together is what lets
+   * `applyBatch` interleave overlapping cross-channel windows.
    *
    * `flushAll` ignores the watermark, for `finalize()`.
    */
@@ -732,11 +740,12 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
     let finalFailure: unknown;
     for (;;) {
       const threshold = flushAll ? Number.POSITIVE_INFINITY : watermarkSourceMs - reorderWindowMs;
+      const held = buffer.filter((entry) => entry.endMs > threshold);
       const batch: BufferedChunk[] = [];
       let manifestBlocked = false;
       for (let i = buffer.length - 1; i >= 0; i--) {
         const candidate = buffer[i];
-        if (candidate.endMs > threshold) continue;
+        if (!isReleaseEligible(candidate, threshold, held)) continue;
         // Record the transcript manifest BEFORE the chunk can be appended, and
         // only once. A chunk whose manifest cannot be written stays buffered
         // with its raw audio: releasing it would let a later, changed
@@ -782,6 +791,7 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
       }
       if (batch.length === 0) {
         if (flushAll && buffer.length > 0) {
+          for (const entry of buffer) persistPending(entry, "evicted");
           throw new Error("buffered chunks could not be released; they are retained for replay");
         }
         return;
@@ -793,44 +803,41 @@ export function createChunkProcessor(deps: ChunkProcessorDeps): ChunkProcessor {
           left.endMs - right.endMs ||
           (left.chunkId < right.chunkId ? -1 : left.chunkId > right.chunkId ? 1 : 0),
       );
-      // Rewind only matters when NOTHING durable changed: then the in-memory
-      // state is ahead of the spool and the retry would collapse conversations
-      // the first attempt split. Once anything is durable — an appended
-      // segment OR a finalized conversation — the spool cannot be rewound, so
-      // neither is the memory that mirrors it (issue #2145).
-      //
-      // The snapshot covers every piece of in-memory state `applyBatch`
-      // touches, not just the assembler: `resume()` and `openConversationId`
-      // are set inside it too, and rewinding the assembler alone would leave
-      // the recovery flags claiming a conversation the assembler no longer has.
-      const checkpoint = {
-        assembler: deps.assembler.checkpoint(),
-        recovered,
-        openConversationId,
-      };
       const progress = { persisted: false };
       try {
         await applyBatch(batch, progress);
       } catch (error) {
-        if (!progress.persisted) {
-          deps.assembler.rewind(checkpoint.assembler);
-          recovered = checkpoint.recovered;
-          openConversationId = checkpoint.openConversationId;
+        // Next apply reseeds from the spool. Drop in-memory assembly here so a
+        // pre-commit failure leaves the assembler empty and a partial persist
+        // does not keep an advanced position (issue #2379).
+        deps.assembler.rewind([]);
+        openConversationId = null;
+        let quarantinedId: string | undefined;
+        if (error instanceof ChunkApplyError) {
+          const failures = (failCounts.get(error.chunkId) ?? 0) + 1;
+          failCounts.set(error.chunkId, failures);
+          if (failures >= QUARANTINE_AFTER_FAILURES) {
+            const poisoned = batch.find((entry) => entry.chunkId === error.chunkId);
+            if (poisoned !== undefined) {
+              persistPending(poisoned, "quarantined");
+              retainedChunks.delete(poisoned.chunkId);
+              quarantinedId = poisoned.chunkId;
+            }
+          }
         }
-        // Requeue FIRST: `report` runs an operator callback that may itself
-        // throw, and losing the batch to a broken telemetry sink would turn an
-        // observer failure into data loss. A throw mid-batch leaves the chunks
-        // after the failure point applied to nothing — they were already
-        // spliced out of the buffer, and the native helper emits each event
-        // once (issue #2145).
         for (const entry of batch) {
           if (processedThisRun.has(entry.chunkId) || bufferedIds.has(entry.chunkId)) continue;
+          if (entry.chunkId === quarantinedId) continue;
           buffer.push(entry);
           bufferedIds.add(entry.chunkId);
         }
-        if (flushAll) finalFailure ??= error;
+        if (flushAll) {
+          for (const entry of buffer) persistPending(entry, "evicted");
+          finalFailure ??= error;
+        }
         report(error, batch[0].event);
         if (finalFailure !== undefined) throw finalFailure;
+        if (quarantinedId !== undefined) continue;
         return;
       }
       // The batch is durable, so no rollback can need the conversations it

--- a/packages/capture-audio/src/spool.ts
+++ b/packages/capture-audio/src/spool.ts
@@ -23,6 +23,12 @@ import { chmodSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 
 import { SPOOL_SCHEMA_VERSION } from "./constants.js";
+import {
+  MAX_QUARANTINED_CHUNKS,
+  type PendingChunkInput,
+  type PendingChunkReason,
+  type PendingChunkRecord,
+} from "./buffer-policy.js";
 import { CaptureConfigError } from "./errors.js";
 import { dateInTimezone, ulid } from "./util.js";
 import { decodeCursor, encodeCursor } from "./validate.js";
@@ -183,6 +189,16 @@ CREATE TABLE IF NOT EXISTS applied_chunks (
   idempotency_key TEXT PRIMARY KEY,
   conversation_id TEXT NOT NULL,
   applied_at_utc TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS pending_chunks (
+  id TEXT PRIMARY KEY,
+  wav_path TEXT NOT NULL,
+  started_at_utc TEXT NOT NULL,
+  ended_at_utc TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  device TEXT,
+  reason TEXT NOT NULL,
+  created_at_utc TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_conv_keyset ON conversations(started_at_utc, id);
 CREATE INDEX IF NOT EXISTS idx_seg_conv ON segments(conversation_id, ordinal);
@@ -882,6 +898,73 @@ export class Spool {
     const row = this.#db.prepare("SELECT COUNT(*) AS n FROM chunks WHERE status = 'pending'").get() as { n: number };
     return row.n;
   }
+
+  recordPendingChunk(input: PendingChunkInput): void {
+    this.#db
+      .prepare(
+        "INSERT INTO pending_chunks(id, wav_path, started_at_utc, ended_at_utc, channel, device, reason, created_at_utc) " +
+          "VALUES (?,?,?,?,?,?,?,?) " +
+          "ON CONFLICT(id) DO UPDATE SET wav_path = excluded.wav_path, started_at_utc = excluded.started_at_utc, " +
+          "ended_at_utc = excluded.ended_at_utc, channel = excluded.channel, device = excluded.device, " +
+          "reason = excluded.reason, created_at_utc = excluded.created_at_utc",
+      )
+      .run(
+        input.id,
+        input.wavPath,
+        canonicalInstant(input.startedAtUtc, "pendingChunk.startedAtUtc"),
+        canonicalInstant(input.endedAtUtc, "pendingChunk.endedAtUtc"),
+        input.channel,
+        input.device,
+        input.reason,
+        new Date().toISOString(),
+      );
+    if (input.reason !== "quarantined") return;
+    const extra = this.#db
+      .prepare(
+        "SELECT id FROM pending_chunks WHERE reason = 'quarantined' ORDER BY created_at_utc ASC, id ASC",
+      )
+      .all() as Array<{ id: string }>;
+    const overflow = extra.length - MAX_QUARANTINED_CHUNKS;
+    if (overflow <= 0) return;
+    const drop = this.#db.prepare("DELETE FROM pending_chunks WHERE id = ?");
+    for (let i = 0; i < overflow; i++) {
+      const id = extra[i]?.id;
+      if (id !== undefined) drop.run(id);
+    }
+  }
+
+  listPendingChunks(reason?: PendingChunkReason): PendingChunkRecord[] {
+    const rows = (
+      reason === undefined
+        ? this.#db.prepare(
+            "SELECT id, wav_path AS wavPath, started_at_utc AS startedAtUtc, ended_at_utc AS endedAtUtc, " +
+              "channel, device, reason, created_at_utc AS createdAtUtc FROM pending_chunks " +
+              "ORDER BY created_at_utc ASC, id ASC",
+          ).all()
+        : this.#db
+            .prepare(
+              "SELECT id, wav_path AS wavPath, started_at_utc AS startedAtUtc, ended_at_utc AS endedAtUtc, " +
+                "channel, device, reason, created_at_utc AS createdAtUtc FROM pending_chunks " +
+                "WHERE reason = ? ORDER BY created_at_utc ASC, id ASC",
+            )
+            .all(reason)
+    ) as Array<{
+      id: string;
+      wavPath: string;
+      startedAtUtc: string;
+      endedAtUtc: string;
+      channel: "mic" | "system";
+      device: string | null;
+      reason: PendingChunkReason;
+      createdAtUtc: string;
+    }>;
+    return rows;
+  }
+
+  deletePendingChunk(id: string): void {
+    this.#db.prepare("DELETE FROM pending_chunks WHERE id = ?").run(id);
+  }
+
 
   stats(): { conversations: number; segments: number; chunks: number } {
     const count = (table: string): number =>


### PR DESCRIPTION
## Summary

Capture-audio release eligibility ignored overlap with still-buffered chunks. A poisoned chunk was requeued forever. Evicted reorder-buffer entries and orphaned WAVs had no startup replay.

This change:

- Holds a chunk while a still-buffered peer overlaps it
- Quarantines a persistently failing chunk so later audio can release
- Reseeds the assembler from durable spool rows after a partial persist
- Writes a pending record on eviction and scans orphaned WAVs at startup

Fixes #2379

## Test

NODE_OPTIONS=--conditions=remnic-source pnpm exec tsx --test src/processor-policy.test.ts — 5/5 pass. Existing processor.test.ts 49 tests also pass.