### PR TITLE
refactor(meetings): use ActivitySnapshot in fusion

### DIFF
--- a/packages/remnic-core/src/meetings/build.test.ts
+++ b/packages/remnic-core/src/meetings/build.test.ts
@@ -5,12 +5,12 @@ import { MeetingsBuilder, type MeetingDayData, type MeetingsDayBuildSummary, typ
 import { DEFAULT_MEETINGS_CONFIG } from "./config.js";
 import { MeetingRecordStore, type MeetingRecordFileIo } from "./store.js";
 import type {
-  MeetingActivitySnapshot,
   MeetingsConfig,
   MeetingAppSpan,
   MeetingAudioWindow,
   MeetingRecord,
 } from "./types.js";
+import type { ActivitySnapshot } from "../activity/types.js";
 import type { FusionConversationInput, FusionSegmentInput } from "../wearables/fusion/types.js";
 import type { MeetingMemoryGenerator, MeetingMemoryOutcome } from "./memory-generator.js";
 
@@ -174,9 +174,25 @@ test("degradation — audio only yields a record with no screen-context section"
 });
 
 test("full — app+audio with activity fuses transcript and screen context", async () => {
-  const activity: MeetingActivitySnapshot[] = [
-    { tsUtc: "2026-03-10T14:05:00.000Z", app: "Preview", title: "Q3-roadmap.pdf" },
-    { tsUtc: "2026-03-10T14:30:00.000Z", app: "Zoom", text: "meeting chat" },
+  const activity: ActivitySnapshot[] = [
+    {
+      machine: "workstation",
+      capturedAtUtc: "2026-03-10T14:05:00.000Z",
+      app: "Preview",
+      windowTitle: "Q3-roadmap.pdf",
+      text: "",
+      textSource: "ax",
+      contentHash: "snap-1",
+    },
+    {
+      machine: "workstation",
+      capturedAtUtc: "2026-03-10T14:30:00.000Z",
+      app: "Zoom",
+      windowTitle: "",
+      text: "meeting chat",
+      textSource: "ax",
+      contentHash: "snap-2",
+    },
   ];
   const { builder: b, store } = builder(
     {

--- a/packages/remnic-core/src/meetings/build.ts
+++ b/packages/remnic-core/src/meetings/build.ts
@@ -22,10 +22,10 @@ import type {
   MeetingMemoryOutcome,
   MeetingsDayFactGenResult,
 } from "./memory-generator.js";
+import type { ActivitySnapshot } from "../activity/types.js";
 import type { FusionConversationInput } from "../wearables/fusion/types.js";
 import type {
   DetectedMeeting,
-  MeetingActivitySnapshot,
   MeetingRecord,
   MeetingsConfig,
   MeetingsDetectionInput,
@@ -38,7 +38,7 @@ export interface MeetingDayData {
   /** Fusion conversation inputs across all wearable sources for the day. */
   conversations: FusionConversationInput[];
   /** Screen-activity snapshots for the day. */
-  activity?: MeetingActivitySnapshot[];
+  activity?: ActivitySnapshot[];
 }
 
 /** Supplies a day's signals. Backed by fixtures in tests; by the activity +

--- a/packages/remnic-core/src/meetings/day-source.test.ts
+++ b/packages/remnic-core/src/meetings/day-source.test.ts
@@ -127,7 +127,9 @@ test("loadDayData assembles detection + activity for the requested day, keyed to
   assert.equal(data.detection.appSpans[0]?.app, "Zoom");
   assert.deepEqual(data.detection.audioWindows, [], "no wearable transcripts → no audio windows");
   assert.equal(data.activity?.length, 2);
-  assert.equal(data.activity?.[0]?.title, "Standup");
+  // Activity is the raw ActivitySnapshot list now — no rename mapper in between.
+  assert.equal(data.activity?.[0]?.windowTitle, "Standup");
+  assert.equal(data.activity?.[0]?.capturedAtUtc, "2026-03-10T14:00:00.000Z");
   assert.equal(data.conversations.length, 0);
 });
 

--- a/packages/remnic-core/src/meetings/day-source.ts
+++ b/packages/remnic-core/src/meetings/day-source.ts
@@ -28,7 +28,6 @@ import type { FusionConversationInput, FusionSegmentInput } from "../wearables/f
 import type { MeetingDayData, MeetingsDaySource } from "./build.js";
 import { MeetingsInputError } from "./errors.js";
 import type {
-  MeetingActivitySnapshot,
   MeetingAppSpan,
   MeetingAudioWindow,
   MeetingsConfig,
@@ -95,15 +94,6 @@ export function storageWearableDayReader(store: WearableDayTranscriptStore): Mee
       return bodies;
     },
   };
-}
-
-/** Map an activity snapshot to the redaction-safe screen snapshot fusion sees. */
-function toMeetingActivitySnapshot(snapshot: ActivitySnapshot): MeetingActivitySnapshot {
-  const out: MeetingActivitySnapshot = { tsUtc: snapshot.capturedAtUtc, app: snapshot.app };
-  if (snapshot.windowTitle.length > 0) out.title = snapshot.windowTitle;
-  if (snapshot.browserUrl !== undefined && snapshot.browserUrl.length > 0) out.url = snapshot.browserUrl;
-  if (snapshot.text.length > 0) out.text = snapshot.text;
-  return out;
 }
 
 /**
@@ -341,12 +331,11 @@ export class ActivityWearablesMeetingsDaySource implements MeetingsDaySource {
     const snapshots = this.deps.activity
       ? await this.deps.activity.listSnapshotsForDay(null, startUtc, endUtc)
       : [];
-    const activity = snapshots.map(toMeetingActivitySnapshot);
     const appSpans = deriveAppSpans(snapshots, this.deps.config.appPatterns);
     const bodies = await this.deps.wearables.readDayBodies(date);
     const tzBySource = new Map(bodies.map((b) => [b.source, b.timezone ?? ""] as const));
     const conversations = shiftFusionInputsToUtc(reconstructFusionInputs(date, bodies), tzBySource);
     const audioWindows = buildAudioWindows(conversations);
-    return { detection: { date, appSpans, audioWindows }, conversations, activity };
+    return { detection: { date, appSpans, audioWindows }, conversations, activity: snapshots };
   }
 }

--- a/packages/remnic-core/src/meetings/fuse.test.ts
+++ b/packages/remnic-core/src/meetings/fuse.test.ts
@@ -1,13 +1,12 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import { DEFAULT_MEETINGS_CONFIG } from "./config.js";
 import { fuseMeeting } from "./fuse.js";
-import type {
-  DetectedMeeting,
-  MeetingActivitySnapshot,
-  MeetingsConfig,
-} from "./types.js";
+import type { ActivitySnapshot } from "../activity/types.js";
+import type { DetectedMeeting, MeetingsConfig } from "./types.js";
 import type { FusionConversationInput, FusionSegmentInput } from "../wearables/fusion/types.js";
 
 const DATE = "2026-03-10";
@@ -51,8 +50,17 @@ function conv(
   return { source, conversationId: id, startIso, endIso, segments };
 }
 
-function snap(overrides: Partial<MeetingActivitySnapshot> & { tsUtc: string; app: string }): MeetingActivitySnapshot {
-  return { ...overrides };
+function snap(
+  overrides: Partial<ActivitySnapshot> & { capturedAtUtc: string; app: string },
+): ActivitySnapshot {
+  return {
+    machine: "workstation",
+    windowTitle: "",
+    text: "",
+    textSource: "ax",
+    contentHash: "snap-hash",
+    ...overrides,
+  };
 }
 
 test("fusion prefers the higher-trust source in overlap regions and records corroboratedBy without duplicating text", () => {
@@ -97,10 +105,10 @@ test("screen context includes a >=20s dwell and omits a 5s alt-tab; meeting-app 
         ]),
       ],
       activity: [
-        snap({ tsUtc: "2026-03-10T14:05:00.000Z", app: "Preview", title: "Q3-roadmap.pdf", text: "Q3 roadmap draft" }),
-        snap({ tsUtc: "2026-03-10T14:05:25.000Z", app: "Notes", title: "scratch" }), // Preview dwell 25s → include; Notes starts
-        snap({ tsUtc: "2026-03-10T14:05:30.000Z", app: "Preview", title: "Q3-roadmap.pdf" }), // Notes dwell 5s → exclude
-        snap({ tsUtc: "2026-03-10T14:10:00.000Z", app: "Zoom", text: "Jane: agenda item one" }), // meeting-app → excerpt
+        snap({ capturedAtUtc: "2026-03-10T14:05:00.000Z", app: "Preview", windowTitle: "Q3-roadmap.pdf", text: "Q3 roadmap draft" }),
+        snap({ capturedAtUtc: "2026-03-10T14:05:25.000Z", app: "Notes", windowTitle: "scratch" }), // Preview dwell 25s → include; Notes starts
+        snap({ capturedAtUtc: "2026-03-10T14:05:30.000Z", app: "Preview", windowTitle: "Q3-roadmap.pdf" }), // Notes dwell 5s → exclude
+        snap({ capturedAtUtc: "2026-03-10T14:10:00.000Z", app: "Zoom", text: "Jane: agenda item one" }), // meeting-app → excerpt
       ],
     },
     config(),
@@ -122,9 +130,9 @@ test("context excerpts respect maxContextChars", () => {
       meeting: meeting(),
       conversations: [],
       activity: [
-        snap({ tsUtc: "2026-03-10T14:01:00.000Z", app: "Zoom", text: "aaaa" }),
-        snap({ tsUtc: "2026-03-10T14:02:00.000Z", app: "Zoom", text: "bbbb" }),
-        snap({ tsUtc: "2026-03-10T14:03:00.000Z", app: "Zoom", text: "cccc" }),
+        snap({ capturedAtUtc: "2026-03-10T14:01:00.000Z", app: "Zoom", text: "aaaa" }),
+        snap({ capturedAtUtc: "2026-03-10T14:02:00.000Z", app: "Zoom", text: "bbbb" }),
+        snap({ capturedAtUtc: "2026-03-10T14:03:00.000Z", app: "Zoom", text: "cccc" }),
       ],
     },
     config({ maxContextChars: 8 }),
@@ -199,10 +207,51 @@ test("a lone trailing other-app snapshot is not inflated to the meeting end", ()
       ],
       // A single Notes snapshot 1 min before the window end. With no later
       // snapshot, the trailing run must NOT count dwell up to the meeting end.
-      activity: [snap({ tsUtc: "2026-03-10T14:29:00.000Z", app: "Notes", title: "scratch" })],
+      activity: [snap({ capturedAtUtc: "2026-03-10T14:29:00.000Z", app: "Notes", windowTitle: "scratch" })],
     },
     config(),
   );
   assert.equal(fused.snapshotCount, 1);
   assert.deepEqual(fused.screenContext, [], "a lone trailing snapshot has zero observed dwell");
+});
+
+test("fusion reads ActivitySnapshot fields — capturedAtUtc, browserUrl runs, windowTitle fallback", () => {
+  const fused = fuseMeeting(
+    {
+      meeting: meeting(),
+      conversations: [],
+      activity: [
+        snap({ capturedAtUtc: "2026-03-10T14:05:00.000Z", app: "Chrome", browserUrl: "https://github.com/org/repo/pull/1" }),
+        snap({ capturedAtUtc: "2026-03-10T14:06:00.000Z", app: "Chrome", browserUrl: "https://github.com/org/repo/pull/1" }),
+        // Different URL on the same app → a separate dwell run.
+        snap({ capturedAtUtc: "2026-03-10T14:06:30.000Z", app: "Chrome", browserUrl: "https://example.com/doc" }),
+        snap({ capturedAtUtc: "2026-03-10T14:07:00.000Z", app: "Chrome", browserUrl: "https://example.com/doc" }),
+        // Empty browserUrl falls back to the window title for key and label.
+        snap({ capturedAtUtc: "2026-03-10T14:07:30.000Z", app: "Chrome", windowTitle: "Spec v2" }),
+        snap({ capturedAtUtc: "2026-03-10T14:08:00.000Z", app: "Chrome", windowTitle: "Spec v2" }),
+      ],
+    },
+    config(),
+  );
+  assert.equal(fused.snapshotCount, 6);
+  assert.deepEqual(
+    fused.screenContext.map((e) => e.label),
+    [
+      "Chrome: github.com/org/repo/pull/1",
+      "Chrome: example.com/doc",
+      "Chrome: Spec v2",
+    ],
+  );
+  // Run dwell ends at the next different-key snapshot (90s, 60s) or, for the
+  // trailing run, at its own last snapshot (30s).
+  assert.deepEqual(fused.screenContext.map((e) => e.dwellSeconds), [90, 60, 30]);
+});
+
+test("MeetingActivitySnapshot and its rename mapper are gone", () => {
+  const here = import.meta.dirname;
+  for (const file of ["types.ts", "fuse.ts", "day-source.ts", "build.ts"]) {
+    const src = readFileSync(join(here, file), "utf8");
+    assert.ok(!src.includes("MeetingActivitySnapshot"), `${file} must not reference MeetingActivitySnapshot`);
+    assert.ok(!src.includes("toMeetingActivitySnapshot"), `${file} must not reference toMeetingActivitySnapshot`);
+  }
 });

--- a/packages/remnic-core/src/meetings/fuse.ts
+++ b/packages/remnic-core/src/meetings/fuse.ts
@@ -23,9 +23,9 @@ import type {
   FusionConversationInput,
   FusionSegmentInput,
 } from "../wearables/fusion/types.js";
+import type { ActivitySnapshot } from "../activity/types.js";
 import type {
   FusedMeeting,
-  MeetingActivitySnapshot,
   MeetingBuildInput,
   MeetingScreenContextEvent,
   MeetingsConfig,
@@ -119,20 +119,22 @@ function shortenUrl(url: string): string {
   return url.replace(/^[a-z]+:\/\//i, "");
 }
 
-function contextLabel(snap: MeetingActivitySnapshot): string {
-  if (snap.url !== undefined && snap.url.length > 0) return `${snap.app}: ${shortenUrl(snap.url)}`;
-  if (snap.title !== undefined && snap.title.length > 0) return `${snap.app}: ${snap.title}`;
+function contextLabel(snap: ActivitySnapshot): string {
+  if (snap.browserUrl !== undefined && snap.browserUrl.length > 0) {
+    return `${snap.app}: ${shortenUrl(snap.browserUrl)}`;
+  }
+  if (snap.windowTitle.length > 0) return `${snap.app}: ${snap.windowTitle}`;
   return snap.app;
 }
 
 /** True when a snapshot is the meeting app itself (captions/chat/participants),
  *  not other context. Matches the meeting's app or any configured app pattern. */
 function isMeetingAppSnapshot(
-  snap: MeetingActivitySnapshot,
+  snap: ActivitySnapshot,
   meetingApp: string | undefined,
   appPatterns: readonly string[],
 ): boolean {
-  const hay = `${snap.app} ${snap.title ?? ""} ${snap.url ?? ""}`.toLowerCase();
+  const hay = `${snap.app} ${snap.windowTitle} ${snap.browserUrl ?? ""}`.toLowerCase();
   if (meetingApp !== undefined && meetingApp.length > 0 && hay.includes(meetingApp.toLowerCase())) {
     return true;
   }
@@ -159,21 +161,25 @@ interface ScreenContextResult {
  * kept. Meeting-app snapshots never enter the timeline but feed excerpts.
  */
 function buildScreenContext(
-  activity: readonly MeetingActivitySnapshot[],
+  activity: readonly ActivitySnapshot[],
   windowStartMs: number,
   windowEndMs: number,
   meetingApp: string | undefined,
   config: MeetingsConfig,
 ): ScreenContextResult {
   const win = activity
-    .map((snap) => ({ snap, ms: Date.parse(snap.tsUtc) }))
+    .map((snap) => ({ snap, ms: Date.parse(snap.capturedAtUtc) }))
     .filter((entry) => Number.isFinite(entry.ms) && entry.ms >= windowStartMs && entry.ms < windowEndMs)
     .sort((a, b) => a.ms - b.ms || SORT_STR(a.snap.app, b.snap.app));
 
-  const keyOf = (snap: MeetingActivitySnapshot): string =>
+  /** Run key detail: the URL when present, else the window title. */
+  const keyDetail = (snap: ActivitySnapshot): string =>
+    snap.browserUrl !== undefined && snap.browserUrl.length > 0 ? snap.browserUrl : snap.windowTitle;
+
+  const keyOf = (snap: ActivitySnapshot): string =>
     isMeetingAppSnapshot(snap, meetingApp, config.appPatterns)
       ? MEETING_APP_KEY
-      : `${snap.app}\u0000${snap.url ?? snap.title ?? ""}`;
+      : `${snap.app}\u0000${keyDetail(snap)}`;
 
   const events: MeetingScreenContextEvent[] = [];
   const includedText: string[] = [];
@@ -197,7 +203,7 @@ function buildScreenContext(
       // Captions / chat / participant text visible on the meeting app itself.
       for (let i = runStartIdx; i < runEndIdx; i++) {
         const text = win[i]!.snap.text;
-        if (text !== undefined && text.trim().length > 0) includedText.push(text.trim());
+        if (text.trim().length > 0) includedText.push(text.trim());
       }
     } else if (dwellSeconds >= config.contextDwellSeconds) {
       events.push({
@@ -209,7 +215,7 @@ function buildScreenContext(
       });
       for (let i = runStartIdx; i < runEndIdx; i++) {
         const text = win[i]!.snap.text;
-        if (text !== undefined && text.trim().length > 0) includedText.push(text.trim());
+        if (text.trim().length > 0) includedText.push(text.trim());
       }
     }
     runStartIdx = runEndIdx;

--- a/packages/remnic-core/src/meetings/types.ts
+++ b/packages/remnic-core/src/meetings/types.ts
@@ -8,6 +8,7 @@
  * timestamps are UTC ISO-8601; windows are half-open [startUtc, endUtc).
  */
 
+import type { ActivitySnapshot } from "../activity/types.js";
 import type {
   FusedSegment,
   FusedSpeaker,
@@ -81,23 +82,6 @@ export interface MeetingsDetectionConfig {
   mergeGapMinutes: number;
 }
 
-/**
- * One screen-activity snapshot fed into meeting fusion (assembled from the
- * activity store by a later wiring slice; injected directly in tests). Text is
- * already post-redaction — meeting fusion never sees raw capture.
- */
-export interface MeetingActivitySnapshot {
-  /** ISO 8601 UTC instant the snapshot was captured. */
-  tsUtc: string;
-  /** Foreground application label (e.g. "Preview", "Chrome", "Zoom"). */
-  app: string;
-  /** Window title, when known. */
-  title?: string;
-  /** Browser URL, when known. */
-  url?: string;
-  /** Extracted on-screen text excerpt, when known. */
-  text?: string;
-}
 
 /** One entry in a meeting's screen-context timeline (an other-app dwell). */
 export interface MeetingScreenContextEvent {
@@ -144,8 +128,9 @@ export interface MeetingBuildInput {
    * is fine (they are clipped in `fuseMeeting`).
    */
   conversations: FusionConversationInput[];
-  /** Day screen-activity snapshots (filtered to the window in `fuseMeeting`). */
-  activity?: MeetingActivitySnapshot[];
+  /** Day screen-activity snapshots (filtered to the window in `fuseMeeting`).
+   * Already post-redaction — meeting fusion never sees raw capture. */
+  activity?: ActivitySnapshot[];
 }
 
 /** The fused, screen-aware view of a meeting produced by `fuseMeeting`. */


### PR DESCRIPTION
## Summary
- Use ActivitySnapshot in meeting build/fusion.
- Delete MeetingActivitySnapshot and the rename mapper.

Fixes #2475