### PR TITLE
fix(chat): route CLI turns through processChatMessage

### DIFF
--- a/packages/remnic-core/src/chat/chat-cli.test.ts
+++ b/packages/remnic-core/src/chat/chat-cli.test.ts
@@ -15,6 +15,12 @@ import { withTempDir as managedWithTempDir } from "../testing/tmp-dir.js";
 import type { EngramAccessService } from "../access-service.js";
 import { parseConfig } from "../config.js";
 import { runChatCli } from "./chat-cli.js";
+import { processChatMessage } from "./chat-factory.js";
+import {
+  createChatSession,
+  loadChatSession,
+  markPendingPlan,
+} from "./chat-session.js";
 import { DEFAULT_CHAT_CONFIG } from "./chat-config.js";
 
 /** Capture stdout.write for the duration of `fn`. */
@@ -135,5 +141,52 @@ test("CLI: resumes an existing session by id", async () => {
       runChatCli({ service, config: service.configRef!.chat, memoryDir, once: true, input: "again", sessionId }),
     );
     assert.ok(second.includes("[session:"), "resumed run should also print a session id");
+  });
+});
+
+test("CLI --once: pending plan is visible on reload the same way as HTTP (issue #2479)", async () => {
+  await withTempDir(async (memoryDir) => {
+    const service = makeService({
+      memoryDir,
+      configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
+    });
+
+    // CLI side: first turn mints the session.
+    const first = await captureStdout(() =>
+      runChatCli({ service, config: service.configRef!.chat, memoryDir, once: true, input: "hello" }),
+    );
+    const sessionId = /\[session: ([^\]]+)\]/.exec(first)![1]!;
+    // Pending plan minted by an earlier correction-preview turn.
+    await markPendingPlan(memoryDir, sessionId, "plan-cli-2479");
+    await captureStdout(() =>
+      runChatCli({ service, config: service.configRef!.chat, memoryDir, once: true, input: "anything else?", sessionId }),
+    );
+    const viaCli = await loadChatSession(memoryDir, sessionId);
+    // HTTP side: identical scenario through the shared processor.
+    const httpSession = await createChatSession(memoryDir, {});
+    await processChatMessage({
+      service,
+      config: service.configRef!.chat,
+      memoryDir,
+      message: "hello",
+      chatSessionId: httpSession.id,
+    });
+    await markPendingPlan(memoryDir, httpSession.id, "plan-http-2479");
+    await processChatMessage({
+      service,
+      config: service.configRef!.chat,
+      memoryDir,
+      message: "anything else?",
+      chatSessionId: httpSession.id,
+    });
+    const viaHttp = await loadChatSession(memoryDir, httpSession.id);
+
+    assert.equal(viaCli?.pendingPlanId, "plan-cli-2479", "CLI turn must leave the pending plan visible on reload");
+    assert.equal(viaHttp?.pendingPlanId, "plan-http-2479", "HTTP turn must leave the pending plan visible on reload");
+    // Transcript shape parity: both surfaces append the same role sequence.
+    assert.deepEqual(
+      viaCli!.transcript.map((e) => e.role),
+      viaHttp!.transcript.map((e) => e.role),
+    );
   });
 });

--- a/packages/remnic-core/src/chat/chat-cli.ts
+++ b/packages/remnic-core/src/chat/chat-cli.ts
@@ -6,28 +6,25 @@
  * and `--once` / non-TTY mode for scripting/tests
  * (`echo "question" | remnic chat --once`).
  *
+ * Every turn routes through the shared `processChatMessage` factory
+ * (issue #2479) so session lifecycle, transcript persistence, and
+ * pending-plan/promotion markers behave identically to the HTTP/MCP
+ * surfaces.
+ *
  * This module is imported by cli.ts with a single thin registration line —
  * the god-file ratchet (#1520) tracks cli.ts LOC.
  */
 
-import readline from "node:readline";
 import { createInterface } from "node:readline";
-import { randomUUID } from "node:crypto";
 
 import type { EngramAccessService } from "../access-service.js";
-import type { PluginConfig } from "../types.js";
-import type { ChatConfig } from "./chat-types.js";
-import type { ChatTurnResult } from "./chat-types.js";
-import { ChatEngine } from "./chat-engine.js";
-import { createProductionChatLlmAdapter } from "./chat-llm.js";
-import { createChatExecutor } from "./chat-executor.js";
+import type { ChatConfig, ChatTurnResult } from "./chat-types.js";
+import { processChatMessage } from "./chat-factory.js";
 import {
   createChatSession,
   loadChatSession,
-  appendTranscriptEntry,
   sessionBelongsToPrincipal,
 } from "./chat-session.js";
-import { isConfirmationMessage } from "./chat-engine.js";
 
 /**
  * Read all of stdin to a UTF-8 string (non-TTY / scripting mode).
@@ -78,16 +75,10 @@ export async function runChatCli(opts: ChatCliOptions): Promise<void> {
     return;
   }
 
-  const adapter = createProductionChatLlmAdapter(llm as {
-    chatCompletion(
-      messages: Array<{ role: string; content: string }>,
-      options?: { model?: string; signal?: AbortSignal },
-    ): Promise<{ content: string } | null>;
-  });
-
-  // Load or create session FIRST so the executor inherits the session's
-  // stored namespace/sessionKey scope — a resumed session created via MCP
-  // must not lose its scope binding (codex review, Thread 19).
+  // Resolve the session up front so the banner and --once output print a
+  // stable session id.  Each turn then routes through processChatMessage,
+  // which reloads the session from disk — persisted state markers
+  // (pending plan/promotion) stay authoritative across turns.
   let session;
   if (opts.sessionId) {
     session = await loadChatSession(opts.memoryDir, opts.sessionId);
@@ -107,21 +98,15 @@ export async function runChatCli(opts: ChatCliOptions): Promise<void> {
     });
   }
 
-  const executor = createChatExecutor({
-    service: opts.service,
-    principal: opts.principal,
-    ...(session.namespace ? { namespace: session.namespace } : {}),
-    ...(session.sessionKey ? { sessionKey: session.sessionKey } : {}),
-  });
-
-  const engine = new ChatEngine({
-    llm: adapter,
-    executor,
-    maxToolCallsPerTurn: config.maxToolCallsPerTurn,
-    ...(config.model ? { model: config.model } : {}),
-    correctionAvailable: false,
-    scopeInspectAvailable: false,
-  });
+  const processTurn = (message: string): Promise<ChatTurnResult> =>
+    processChatMessage({
+      service: opts.service,
+      config,
+      memoryDir: opts.memoryDir,
+      message,
+      chatSessionId: session.id,
+      principal: opts.principal,
+    });
 
   // ── Non-TTY / --once mode ───────────────────────────────────────────
   if (opts.once) {
@@ -131,17 +116,7 @@ export async function runChatCli(opts: ChatCliOptions): Promise<void> {
       process.stdout.write("[error] No input provided.\n");
       return;
     }
-    const userEntry = await appendTranscriptEntry(opts.memoryDir, session.id, {
-      role: "user",
-      content: message,
-    });
-    session.transcript.push(userEntry);
-    const result = await engine.processMessage(message, session);
-    const assistantEntry = await appendTranscriptEntry(opts.memoryDir, session.id, {
-      role: "assistant",
-      content: result.reply,
-    });
-    session.transcript.push(assistantEntry);
+    const result = await processTurn(message);
     process.stdout.write(result.reply + "\n");
     process.stdout.write(`[session: ${session.id}]\n`);
     return;
@@ -173,18 +148,7 @@ export async function runChatCli(opts: ChatCliOptions): Promise<void> {
     // Serialize turns: a second line waits for the first to finish so
     // transcript updates and engine state don't race on the same session.
     inFlight = inFlight.then(async () => {
-    const userEntry = await appendTranscriptEntry(opts.memoryDir, session!.id, {
-      role: "user",
-      content: message,
-    });
-    session!.transcript.push(userEntry);
-
-    const result = await engine.processMessage(message, session!);
-    const assistantEntry = await appendTranscriptEntry(opts.memoryDir, session!.id, {
-      role: "assistant",
-      content: result.reply,
-    });
-    session!.transcript.push(assistantEntry);
+    const result = await processTurn(message);
 
     console.log(`\nassistant> ${result.reply}\n`);
     if (result.pendingPlan) {


### PR DESCRIPTION
## Summary
- Route chat CLI --once and interactive turns through processChatMessage.
- Pending plan / promotion now persist the same way as HTTP/MCP.

Fixes #2479