### PR TITLE
fix(binary-lifecycle): stamp redirectedAt only after verify

### DIFF
--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -587,7 +587,7 @@ test("binary lifecycle resumes redirects after verification read failures", asyn
     assert.match(firstResult.errors.join("\n"), /injected verification read failure/);
     assert.equal(await readFile(notePath, "utf8"), "![img](remote/image.png)");
     assert.equal(manifest.assets[0]?.status, "error");
-    assert.equal(typeof manifest.assets[0]?.redirectedAt, "string");
+    assert.equal(manifest.assets[0]?.redirectedAt, undefined);
 
     const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, nestedRemoteBackend, noopLogger);
     manifest = JSON.parse(

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -294,11 +294,25 @@ async function stageRedirect(
         }
 
         if (asset.redirectedAt === undefined) {
-          if (!dryRun) {
-            asset.status = "mirrored";
+          let remoteSeen = false;
+          for (const mdPath of mdFiles) {
+            try {
+              const content = await readMarkdownFile(mdPath);
+              if (content.includes(asset.mirroredPath)) {
+                remoteSeen = true;
+                break;
+              }
+            } catch {
+              // Verify already succeeded; a later read error is not a local ref.
+            }
           }
-          log.info(`[binary-lifecycle] preserved mirrored asset without redirected marker: ${asset.originalPath}${dryRun ? " [dry-run]" : ""}`);
-          continue;
+          if (!remoteSeen) {
+            if (!dryRun) {
+              asset.status = "mirrored";
+            }
+            log.info(`[binary-lifecycle] preserved mirrored asset without redirected marker: ${asset.originalPath}${dryRun ? " [dry-run]" : ""}`);
+            continue;
+          }
         }
 
         if (!Number.isFinite(new Date(asset.mirroredAt).getTime())) {
@@ -400,9 +414,6 @@ async function stageRedirect(
       continue;
     }
 
-    const redirectedAt = new Date().toISOString();
-    asset.redirectedAt = redirectedAt;
-
     const verifyResult = await countRemainingLocalReferences(
       memoryDir,
       asset,
@@ -411,7 +422,10 @@ async function stageRedirect(
       readMarkdownFile,
     );
     if (verifyResult.errors.length > 0 || verifyResult.remaining > 0) {
-      asset.status = "error";
+asset.status = "error";
+// Failed verify must not read as a completed redirect (#2471); this also
+// clears stale stamps written by manifests from before that fix.
+delete asset.redirectedAt;
       for (const msg of verifyResult.errors) {
         log.error(`[binary-lifecycle] ${msg}`);
         errors.push(msg);
@@ -424,7 +438,7 @@ async function stageRedirect(
       continue;
     }
     asset.status = "redirected";
-    asset.redirectedAt = redirectedAt;
+asset.redirectedAt = new Date().toISOString();
     redirected++;
     log.info(`[binary-lifecycle] redirected: ${asset.originalPath}`);
   }


### PR DESCRIPTION
Fixes #2471.

`redirectedAt` is set only when verify succeeds and status becomes `redirected`. A failed verify leaves `status=error` and no stamp.

Resume still completes when remote refs are already written.

## Test
`node --import tsx --test packages/remnic-core/src/binary-lifecycle/pipeline.test.ts`