### PR TITLE
refactor(dedup): derive strip-negation regex from NEGATION_WORDS

### DIFF
--- a/packages/remnic-core/src/dedup/index.test.ts
+++ b/packages/remnic-core/src/dedup/index.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { findContradictions, findDuplicates } from "./index.js";
+import { NEGATION_WORDS, findContradictions, findDuplicates } from "./index.js";
 
 test("findContradictions detects can versus cannot statements", async () => {
   const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-dedup-contradiction-"));
@@ -147,5 +147,36 @@ test("dedup scans reject symlinked category directories outside memoryDir", asyn
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("strip-negation pattern is derived from NEGATION_WORDS", async () => {
+  NEGATION_WORDS.add("seldom");
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-dedup-negation-"));
+
+  try {
+    const factsDir = path.join(memoryDir, "facts");
+    await mkdir(factsDir);
+    await writeFile(
+      path.join(factsDir, "plain.md"),
+      ["---", "id: mem-plain", "category: fact", "---", "The user enjoys morning runs."].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      path.join(factsDir, "seldom.md"),
+      ["---", "id: mem-seldom", "category: fact", "---", "The user seldom enjoys morning runs."].join("\n"),
+      "utf8"
+    );
+
+    const result = findContradictions({ memoryDir, categories: ["facts"] });
+
+    // "high" requires the stripped texts to match exactly, which only happens
+    // when the strip pattern honors the word the test added to the set.
+    assert.equal(result.contradictions.length, 1);
+    assert.equal(result.contradictions[0]?.severity, "high");
+    assert.equal(result.contradictions[0]?.reason, "Negated version of similar content");
+  } finally {
+    NEGATION_WORDS.delete("seldom");
+    await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/dedup/index.test.ts
+++ b/packages/remnic-core/src/dedup/index.test.ts
@@ -180,3 +180,36 @@ test("strip-negation pattern is derived from NEGATION_WORDS", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("strip-negation cache rebuilds on same-size vocabulary swap", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-dedup-negation-swap-"));
+
+  try {
+    const factsDir = path.join(memoryDir, "facts");
+    await mkdir(factsDir);
+    await writeFile(
+      path.join(factsDir, "plain.md"),
+      ["---", "id: mem-swap-plain", "category: fact", "---", "The user enjoys morning runs."].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      path.join(factsDir, "rarely.md"),
+      ["---", "id: mem-swap-rarely", "category: fact", "---", "The user rarely enjoys morning runs."].join("\n"),
+      "utf8"
+    );
+
+    // Warm the pattern cache with the current vocabulary (no "rarely" yet).
+    assert.equal(findContradictions({ memoryDir, categories: ["facts"] }).contradictions.length, 0);
+
+    // Same-size swap: the size-keyed cache would keep serving the stale pattern.
+    NEGATION_WORDS.delete("never");
+    NEGATION_WORDS.add("rarely");
+    const result = findContradictions({ memoryDir, categories: ["facts"] });
+    assert.equal(result.contradictions.length, 1);
+    assert.equal(result.contradictions[0]?.severity, "high");
+  } finally {
+    NEGATION_WORDS.delete("rarely");
+    NEGATION_WORDS.add("never");
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -245,7 +245,7 @@ function tokenizeForSimilarity(text: string): Set<string> {
 
 // ── Contradiction detection ──────────────────────────────────────────────────
 
-const NEGATION_WORDS = new Set([
+export const NEGATION_WORDS = new Set([
   "not",
   "don't",
   "doesn't",
@@ -317,9 +317,32 @@ function containsNegation(text: string): boolean {
   return words.some((w) => NEGATION_WORDS.has(w));
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Single vocabulary source: the strip pattern is derived from NEGATION_WORDS,
+// never hand-maintained. Size-keyed cache so per-pair calls do not rebuild it.
+// ponytail: a same-size edit to the set would serve a stale pattern; rebuild
+// unconditionally if that ever matters.
+let stripNegationPattern: RegExp | null = null;
+let stripNegationPatternSize = -1;
+
+function stripNegationRegex(): RegExp {
+  if (stripNegationPattern === null || stripNegationPatternSize !== NEGATION_WORDS.size) {
+    const alternation = [...NEGATION_WORDS]
+      .sort((a, b) => b.length - a.length)
+      .map(escapeRegExp)
+      .join("|");
+    stripNegationPattern = new RegExp(`\\b(?:${alternation})\\b`, "gi");
+    stripNegationPatternSize = NEGATION_WORDS.size;
+  }
+  return stripNegationPattern;
+}
+
 function stripNegation(text: string): string {
   return text
-    .replace(/\b(not|don't|doesn't|isn't|aren't|won't|can't|cannot|never|no|none|neither|nor|nothing|nowhere)\b/gi, "")
+    .replace(stripNegationRegex(), "")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -322,20 +322,19 @@ function escapeRegExp(value: string): string {
 }
 
 // Single vocabulary source: the strip pattern is derived from NEGATION_WORDS,
-// never hand-maintained. Size-keyed cache so per-pair calls do not rebuild it.
-// ponytail: a same-size edit to the set would serve a stale pattern; rebuild
-// unconditionally if that ever matters.
+// never hand-maintained. Keyed on the alternation content so any vocabulary
+// change (not just a size change) rebuilds the pattern.
 let stripNegationPattern: RegExp | null = null;
-let stripNegationPatternSize = -1;
+let stripNegationPatternSource: string | null = null;
 
 function stripNegationRegex(): RegExp {
-  if (stripNegationPattern === null || stripNegationPatternSize !== NEGATION_WORDS.size) {
-    const alternation = [...NEGATION_WORDS]
-      .sort((a, b) => b.length - a.length)
-      .map(escapeRegExp)
-      .join("|");
+  const alternation = [...NEGATION_WORDS]
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join("|");
+  if (stripNegationPattern === null || stripNegationPatternSource !== alternation) {
     stripNegationPattern = new RegExp(`\\b(?:${alternation})\\b`, "gi");
-    stripNegationPatternSize = NEGATION_WORDS.size;
+    stripNegationPatternSource = alternation;
   }
   return stripNegationPattern;
 }


### PR DESCRIPTION
## Summary
- Build the strip-negation regex from NEGATION_WORDS.
- One vocabulary source; literals are escaped.

Fixes #2480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contradiction detection for dynamically added negation terms.
  * Ensured longer negation phrases are matched correctly and vocabulary entries are handled safely.

* **Tests**
  * Added coverage confirming newly added negation terms trigger high-severity contradiction detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->