### PR TITLE
chore(namespaces): drop dead NamespaceKind values and unused hints

### DIFF
--- a/packages/remnic-core/src/access-http-query.ts
+++ b/packages/remnic-core/src/access-http-query.ts
@@ -1,4 +1,5 @@
 import { EngramAccessInputError } from "./access-service.js";
+import { isNamespaceKind, type NamespaceKind } from "./namespaces/catalog.js";
 
 /** Optional string field from a JSON body: absent/null/"" → undefined. */
 export function optionalQueryString(value: unknown, label: string): string | undefined {
@@ -22,4 +23,15 @@ export function positiveIntQueryParam(value: string | null, label: string): numb
     throw new EngramAccessInputError(`${label} expects a positive integer`);
   }
   return parsed;
+}
+
+/** Optional namespace-kind query param; rejects dead or unknown kinds. */
+export function optionalNamespaceKindQueryParam(value: string | null): NamespaceKind | undefined {
+  if (value === null || value.length === 0) return undefined;
+  if (!isNamespaceKind(value)) {
+    throw new EngramAccessInputError(
+      "kind must be one of: default, shared, project, branch, team-project, explicit",
+    );
+  }
+  return value;
 }

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -728,6 +728,38 @@ test("HTTP admin dashboard endpoints require bearer authentication and apply con
   }
 });
 
+test("HTTP admin namespaces rejects dead kinds and accepts live kinds", async () => {
+  const filters: unknown[] = [];
+  const service = {
+    adminListNamespaces: async (filter: unknown) => {
+      filters.push(filter);
+      return { enabled: true, entries: [] };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  try {
+    const rejected = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/admin/namespaces?kind=self`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(rejected.status, 400);
+    const accepted = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/admin/namespaces?kind=default`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(accepted.status, 200);
+    assert.deepEqual(filters, [{ kind: "default" }]);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP coding-context endpoint accepts projectTag shorthand", async () => {
   const calls: unknown[] = [];
   const service = {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -68,6 +68,7 @@ import { isValidResolutionVerb, executeResolution } from "./contradiction/resolu
 import { RelayMissionStoreError } from "./relay/mission.js";
 import { SupportPassportAccessHttpBase } from "./support-passport/access-http-base.js";
 import { serializeInlineScriptValue } from "./inline-script.js";
+import { isNamespaceKind } from "./namespaces/catalog.js";
 import type { SupportPassportExternalRequestHandler } from "./support-passport/public-http.js";
 export interface AccessHttpReadinessState {
   ready: boolean;
@@ -2989,13 +2990,17 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
       }
       this.requireOperatorToken();
       const kind = parsed.searchParams.get("kind");
-      const principal = parsed.searchParams.get("principal");
-      const projectId = parsed.searchParams.get("projectId");
+      if (kind && !isNamespaceKind(kind)) {
+        this.respondJson(res, 400, {
+          error: "invalid_request",
+          code: "invalid_request",
+          message: "kind must be one of: default, shared, project, branch, team-project, explicit",
+        });
+        return;
+      }
       const discoveredBy = parsed.searchParams.get("discoveredBy");
       const result = await this.service.adminListNamespaces({
-        ...(kind ? { kind: kind as "default" | "self" | "shared" | "project" | "branch" | "team-project" | "explicit" | "legacy" } : {}),
-        ...(principal && principal.length > 0 ? { principal } : {}),
-        ...(projectId && projectId.length > 0 ? { projectId } : {}),
+        ...(kind && isNamespaceKind(kind) ? { kind } : {}),
         ...(discoveredBy
           ? { discoveredBy: discoveredBy as "config" | "write" | "read" | "scan" | "migration" }
           : {}),

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -22,7 +22,7 @@ import {
   respondOfflineManifestStream,
   respondOfflineSnapshotStream,
 } from "./access-http-offline-stream.js";
-import { nonEmptyQueryParam, optionalQueryString, positiveIntQueryParam } from "./access-http-query.js";
+import { nonEmptyQueryParam, optionalNamespaceKindQueryParam, optionalQueryString, positiveIntQueryParam } from "./access-http-query.js";
 import { CorrectionContractError } from "./correction/correction-contract.js";
 import { WearablesInputError } from "./wearables/errors.js"; import { respondMeetingsList, respondMeetingsGet, respondMeetingsBuild } from "./meetings/http-glue.js";
 import { EngramMcpServer, MCP_SUPPORTED_PROTOCOL_VERSIONS } from "./access-mcp.js";
@@ -68,7 +68,6 @@ import { isValidResolutionVerb, executeResolution } from "./contradiction/resolu
 import { RelayMissionStoreError } from "./relay/mission.js";
 import { SupportPassportAccessHttpBase } from "./support-passport/access-http-base.js";
 import { serializeInlineScriptValue } from "./inline-script.js";
-import { isNamespaceKind } from "./namespaces/catalog.js";
 import type { SupportPassportExternalRequestHandler } from "./support-passport/public-http.js";
 export interface AccessHttpReadinessState {
   ready: boolean;
@@ -2989,18 +2988,10 @@ export class EngramAccessHttpServer extends SupportPassportAccessHttpBase {
         return;
       }
       this.requireOperatorToken();
-      const kind = parsed.searchParams.get("kind");
-      if (kind && !isNamespaceKind(kind)) {
-        this.respondJson(res, 400, {
-          error: "invalid_request",
-          code: "invalid_request",
-          message: "kind must be one of: default, shared, project, branch, team-project, explicit",
-        });
-        return;
-      }
+      const kind = optionalNamespaceKindQueryParam(parsed.searchParams.get("kind"));
       const discoveredBy = parsed.searchParams.get("discoveredBy");
       const result = await this.service.adminListNamespaces({
-        ...(kind && isNamespaceKind(kind) ? { kind } : {}),
+        ...(kind ? { kind } : {}),
         ...(discoveredBy
           ? { discoveredBy: discoveredBy as "config" | "write" | "read" | "scan" | "migration" }
           : {}),

--- a/packages/remnic-core/src/admin/admin-surfaces.test.ts
+++ b/packages/remnic-core/src/admin/admin-surfaces.test.ts
@@ -200,20 +200,15 @@ test("listAdminNamespaces lists configured + discovered namespaces and marks sta
   }
 });
 
-test("listAdminNamespaces filters by principal", async () => {
+test("listAdminNamespaces filters by kind", async () => {
   const memoryDir = await makeTempDir();
   try {
-    const config = makeConfig({
-      memoryDir,
-      namespacePolicies: [
-        { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
-        { name: "bob", readPrincipals: ["bob"], writePrincipals: ["bob"] },
-      ],
-    });
+    const config = makeConfig({ memoryDir });
     const catalog = new NamespaceCatalog(config);
     await catalog.registerConfiguredNamespaces();
-    const result = await listAdminNamespaces({ catalog, filter: { principal: "alice" } });
-    assert.ok(result.entries.every((entry) => entry.principal === "alice"));
+    const result = await listAdminNamespaces({ catalog, filter: { kind: "default" } });
+    assert.ok(result.entries.length > 0, "default kind filter must return the default namespace");
+    assert.ok(result.entries.every((entry) => entry.kind === "default"));
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/admin/admin-surfaces.ts
+++ b/packages/remnic-core/src/admin/admin-surfaces.ts
@@ -322,8 +322,6 @@ export function inspectScope(options: InspectScopeOptions): ScopeInspection {
 /** Filters the namespace browser accepts (superset of {@link NamespaceCatalogFilter}). */
 export interface AdminNamespaceFilter {
   kind?: NamespaceRecord["kind"];
-  principal?: string;
-  projectId?: string;
   discoveredBy?: NamespaceRecord["discoveredBy"];
   /** Only namespaces with a write at/after this instant. */
   writtenSince?: Date;
@@ -336,10 +334,6 @@ export interface AdminNamespaceEntry {
   namespace: string;
   identityToken: string;
   kind: NamespaceRecord["kind"];
-  principal?: string;
-  projectId?: string;
-  branch?: string;
-  parentNamespace?: string;
   createdAt: string;
   lastReadAt?: string;
   lastWriteAt?: string;
@@ -386,12 +380,6 @@ export async function listAdminNamespaces(options: ListAdminNamespacesOptions): 
 
   let entries: AdminNamespaceEntry[] = records.map((record) => toAdminEntry(record, staleBefore));
 
-  if (filter?.principal) {
-    entries = entries.filter((entry) => entry.principal === filter.principal);
-  }
-  if (filter?.projectId) {
-    entries = entries.filter((entry) => entry.projectId === filter.projectId);
-  }
   if (filter?.staleBefore) {
     const cutoff = filter.staleBefore.getTime();
     entries = entries.filter((entry) => {
@@ -411,10 +399,6 @@ function toAdminEntry(record: NamespaceRecord, staleBefore: Date): AdminNamespac
     namespace: record.namespace,
     identityToken: record.identityToken,
     kind: record.kind,
-    principal: record.principal,
-    projectId: record.projectId,
-    branch: record.branch,
-    parentNamespace: record.parentNamespace,
     createdAt: record.createdAt,
     lastReadAt: record.lastReadAt,
     lastWriteAt: record.lastWriteAt,

--- a/packages/remnic-core/src/maintenance/namespace-planner.ts
+++ b/packages/remnic-core/src/maintenance/namespace-planner.ts
@@ -177,8 +177,6 @@ function candidatePriority(candidate: NamespaceMaintenanceCandidate): number {
   if (candidate.source === "configured") return 2;
   if (candidate.kind === "team-project") return 3;
   if (candidate.kind === "project") return 4;
-  if (candidate.kind === "self") return 5;
-  if (candidate.kind === "legacy") return 6;
   if (candidate.kind === "branch") return 8;
   return 7;
 }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -600,15 +600,16 @@ test("catalog quarantines malformed JSONL record fields at the parse boundary", 
 
     assert.deepEqual(
       list.map((r) => r.namespace),
-      ["valid"],
-      "invalid enum/token/timestamp records must not surface",
+      ["bad-kind", "valid"],
+      "unknown kinds coerce to explicit; other malformed records stay quarantined",
     );
-    assert.equal(list[0]?.identityToken, validToken);
-    assert.equal(list[0]?.kind, "project");
-    assert.equal(list[0]?.discoveredBy, "write");
-    assert.equal(list[0]?.lastReadAt, undefined);
-    assert.equal(list[0]?.lastWriteAt, undefined);
-    assert.deepEqual(list[0]?.lastMaintenanceAt, { ok: now });
+    assert.equal(list.find((r) => r.namespace === "bad-kind")?.kind, "explicit");
+    const valid = list.find((r) => r.namespace === "valid");
+    assert.equal(valid?.kind, "project");
+    assert.equal(valid?.discoveredBy, "write");
+    assert.equal(valid?.lastReadAt, undefined);
+    assert.equal(valid?.lastWriteAt, undefined);
+    assert.deepEqual(valid?.lastMaintenanceAt, { ok: now });
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -3952,3 +3953,47 @@ test("#1903 cross-instance compaction never drops another instance's rows", asyn
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("#2469 persisted self/legacy kinds coerce to explicit and drop unused hints", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-dead-kind";
+    const token = namespaceIdentityToken(ns);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const line = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "self",
+      principal: "unused",
+      projectId: "unused",
+      branch: "unused",
+      parentNamespace: "unused",
+      createdAt: "2026-08-17T00:00:00.000Z",
+      storageDir: path.join(memoryDir, "namespaces", token),
+      discoveredBy: "write",
+    });
+    const legacyLine = JSON.stringify({
+      namespace: "shared",
+      identityToken: namespaceIdentityToken("shared"),
+      kind: "legacy",
+      createdAt: "2026-08-17T00:00:00.000Z",
+      storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken("shared")),
+      discoveredBy: "config",
+    });
+    await writeFile(path.join(stateDir, "namespaces.jsonl"), `${line}\n${legacyLine}\n`, "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const selfRecord = await catalog.getNamespaceRecord(ns);
+    assert.equal(selfRecord?.kind, "explicit");
+    assert.equal(
+      (selfRecord as { principal?: string } | null)?.principal,
+      undefined,
+    );
+    const legacyRecord = await catalog.getNamespaceRecord("shared");
+    assert.equal(legacyRecord?.kind, "explicit");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -263,7 +263,7 @@ function isValidIsoTimestamp(value: string): boolean {
   return Number.isFinite(ms);
 }
 
-function isNamespaceKind(value: unknown): value is NamespaceKind {
+export function isNamespaceKind(value: unknown): value is NamespaceKind {
   return typeof value === "string" && (NAMESPACE_KINDS as readonly string[]).includes(value);
 }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -59,13 +59,11 @@ import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
 export type NamespaceKind =
   | "default"
-  | "self"
   | "shared"
   | "project"
   | "branch"
   | "team-project"
-  | "explicit"
-  | "legacy";
+  | "explicit";
 
 export type NamespaceDiscoverySource = "config" | "write" | "read" | "scan" | "migration";
 
@@ -73,10 +71,6 @@ export interface NamespaceRecord {
   namespace: string;
   identityToken: string;
   kind: NamespaceKind;
-  principal?: string;
-  projectId?: string;
-  branch?: string;
-  parentNamespace?: string;
   createdAt: string;
   lastReadAt?: string;
   lastWriteAt?: string;
@@ -95,10 +89,6 @@ export interface NamespaceCatalogFilter {
 export interface NamespaceTouchMetadata {
   discoveredBy?: NamespaceDiscoverySource;
   kind?: NamespaceKind;
-  principal?: string;
-  projectId?: string;
-  branch?: string;
-  parentNamespace?: string;
   /** Explicit storage dir (when the caller already resolved it). */
   storageDir?: string;
   /** Override the touch timestamp (mainly for tests / migration replay). */
@@ -129,13 +119,11 @@ export interface NamespaceCatalogRebuildResult {
 
 const NAMESPACE_KINDS: readonly NamespaceKind[] = [
   "default",
-  "self",
   "shared",
   "project",
   "branch",
   "team-project",
   "explicit",
-  "legacy",
 ];
 
 const NAMESPACE_DISCOVERY_SOURCES: readonly NamespaceDiscoverySource[] = [
@@ -301,8 +289,7 @@ function coerceRecord(value: unknown): NamespaceRecord | null {
   if (typeof v.storageDir !== "string" || v.storageDir.length === 0) return null;
   if (typeof v.createdAt !== "string" || v.createdAt.length === 0) return null;
   if (!isValidIsoTimestamp(v.createdAt)) return null;
-  const kind = v.kind === undefined ? "explicit" : isNamespaceKind(v.kind) ? v.kind : null;
-  if (!kind) return null;
+  const kind = isNamespaceKind(v.kind) ? v.kind : "explicit";
   const discoveredBy =
     v.discoveredBy === undefined
       ? "scan"
@@ -318,10 +305,6 @@ function coerceRecord(value: unknown): NamespaceRecord | null {
     storageDir: v.storageDir,
     discoveredBy,
   };
-  if (typeof v.principal === "string") record.principal = v.principal;
-  if (typeof v.projectId === "string") record.projectId = v.projectId;
-  if (typeof v.branch === "string") record.branch = v.branch;
-  if (typeof v.parentNamespace === "string") record.parentNamespace = v.parentNamespace;
   if (typeof v.lastReadAt === "string" && isValidIsoTimestamp(v.lastReadAt)) {
     record.lastReadAt = v.lastReadAt;
   }
@@ -792,12 +775,6 @@ export class NamespaceCatalog {
     if (kind === "read" && cached.lastReadAt === undefined) return true;
     if (!metadata) return false;
     if (metadata.kind !== undefined && metadata.kind !== cached.kind) return true;
-    if (metadata.principal !== undefined && metadata.principal !== cached.principal) return true;
-    if (metadata.projectId !== undefined && metadata.projectId !== cached.projectId) return true;
-    if (metadata.branch !== undefined && metadata.branch !== cached.branch) return true;
-    if (metadata.parentNamespace !== undefined && metadata.parentNamespace !== cached.parentNamespace) {
-      return true;
-    }
     // A changed storageDir repoints routing/containment for this namespace —
     // must be observable at once, not held stale by the coalesce window (#1903, Cursor).
     if (metadata.storageDir !== undefined && metadata.storageDir !== cached.storageDir) return true;
@@ -1399,15 +1376,10 @@ export class NamespaceCatalog {
                 (kind === "register" ? "config" : kind === "maintenance" ? "scan" : kind),
             };
 
-        // Update mutable fields. storageDir, kind, and the principal/project hints
-        // may legitimately change over a namespace's lifetime, so they upsert.
+        // Update mutable fields. storageDir and kind may change over a
+        // namespace's lifetime, so they upsert.
         record.storageDir = storageDir;
         if (metadata?.kind) record.kind = metadata.kind;
-        if (metadata?.principal !== undefined) record.principal = metadata.principal;
-        if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
-        if (metadata?.branch !== undefined) record.branch = metadata.branch;
-        if (metadata?.parentNamespace !== undefined)
-          record.parentNamespace = metadata.parentNamespace;
         // PROVENANCE (creation-only, with one upgrade — round 6, codex P2 NBPmT):
         // `discoveredBy` is otherwise preserved for existing records (a routine
         // read/register/resolve never relabels it). The single exception is a real
@@ -2109,10 +2081,6 @@ export class NamespaceCatalog {
     if (prior.lastReadAt) merged.lastReadAt = prior.lastReadAt;
     if (prior.lastWriteAt) merged.lastWriteAt = prior.lastWriteAt;
     if (prior.lastMaintenanceAt) merged.lastMaintenanceAt = { ...prior.lastMaintenanceAt };
-    if (prior.principal !== undefined) merged.principal = prior.principal;
-    if (prior.projectId !== undefined) merged.projectId = prior.projectId;
-    if (prior.branch !== undefined) merged.branch = prior.branch;
-    if (prior.parentNamespace !== undefined) merged.parentNamespace = prior.parentNamespace;
     return merged;
   }
   // ── Persistence ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #2469.

Remove `self` and `legacy` from `NamespaceKind`. Unknown persisted kinds still load as `explicit`. Drop unused catalog hint fields (`principal`, `projectId`, `branch`, `parentNamespace`).

`catalog.ts` shrinks (2331 -> 2299).

## Test
`node --import tsx --test packages/remnic-core/src/namespaces/catalog.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog handling for older or unrecognized namespace records.
  * Invalid namespace kinds are now normalized consistently instead of being quarantined.
  * Malformed timestamps and invalid fields continue to be sanitized or rejected appropriately.
  * Obsolete namespace metadata is no longer retained during catalog updates or rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->