### PR TITLE
fix(qmd): kill subprocess descendants on timeout and abort

### DIFF
--- a/.changeset/kill-qmd-process-groups.md
+++ b/.changeset/kill-qmd-process-groups.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Terminate QMD subprocess process groups on timeout or abort so model and embedding descendants cannot remain orphaned.

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -15,6 +16,57 @@ import {
   QmdClient,
   shouldAutoUpgradeQmd,
 } from "./qmd.js";
+
+test("QMD subprocess timeout kills launcher descendants", {
+  skip: process.platform === "win32",
+}, async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-process-group-"));
+  const launcherPath = path.join(dir, "fake-qmd");
+  const grandchildPidPath = path.join(dir, "grandchild.pid");
+  try {
+    await writeFile(
+      launcherPath,
+      `#!${process.execPath}\n` +
+        `const { spawn } = require("node:child_process");\n` +
+        `const fs = require("node:fs");\n` +
+        `const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });\n` +
+        `fs.writeFileSync(process.argv[2], String(child.pid));\n` +
+        `setInterval(() => {}, 1000);\n`,
+      "utf8",
+    );
+    await chmod(launcherPath, 0o755);
+
+    const client = new QmdClient("process-group-test", 1, { qmdPath: launcherPath });
+    const internals = client as unknown as {
+      runQmdCommand: (
+        args: string[],
+        timeoutMs: number,
+      ) => Promise<{ stdout: string; stderr: string }>;
+    };
+
+    await assert.rejects(
+      internals.runQmdCommand([grandchildPidPath], 150),
+      /timed out after 150ms/,
+    );
+    const grandchildPid = Number.parseInt(await readFile(grandchildPidPath, "utf8"), 10);
+    assert.ok(Number.isInteger(grandchildPid) && grandchildPid > 0);
+
+    let alive = true;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      try {
+        const stat = await readFile(`/proc/${grandchildPid}/stat`, "utf8");
+        alive = stat.split(" ")[2] !== "Z";
+      } catch {
+        alive = false;
+      }
+      if (!alive) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(alive, false, "QMD timeout must not leave its grandchild running");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
 test("parseQmdVersion extracts semantic version from qmd output", () => {
   assert.deepEqual(parseQmdVersion("qmd 2.5.3 (abcdef)"), [2, 5, 3]);

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -562,6 +562,9 @@ function runCommandWithTimeout(
     const child = launchProcess(command, args, {
       env: mergeEnv({ NO_COLOR: "1", ...options.env }),
       stdio: ["ignore", "pipe", "pipe"],
+      // QMD may launch embedding/model workers. Give the command its own
+      // process group so timeout/abort cleanup can terminate descendants too.
+      detached: process.platform !== "win32",
     });
     if (!child.stdout || !child.stderr) {
       reject(new Error(`${label} failed to open stdio pipes`));
@@ -575,7 +578,7 @@ function runCommandWithTimeout(
     const timer = setTimeout(() => {
       settled = true;
       cleanup();
-      child.kill("SIGKILL");
+      killQmdCommandTree(child, "SIGKILL");
       // Flag the deadline breach so classifyProbeFailure can tell a genuine
       // timeout from a non-zero-exit error whose message merely embeds stderr.
       reject(
@@ -589,7 +592,7 @@ function runCommandWithTimeout(
       settled = true;
       clearTimeout(timer);
       cleanup();
-      child.kill("SIGKILL");
+      killQmdCommandTree(child, "SIGKILL");
       reject(abortError(`${label} aborted`));
     };
     const cleanup = () => {
@@ -622,6 +625,25 @@ function runCommandWithTimeout(
       }
     });
   });
+}
+
+function killQmdCommandTree(
+  child: CommandChildProcess,
+  signal: NodeJS.Signals,
+): void {
+  if (process.platform !== "win32" && typeof child.pid === "number") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // The group may already be gone or unavailable; fall back to the child.
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // Ignore exit races during timeout/abort cleanup.
+  }
 }
 
 function runProcessCommand(


### PR DESCRIPTION
## Summary

- launch bounded QMD subprocesses in their own POSIX process group
- terminate the full process group on timeout or abort, with child-only fallback
- prevent model and embedding descendants from remaining orphaned
- leave the long-lived QMD MCP daemon lifecycle unchanged

Fixes #2456

## Validation

- [x] Integration regression test: fake QMD launcher spawns a grandchild; timeout removes both
- [x] `node scripts/pnpm.mjs --filter @remnic/core run check-types`
- [x] `git diff --check`
- [x] Changeset added for `@remnic/core`

## Risk assessment

The group signal is used only for QMD commands launched with `detached: true` on POSIX. Windows and group-signal failures retain the existing direct-child fallback.
