### PR TITLE
fix(openclaw): do not couple completed compaction to flush-plan replay latency

### DIFF
--- a/.changeset/detach-after-compaction-flush-replay.md
+++ b/.changeset/detach-after-compaction-flush-replay.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Keep completed OpenClaw compactions independent from long-running flush-plan backlog replay.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4373,9 +4373,10 @@ const pluginDefinition = {
               log.debug(`LCM after_compaction error: ${lcmErr}`);
             }
           }
-          await queueOpenClawFlushPlanProcessing("after_compaction", workspaceDir, {
-            timeoutMs: cfg.beforeResetTimeoutMs,
-          });
+          // A completed compaction must not fail because replaying an unrelated
+          // flush-plan backlog exceeds the hook deadline. Keep the serialized
+          // drain in the background; lifecycle/startup triggers can retry it.
+          void queueOpenClawFlushPlanProcessing("after_compaction", workspaceDir);
 
           if (!orchestrator.config.compactionResetEnabled) {
             log.debug(

--- a/tests/sdk-compat-hook-handlers.test.ts
+++ b/tests/sdk-compat-hook-handlers.test.ts
@@ -2224,6 +2224,80 @@ test("after_compaction preserves the Codex heuristic baseline when the signal fl
   );
 });
 
+test("after_compaction does not await a long-running flush-plan drain", async () => {
+  const { default: plugin } = await import("../src/index.js");
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-after-compaction-flush-"));
+  try {
+    const api = buildHandlerCapturingApi("after-compaction-detached-flush-test");
+    api.pluginConfig = {
+      qmdEnabled: false,
+      modelSource: "gateway",
+      transcriptEnabled: false,
+      hourlySummariesEnabled: false,
+      workspaceDir,
+      openclawFlushPlanProcessingEnabled: true,
+      beforeResetTimeoutMs: 25,
+    };
+    plugin.register(api as any);
+
+    const afterCompaction = api.handlers.get("after_compaction");
+    assert.ok(afterCompaction, "after_compaction handler should be registered");
+
+    const orchestrator = (globalThis as any).__openclawEngramOrchestrator;
+    orchestrator.config.compactionResetEnabled = false;
+    orchestrator.lcmEngine = { enabled: false };
+
+    let markIngestStarted!: () => void;
+    const ingestStarted = new Promise<void>((resolve) => {
+      markIngestStarted = resolve;
+    });
+    let releaseIngest!: () => void;
+    const ingestReleased = new Promise<void>((resolve) => {
+      releaseIngest = resolve;
+    });
+    orchestrator.ingestBulkImportBatch = async () => {
+      markIngestStarted();
+      await ingestReleased;
+      return undefined;
+    };
+
+    const flushPlanPath = path.join(
+      workspaceDir,
+      "state",
+      "plugins",
+      SERVICE_ID,
+      "flush-plan.md",
+    );
+    await mkdir(path.dirname(flushPlanPath), { recursive: true });
+    await writeFile(flushPlanPath, "- Durable note queued after compaction.\n", "utf8");
+
+    const outcome = await Promise.race([
+      afterCompaction(
+        { sessionKey: "detached-after-compaction-flush" },
+        { sessionKey: "detached-after-compaction-flush", workspaceDir },
+      ).then(() => "resolved"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed_out"), 250)),
+    ]);
+    assert.equal(
+      outcome,
+      "resolved",
+      "after_compaction must not couple compaction success to backlog ingestion",
+    );
+
+    const drainStarted = await Promise.race([
+      ingestStarted.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 300)),
+    ]);
+    assert.equal(drainStarted, true, "the detached flush-plan drain should still start");
+
+    releaseIngest();
+    await waitForFlushPlanProcessingQueueToEmpty();
+    assert.equal(await readFile(flushPlanPath, "utf8"), "");
+  } finally {
+    await rm(workspaceDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  }
+});
+
 test("before_prompt_build uses the Codex heuristic fallback when thread history shrinks", async () => {
   const { default: plugin } = await import("../src/index.js");
   const api = buildHandlerCapturingApi("before-prompt-build-codex-heuristic-test");


### PR DESCRIPTION
## Summary

- detach OpenClaw flush-plan replay from the `after_compaction` hook result
- keep replay serialized through the existing shared queue without propagating the 30-second hook deadline
- add regression coverage proving the hook resolves while a background drain remains in flight and that the drain still completes

Fixes #2454

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [x] `node scripts/pnpm.mjs --filter @remnic/plugin-openclaw run check-types`
- [x] Targeted SDK hook tests (2 passed)
- [x] Added/updated tests for behavior changes
- [x] `git diff --check`
- [ ] Full `npm test` (targeted lifecycle coverage used for this narrow change)
- [ ] `npm run review:cursor` (Cursor CLI unavailable in this environment)

## Changelog

- [x] Changeset added for `@remnic/plugin-openclaw` patch release

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [x] Promise chain resilience preserved: the existing shared serialized/fenced queue is unchanged

## Notes for reviewers

LCM may have already persisted a valid compacted summary when flush-plan extraction exceeds the hook budget. The old synchronous wait made unrelated backlog latency turn that completed compaction into a hook failure. This change only detaches the wait; it does not remove replay, bypass queue serialization, or overlap file mutation.

## PR workflow

- [x] PR scope is narrow
- [x] Synced with latest `main` before implementation
- [x] Batched review fixes by subsystem instead of micro-pushing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compaction completion no longer waits for lengthy background flush-plan processing.
  * Flush-plan replay continues asynchronously and completes reliably after compaction.

* **Tests**
  * Added coverage verifying prompt compaction completion, successful background processing, file draining, and workspace cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->