### PR TITLE
fix(cli): honor REMNIC_DAEMON_URL for status and query

### DIFF
--- a/.changeset/2448-cli-remote-https.md
+++ b/.changeset/2448-cli-remote-https.md
@@ -1,0 +1,5 @@
+---
+"@remnic/cli": patch
+---
+
+Honor REMNIC_DAEMON_URL / server.url as a full https origin for remnic status, query, doctor, and xray so a hosted Remnic is not silently replaced by localhost:4318.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -41,6 +41,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
+import { writeFile as fsWriteFile } from "node:fs/promises";
 import * as childProcess from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
@@ -285,6 +286,17 @@ import {
 } from "./openclaw-managed-upgrade-loader.js";
 import { expandTilde, resolveHomeDir } from "./path-utils.js";
 import {
+  probeDaemonHealth,
+  printHealthCheck,
+  readCompatEnv,
+  remoteRecall,
+  remoteRecallXray,
+  resolveDaemonBaseUrl,
+  resolveOperatorToken,
+  resolveRemoteDaemon,
+  type RemoteRecallResult,
+} from "./remote-daemon.js";
+import {
   inspectLaunchdPlist,
   launchdLoadPlist,
   launchdUnloadPlist,
@@ -440,9 +452,7 @@ export interface BenchCatalogEntry {
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-function readCompatEnv(primary: string, legacy: string): string | undefined {
-  return process.env[primary] ?? process.env[legacy];
-}
+
 
 const PID_DIR = path.join(resolveHomeDir(), ".remnic");
 const LEGACY_PID_DIR = path.join(resolveHomeDir(), ".engram");
@@ -4600,13 +4610,13 @@ function cmdInit(): void {
  * Resolve a bearer token for the local status/health probe (issue #2006).
  * Precedence mirrors the daemon: operator token first (env
  * `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN`, then config `server.authToken`
- * via `oauthResolveOperatorToken()`), then any connector token from the
+ * via `resolveOperatorToken()`), then any connector token from the
  * local token store — the access server accepts connector tokens for
  * health. Returns `undefined` for open daemons so the probe stays
  * unauthenticated exactly as before.
  */
 function resolveStatusProbeToken(): string | undefined {
-  const operatorToken = oauthResolveOperatorToken();
+  const operatorToken = resolveOperatorToken(resolveConfigPath());
   if (operatorToken) return operatorToken;
   try {
     // Connector tokens authorize health EXCEPT chatgpt-minted ones, which
@@ -4625,6 +4635,29 @@ function resolveStatusProbeToken(): string | undefined {
 export const __statusHealthTestHooks = { resolveStatusProbeToken };
 
 async function cmdStatus(json: boolean): Promise<void> {
+  // Remote mode (issue #2448): a configured REMNIC_DAEMON_URL / server.url
+  // origin is the target. No local service-manager probe, no PID file —
+  // "running" means the remote health endpoint answered.
+  const remote = resolveRemoteDaemon(resolveConfigPath());
+  if (remote) {
+    if (json) {
+      const probe = await probeDaemonHealth(remote.baseUrl, remote.token);
+      console.log(
+        JSON.stringify({
+          running: probe.ok,
+          pid: null,
+          pidFile: null,
+          logFile: null,
+          remote: remote.baseUrl,
+        }),
+      );
+      return;
+    }
+    console.log(`Remnic server: remote (${remote.baseUrl})`);
+    await printHealthCheck(remote.baseUrl, remote.token);
+    return;
+  }
+
   const { running, pid } = isServiceRunning();
   if (json) {
     console.log(JSON.stringify({ running, pid: pid ?? null, pidFile: PID_FILE, logFile: LOG_FILE }));
@@ -4635,55 +4668,7 @@ async function cmdStatus(json: boolean): Promise<void> {
     return;
   }
   console.log(`Remnic server: running${pid ? ` (pid ${pid})` : ""}`);
-
-  const port = inferPort();
-  const probeToken = resolveStatusProbeToken();
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 3000);
-  try {
-    const response = await fetch(`http://127.0.0.1:${port}/engram/v1/health`, {
-      signal: controller.signal,
-      ...(probeToken ? { headers: { Authorization: `Bearer ${probeToken}` } } : {}),
-    });
-    if (!response.ok) {
-      const hint =
-        response.status === 401 && !probeToken
-          ? " (daemon requires auth and no local token was found — set REMNIC_AUTH_TOKEN, configure server.authToken, or run 'remnic token generate')"
-          : response.status === 401
-            ? " (local token rejected by the daemon)"
-            : "";
-      console.log(`Health: server responded with ${response.status} ${response.statusText}${hint}`);
-    } else {
-      const health = (await response.json()) as {
-        status?: unknown;
-        qmd?: {
-          pendingEmbeddings?: number | null;
-          oldestPendingAgeMs?: number | null;
-          embeddingBacklogThreshold?: number;
-          degradedReason?: string;
-        };
-      };
-      const status = typeof health.status === "string" ? health.status : "ok";
-      console.log(`Health: ${status}`);
-      const qmd = health.qmd;
-      if (qmd?.pendingEmbeddings != null) {
-        console.log(`  Pending embeddings: ${qmd.pendingEmbeddings}`);
-        if (qmd.oldestPendingAgeMs != null) {
-          console.log(`  Oldest pending: ${Math.round(qmd.oldestPendingAgeMs / 60_000)}m`);
-        }
-        if (qmd.embeddingBacklogThreshold != null) {
-          console.log(`  Backlog threshold: ${qmd.embeddingBacklogThreshold}`);
-        }
-      }
-      if (qmd?.degradedReason) {
-        console.log(`  Degraded: ${qmd.degradedReason}`);
-      }
-    }
-  } catch {
-    console.log("Health: unable to reach server");
-  } finally {
-    clearTimeout(timeoutId);
-  }
+  await printHealthCheck(resolveDaemonBaseUrl(resolveConfigPath()), resolveStatusProbeToken());
 }
 // ── OAuth operator commands ─────────────────────────────────────────────────
 //
@@ -4719,101 +4704,6 @@ interface OAuthDecisionResponse {
   redirect?: string;
 }
 
-/**
- * Read + parse the remnic config file, returning a `Record<string, unknown>`
- * view of its top level. Returns `undefined` on any IO / parse error so
- * the caller can fall through to the env / default path. The cast is
- * unavoidable here — `JSON.parse` returns `any` and the on-disk shape is
- * user-authored — so this helper is the single point that materialises
- * the unsafe boundary. Callers narrow with `typeof` / `in` at every
- * access (rule: `ts-no-inline-cast-access`).
- */
-function oauthReadConfigRecord(configPath: string): Record<string, unknown> | undefined {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-    return undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function oauthResolveBaseUrl(): string {
-  const configPath = resolveConfigPath();
-  let port = 4318;
-  let host = "127.0.0.1";
-  const raw = oauthReadConfigRecord(configPath);
-  if (raw && "server" in raw) {
-    const server = raw.server;
-    if (server && typeof server === "object") {
-      const hostCandidate = (server as Record<string, unknown>).host;
-      if (typeof hostCandidate === "string" && hostCandidate.length > 0) {
-        host = hostCandidate;
-      }
-      const portCandidate = (server as Record<string, unknown>).port;
-      if (typeof portCandidate === "number" && Number.isInteger(portCandidate)) {
-        port = portCandidate;
-      }
-    }
-  }
-  // Env overrides win over the file, matching the daemon: startServer()
-  // merges REMNIC_HOST/REMNIC_PORT (ENGRAM_* legacy) over server.host/port,
-  // so the CLI must resolve the same endpoint or it targets the wrong port.
-  const envHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
-  if (typeof envHost === "string" && envHost.length > 0) {
-    host = envHost;
-  }
-  const envPortRaw = readCompatEnv("REMNIC_PORT", "ENGRAM_PORT");
-  if (typeof envPortRaw === "string" && envPortRaw.length > 0) {
-    const envPort = Number(envPortRaw);
-    // Reject an explicitly-set-but-invalid port instead of silently
-    // falling back (the daemon rejects it too, so a bad value is a
-    // misconfiguration the operator must see, not paper over).
-    if (!Number.isInteger(envPort) || envPort < 1 || envPort > 65535) {
-      throw new Error(
-        `Invalid REMNIC_PORT/ENGRAM_PORT "${envPortRaw}": expected an integer in [1, 65535].`,
-      );
-    }
-    port = envPort;
-  }
-  return `http://${host}:${port}`;
-}
-
-/**
- * Resolve the operator bearer token, matching the daemon's precedence
- * exactly. `startServer()` merges `REMNIC_AUTH_TOKEN` (env) OVER
- * `server.authToken` (file), so the running daemon accepts the env token
- * when both are set. This resolver therefore checks env FIRST, then the
- * file value (with `ENGRAM_AUTH_TOKEN` as the legacy env alias). A file
- * that still holds the literal `${REMNIC_AUTH_TOKEN}` placeholder no
- * longer shadows the real env token. Returns `undefined` when no token is
- * configured; callers fail loudly rather than auto-pick a default.
- */
-function oauthResolveOperatorToken(): string | undefined {
-  const envToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
-  if (typeof envToken === "string" && envToken.length > 0) return envToken;
-  const raw = oauthReadConfigRecord(resolveConfigPath());
-  if (raw && "server" in raw) {
-    const server = raw.server;
-    if (server && typeof server === "object" && "authToken" in server) {
-      const candidate = (server as Record<string, unknown>).authToken;
-      // A config created by `remnic init` may still hold the literal
-      // `${REMNIC_AUTH_TOKEN}` placeholder; treat that as unresolved so
-      // callers fall through to other sources (env, token store) rather
-      // than sending the placeholder as a real bearer token.
-      if (
-        typeof candidate === "string" &&
-        candidate.length > 0 &&
-        !candidate.includes("${")
-      ) {
-        return candidate;
-      }
-    }
-  }
-  return undefined;
-}
 
 /**
  * Hit one of the operator OAuth endpoints. Centralises the auth header,
@@ -4847,7 +4737,7 @@ async function oauthFetch(
     if (body !== undefined) {
       init.body = JSON.stringify(body);
     }
-    const response = await fetch(`${oauthResolveBaseUrl()}${path}`, init);
+    const response = await fetch(`${resolveDaemonBaseUrl(resolveConfigPath())}${path}`, init);
     if (response.status === 401) {
       throw new Error(
         "operator token rejected by remnic-server (HTTP 401). Update `server.authToken` or `REMNIC_AUTH_TOKEN` to match the running daemon.",
@@ -4896,7 +4786,7 @@ async function oauthFetch(
         msg.includes("ENOTFOUND")
       ) {
         throw new Error(
-          `cannot reach remnic-server at ${oauthResolveBaseUrl()} — is remnic-server running? Start it with \`remnic daemon start\`.`,
+          `cannot reach remnic-server at ${resolveDaemonBaseUrl(resolveConfigPath())} — is remnic-server running? Start it with \`remnic daemon start\` (or point REMNIC_DAEMON_URL at a remote daemon).`,
         );
       }
       throw err;
@@ -5000,7 +4890,7 @@ Server endpoints (operator bearer auth):
  * env/config state (rule: validate inputs first, deterministically).
  */
 function oauthRequireOperatorToken(): string {
-  const token = oauthResolveOperatorToken();
+  const token = resolveOperatorToken(resolveConfigPath());
   if (!token) {
     console.error(
       "remnic oauth: no operator token configured. Set `server.authToken` in remnic.config.json or export REMNIC_AUTH_TOKEN.",
@@ -5194,7 +5084,7 @@ async function cmdOAuth(rest: string[]): Promise<void> {
   }
 }
 
-interface QueryRenderableResult {
+export interface QueryRenderableResult {
   content?: string;
   preview?: string;
   context?: string;
@@ -5281,6 +5171,20 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     process.exit(1);
   }
 
+  // Remote mode (issue #2448): route the recall through the configured
+  // origin instead of booting a local orchestrator.
+  const remote = resolveRemoteDaemon(resolveConfigPath());
+  if (remote) {
+    const started = Date.now();
+    const result = await remoteRecall(remote, buildQueryRecallRequest(queryText));
+    if (explain) {
+      printMinimalQueryExplain(queryText, result, Date.now() - started, json);
+      return;
+    }
+    printQueryResult(result, json);
+    return;
+  }
+
   initLogger();
   const configPath = resolveConfigPath();
   const raw = fs.existsSync(configPath)
@@ -5318,55 +5222,68 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
 
       const explainStart = Date.now();
       const recallResult = await service.recall(recallRequest);
-      const totalDurationMs = Date.now() - explainStart;
-      // recall() returns { count, results, memoryIds, ... } (see
-      // EngramAccessRecallResponse). A prior version of this fallback
-      // read .memories, which doesn't exist, so resultsCount was always
-      // 0 and users saw misleading explain output. (Codex feedback on
-      // PR #545.) Prefer the numeric count and fall back to
-      // results.length for robustness across future schema tweaks.
-      const resultsCount =
-        typeof recallResult.count === "number"
-          ? recallResult.count
-          : Array.isArray(recallResult.results)
-            ? recallResult.results.length
-            : 0;
-      const minimalExplain = {
-        query: queryText,
-        totalDurationMs,
-        resultsCount,
-        results: summarizeQueryExplainFallbackResults(recallResult),
-        note: "Install @remnic/bench for a full tier-level explain breakdown.",
-      };
-      if (json) {
-        console.log(JSON.stringify(minimalExplain, null, 2));
-      } else {
-        console.log(`Query: ${minimalExplain.query}`);
-        console.log(`Total duration: ${minimalExplain.totalDurationMs}ms`);
-        console.log(`Results: ${minimalExplain.resultsCount}`);
-        for (const result of minimalExplain.results) {
-          const suffix = result.source ? ` (${result.source})` : "";
-          console.log(`  ${result.index}. ${result.text}${suffix}`);
-        }
-        console.log(`Note: ${minimalExplain.note}`);
-      }
+      printMinimalQueryExplain(queryText, recallResult, Date.now() - explainStart, json);
       return;
     }
 
-    const result = await service.recall(recallRequest);
-    if (json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      for (const line of renderQueryTextLines(result)) {
-        console.log(line);
-      }
-    }
+    printQueryResult(await service.recall(recallRequest), json);
   } finally {
     // One-shot CLI calls should not wait for or orphan deferred QMD
     // maintenance; the daemon/gateway process performs full warmup instead.
     orchestrator.abortDeferredInit();
     await orchestrator.destroy();
   }
+}
+
+function printQueryResult(result: RemoteRecallResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  for (const line of renderQueryTextLines(result)) {
+    console.log(line);
+  }
+}
+
+/**
+ * Minimal `query --explain` fallback used when @remnic/bench is absent —
+ * locally and for remote daemons (the bench explainer needs an in-process
+ * access service). recall() returns `{ count, results, memoryIds, ... }`
+ * (see EngramAccessRecallResponse); prefer the numeric count and fall
+ * back to results.length (a prior version read `.memories`, which doesn't
+ * exist — Codex feedback on PR #545).
+ */
+function printMinimalQueryExplain(
+  queryText: string,
+  result: RemoteRecallResult,
+  totalDurationMs: number,
+  json: boolean,
+): void {
+  const resultsCount =
+    typeof result.count === "number"
+      ? result.count
+      : Array.isArray(result.results)
+        ? result.results.length
+        : 0;
+  const minimalExplain = {
+    query: queryText,
+    totalDurationMs,
+    resultsCount,
+    results: summarizeQueryExplainFallbackResults(result),
+    note: "Install @remnic/bench for a full tier-level explain breakdown.",
+  };
+  if (json) {
+    console.log(JSON.stringify(minimalExplain, null, 2));
+    return;
+  }
+  console.log(`Query: ${minimalExplain.query}`);
+  console.log(`Total duration: ${minimalExplain.totalDurationMs}ms`);
+  console.log(`Results: ${minimalExplain.resultsCount}`);
+  for (const resultLine of minimalExplain.results) {
+    const suffix = resultLine.source ? ` (${resultLine.source})` : "";
+    console.log(`  ${resultLine.index}. ${resultLine.text}${suffix}`);
+  }
+  console.log(`Note: ${minimalExplain.note}`);
 }
 
 // ── Action confidence ──────────────────────────────────────────────────────
@@ -5563,6 +5480,14 @@ async function cmdXray(rest: string[]): Promise<void> {
   const { rawQuery, options } = extractXrayRawArgs(rest);
   parseXrayCliOptions(rawQuery, options);
 
+  // Remote mode (issue #2448): the X-ray endpoint lives on the remote
+  // daemon; no local orchestrator boot.
+  const remote = resolveRemoteDaemon(resolveConfigPath());
+  if (remote) {
+    await runXrayCommand(rest, xrayCliIo((request) => remoteRecallXray(remote, request)));
+    return;
+  }
+
   initLogger();
   const configPath = resolveConfigPath();
   const raw = fs.existsSync(configPath)
@@ -5576,19 +5501,22 @@ async function cmdXray(rest: string[]): Promise<void> {
   const service = new EngramAccessService(orchestrator);
 
   try {
-    await runXrayCommand(rest, {
-      recallXray: (request) => service.recallXray(request),
-      writeFile: async (filePath, data) => {
-        const { writeFile: fsWriteFile } = await import("node:fs/promises");
-        await fsWriteFile(filePath, data, "utf8");
-      },
-      stdout: (line) => console.log(line),
-    });
+    await runXrayCommand(rest, xrayCliIo((request) => service.recallXray(request)));
   } finally {
     // Xray is diagnostic, so it waits for deferred startup sync before recall;
     // abort remains a no-op guard if startup behavior changes later.
     orchestrator.abortDeferredInit();
   }
+}
+
+function xrayCliIo(
+  recallXray: Parameters<typeof runXrayCommand>[1]["recallXray"],
+): Parameters<typeof runXrayCommand>[1] {
+  return {
+    recallXray,
+    writeFile: (filePath, data) => fsWriteFile(filePath, data, "utf8"),
+    stdout: (line) => console.log(line),
+  };
 }
 
 // ── Page-level versioning (issue #371) ─────────────────────────────────────
@@ -6620,22 +6548,39 @@ async function cmdDoctor(): Promise<void> {
       : "not set (required for direct OpenAI-backed extraction)",
   });
 
-  const svcState = isServiceRunning();
-  const standaloneServiceInstalled = isStandaloneServiceInstalled();
-  const daemonOptionalForOpenclaw = openclawPluginModeConfigured && !standaloneServiceInstalled;
-  checks.push({
-    name: "Server daemon",
-    ok: svcState.running || daemonOptionalForOpenclaw,
-    warn: !svcState.running,
-    detail: svcState.running
-      ? `running${svcState.pid ? ` (pid ${svcState.pid})` : ""}`
-      : daemonOptionalForOpenclaw
-      ? "stopped (not required for OpenClaw plugin mode)"
-      : "stopped",
-    remediation: !svcState.running && standaloneServiceInstalled
-      ? "Run `remnic daemon start`, or `remnic daemon uninstall` if you only use the OpenClaw plugin."
-      : undefined,
-  });
+  // Remote mode (issue #2448): probe the configured origin instead of the
+  // local service manager. Nothing is spawned locally.
+  const remoteDaemon = resolveRemoteDaemon(configPath);
+  if (remoteDaemon) {
+    const probe = await probeDaemonHealth(remoteDaemon.baseUrl, remoteDaemon.token);
+    const detail = probe.ok
+      ? `remote ${remoteDaemon.baseUrl} (reachable)`
+      : `remote ${remoteDaemon.baseUrl} (unreachable${probe.status ? `, HTTP ${probe.status}` : probe.error ? `, ${probe.error}` : ""})`;
+    checks.push({
+      name: "Server daemon",
+      ok: probe.ok,
+      warn: !probe.ok,
+      detail,
+      remediation: probe.ok ? undefined : "Check REMNIC_DAEMON_URL / server.url and the remote server's availability.",
+    });
+  } else {
+    const svcState = isServiceRunning();
+    const standaloneServiceInstalled = isStandaloneServiceInstalled();
+    const daemonOptionalForOpenclaw = openclawPluginModeConfigured && !standaloneServiceInstalled;
+    checks.push({
+      name: "Server daemon",
+      ok: svcState.running || daemonOptionalForOpenclaw,
+      warn: !svcState.running,
+      detail: svcState.running
+        ? `running${svcState.pid ? ` (pid ${svcState.pid})` : ""}`
+        : daemonOptionalForOpenclaw
+        ? "stopped (not required for OpenClaw plugin mode)"
+        : "stopped",
+      remediation: !svcState.running && standaloneServiceInstalled
+        ? "Run `remnic daemon start`, or `remnic daemon uninstall` if you only use the OpenClaw plugin."
+        : undefined,
+    });
+  }
 
   if (isMacOS()) {
     const launchdInspection = selectLaunchdInspection(openclawPluginModeConfigured);

--- a/packages/remnic-cli/src/remote-daemon.test.ts
+++ b/packages/remnic-cli/src/remote-daemon.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Remote daemon targeting tests (issue #2448).
+ *
+ * Covers the URL/token resolvers in `remote-daemon.ts` and the remote
+ * status/query/xray fetch paths against a mocked `globalThis.fetch` —
+ * asserting the configured https origin is used verbatim (never forced
+ * to `http://host:port`) and the bearer token from `REMNIC_AUTH_TOKEN`
+ * reaches the wire.
+ */
+
+import test, { after, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  probeDaemonHealth,
+  printHealthCheck,
+  remoteRecall,
+  remoteRecallXray,
+  resolveDaemonBaseUrl,
+  resolveOperatorToken,
+  resolveRemoteDaemon,
+  resolveRemoteDaemonUrl,
+} from "./remote-daemon.js";
+
+const ENV_KEYS = [
+  "REMNIC_DAEMON_URL",
+  "ENGRAM_DAEMON_URL",
+  "REMNIC_AUTH_TOKEN",
+  "ENGRAM_AUTH_TOKEN",
+  "REMNIC_HOST",
+  "REMNIC_PORT",
+] as const;
+
+let tempDir = "";
+const savedEnv: Record<string, string | undefined> = {};
+
+before(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-remote-"));
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+after(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeConfig(config: Record<string, unknown>): string {
+  const configPath = path.join(tempDir, "remnic.config.json");
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  return configPath;
+}
+
+type FetchCall = { url: string; init: RequestInit | undefined };
+
+function mockFetch(
+  handler: (url: URL, init: RequestInit | undefined) => Response,
+): { calls: FetchCall[]; restore: () => void } {
+  const original = globalThis.fetch;
+  const calls: FetchCall[] = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    calls.push({ url: url.toString(), init });
+    return Promise.resolve(handler(url, init));
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ── resolveRemoteDaemonUrl / resolveDaemonBaseUrl ────────────────────────────
+
+test("REMNIC_DAEMON_URL env wins and keeps the https scheme", () => {
+  const configPath = writeConfig({ server: { url: "http://other.test" } });
+  process.env.REMNIC_DAEMON_URL = "https://example.test";
+
+  assert.equal(resolveRemoteDaemonUrl(configPath), "https://example.test");
+  assert.equal(resolveDaemonBaseUrl(configPath), "https://example.test");
+});
+
+test("server.url is honored with a path prefix and trailing slash stripped", () => {
+  const configPath = writeConfig({ server: { url: "https://example.test/remnic/" } });
+
+  assert.equal(resolveRemoteDaemonUrl(configPath), "https://example.test/remnic");
+});
+
+test("a non-http(s) remote URL fails loud instead of falling back to local", () => {
+  process.env.REMNIC_DAEMON_URL = "ftp://example.test";
+  assert.throws(
+    () => resolveRemoteDaemonUrl("/nonexistent/remnic.config.json"),
+    /scheme must be http:\/\/ or https:\/\//,
+  );
+});
+
+test("an unparseable remote URL fails loud", () => {
+  process.env.REMNIC_DAEMON_URL = "not a url";
+  assert.throws(
+    () => resolveRemoteDaemonUrl("/nonexistent/remnic.config.json"),
+    /Invalid REMNIC_DAEMON_URL/,
+  );
+});
+
+test("without a remote URL the local http://host:port form is preserved", () => {
+  const configPath = writeConfig({ server: { host: "10.0.0.5", port: 9999 } });
+
+  assert.equal(resolveDaemonBaseUrl(configPath), "http://10.0.0.5:9999");
+  assert.equal(resolveRemoteDaemon(configPath), undefined);
+
+  process.env.REMNIC_PORT = "7777";
+  assert.equal(resolveDaemonBaseUrl(configPath), "http://10.0.0.5:7777");
+
+  process.env.REMNIC_PORT = "not-a-port";
+  assert.throws(() => resolveDaemonBaseUrl(configPath), /Invalid REMNIC_PORT/);
+});
+
+// ── token resolution ─────────────────────────────────────────────────────────
+
+test("remote token prefers env over server.authToken and skips placeholders", () => {
+  const configPath = writeConfig({
+    server: { url: "https://example.test", authToken: "file-token" },
+  });
+
+  process.env.REMNIC_AUTH_TOKEN = "env-token";
+  assert.deepEqual(resolveRemoteDaemon(configPath), {
+    baseUrl: "https://example.test",
+    token: "env-token",
+  });
+
+  delete process.env.REMNIC_AUTH_TOKEN;
+  assert.equal(resolveOperatorToken(configPath), "file-token");
+
+  const placeholderPath = writeConfig({
+    server: { url: "https://example.test", authToken: "${REMNIC_AUTH_TOKEN}" },
+  });
+  assert.equal(resolveOperatorToken(placeholderPath), undefined);
+  assert.deepEqual(resolveRemoteDaemon(placeholderPath), {
+    baseUrl: "https://example.test",
+  });
+});
+
+// ── remote status path (mocked fetch) ────────────────────────────────────────
+
+test("probeDaemonHealth targets the remote https origin with the bearer token", async () => {
+  const { calls, restore } = mockFetch(() => jsonResponse(200, { status: "ok" }));
+  try {
+    const probe = await probeDaemonHealth("https://example.test", "tok");
+
+    assert.deepEqual(probe, { ok: true, status: 200 });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.url, "https://example.test/engram/v1/health");
+    assert.equal(
+      (calls[0]?.init?.headers as Record<string, string>).authorization,
+      "Bearer tok",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("probeDaemonHealth reports non-ok statuses without throwing", async () => {
+  const { restore } = mockFetch(() => jsonResponse(401, { error: "unauthorized" }));
+  try {
+    const probe = await probeDaemonHealth("https://example.test", undefined);
+    assert.deepEqual(probe, { ok: false, status: 401 });
+  } finally {
+    restore();
+  }
+});
+
+test("printHealthCheck renders the remote health payload", async () => {
+  const { restore } = mockFetch(
+    () => jsonResponse(200, {
+      status: "ok",
+      qmd: { pendingEmbeddings: 2, oldestPendingAgeMs: 120_000, degradedReason: "backlog" },
+    }),
+  );
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (line: unknown) => {
+    lines.push(String(line));
+  };
+  try {
+    await printHealthCheck("https://example.test", "tok");
+  } finally {
+    console.log = originalLog;
+    restore();
+  }
+  assert.ok(lines.includes("Health: ok"));
+  assert.ok(lines.includes("  Pending embeddings: 2"));
+  assert.ok(lines.includes("  Oldest pending: 2m"));
+  assert.ok(lines.includes("  Degraded: backlog"));
+});
+
+// ── remote query path (mocked fetch) ─────────────────────────────────────────
+
+test("remoteRecall POSTs the recall request to the remote origin", async () => {
+  const { calls, restore } = mockFetch(
+    () => jsonResponse(200, { count: 1, results: [{ content: "known fact" }] }),
+  );
+  try {
+    const result = await remoteRecall(
+      { baseUrl: "https://example.test", token: "tok" },
+      { query: "known fact", mode: "auto", sessionKey: "remnic-cli:query:test" },
+    );
+
+    assert.equal(result.count, 1);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.url, "https://example.test/engram/v1/recall");
+    assert.equal(calls[0]?.init?.method, "POST");
+    const headers = calls[0]?.init?.headers as Record<string, string>;
+    assert.equal(headers.authorization, "Bearer tok");
+    assert.equal(headers["content-type"], "application/json");
+    assert.deepEqual(JSON.parse(String(calls[0]?.init?.body)), {
+      query: "known fact",
+      mode: "auto",
+      sessionKey: "remnic-cli:query:test",
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("remoteRecall maps 401 to an operator-facing error", async () => {
+  const { restore } = mockFetch(() => jsonResponse(401, { error: "unauthorized" }));
+  try {
+    await assert.rejects(
+      () => remoteRecall(
+        { baseUrl: "https://example.test", token: "bad" },
+        { query: "q", mode: "auto", sessionKey: "s" },
+      ),
+      /token rejected by remnic-server at https:\/\/example\.test/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+// ── remote xray path (mocked fetch) ──────────────────────────────────────────
+
+test("remoteRecallXray GETs query params and maps the snapshot payload", async () => {
+  const { calls, restore } = mockFetch(
+    () => jsonResponse(200, { snapshotFound: true, snapshot: { query: "known fact" } }),
+  );
+  try {
+    const response = await remoteRecallXray(
+      { baseUrl: "https://example.test/remnic", token: "tok" },
+      { query: "known fact", budget: 5 },
+    );
+
+    assert.equal(response.snapshotFound, true);
+    assert.deepEqual(response.snapshot, { query: "known fact" });
+    assert.equal(calls.length, 1);
+    const url = new URL(String(calls[0]?.url));
+    assert.equal(url.protocol, "https:");
+    assert.equal(url.pathname, "/remnic/engram/v1/recall/xray");
+    assert.equal(url.searchParams.get("q"), "known fact");
+    assert.equal(url.searchParams.get("budget"), "5");
+  } finally {
+    restore();
+  }
+});
+
+test("remoteRecallXray reports snapshotFound false when no snapshot was captured", async () => {
+  const { restore } = mockFetch(() => jsonResponse(200, { snapshotFound: false }));
+  try {
+    const response = await remoteRecallXray(
+      { baseUrl: "https://example.test" },
+      { query: "known fact" },
+    );
+    assert.deepEqual(response, { snapshotFound: false });
+  } finally {
+    restore();
+  }
+});

--- a/packages/remnic-cli/src/remote-daemon.ts
+++ b/packages/remnic-cli/src/remote-daemon.ts
@@ -1,0 +1,412 @@
+/**
+ * Remote daemon targeting for `@remnic/cli` (issue #2448).
+ *
+ * The CLI historically built every daemon URL as
+ * `http://${server.host}:${server.port}`, so a TLS-terminated remnic-server
+ * origin was unreachable from the CLI. This module owns URL resolution now:
+ *
+ * - `REMNIC_DAEMON_URL` (legacy `ENGRAM_DAEMON_URL`) or `server.url` in
+ *   remnic.config.json configures a full remote origin — `http://` or
+ *   `https://`, with an optional path prefix for reverse proxies. Env wins
+ *   over the file, mirroring the daemon's own env-over-config precedence.
+ * - With a remote origin set, `status`, `query`, `xray`, the `doctor`
+ *   daemon check, and the `oauth` commands target that origin with
+ *   `Authorization: Bearer <token>` (token precedence identical to
+ *   `resolveOperatorToken`). No local daemon is spawned or probed;
+ *   `remnic daemon start|install` stays local by design.
+ * - Without a remote origin, `resolveDaemonBaseUrl()` keeps the previous
+ *   `http://host:port` behavior, env overrides included, so it matches
+ *   the endpoint `startServer()` actually binds.
+ *
+ * Invalid remote URLs throw instead of silently falling back to the
+ * local `http://host:port` form, and an `https://` origin is never
+ * rewritten to plain http — that downgrade is a loud error.
+ */
+import fs from "node:fs";
+import type { RecallXraySnapshot } from "@remnic/core";
+import type { QueryRenderableResult } from "./index.js";
+
+/** Remote daemon target: normalized base URL plus its bearer token. */
+export interface RemoteDaemon {
+  baseUrl: string;
+  token?: string;
+}
+
+/** Primary env var wins; legacy env var is checked as fallback. */
+export function readCompatEnv(primary: string, legacy: string): string | undefined {
+  return process.env[primary] ?? process.env[legacy];
+}
+
+/**
+ * Read + parse the remnic config file, returning a `Record<string, unknown>`
+ * view of its top level. Returns `undefined` on any IO / parse error so
+ * callers can fall through to the env / default path. The cast is the
+ * single point that materialises the unsafe boundary; callers narrow with
+ * `typeof` / `in` at every access (rule: `ts-no_inline-cast-access`).
+ */
+export function readRemnicConfigRecord(configPath: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Normalize a configured remote daemon URL to a base URL (origin plus an
+ * optional path prefix, no trailing slash). Throws for anything the client
+ * cannot honor — an unparseable URL or a non-http(s) scheme — so a bad
+ * `REMNIC_DAEMON_URL` / `server.url` surfaces at the call site instead of
+ * silently downgrading to the local `http://host:port` form.
+ */
+export function normalizeRemoteDaemonUrl(raw: string, source: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new Error(`Invalid ${source} "${raw}": expected an http:// or https:// URL.`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid ${source} "${raw}": scheme must be http:// or https://.`);
+  }
+  return `${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}`;
+}
+
+/**
+ * Resolve the remote origin, if one is configured. Env
+ * `REMNIC_DAEMON_URL` (legacy `ENGRAM_DAEMON_URL`) wins over `server.url`
+ * in the config file. Returns `undefined` in local mode.
+ */
+export function resolveRemoteDaemonUrl(configPath: string): string | undefined {
+  const envUrl = readCompatEnv("REMNIC_DAEMON_URL", "ENGRAM_DAEMON_URL");
+  if (typeof envUrl === "string" && envUrl.trim().length > 0) {
+    return normalizeRemoteDaemonUrl(envUrl, "REMNIC_DAEMON_URL/ENGRAM_DAEMON_URL");
+  }
+  const raw = readRemnicConfigRecord(configPath);
+  if (raw && "server" in raw) {
+    const server = raw.server;
+    if (server && typeof server === "object") {
+      const candidate = (server as Record<string, unknown>).url;
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return normalizeRemoteDaemonUrl(candidate, "server.url");
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the base URL every CLI daemon call targets. A configured remote
+ * origin (http or https, verified) wins; otherwise this resolves the local
+ * daemon endpoint. Env overrides win over the file for host/port, matching
+ * the daemon: `startServer()` merges REMNIC_HOST/REMNIC_PORT (ENGRAM_*
+ * legacy) over `server.host`/`server.port`, so the CLI must resolve the
+ * same endpoint or it targets the wrong port.
+ */
+export function resolveDaemonBaseUrl(configPath: string): string {
+  const remoteUrl = resolveRemoteDaemonUrl(configPath);
+  if (remoteUrl) return remoteUrl;
+
+  let port = 4318;
+  let host = "127.0.0.1";
+  const raw = readRemnicConfigRecord(configPath);
+  if (raw && "server" in raw) {
+    const server = raw.server;
+    if (server && typeof server === "object") {
+      const hostCandidate = (server as Record<string, unknown>).host;
+      if (typeof hostCandidate === "string" && hostCandidate.length > 0) {
+        host = hostCandidate;
+      }
+      const portCandidate = (server as Record<string, unknown>).port;
+      if (typeof portCandidate === "number" && Number.isInteger(portCandidate)) {
+        port = portCandidate;
+      }
+    }
+  }
+  const envHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
+  if (typeof envHost === "string" && envHost.length > 0) {
+    host = envHost;
+  }
+  const envPortRaw = readCompatEnv("REMNIC_PORT", "ENGRAM_PORT");
+  if (typeof envPortRaw === "string" && envPortRaw.length > 0) {
+    const envPort = Number(envPortRaw);
+    // Reject an explicitly-set-but-invalid port instead of silently
+    // falling back (the daemon rejects it too, so a bad value is a
+    // misconfiguration the operator must see, not paper over).
+    if (!Number.isInteger(envPort) || envPort < 1 || envPort > 65535) {
+      throw new Error(
+        `Invalid REMNIC_PORT/ENGRAM_PORT "${envPortRaw}": expected an integer in [1, 65535].`,
+      );
+    }
+    port = envPort;
+  }
+  return `http://${host}:${port}`;
+}
+
+/**
+ * Resolve the operator bearer token, matching the daemon's precedence
+ * exactly. `startServer()` merges `REMNIC_AUTH_TOKEN` (env) OVER
+ * `server.authToken` (file), so the running daemon accepts the env token
+ * when both are set. This resolver therefore checks env FIRST, then the
+ * file value (with `ENGRAM_AUTH_TOKEN` as the legacy env alias). A file
+ * that still holds the literal `${REMNIC_AUTH_TOKEN}` placeholder no
+ * longer shadows the real env token. Returns `undefined` when no token is
+ * configured; callers fail loudly rather than auto-pick a default.
+ */
+export function resolveOperatorToken(configPath: string): string | undefined {
+  const envToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
+  if (typeof envToken === "string" && envToken.length > 0) return envToken;
+  const raw = readRemnicConfigRecord(configPath);
+  if (raw && "server" in raw) {
+    const server = raw.server;
+    if (server && typeof server === "object" && "authToken" in server) {
+      const candidate = (server as Record<string, unknown>).authToken;
+      // A config created by `remnic init` may still hold the literal
+      // `${REMNIC_AUTH_TOKEN}` placeholder; treat that as unresolved so
+      // callers fall through to other sources rather than sending the
+      // placeholder as a real bearer token.
+      if (
+        typeof candidate === "string" &&
+        candidate.length > 0 &&
+        !candidate.includes("${")
+      ) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the full remote target (base URL + bearer token) or `undefined`
+ * when the CLI should keep using the local daemon.
+ */
+export function resolveRemoteDaemon(configPath: string): RemoteDaemon | undefined {
+  const baseUrl = resolveRemoteDaemonUrl(configPath);
+  if (!baseUrl) return undefined;
+  const token = resolveOperatorToken(configPath);
+  return token ? { baseUrl, token } : { baseUrl };
+}
+
+function isTransportError(err: unknown): boolean {
+  return err instanceof Error && (
+    err.message.includes("ECONNREFUSED") ||
+    err.message.includes("ECONNRESET") ||
+    err.message.includes("fetch failed") ||
+    err.message.includes("aborted") ||
+    err.message.includes("ENOTFOUND")
+  );
+}
+
+function unreachableError(baseUrl: string): Error {
+  return new Error(
+    `cannot reach remnic-server at ${baseUrl} — check REMNIC_DAEMON_URL / server.url and the remote server's availability.`,
+  );
+}
+
+/**
+ * Fetch one daemon endpoint. Applies the bearer token and a timeout, and
+ * enforces the https guard: a base URL configured as `https://` must never
+ * be silently rewritten to `http://host:port` — that downgrade is a loud
+ * error, not a fallback (issue #2448).
+ */
+async function daemonFetch(
+  baseUrl: string,
+  relativePath: string,
+  token: string | undefined,
+  timeoutMs: number,
+  init?: RequestInit,
+): Promise<Response> {
+  // `relativePath` is resolved RELATIVE to the base URL so a configured
+  // path prefix (a reverse-proxy mount) is preserved — an absolute
+  // "/engram/..." path would silently drop it.
+  const url = new URL(relativePath, `${baseUrl}/`);
+  if (baseUrl.startsWith("https:") && url.protocol !== "https:") {
+    throw new Error(
+      `refusing to downgrade https daemon URL ${baseUrl} to ${url.protocol}// — fix REMNIC_DAEMON_URL / server.url.`,
+    );
+  }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers: Record<string, string> = { accept: "application/json" };
+    if (token) headers.authorization = `Bearer ${token}`;
+    return await fetch(url, {
+      ...init,
+      headers: { ...headers, ...init?.headers as Record<string, string> | undefined },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export interface DaemonHealthProbe {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+/** Probe `/engram/v1/health` without printing. Never throws. */
+export async function probeDaemonHealth(
+  baseUrl: string,
+  token: string | undefined,
+  timeoutMs = 3000,
+): Promise<DaemonHealthProbe> {
+  try {
+    const response = await daemonFetch(baseUrl, "engram/v1/health", token, timeoutMs);
+    return response.ok ? { ok: true, status: response.status } : { ok: false, status: response.status };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Print the `remnic status` health section for a daemon base URL. Moved
+ * from the inline `cmdStatus` block so the local and remote paths render
+ * identically.
+ */
+export async function printHealthCheck(
+  baseUrl: string,
+  token: string | undefined,
+  timeoutMs = 3000,
+): Promise<void> {
+  try {
+    const response = await daemonFetch(baseUrl, "engram/v1/health", token, timeoutMs);
+    if (!response.ok) {
+      const hint =
+        response.status === 401 && !token
+          ? " (daemon requires auth and no token was found — set REMNIC_AUTH_TOKEN or configure server.authToken)"
+          : response.status === 401
+            ? " (token rejected by the daemon)"
+            : "";
+      console.log(`Health: server responded with ${response.status} ${response.statusText}${hint}`);
+      return;
+    }
+    const health = (await response.json()) as {
+      status?: unknown;
+      qmd?: {
+        pendingEmbeddings?: number | null;
+        oldestPendingAgeMs?: number | null;
+        embeddingBacklogThreshold?: number;
+        degradedReason?: string;
+      };
+    };
+    const status = typeof health.status === "string" ? health.status : "ok";
+    console.log(`Health: ${status}`);
+    const qmd = health.qmd;
+    if (qmd?.pendingEmbeddings != null) {
+      console.log(`  Pending embeddings: ${qmd.pendingEmbeddings}`);
+      if (qmd.oldestPendingAgeMs != null) {
+        console.log(`  Oldest pending: ${Math.round(qmd.oldestPendingAgeMs / 60_000)}m`);
+      }
+      if (qmd.embeddingBacklogThreshold != null) {
+        console.log(`  Backlog threshold: ${qmd.embeddingBacklogThreshold}`);
+      }
+    }
+    if (qmd?.degradedReason) {
+      console.log(`  Degraded: ${qmd.degradedReason}`);
+    }
+  } catch {
+    console.log("Health: unable to reach server");
+  }
+}
+
+/** Minimal recall-response shape the CLI query renderers consume. */
+export interface RemoteRecallResult {
+  results?: QueryRenderableResult[];
+  count?: number;
+  context?: string;
+}
+
+/**
+ * Run a recall against the remote daemon's `POST /engram/v1/recall`.
+ * The request body is the same shape `buildQueryRecallRequest` builds and
+ * `readValidatedBody(req, "recall")` validates server-side. Throws with a
+ * user-facing message on transport errors, 401, or non-JSON responses.
+ */
+export async function remoteRecall(
+  daemon: RemoteDaemon,
+  request: { query: string; mode?: string; sessionKey: string },
+): Promise<RemoteRecallResult> {
+  let response: Response;
+  try {
+    response = await daemonFetch(daemon.baseUrl, "engram/v1/recall", daemon.token, 10_000, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+  } catch (err) {
+    if (isTransportError(err)) throw unreachableError(daemon.baseUrl);
+    throw err;
+  }
+  if (response.status === 401) {
+    throw new Error(
+      `token rejected by remnic-server at ${daemon.baseUrl} (HTTP 401). Update server.authToken or REMNIC_AUTH_TOKEN to match the remote daemon.`,
+    );
+  }
+  if (!response.ok) {
+    throw new Error(`remnic-server returned HTTP ${response.status} ${response.statusText}`);
+  }
+  try {
+    return await response.json() as RemoteRecallResult;
+  } catch {
+    throw new Error("remnic-server returned a non-JSON response");
+  }
+}
+
+/**
+ * Run a recall X-ray against the remote daemon's
+ * `GET /engram/v1/recall/xray`. Returns the same `{ snapshotFound,
+ * snapshot? }` shape `runXrayCommand`'s IO contract expects, so remote and
+ * local xray share all rendering.
+ */
+export async function remoteRecallXray(
+  daemon: RemoteDaemon,
+  request: { query: string; namespace?: string; budget?: number },
+): Promise<{ snapshotFound: boolean; snapshot?: RecallXraySnapshot }> {
+  const params = new URLSearchParams({ q: request.query });
+  if (request.namespace && request.namespace.length > 0) {
+    params.set("namespace", request.namespace);
+  }
+  if (request.budget !== undefined) {
+    params.set("budget", String(request.budget));
+  }
+  let response: Response;
+  try {
+    response = await daemonFetch(
+      daemon.baseUrl,
+      `engram/v1/recall/xray?${params.toString()}`,
+      daemon.token,
+      10_000,
+    );
+  } catch (err) {
+    if (isTransportError(err)) throw unreachableError(daemon.baseUrl);
+    throw err;
+  }
+  if (response.status === 401) {
+    throw new Error(
+      `token rejected by remnic-server at ${daemon.baseUrl} (HTTP 401). Update server.authToken or REMNIC_AUTH_TOKEN to match the remote daemon.`,
+    );
+  }
+  if (!response.ok) {
+    throw new Error(`remnic-server returned HTTP ${response.status} ${response.statusText}`);
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("remnic-server returned a non-JSON response");
+  }
+  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+    const record = payload as Record<string, unknown>;
+    if (record.snapshotFound === true && record.snapshot && typeof record.snapshot === "object") {
+      return { snapshotFound: true, snapshot: record.snapshot as RecallXraySnapshot };
+    }
+  }
+  return { snapshotFound: false };
+}


### PR DESCRIPTION
## Summary

remnic status, query, doctor, and xray probed http://host:port and ignored REMNIC_DAEMON_URL. A TLS Remnic origin could not be targeted.

The CLI now honors REMNIC_DAEMON_URL / server.url as a full origin, including https, and uses REMNIC_AUTH_TOKEN as Bearer auth. daemon start/install stay local.

packages/remnic-cli/src/index.ts shrank (fileSizeGrandfather 13629).

Fixes #2448

## Test

NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-cli/src/remote-daemon.test.ts — 13/13 pass.