### PR TITLE
fix(openclaw): bypass LCM for flush-plan recovery imports

### DIFF
--- a/.changeset/skip-flush-plan-lcm.md
+++ b/.changeset/skip-flush-plan-lcm.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Skip LCM observation for OpenClaw flush-plan recovery imports while preserving observation for ordinary bulk imports.

--- a/packages/remnic-core/src/orchestration/turn-ingestion.ts
+++ b/packages/remnic-core/src/orchestration/turn-ingestion.ts
@@ -456,7 +456,12 @@ export class TurnIngestionCoordinator {
       };
     }
 
-    if (this.deps.lcmEngine?.enabled) {
+    const isOpenClawFlushPlanImport = sessionTurns.some((turn) => {
+      const provenance = turn.importProvenance;
+      return provenance?.sourceLabel === "OpenClaw flush plan" ||
+        provenance?.sourceId?.includes(":flush-plan") === true;
+    });
+    if (this.deps.lcmEngine?.enabled && !isOpenClawFlushPlanImport) {
       await this.deps.lcmEngine.observeMessages(
         sessionKey,
         sessionTurns.map((turn) => ({

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -751,6 +751,70 @@ test("ingestBulkImportBatch reports post-persist metadata failures separately", 
   assert.equal(result.postPersistMetadataFailureCount, 1);
 });
 
+test("ingestBulkImportBatch skips LCM observation for OpenClaw flush-plan imports", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  orchestrator.config = parseConfig({});
+  orchestrator.extractionQueueCoordinator = new ExtractionQueueCoordinator();
+  let observed = 0;
+  orchestrator.lcmEngine = {
+    enabled: true,
+    async observeMessages() {
+      observed += 1;
+    },
+  };
+  orchestrator.runExtraction = async () => ({
+    status: "completed",
+    persistedCount: 1,
+    durableOutputCount: 1,
+  });
+
+  await orchestrator.ingestBulkImportBatch([
+    {
+      role: "user",
+      timestamp: "2026-08-17T00:00:00.000Z",
+      content: "Recovered compaction memory.",
+      importProvenance: {
+        sourceLabel: "OpenClaw flush plan",
+        sourceId: "openclaw-remnic:flush-plan:1/2",
+      },
+    },
+  ]);
+
+  assert.equal(observed, 0);
+});
+
+test("ingestBulkImportBatch still observes ordinary imports with LCM", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  orchestrator.config = parseConfig({});
+  orchestrator.extractionQueueCoordinator = new ExtractionQueueCoordinator();
+  let observed = 0;
+  orchestrator.lcmEngine = {
+    enabled: true,
+    async observeMessages() {
+      observed += 1;
+    },
+  };
+  orchestrator.runExtraction = async () => ({
+    status: "completed",
+    persistedCount: 1,
+    durableOutputCount: 1,
+  });
+
+  await orchestrator.ingestBulkImportBatch([
+    {
+      role: "user",
+      timestamp: "2026-08-17T00:00:00.000Z",
+      content: "Imported durable memory.",
+      importProvenance: {
+        sourceLabel: "Chat export",
+        sourceId: "chat-export:1",
+      },
+    },
+  ]);
+
+  assert.equal(observed, 1);
+});
+
 test("ingestBulkImportBatch can disable source-valid-at replay context", async () => {
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   orchestrator.config = parseConfig({});


### PR DESCRIPTION
## Summary

- identify OpenClaw flush-plan recovery batches using their existing trusted provenance
- skip LCM observation for those already-compacted recovery turns
- preserve normal LCM observation for every ordinary bulk import
- leave extraction and persistence behavior unchanged

Fixes #2457

## Validation

- [x] Flush-plan import skips LCM observation
- [x] Ordinary import still invokes LCM observation
- [x] `node scripts/pnpm.mjs --filter @remnic/core run check-types`
- [x] `git diff --check`
- [x] Changeset added for `@remnic/core`

## Risk assessment

The bypass is narrowly gated by `sourceLabel === "OpenClaw flush plan"` or the established `:flush-plan` source identifier. Other imports retain existing behavior.
