### PR TITLE
fix(extraction): salvage valid items from mixed-invalid model output

### DIFF
--- a/.changeset/salvage-mixed-extraction-results.md
+++ b/.changeset/salvage-mixed-extraction-results.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Preserve valid extraction items when a gateway model returns mixed-validity result arrays while retaining retries for wholly invalid output.

--- a/packages/remnic-core/src/extraction-prompt-safety.test.ts
+++ b/packages/remnic-core/src/extraction-prompt-safety.test.ts
@@ -333,3 +333,59 @@ test("extraction schema permits empty optional question output", () => {
   assert.deepEqual(parsed.data?.questions, []);
   assert.match(ExtractionResultSchema.shape.questions.description ?? "", /zero to three/i);
 });
+
+test("extraction schema salvages valid items from mixed-validity model arrays", () => {
+  const parsed = ExtractionResultSchema.parse({
+    facts: [
+      {
+        category: "fact",
+        content: "Keep this valid memory.",
+        confidence: 0.95,
+        tags: ["salvage"],
+      },
+      {
+        category: "procedure",
+        content: "Malformed one-step procedure.",
+        confidence: 0.8,
+        tags: ["salvage"],
+        procedureSteps: [{ order: 1, intent: "Only one step" }],
+      },
+      {
+        category: "invented_category",
+        content: "Invalid enum value.",
+        confidence: 0.7,
+        tags: ["salvage"],
+      },
+    ],
+    profileUpdates: ["Keep this profile update.", { invalid: true }],
+    entities: [
+      { name: "qmd", type: "tool", facts: ["Valid entity fact."] },
+      { name: "invalid", type: "skill", facts: ["Invalid entity type."] },
+    ],
+    questions: [
+      { question: "Valid question?", context: "Schema fixture", priority: 0.5 },
+      { question: "Invalid priority", context: "Schema fixture", priority: 9 },
+    ],
+    relationships: [
+      { source: "remnic", target: "qmd", label: "uses" },
+      { source: "missing-fields" },
+    ],
+  });
+
+  assert.deepEqual(parsed.facts.map((fact) => fact.content), ["Keep this valid memory."]);
+  assert.deepEqual(parsed.profileUpdates, ["Keep this profile update."]);
+  assert.deepEqual(parsed.entities.map((entity) => entity.name), ["qmd"]);
+  assert.deepEqual(parsed.questions.map((question) => question.question), ["Valid question?"]);
+  assert.deepEqual(parsed.relationships?.map((relationship) => relationship.label), ["uses"]);
+});
+
+test("extraction schema rejects wholly-invalid non-empty arrays for retry", () => {
+  const parsed = ExtractionResultSchema.safeParse({
+    facts: [{ category: "invented_category", content: "Invalid.", confidence: 0.7, tags: [] }],
+    profileUpdates: [],
+    entities: [],
+    questions: [],
+  });
+
+  assert.equal(parsed.success, false);
+});

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -253,26 +253,52 @@ export const ExtractedRelationshipSchema = z.object({
     .describe("Optional proactive follow-up question that surfaced this relationship."),
 });
 
+function salvageArrayItems<T>(raw: unknown, schema: z.ZodType<T>): unknown {
+  if (!Array.isArray(raw)) return [];
+  const salvaged: T[] = [];
+  for (const item of raw) {
+    const parsed = schema.safeParse(item);
+    if (parsed.success) salvaged.push(parsed.data);
+  }
+  // Keep a wholly-invalid non-empty array invalid so callers can retry rather
+  // than silently accepting an empty extraction. Mixed batches retain the
+  // valid items instead of discarding the entire model response.
+  return raw.length > 0 && salvaged.length === 0 ? raw : salvaged;
+}
+
+function salvageStringItems(raw: unknown): unknown {
+  if (!Array.isArray(raw)) return [];
+  const salvaged = raw.filter((item): item is string => typeof item === "string");
+  return raw.length > 0 && salvaged.length === 0 ? raw : salvaged;
+}
+
 export const ProactiveExtractionResultSchema = z.object({
   facts: z
-    .array(ExtractedFactSchema)
+    .preprocess(
+      (raw) => salvageArrayItems(raw, ExtractedFactSchema),
+      z.array(ExtractedFactSchema),
+    )
     .describe(
       "Additional high-confidence memories recovered only after answering proactive follow-up questions from the same buffered conversation.",
     ),
   profileUpdates: z
-    .array(z.string())
+    .preprocess(salvageStringItems, z.array(z.string()))
     .describe(
       "Additional profile updates directly supported by the buffered conversation. Omit anything speculative.",
     ),
   entities: z
-    .array(EntityMentionSchema)
+    .preprocess(
+      (raw) => salvageArrayItems(raw, EntityMentionSchema),
+      z.array(EntityMentionSchema),
+    )
     .describe(
       "Additional entities or entity facts surfaced by the proactive follow-up pass.",
     ),
   relationships: z
-    .array(ExtractedRelationshipSchema)
-    .optional()
-    .nullable()
+    .preprocess(
+      (raw) => raw == null ? raw : salvageArrayItems(raw, ExtractedRelationshipSchema),
+      z.array(ExtractedRelationshipSchema).optional().nullable(),
+    )
     .describe(
       "Additional relationships surfaced by the proactive follow-up pass.",
     ),
@@ -280,22 +306,31 @@ export const ProactiveExtractionResultSchema = z.object({
 
 export const ExtractionResultSchema = z.object({
   facts: z
-    .array(ExtractedFactSchema)
+    .preprocess(
+      (raw) => salvageArrayItems(raw, ExtractedFactSchema),
+      z.array(ExtractedFactSchema),
+    )
     .describe(
       "Extracted memories from the conversation. Include facts, preferences, corrections, and decisions. Only extract genuinely new, durable information — skip transient task state.",
     ),
   profileUpdates: z
-    .array(z.string())
+    .preprocess(salvageStringItems, z.array(z.string()))
     .describe(
       "Updates to the user's behavioral profile. Each string is a standalone statement about the user's preferences, habits, or personality. Only include genuinely new insights.",
     ),
   entities: z
-    .array(EntityMentionSchema)
+    .preprocess(
+      (raw) => salvageArrayItems(raw, EntityMentionSchema),
+      z.array(EntityMentionSchema),
+    )
     .describe(
       "Entities mentioned in the conversation with new facts about them.",
     ),
   questions: z
-    .array(ExtractedQuestionSchema)
+    .preprocess(
+      (raw) => salvageArrayItems(raw, ExtractedQuestionSchema),
+      z.array(ExtractedQuestionSchema),
+    )
     .describe(
       "Zero to three source-grounded questions useful in future sessions. Return an empty array when the conversation supports none.",
     ),
@@ -312,9 +347,10 @@ export const ExtractionResultSchema = z.object({
     .nullable()
     .describe("A six-to-eight word title for this conversation segment."),
   relationships: z
-    .array(ExtractedRelationshipSchema)
-    .optional()
-    .nullable()
+    .preprocess(
+      (raw) => raw == null ? raw : salvageArrayItems(raw, ExtractedRelationshipSchema),
+      z.array(ExtractedRelationshipSchema).optional().nullable(),
+    )
     .describe(
       "Relationships between entities discovered in this conversation. Max 5 per extraction. Format: {source, target, label}.",
     ),


### PR DESCRIPTION
## Summary

- isolate schema failures to malformed items in mixed-validity extraction arrays
- retain valid facts, profile updates, entities, questions, and relationships from the same model response
- keep wholly-invalid non-empty arrays invalid so bounded retries still run instead of silently accepting an empty extraction
- preserve strict consolidation schemas

Fixes #2455

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [x] `node scripts/pnpm.mjs --filter @remnic/core run check-types`
- [x] Targeted extraction schema tests (2 passed)
- [x] Added tests for mixed-validity salvage and wholly-invalid retry behavior
- [x] `git diff --check`
- [ ] Full `npm test` (targeted schema coverage used for this narrow change)
- [ ] `npm run review:cursor` (Cursor CLI unavailable in this environment)

## Changelog

- [x] Changeset added for `@remnic/core` patch release

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [x] Invalid user/model input remains rejected when no valid item can be recovered

## Notes for reviewers

The strict item schemas are unchanged. The preprocessors only change failure isolation:

- mixed valid/invalid arrays retain independently valid items;
- wholly-invalid non-empty arrays are passed through unchanged and fail normal Zod validation;
- empty arrays retain existing behavior.

This prevents one malformed enrichment from reducing an otherwise useful gateway extraction to `fallback_no_parsed_output` without weakening the retry path.

## PR workflow

- [x] PR scope is narrow
- [x] Synced with latest `main` before implementation
- [x] Batched review fixes by subsystem instead of micro-pushing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved valid extraction results when gateway responses contain a mix of valid and invalid entries.
  - Discarded only invalid items across facts, profile updates, entities, questions, and relationships.
  - Continued retry handling for responses containing no valid items.
  - Applied consistent handling across standard and proactive extraction results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->