### PR TITLE
fix(openclaw): replay flush-plan chunks in isolated serial batches

### DIFF
--- a/.changeset/serialize-flush-plan-replay.md
+++ b/.changeset/serialize-flush-plan-replay.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Replay OpenClaw flush-plan chunks serially so each extraction uses an isolated import session.

--- a/src/openclaw-flush-plan-lifecycle.ts
+++ b/src/openclaw-flush-plan-lifecycle.ts
@@ -789,25 +789,51 @@ async function ingestFlushPlanImportTurns(params: {
   importTurns: ImportTurn[];
   deadlineMs?: number;
 }): Promise<void | OpenClawFlushPlanIngestResult> {
-  try {
-    return await params.ingestor.ingestBulkImportBatch(params.importTurns, {
-      ...(params.deadlineMs === undefined
-        ? {}
-        : { deadlineMs: params.deadlineMs }),
-      failOnExtractionFailure: true,
-      includeSourceValidAtContext: false,
-    });
-  } catch (error) {
-    const partialResult = partialIngestResultFromError(error);
-    if (
-      partialResult &&
-      typeof partialResult.processedTurnCount === "number" &&
-      partialResult.processedTurnCount > 0
-    ) {
-      return partialResult;
+  const aggregate: Required<OpenClawFlushPlanIngestResult> = {
+    attemptedTurnCount: 0,
+    extractionCount: 0,
+    persistedCount: 0,
+    durableOutputCount: 0,
+    skippedCount: 0,
+    failedCount: 0,
+    postPersistMetadataFailureCount: 0,
+    processedTurnCount: 0,
+  };
+  const addResult = (result: void | OpenClawFlushPlanIngestResult): void => {
+    if (!result) return;
+    for (const key of Object.keys(aggregate) as Array<keyof typeof aggregate>) {
+      const value = result[key];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        aggregate[key] += value;
+      }
     }
-    throw error;
+  };
+
+  for (const importTurn of params.importTurns) {
+    try {
+      const result = await params.ingestor.ingestBulkImportBatch([importTurn], {
+        ...(params.deadlineMs === undefined
+          ? {}
+          : { deadlineMs: params.deadlineMs }),
+        failOnExtractionFailure: true,
+        includeSourceValidAtContext: false,
+      });
+      addResult(result);
+      if (isFailedIngestResult(result)) return aggregate;
+      if (!result || typeof result.processedTurnCount !== "number") {
+        aggregate.processedTurnCount += 1;
+      }
+    } catch (error) {
+      const partialResult = partialIngestResultFromError(error);
+      addResult(partialResult);
+      if (aggregate.processedTurnCount > 0) {
+        aggregate.failedCount = Math.max(1, aggregate.failedCount);
+        return aggregate;
+      }
+      throw error;
+    }
   }
+  return aggregate;
 }
 
 function hasPostPersistMetadataFailure(

--- a/tests/openclaw-flush-plan-lifecycle.test.ts
+++ b/tests/openclaw-flush-plan-lifecycle.test.ts
@@ -306,6 +306,7 @@ test("processOpenClawFlushPlanFile chunks oversized snapshots before clearing", 
     ].join("\n");
     await writeFlushPlan(flushPlanPath, content);
     const received: ImportTurn[] = [];
+    const batchSizes: number[] = [];
 
     const result = await processOpenClawFlushPlanFile({
       enabled: true,
@@ -315,6 +316,7 @@ test("processOpenClawFlushPlanFile chunks oversized snapshots before clearing", 
       now: () => new Date("2026-06-24T00:00:00.000Z"),
       ingestor: {
         async ingestBulkImportBatch(turns) {
+          batchSizes.push(turns.length);
           received.push(...turns);
         },
       },
@@ -323,6 +325,7 @@ test("processOpenClawFlushPlanFile chunks oversized snapshots before clearing", 
     assert.equal(result.status, "processed");
     assert.equal(await readFile(flushPlanPath, "utf8"), "");
     assert.ok(received.length > 1);
+    assert.deepEqual(batchSizes, Array(received.length).fill(1));
     assert.ok(received.every((turn) => turn.content.length <= maxTurnChars));
     assert.equal(
       new Set(received.map((turn) => turn.timestamp)).size,


### PR DESCRIPTION
## Summary

- replay flush-plan chunks serially, one turn per bulk-import batch
- prevent chunked recovery material from being recombined into one shared extraction session
- aggregate ingest counters across successful chunks
- stop on the first failed chunk and preserve only the unprocessed tail

Fixes #2459

## Validation

- [x] Oversized-plan regression test verifies every ingest batch contains exactly one turn
- [x] Existing chunking and cleanup behavior remains green
- [x] `node scripts/pnpm.mjs --filter @remnic/plugin-openclaw run check-types`
- [x] `git diff --check`
- [x] Changeset added for `@remnic/plugin-openclaw`

## Risk assessment

Ordering remains serial and existing fingerprint, marker, partial-prefix, deadline, and tail-preservation paths are reused. The change reduces extraction batch size rather than introducing concurrency.
