### PR TITLE
chore(plugin-openclaw): re-export plugin ids from core

### DIFF
--- a/packages/plugin-openclaw/src/managed-upgrade.ts
+++ b/packages/plugin-openclaw/src/managed-upgrade.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export const REMNIC_OPENCLAW_PLUGIN_ID = "openclaw-remnic";
+import { REMNIC_OPENCLAW_PLUGIN_ID } from "./plugin-id.js";
+
+export { REMNIC_OPENCLAW_PLUGIN_ID };
+
 const OPENCLAW_EXEC_TIMEOUT_MS = 120_000;
 const OPENCLAW_PLUGIN_PACKAGE = "@remnic/plugin-openclaw";
 const DIST_TAG_SELECTOR = /^[A-Za-z][0-9A-Za-z._-]*$/;

--- a/packages/plugin-openclaw/src/plugin-id.test.ts
+++ b/packages/plugin-openclaw/src/plugin-id.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "@remnic/core/plugin-id";
+import {
+  LEGACY_PLUGIN_ID as ADAPTER_LEGACY,
+  PLUGIN_ID as ADAPTER_CANONICAL,
+  REMNIC_OPENCLAW_LEGACY_PLUGIN_ID,
+  REMNIC_OPENCLAW_PLUGIN_ID,
+  REMNIC_OPENCLAW_PLUGIN_IDS,
+} from "./plugin-id.js";
+
+test("#2470 adapter plugin ids are re-exports of @remnic/core/plugin-id", () => {
+  assert.equal(REMNIC_OPENCLAW_PLUGIN_ID, PLUGIN_ID);
+  assert.equal(REMNIC_OPENCLAW_LEGACY_PLUGIN_ID, LEGACY_PLUGIN_ID);
+  assert.equal(ADAPTER_CANONICAL, PLUGIN_ID);
+  assert.equal(ADAPTER_LEGACY, LEGACY_PLUGIN_ID);
+  assert.deepEqual(REMNIC_OPENCLAW_PLUGIN_IDS, [PLUGIN_ID, LEGACY_PLUGIN_ID]);
+});

--- a/packages/plugin-openclaw/src/plugin-id.ts
+++ b/packages/plugin-openclaw/src/plugin-id.ts
@@ -1,46 +1,14 @@
-import { resolvePluginEntry } from "@remnic/core/plugin-entry-resolver";
+import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "@remnic/core/plugin-id";
 
-export const REMNIC_OPENCLAW_PLUGIN_ID = "openclaw-remnic" as const;
-export const REMNIC_OPENCLAW_LEGACY_PLUGIN_ID = "openclaw-engram" as const;
+export { PLUGIN_ID, LEGACY_PLUGIN_ID } from "@remnic/core/plugin-id";
+export {
+  resolveRemnicPluginEntry as resolveRemnicOpenClawPluginEntry,
+} from "@remnic/core/plugin-id";
 
+export const REMNIC_OPENCLAW_PLUGIN_ID = PLUGIN_ID;
+export const REMNIC_OPENCLAW_LEGACY_PLUGIN_ID = LEGACY_PLUGIN_ID;
 export const REMNIC_OPENCLAW_PLUGIN_IDS = [
   REMNIC_OPENCLAW_PLUGIN_ID,
   REMNIC_OPENCLAW_LEGACY_PLUGIN_ID,
 ] as const;
 
-function getOpenClawPluginEntries(raw: Record<string, unknown>): Record<string, unknown> | undefined {
-  const plugins =
-    raw["plugins"] && typeof raw["plugins"] === "object" && !Array.isArray(raw["plugins"])
-      ? (raw["plugins"] as Record<string, unknown>)
-      : undefined;
-  const entries =
-    plugins && plugins["entries"] && typeof plugins["entries"] === "object" && !Array.isArray(plugins["entries"])
-      ? (plugins["entries"] as Record<string, unknown>)
-      : undefined;
-  return entries;
-}
-
-function getOpenClawMemorySlotId(raw: Record<string, unknown>): string | undefined {
-  const plugins =
-    raw["plugins"] && typeof raw["plugins"] === "object" && !Array.isArray(raw["plugins"])
-      ? (raw["plugins"] as Record<string, unknown>)
-      : undefined;
-  const slots =
-    plugins && plugins["slots"] && typeof plugins["slots"] === "object" && !Array.isArray(plugins["slots"])
-      ? (plugins["slots"] as Record<string, unknown>)
-      : undefined;
-  const slotId = slots?.["memory"];
-  return typeof slotId === "string" ? slotId : undefined;
-}
-
-export function resolveRemnicOpenClawPluginEntry(
-  raw: unknown,
-  preferredId?: string,
-): Record<string, unknown> | undefined {
-  return resolvePluginEntry(raw, {
-    candidateIds: REMNIC_OPENCLAW_PLUGIN_IDS,
-    preferredId,
-    getEntries: getOpenClawPluginEntries,
-    getSlotId: getOpenClawMemorySlotId,
-  });
-}

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -1,8 +1,11 @@
+import {
+  LEGACY_PLUGIN_ID as LEGACY_REMNIC_MEMORY_SLOT_ID,
+  PLUGIN_ID as CANONICAL_REMNIC_MEMORY_SLOT_ID,
+} from "./plugin-id.js";
+
 export type SlotMismatchMode = "error" | "warn" | "silent";
 export type SlotValidationResult = "ok" | "passive";
 
-const CANONICAL_REMNIC_MEMORY_SLOT_ID = "openclaw-remnic";
-const LEGACY_REMNIC_MEMORY_SLOT_ID = "openclaw-engram";
 const MAX_SLOT_DISTANCE_INPUT_LENGTH = 256;
 
 export interface SlotValidationContext {


### PR DESCRIPTION
Fixes #2470.

Adapter plugin-id names now re-export `@remnic/core/plugin-id`. `managed-upgrade` and `slot-validator` import those names instead of repeating the strings.

## Test
`node --import tsx --test packages/plugin-openclaw/src/plugin-id.test.ts packages/plugin-openclaw/src/slot-validator.test.ts`