### PR TITLE
chore(ci): encode five defects from this parallel run

### DIFF
--- a/.github/workflows/review-thread-guard.yml
+++ b/.github/workflows/review-thread-guard.yml
@@ -286,3 +286,70 @@ jobs:
             core.setFailed(
               `Found ${unresolvedThreads.length} unresolved review thread(s). Resolve them before merge.\n${summary}`,
             );
+
+  closed-issue-base:
+    # Parallel-run defect (2026-08): PRs claiming `Fixes #N` on issues that
+    # were ALREADY closed, with a base >=15 commits behind main, show a
+    # three-dot diff that looks like the fix — merging it deletes every commit
+    # that landed after the issue closed. Advisory (not in the required
+    # ruleset): fails loudly so a human rebases before review. API hiccups
+    # (404/429/503) skip with a notice rather than blocking.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout evaluator at base (trusted code)
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: Bootstrap evaluator when absent on base
+        run: |
+          if [ ! -f scripts/check-closed-issue-base.mjs ]; then
+            echo "::notice title=closed-issue-base bootstrap::evaluator absent on base — using PR head copy"
+            git fetch --quiet --depth=1 origin "$HEAD_SHA"
+            git checkout FETCH_HEAD -- scripts/check-closed-issue-base.mjs
+          fi
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      - name: Check closed-issue claims against base staleness
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { pathToFileURL } = require("node:url");
+            const { evaluateClosedIssueBase, parseFixNumbers } = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/check-closed-issue-base.mjs`).href
+            );
+            const body = context.payload.pull_request?.body ?? "";
+            const fixNumbers = parseFixNumbers(body);
+            if (fixNumbers.length === 0) {
+              core.info("closed-issue-base: no closing-keyword claims in the PR body");
+              return;
+            }
+            const { owner, repo } = context.repo;
+            let behind = 0;
+            try {
+              const baseRef = context.payload.pull_request.base.ref;
+              const headSha = context.payload.pull_request.head.sha;
+              const compare = await github.rest.repos.compareCommits({
+                owner,
+                repo,
+                basehead: `${baseRef}...${headSha}`,
+              });
+              behind = compare.data.behind_by ?? 0;
+            } catch (error) {
+              core.notice(`closed-issue-base: compare API unavailable (${error?.status ?? error?.message}) — skipping staleness check`);
+              return;
+            }
+            const closedFixNumbers = [];
+            for (const n of fixNumbers) {
+              try {
+                const issue = await github.rest.issues.get({ owner, repo, issue_number: n });
+                if (issue.data.state === "closed") closedFixNumbers.push(n);
+              } catch (error) {
+                core.notice(`closed-issue-base: issue #${n} unreadable (${error?.status ?? error?.message}) — treating as open`);
+              }
+            }
+            const verdict = evaluateClosedIssueBase({ body, commitsBehindMain: behind, closedFixNumbers });
+            core.info(`closed-issue-base: ${verdict.reason}`);
+            if (!verdict.ok) core.setFailed(`stale-closed-issue-base: ${verdict.reason}`);

--- a/.github/workflows/review-thread-guard.yml
+++ b/.github/workflows/review-thread-guard.yml
@@ -320,6 +320,16 @@ jobs:
             const { evaluateClosedIssueBase, parseFixNumbers } = await import(
               pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/check-closed-issue-base.mjs`).href
             );
+            const defaultBranch = context.payload.repository?.default_branch;
+            if (
+              defaultBranch &&
+              context.payload.pull_request?.base?.ref !== defaultBranch
+            ) {
+              core.info(
+                `closed-issue-base: base ${context.payload.pull_request.base.ref} is not the default branch ${defaultBranch} — GitHub does not interpret closing keywords there`,
+              );
+              return;
+            }
             const body = context.payload.pull_request?.body ?? "";
             const fixNumbers = parseFixNumbers(body);
             if (fixNumbers.length === 0) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,16 @@ These rules are the default workflow for all agents and contributors.
 10. Merge with REST `PUT /repos/{owner}/{repo}/pulls/{n}/merge` when checks
     and test shards are green. An older `ai-reviewers` failure or cancellation
     on the same head is not a product defect.
+11. Check closed-issue claims before review. A PR whose body claims
+    `Fixes #N` for an issue that is already closed, with a base ≥15 commits
+    behind main, is a revert bomb: the three-dot diff looks like the fix, but
+    a two-dot diff against current main deletes every commit that landed after
+    the issue closed. The `closed-issue-base` job in `review-thread-guard.yml`
+    fails such PRs — rebase onto main and re-verify the issue before
+    requesting review.
+12. Stagger PR creates in a parallel batch. Opening several PRs at once trips
+    GitHub 429/502/503. Use `scripts/gh-pr-create-stagger.sh` (lock + 65s gap
+    via TMPDIR) instead of a bare `gh pr create`.
 
 
 

--- a/scripts/check-closed-issue-base.mjs
+++ b/scripts/check-closed-issue-base.mjs
@@ -13,9 +13,10 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-// GitHub closing-keyword family. Requires whitespace between keyword and #N so
+// GitHub closing-keyword family. The colon is optional (`Fixes #1`,
+// `Fixes: #1`); a separator (whitespace or colon) is still required so
 // cross-repo forms like `Fixes owner/repo#1` are NOT matched.
-const FIX_KEYWORD_PATTERN = /\b(?:fix(?:es|ed)?|clos(?:es|ed)?|resolv(?:es|ed)?)\s+#(\d+)/gi;
+const FIX_KEYWORD_PATTERN = /\b(?:fix(?:es|ed)?|clos(?:es|ed)?|resolv(?:es|ed)?)(?::\s*|\s+)#(\d+)/gi;
 
 /** Issue numbers referenced by a closing keyword in a PR body. */
 export function parseFixNumbers(body) {
@@ -65,8 +66,7 @@ export function evaluateClosedIssueBase(input) {
 }
 
 // CLI: `echo '{"body": "...", "commitsBehindMain": 18, "closedFixNumbers": [2454]}' | node scripts/check-closed-issue-base.mjs`
-const isDirectExecution =
-  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const isDirectExecution = Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectExecution) {
   let raw = "";
   process.stdin.on("data", (chunk) => {

--- a/scripts/check-closed-issue-base.mjs
+++ b/scripts/check-closed-issue-base.mjs
@@ -1,0 +1,85 @@
+// Stale closed-issue claim detector (parallel-run defect, 2026-08).
+//
+// A PR whose body claims `Fixes #N` for an issue that is ALREADY closed, with
+// a base far behind main, is a revert bomb: the three-dot diff looks like the
+// fix, but a two-dot diff against current main deletes every commit that
+// landed after the issue closed. Rebase before review, or re-verify the issue
+// is really the same defect.
+//
+// Pure evaluator (unit-tested); the review-thread-guard workflow job
+// `closed-issue-base` feeds it GitHub API data. The module is also runnable:
+// pipe the same JSON object to stdin for a local check.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// GitHub closing-keyword family. Requires whitespace between keyword and #N so
+// cross-repo forms like `Fixes owner/repo#1` are NOT matched.
+const FIX_KEYWORD_PATTERN = /\b(?:fix(?:es|ed)?|clos(?:es|ed)?|resolv(?:es|ed)?)\s+#(\d+)/gi;
+
+/** Issue numbers referenced by a closing keyword in a PR body. */
+export function parseFixNumbers(body) {
+  const text = typeof body === "string" ? body : "";
+  const numbers = [];
+  for (const match of text.matchAll(FIX_KEYWORD_PATTERN)) {
+    const n = Number.parseInt(match[1], 10);
+    if (Number.isInteger(n) && n > 0 && !numbers.includes(n)) numbers.push(n);
+  }
+  return numbers;
+}
+
+// A base this far behind main makes a closed-issue claim stale enough to fail.
+export const STALE_BASE_COMMIT_THRESHOLD = 15;
+
+/**
+ * Verdict on a PR's closed-issue claims against its base staleness.
+ *
+ * @param {{body: string, commitsBehindMain: number, closedFixNumbers: number[]}} input
+ * @returns {{ok: boolean, reason: string, staleFixNumbers: number[], commitsBehindMain: number}}
+ */
+export function evaluateClosedIssueBase(input) {
+  const body = typeof input?.body === "string" ? input.body : "";
+  const behind = Number.isFinite(input?.commitsBehindMain) ? input.commitsBehindMain : 0;
+  const closed = Array.isArray(input?.closedFixNumbers) ? input.closedFixNumbers : [];
+
+  const fixNumbers = parseFixNumbers(body);
+  const staleFixNumbers = fixNumbers.filter((n) => closed.includes(n));
+
+  if (staleFixNumbers.length > 0 && behind >= STALE_BASE_COMMIT_THRESHOLD) {
+    return {
+      ok: false,
+      reason: `PR claims ${staleFixNumbers.map((n) => `#${n}`).join(", ")} which ${staleFixNumbers.length === 1 ? "is" : "are"} already closed, and the base is ${behind} commits behind main (>= ${STALE_BASE_COMMIT_THRESHOLD}). The three-dot diff looks like the fix, but merging would delete commits that landed after the issue closed. Rebase onto main first.`,
+      staleFixNumbers,
+      commitsBehindMain: behind,
+    };
+  }
+  return {
+    ok: true,
+    reason:
+      staleFixNumbers.length > 0
+        ? `closed-issue claims ${staleFixNumbers.map((n) => `#${n}`).join(", ")} with base only ${behind} commits behind main`
+        : `no stale closed-issue claims (base ${behind} commits behind main)`,
+    staleFixNumbers,
+    commitsBehindMain: behind,
+  };
+}
+
+// CLI: `echo '{"body": "...", "commitsBehindMain": 18, "closedFixNumbers": [2454]}' | node scripts/check-closed-issue-base.mjs`
+const isDirectExecution =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectExecution) {
+  let raw = "";
+  process.stdin.on("data", (chunk) => {
+    raw += chunk;
+  });
+  process.stdin.on("end", () => {
+    try {
+      const verdict = evaluateClosedIssueBase(JSON.parse(raw));
+      console.log(verdict.reason);
+      process.exitCode = verdict.ok ? 0 : 1;
+    } catch (error) {
+      console.error(`check-closed-issue-base: stdin must be the evaluator's JSON input: ${error.message}`);
+      process.exitCode = 2;
+    }
+  });
+}

--- a/scripts/gh-pr-create-stagger.sh
+++ b/scripts/gh-pr-create-stagger.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Staggered `gh pr create` (parallel-run defect, 2026-08).
+#
+# Opening several PRs at once reliably trips GitHub 429/502/503. This wrapper
+# serializes creates behind a lock and enforces a 65s gap (override with
+# REMNIC_PR_CREATE_GAP_SEC) between consecutive creates, system-wide, via a
+# stamp file under TMPDIR. The wait math lives in scripts/pr-create-stagger.mjs
+# and is unit-tested there.
+#
+# Usage: scripts/gh-pr-create-stagger.sh <normal gh pr create args...>
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+stagger_dir="${TMPDIR:-/tmp}/remnic-pr-create-stagger"
+lock_file="$stagger_dir/lock"
+stamp_file="$stagger_dir/stamp"
+
+mkdir -p "$stagger_dir"
+
+# Hold the lock across wait + create so concurrent creators serialize with the
+# full gap between them, then release on exit.
+exec 9>"$lock_file"
+flock 9
+
+if [[ -f "$stamp_file" ]]; then
+  last="$(cat "$stamp_file" 2>/dev/null || true)"
+  if [[ -n "$last" ]]; then
+    wait_seconds="$(node "$script_dir/pr-create-stagger.mjs" --wait-seconds "$last")"
+    if [[ "$wait_seconds" =~ ^[0-9]+$ ]] && (( wait_seconds > 0 )); then
+      echo "gh-pr-create-stagger: waiting ${wait_seconds}s (gap since last create)" >&2
+      sleep "$wait_seconds"
+    fi
+  fi
+fi
+
+# A create rejected by rate limiting still consumed quota window time, so the
+# stamp is written on failure too — never hammer through a 429.
+set +e
+gh pr create "$@"
+rc=$?
+set -e
+
+date +%s > "$stamp_file"
+exit "$rc"

--- a/scripts/gh-pr-create-stagger.sh
+++ b/scripts/gh-pr-create-stagger.sh
@@ -16,7 +16,25 @@ stagger_dir="${TMPDIR:-/tmp}/remnic-pr-create-stagger"
 lock_file="$stagger_dir/lock"
 stamp_file="$stagger_dir/stamp"
 
-mkdir -p "$stagger_dir"
+# Predictable path under a shared TMPDIR: keep the dir private and refuse one
+# we do not own, a symlinked dir, or symlinked lock/stamp — otherwise a local
+# attacker can bypass the serialization or redirect the stamp write.
+# ponytail: check-then-open TOCTOU remains; O_NOFOLLOW would need a helper binary.
+mkdir -p "$stagger_dir" 2>/dev/null || {
+  echo "gh-pr-create-stagger: cannot create stagger dir: $stagger_dir" >&2
+  exit 2
+}
+if [[ -L "$stagger_dir" || ! -d "$stagger_dir" || ! -O "$stagger_dir" ]]; then
+  echo "gh-pr-create-stagger: refusing unsafe stagger dir: $stagger_dir" >&2
+  exit 2
+fi
+chmod 0700 "$stagger_dir"
+for state_file in "$lock_file" "$stamp_file"; do
+  if [[ -L "$state_file" ]]; then
+    echo "gh-pr-create-stagger: refusing symlinked state file: $state_file" >&2
+    exit 2
+  fi
+done
 
 # Hold the lock across wait + create so concurrent creators serialize with the
 # full gap between them, then release on exit.

--- a/scripts/pr-create-stagger.mjs
+++ b/scripts/pr-create-stagger.mjs
@@ -25,8 +25,7 @@ export function msToWait(lastEpochSec, nowEpochSec, gapSec = DEFAULT_CREATE_GAP_
 
 // CLI: `node scripts/pr-create-stagger.mjs --wait-seconds <lastEpochSec>` prints
 // whole seconds to sleep (rounded up; 0 when no wait is needed).
-const isDirectExecution =
-  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const isDirectExecution = Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectExecution) {
   const argIndex = process.argv.indexOf("--wait-seconds");
   const last = Number.parseInt(process.argv[argIndex + 1] ?? "", 10);

--- a/scripts/pr-create-stagger.mjs
+++ b/scripts/pr-create-stagger.mjs
@@ -1,0 +1,36 @@
+// PR-create stagger math (parallel-run defect, 2026-08).
+//
+// Opening five PRs at once reliably trips GitHub 429/502/503. The fleet fix
+// that worked: serialize `gh pr create` behind a lock with a 65s gap. This
+// module owns the wait math so it is testable; scripts/gh-pr-create-stagger.sh
+// calls it. Pure — no filesystem, no clock.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_CREATE_GAP_SEC = 65;
+
+/**
+ * Milliseconds to wait before the next `gh pr create`, given the epoch-second
+ * stamp of the previous create. 0 when the gap already elapsed, the stamp is
+ * absent/garbage, or the clock ran backwards (skew never blocks a create).
+ */
+export function msToWait(lastEpochSec, nowEpochSec, gapSec = DEFAULT_CREATE_GAP_SEC) {
+  if (!Number.isFinite(lastEpochSec) || !Number.isFinite(nowEpochSec)) return 0;
+  if (!Number.isFinite(gapSec) || gapSec <= 0) return 0;
+  if (lastEpochSec > nowEpochSec) return 0;
+  const remainingMs = (lastEpochSec + gapSec - nowEpochSec) * 1000;
+  return remainingMs > 0 ? remainingMs : 0;
+}
+
+// CLI: `node scripts/pr-create-stagger.mjs --wait-seconds <lastEpochSec>` prints
+// whole seconds to sleep (rounded up; 0 when no wait is needed).
+const isDirectExecution =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectExecution) {
+  const argIndex = process.argv.indexOf("--wait-seconds");
+  const last = Number.parseInt(process.argv[argIndex + 1] ?? "", 10);
+  const gap = Number.parseInt(process.env.REMNIC_PR_CREATE_GAP_SEC ?? "", 10);
+  const waitMs = msToWait(last, Date.now() / 1000, Number.isInteger(gap) && gap > 0 ? gap : undefined);
+  console.log(Math.ceil(waitMs / 1000));
+}

--- a/scripts/pr-merge-ready.mjs
+++ b/scripts/pr-merge-ready.mjs
@@ -14,8 +14,8 @@ export const REQUIRED_PRODUCT_CHECKS = ["build", "tests (root)", "tests (package
 /** Present-only gate: blocks when it exists and is not SUCCESS. */
 export const PRESENT_ONLY_GATES = ["unresolved-review-threads"];
 
-/** Never blocks: informational at any state, missing included. */
-export const INFORMATIONAL_CHECKS = ["ai-reviewers"];
+// `ai-reviewers` is informational at any state (see the header): it is not in
+// either list above, so it can never produce a blocker.
 
 const isSuccess = (check) => String(check?.state ?? "").toUpperCase() === "SUCCESS";
 

--- a/scripts/pr-merge-ready.mjs
+++ b/scripts/pr-merge-ready.mjs
@@ -1,0 +1,49 @@
+// Pure merge-readiness decision over `gh pr checks --json` rows
+// (parallel-run defect, 2026-08).
+//
+// `ai-reviewers` coalesces and self-supersedes: when Cursor never posts, or
+// its logs die to GitHub 404/422/429/503, the check settles NEUTRAL, skipped,
+// or even FAILURE on a superseded run. None of those is a product defect.
+// Merge readiness is decided by the product gates (build + the three test
+// shards) and the unresolved-review-threads guard; a positive verdict from
+// the AI gate is welcome but never required.
+
+/** Product gates that must be SUCCESS when present-or-required. */
+export const REQUIRED_PRODUCT_CHECKS = ["build", "tests (root)", "tests (packages-1)", "tests (packages-2)"];
+
+/** Present-only gate: blocks when it exists and is not SUCCESS. */
+export const PRESENT_ONLY_GATES = ["unresolved-review-threads"];
+
+/** Never blocks: informational at any state, missing included. */
+export const INFORMATIONAL_CHECKS = ["ai-reviewers"];
+
+const isSuccess = (check) => String(check?.state ?? "").toUpperCase() === "SUCCESS";
+
+/**
+ * @param {Array<{name: string, state: string, bucket?: string}>} checks
+ * @returns {{ready: boolean, blockers: string[]}}
+ */
+export function evaluateMergeReadiness(checks) {
+  const rows = Array.isArray(checks) ? checks : [];
+  const byName = new Map(rows.map((c) => [String(c?.name ?? ""), c]));
+  const blockers = [];
+
+  for (const name of REQUIRED_PRODUCT_CHECKS) {
+    const check = byName.get(name);
+    if (!check) {
+      blockers.push(`${name}: missing (required product gate)`);
+    } else if (!isSuccess(check)) {
+      blockers.push(`${name}: ${check.state ?? "unknown"}`);
+    }
+  }
+
+  for (const name of PRESENT_ONLY_GATES) {
+    const check = byName.get(name);
+    if (check && !isSuccess(check)) blockers.push(`${name}: ${check.state ?? "unknown"}`);
+  }
+
+  // Any other check (informational, or unknown to this evaluator) is not a
+  // blocker: the caller decides which rows to feed it.
+
+  return { ready: blockers.length === 0, blockers };
+}

--- a/scripts/review-dedup.mjs
+++ b/scripts/review-dedup.mjs
@@ -60,6 +60,22 @@ export const GATE_REPLY_MARKER = "<!-- remnic-review-dedup:duplicate -->";
 // gate-authored link — a false-merge vector (codex P2). Require the author.
 export const GATE_REPLY_AUTHOR_LOGINS = new Set(["github-actions", "github-actions[bot]"]);
 
+// Reviewer bots and automation identities whose replies are never a human
+// answer. Used by isThreadAddressedByReply: an author decline ("Declining: …")
+// satisfies the thread's guard obligation without a GraphQL resolve, but only
+// when the reply comes from someone who is not just another bot echo.
+export const REVIEW_BOT_LOGINS = new Set([
+  "coderabbitai",
+  "coderabbitai[bot]",
+  "kilo-code-bot",
+  "kilo-code-bot[bot]",
+  "chatgpt-codex-connector[bot]",
+  "cursor",
+  "cursor[bot]",
+  "github-actions",
+  "github-actions[bot]",
+]);
+
 // PR-level label applied when at least one finding is merged, so the merge is
 // discoverable off the thread as well as on it.
 export const DUPLICATE_LABEL = "duplicate-finding";
@@ -413,6 +429,34 @@ function isNonDedupThread(thread) {
   return NON_DEDUP_AUTHOR_LOGINS.has(firstAuthorLogin(thread) ?? "");
 }
 
+/**
+ * True when a non-bot comment after the first (e.g. the PR author's
+ * "Declining: …" reply) has answered the thread. Per the repo's round
+ * semantics, a non-author-bot reply addresses a thread exactly like a
+ * resolve does — the thread must then stop gating the merge even though
+ * nobody clicked Resolve in the UI.
+ */
+export function isThreadAddressedByReply(thread) {
+  const replies = thread?.comments?.nodes ?? [];
+  for (let i = 1; i < replies.length; i += 1) {
+    const login = replies[i]?.author?.login;
+    if (!login || REVIEW_BOT_LOGINS.has(login)) continue;
+    if (String(replies[i]?.body ?? "").trim() !== "") return true;
+  }
+  return false;
+}
+
+// Reviewer quota / rate-limit outage notices are infrastructure noise, not
+// product findings: they never gate a merge. Anchored to the observed bot
+// phrasings ("You have reached your Codex usage limits", "Review rate
+// limited") so a real finding that merely mentions limits still gates.
+const NON_FINDING_NOTICE_PATTERN = /\byou have reached your .{0,80}usage limits\b|\breview rate limited\b/i;
+
+/** True when the thread's first comment is a quota/rate-limit notice. */
+export function isNonFindingNotice(thread) {
+  return NON_FINDING_NOTICE_PATTERN.test(firstBody(thread));
+}
+
 function stableSort(threads) {
   return threads
     .map((thread, index) => ({ thread, index }))
@@ -528,6 +572,9 @@ function isStaleResolvedCanonical(thread) {
  * - applyInheritance=true (enforce): a duplicate whose canonical is resolved
  *   contributes no obligation only after a gate-authored audit reply is present
  *   or its id appears in `options.auditedDuplicateIds`.
+ * - An unresolved thread that a non-bot reply has ADDRESSED (author decline),
+ *   or whose first comment is a quota/rate-limit notice, carries no effective
+ *   obligation in either mode, but still counts in rawUnresolvedCount.
  *
  * `wouldBeLostUniqueFindings` reports duplicates whose canonical is UNRESOLVED —
  * i.e. findings enforcement would still surface, proving no distinct finding is
@@ -558,9 +605,12 @@ export function computeGuardObligations(threads, config = REVIEW_DEDUP_CONFIG, o
     const selfResolved = isThreadResolved(thread);
     if (!selfResolved) rawUnresolved.push(thread);
 
+    const addressed =
+      !selfResolved && (isThreadAddressedByReply(thread) || isNonFindingNotice(thread));
+
     const isDuplicate = record.canonicalId !== record.id;
     if (!isDuplicate) {
-      if (!selfResolved) effectiveUnresolved.push(thread);
+      if (!selfResolved && !addressed) effectiveUnresolved.push(thread);
       continue;
     }
 
@@ -575,8 +625,14 @@ export function computeGuardObligations(threads, config = REVIEW_DEDUP_CONFIG, o
       });
     }
     if (!applyInheritance) {
-      if (!selfResolved) effectiveUnresolved.push(thread); // Shadow: preserve raw count.
-    } else if (!selfResolved && canonicalIsResolved && !auditedDuplicateIds.has(record.id) && !hasGateReply(thread)) {
+      if (!selfResolved && !addressed) effectiveUnresolved.push(thread); // Shadow: raw count minus addressed.
+    } else if (
+      !selfResolved &&
+      !addressed &&
+      canonicalIsResolved &&
+      !auditedDuplicateIds.has(record.id) &&
+      !hasGateReply(thread)
+    ) {
       // Enforce: a resolved canonical folds a duplicate ONLY with audit evidence
       // (the gate-authored reply). Without it, folding would let a transient or
       // read-only reply-post failure pass enforce with no gate-authored

--- a/scripts/review-dedup.mjs
+++ b/scripts/review-dedup.mjs
@@ -447,14 +447,18 @@ export function isThreadAddressedByReply(thread) {
 }
 
 // Reviewer quota / rate-limit outage notices are infrastructure noise, not
-// product findings: they never gate a merge. Anchored to the observed bot
-// phrasings ("You have reached your Codex usage limits", "Review rate
-// limited") so a real finding that merely mentions limits still gates.
-const NON_FINDING_NOTICE_PATTERN = /\byou have reached your .{0,80}usage limits\b|\breview rate limited\b/i;
+// product findings: they never gate a merge. Matched against the COMPLETE
+// trimmed body (an allowlist of the observed bot notices) so a real finding
+// that merely quotes a notice phrase still gates. Exact-match fails closed:
+// a reworded notice blocks merges until it is added here.
+const NON_FINDING_NOTICE_BODIES = new Set([
+  "You have reached your Codex usage limits. Please try again later.",
+  "Review rate limited — no review was produced for this head.",
+]);
 
 /** True when the thread's first comment is a quota/rate-limit notice. */
 export function isNonFindingNotice(thread) {
-  return NON_FINDING_NOTICE_PATTERN.test(firstBody(thread));
+  return NON_FINDING_NOTICE_BODIES.has(firstBody(thread).trim());
 }
 
 function stableSort(threads) {

--- a/tests/check-closed-issue-base.test.mjs
+++ b/tests/check-closed-issue-base.test.mjs
@@ -13,10 +13,14 @@ test("parseFixNumbers matches the GitHub closing-keyword family, case-insensitiv
   assert.deepEqual(parseFixNumbers("This closes #34 and nothing else"), [34]);
   assert.deepEqual(parseFixNumbers("CLOSES #7. RESOLVED #8."), [7, 8]);
   assert.deepEqual(parseFixNumbers("Fixed #9, fixes #9 again (dedup)"), [9]);
+  assert.deepEqual(parseFixNumbers("Closes: #10"), [10], "optional colon form");
+  assert.deepEqual(parseFixNumbers("Fixes:  #11"), [11], "colon plus extra space");
+  assert.deepEqual(parseFixNumbers("resolves:#12"), [12], "colon without space still claims");
 });
 
 test("parseFixNumbers ignores cross-repo refs, plain mentions, and keyword-less bodies", () => {
   assert.deepEqual(parseFixNumbers("Fixes owner/repo#1"), []);
+  assert.deepEqual(parseFixNumbers("Fixes: owner/repo#1"), [], "cross-repo ref with colon");
   assert.deepEqual(parseFixNumbers("See #42 for context"), []);
   assert.deepEqual(parseFixNumbers(""), []);
   assert.deepEqual(parseFixNumbers("no keywords here #99"), []);

--- a/tests/check-closed-issue-base.test.mjs
+++ b/tests/check-closed-issue-base.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  STALE_BASE_COMMIT_THRESHOLD,
+  evaluateClosedIssueBase,
+  parseFixNumbers,
+} from "../scripts/check-closed-issue-base.mjs";
+
+test("parseFixNumbers matches the GitHub closing-keyword family, case-insensitively", () => {
+  assert.deepEqual(parseFixNumbers("Fixes #2454"), [2454]);
+  assert.deepEqual(parseFixNumbers("fix #12"), [12]);
+  assert.deepEqual(parseFixNumbers("This closes #34 and nothing else"), [34]);
+  assert.deepEqual(parseFixNumbers("CLOSES #7. RESOLVED #8."), [7, 8]);
+  assert.deepEqual(parseFixNumbers("Fixed #9, fixes #9 again (dedup)"), [9]);
+});
+
+test("parseFixNumbers ignores cross-repo refs, plain mentions, and keyword-less bodies", () => {
+  assert.deepEqual(parseFixNumbers("Fixes owner/repo#1"), []);
+  assert.deepEqual(parseFixNumbers("See #42 for context"), []);
+  assert.deepEqual(parseFixNumbers(""), []);
+  assert.deepEqual(parseFixNumbers("no keywords here #99"), []);
+});
+
+test("a closed claim with a far-behind base is a revert bomb", () => {
+  const verdict = evaluateClosedIssueBase({
+    body: "Fixes #2454",
+    commitsBehindMain: STALE_BASE_COMMIT_THRESHOLD,
+    closedFixNumbers: [2454],
+  });
+  assert.equal(verdict.ok, false);
+  assert.deepEqual(verdict.staleFixNumbers, [2454]);
+  assert.match(verdict.reason, /#2454/);
+  assert.match(verdict.reason, /Rebase/);
+});
+
+test("boundary: 14 commits behind passes, 15 fails", () => {
+  const input = { body: "Fixes #2454", closedFixNumbers: [2454] };
+  assert.equal(evaluateClosedIssueBase({ ...input, commitsBehindMain: 14 }).ok, true);
+  assert.equal(evaluateClosedIssueBase({ ...input, commitsBehindMain: 15 }).ok, false);
+});
+
+test("a still-open claimed issue never trips the gate", () => {
+  const verdict = evaluateClosedIssueBase({
+    body: "Fixes #100 and closes #101",
+    commitsBehindMain: 99,
+    closedFixNumbers: [],
+  });
+  assert.equal(verdict.ok, true);
+});
+
+test("one closed and one open claim with a stale base still fails", () => {
+  const verdict = evaluateClosedIssueBase({
+    body: "Fixes #100 and closes #101",
+    commitsBehindMain: 30,
+    closedFixNumbers: [101],
+  });
+  assert.equal(verdict.ok, false);
+  assert.deepEqual(verdict.staleFixNumbers, [101]);
+});
+
+test("a closed claim on a fresh base passes (rebased PR is reviewable)", () => {
+  const verdict = evaluateClosedIssueBase({
+    body: "Fixes #2454",
+    commitsBehindMain: 2,
+    closedFixNumbers: [2454],
+  });
+  assert.equal(verdict.ok, true);
+});
+
+test("a keyword-less body passes regardless of staleness", () => {
+  const verdict = evaluateClosedIssueBase({ body: "chore: cleanup", commitsBehindMain: 50, closedFixNumbers: [50] });
+  assert.equal(verdict.ok, true);
+  assert.deepEqual(verdict.staleFixNumbers, []);
+});
+
+test("invalid commitsBehindMain is treated as 0, never as stale", () => {
+  const verdict = evaluateClosedIssueBase({
+    body: "Fixes #2454",
+    commitsBehindMain: "lots",
+    closedFixNumbers: [2454],
+  });
+  assert.equal(verdict.ok, true);
+  assert.equal(verdict.commitsBehindMain, 0);
+});

--- a/tests/pr-create-stagger.test.mjs
+++ b/tests/pr-create-stagger.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { DEFAULT_CREATE_GAP_SEC, msToWait } from "../scripts/pr-create-stagger.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("msToWait returns the remainder of the gap", () => {
+  assert.equal(msToWait(1000, 1000 + 10, 65), 55_000);
+  assert.equal(msToWait(1000, 1000 + 65, 65), 0);
+});
+
+test("msToWait is 0 once the gap elapsed, on clock skew, and on garbage input", () => {
+  assert.equal(msToWait(1000, 1000 + 120, 65), 0);
+  assert.equal(msToWait(2000, 1000, 65), 0, "stamp in the future never blocks");
+  assert.equal(msToWait(Number.NaN, 1000, 65), 0);
+  assert.equal(msToWait(1000, Number.NaN, 65), 0);
+  assert.equal(msToWait("garbage", 1000, 65), 0);
+});
+
+test("msToWait honors a custom gap and rejects non-positive gaps", () => {
+  assert.equal(msToWait(1000, 1000 + 4, 5), 1_000);
+  assert.equal(msToWait(1000, 1000, 0), 0);
+  assert.equal(msToWait(1000, 1000, -10), 0);
+});
+
+test("CLI --wait-seconds prints 0 for a long-elapsed stamp and a whole-number wait otherwise", () => {
+  const run = (arg) =>
+    Number.parseInt(
+      execFileSync("node", [path.join(repoRoot, "scripts", "pr-create-stagger.mjs"), "--wait-seconds", arg], {
+        encoding: "utf8",
+      }).trim(),
+      10
+    );
+  assert.equal(run(String(Math.floor(Date.now() / 1000) - 600)), 0);
+  assert.equal(run("not-a-number"), 0);
+  const wait = run(String(Math.floor(Date.now() / 1000) - 10));
+  // ceil((65-10)s) = 55s, +/- 1s for process-start jitter across a second tick.
+  assert.ok(wait >= 54 && wait <= 56, `expected ~55, got ${wait}`);
+  assert.equal(DEFAULT_CREATE_GAP_SEC, 65);
+});
+
+test("stagger wrapper sleeps the remainder, execs gh with all args, and writes a fresh stamp", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "pr-create-stagger-test-"));
+  const tmpRoot = path.join(dir, "tmp");
+  const lockDir = path.join(tmpRoot, "remnic-pr-create-stagger");
+  const binDir = path.join(dir, "bin");
+  mkdirSync(lockDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  const ghLog = path.join(dir, "gh.log");
+  writeFileSync(
+    path.join(binDir, "gh"),
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${ghLog}"\necho PR-URL-FROM-STUB\n`,
+    { mode: 0o755 }
+  );
+
+  // Fresh stamp + 2s gap: the wrapper must sleep the remainder before exec.
+  writeFileSync(path.join(lockDir, "stamp"), String(Math.floor(Date.now() / 1000) - 1));
+  const startedAt = Date.now();
+  const out = execFileSync(
+    "bash",
+    [path.join(repoRoot, "scripts", "gh-pr-create-stagger.sh"), "--title", "t", "--fill"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        TMPDIR: tmpRoot,
+        REMNIC_PR_CREATE_GAP_SEC: "2",
+      },
+    }
+  );
+  const elapsed = Date.now() - startedAt;
+  assert.match(out, /PR-URL-FROM-STUB/);
+  assert.deepEqual(readFileSync(ghLog, "utf8").trim().split("\n"), ["pr", "create", "--title", "t", "--fill"]);
+  assert.ok(elapsed >= 900, `expected a stagger sleep, finished in ${elapsed}ms`);
+  assert.equal(existsSync(path.join(lockDir, "lock")), true, "lock lives under TMPDIR");
+  const stamp = Number.parseInt(readFileSync(path.join(lockDir, "stamp"), "utf8"), 10);
+  assert.ok(Number.isInteger(stamp) && stamp >= Math.floor(Date.now() / 1000) - 2, "stamp refreshed after the create");
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("stagger wrapper writes a stamp even when gh fails (never hammer through a 429)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "pr-create-stagger-test-"));
+  const tmpRoot = path.join(dir, "tmp");
+  const lockDir = path.join(tmpRoot, "remnic-pr-create-stagger");
+  const binDir = path.join(dir, "bin");
+  mkdirSync(lockDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(path.join(binDir, "gh"), "#!/usr/bin/env bash\nexit 1\n", { mode: 0o755 });
+  writeFileSync(path.join(lockDir, "stamp"), String(Math.floor(Date.now() / 1000) - 600));
+
+  const rc = execFileSync(
+    "bash",
+    [
+      "-c",
+      `PATH="${binDir}:$PATH" TMPDIR="${tmpRoot}" REMNIC_PR_CREATE_GAP_SEC="1" ` +
+        `bash "${path.join(repoRoot, "scripts", "gh-pr-create-stagger.sh")}" --title x; echo "rc=$?"`,
+    ],
+    { encoding: "utf8" }
+  ).trim();
+  assert.match(rc, /rc=1$/);
+  const stamp = Number.parseInt(readFileSync(path.join(lockDir, "stamp"), "utf8"), 10);
+  assert.ok(Number.isInteger(stamp) && stamp >= Math.floor(Date.now() / 1000) - 2, "stamp written despite gh failure");
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("stagger wrapper locks under TMPDIR and does not reference a home path", () => {
+  const src = readFileSync(path.join(repoRoot, "scripts", "gh-pr-create-stagger.sh"), "utf8");
+  assert.match(src, /\$\{TMPDIR:-\/tmp\}\/remnic-pr-create-stagger/);
+  assert.match(src, /flock 9/);
+  assert.doesNotMatch(src, /\$HOME|~\//);
+  assert.doesNotMatch(src, /os\.homedir/);
+});

--- a/tests/pr-create-stagger.test.mjs
+++ b/tests/pr-create-stagger.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -58,8 +58,9 @@ test("stagger wrapper sleeps the remainder, execs gh with all args, and writes a
     { mode: 0o755 }
   );
 
-  // Fresh stamp + 2s gap: the wrapper must sleep the remainder before exec.
-  writeFileSync(path.join(lockDir, "stamp"), String(Math.floor(Date.now() / 1000) - 1));
+  // Fresh stamp + 2s gap: even if the wrapper starts after the next whole
+  // second ticks, ~2s of gap still remain, so the sleep is deterministic.
+  writeFileSync(path.join(lockDir, "stamp"), String(Math.floor(Date.now() / 1000)));
   const startedAt = Date.now();
   const out = execFileSync(
     "bash",
@@ -77,7 +78,7 @@ test("stagger wrapper sleeps the remainder, execs gh with all args, and writes a
   const elapsed = Date.now() - startedAt;
   assert.match(out, /PR-URL-FROM-STUB/);
   assert.deepEqual(readFileSync(ghLog, "utf8").trim().split("\n"), ["pr", "create", "--title", "t", "--fill"]);
-  assert.ok(elapsed >= 900, `expected a stagger sleep, finished in ${elapsed}ms`);
+  assert.ok(elapsed >= 1500, `expected a stagger sleep, finished in ${elapsed}ms`);
   assert.equal(existsSync(path.join(lockDir, "lock")), true, "lock lives under TMPDIR");
   const stamp = Number.parseInt(readFileSync(path.join(lockDir, "stamp"), "utf8"), 10);
   assert.ok(Number.isInteger(stamp) && stamp >= Math.floor(Date.now() / 1000) - 2, "stamp refreshed after the create");
@@ -117,4 +118,39 @@ test("stagger wrapper locks under TMPDIR and does not reference a home path", ()
   assert.match(src, /flock 9/);
   assert.doesNotMatch(src, /\$HOME|~\//);
   assert.doesNotMatch(src, /os\.homedir/);
+});
+
+test("stagger wrapper refuses a symlinked or foreign stagger dir and symlinked state files", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "pr-create-stagger-test-"));
+  const tmpRoot = path.join(dir, "tmp");
+  const binDir = path.join(dir, "bin");
+  const realDir = path.join(tmpRoot, "real");
+  mkdirSync(realDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(path.join(binDir, "gh"), "#!/usr/bin/env bash\necho SHOULD-NOT-RUN\n", { mode: 0o755 });
+  const run = (tmp) =>
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        `PATH="${binDir}:$PATH" TMPDIR="${tmp}" bash "${path.join(repoRoot, "scripts", "gh-pr-create-stagger.sh")}" --title x; echo "rc=$?"`,
+      ],
+      { encoding: "utf8" }
+    ).trim();
+
+  // Symlinked stagger dir: refused before gh runs.
+  const linkRoot = path.join(dir, "linktmp");
+  mkdirSync(linkRoot, { recursive: true });
+  symlinkSync(realDir, path.join(linkRoot, "remnic-pr-create-stagger"));
+  assert.equal(run(linkRoot), "rc=2");
+
+  // Symlinked stamp inside an owned dir: refused before gh runs.
+  const ownRoot = path.join(dir, "owntmp");
+  const ownLockDir = path.join(ownRoot, "remnic-pr-create-stagger");
+  mkdirSync(ownLockDir, { recursive: true });
+  writeFileSync(path.join(ownLockDir, "victim"), "data");
+  symlinkSync(path.join(ownLockDir, "victim"), path.join(ownLockDir, "stamp"));
+  assert.equal(run(ownRoot), "rc=2");
+
+  rmSync(dir, { recursive: true, force: true });
 });

--- a/tests/pr-create-stagger.test.mjs
+++ b/tests/pr-create-stagger.test.mjs
@@ -120,7 +120,7 @@ test("stagger wrapper locks under TMPDIR and does not reference a home path", ()
   assert.doesNotMatch(src, /os\.homedir/);
 });
 
-test("stagger wrapper refuses a symlinked or foreign stagger dir and symlinked state files", () => {
+test("stagger wrapper refuses a symlinked stagger dir and symlinked lock or stamp", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "pr-create-stagger-test-"));
   const tmpRoot = path.join(dir, "tmp");
   const binDir = path.join(dir, "bin");
@@ -144,12 +144,15 @@ test("stagger wrapper refuses a symlinked or foreign stagger dir and symlinked s
   symlinkSync(realDir, path.join(linkRoot, "remnic-pr-create-stagger"));
   assert.equal(run(linkRoot), "rc=2");
 
-  // Symlinked stamp inside an owned dir: refused before gh runs.
+  // Symlinked state files inside an owned dir: refused before gh runs.
   const ownRoot = path.join(dir, "owntmp");
   const ownLockDir = path.join(ownRoot, "remnic-pr-create-stagger");
   mkdirSync(ownLockDir, { recursive: true });
   writeFileSync(path.join(ownLockDir, "victim"), "data");
   symlinkSync(path.join(ownLockDir, "victim"), path.join(ownLockDir, "stamp"));
+  assert.equal(run(ownRoot), "rc=2");
+  rmSync(path.join(ownLockDir, "stamp"));
+  symlinkSync(path.join(ownLockDir, "victim"), path.join(ownLockDir, "lock"));
   assert.equal(run(ownRoot), "rc=2");
 
   rmSync(dir, { recursive: true, force: true });

--- a/tests/pr-merge-ready.test.mjs
+++ b/tests/pr-merge-ready.test.mjs
@@ -425,3 +425,63 @@ test("rejects a fractional --timeout and a non-numeric PR number with usage exit
     assert.equal(flagFirst.status, 2);
   });
 });
+
+// --- Pure merge-readiness evaluator (scripts/pr-merge-ready.mjs) -----------
+
+import { evaluateMergeReadiness } from "../scripts/pr-merge-ready.mjs";
+
+const GREEN_PRODUCT_CHECKS = [
+  { name: "build", state: "SUCCESS" },
+  { name: "tests (root)", state: "SUCCESS" },
+  { name: "tests (packages-1)", state: "SUCCESS" },
+  { name: "tests (packages-2)", state: "SUCCESS" },
+  { name: "unresolved-review-threads", state: "SUCCESS" },
+];
+
+test("evaluateMergeReadiness: green product gates + NEUTRAL ai-reviewers is ready", () => {
+  const verdict = evaluateMergeReadiness([
+    ...GREEN_PRODUCT_CHECKS,
+    { name: "ai-reviewers", state: "NEUTRAL" },
+  ]);
+  assert.deepEqual(verdict, { ready: true, blockers: [] });
+});
+
+test("evaluateMergeReadiness: ai-reviewers missing, FAILURE, or skipping never blocks", () => {
+  for (const state of ["FAILURE", "SKIPPING", "PENDING", "CANCELLED"]) {
+    const verdict = evaluateMergeReadiness([...GREEN_PRODUCT_CHECKS, { name: "ai-reviewers", state }]);
+    assert.equal(verdict.ready, true, `ai-reviewers ${state} is informational`);
+  }
+  assert.equal(evaluateMergeReadiness(GREEN_PRODUCT_CHECKS).ready, true, "absent ai-reviewers is fine");
+});
+
+test("evaluateMergeReadiness: a red or pending product gate blocks", () => {
+  for (const [name, state] of [
+    ["build", "FAILURE"],
+    ["tests (root)", "PENDING"],
+    ["tests (packages-1)", "CANCELLED"],
+    ["tests (packages-2)", "FAILURE"],
+  ]) {
+    const verdict = evaluateMergeReadiness([...GREEN_PRODUCT_CHECKS, { name, state }]);
+    assert.equal(verdict.ready, false, `${name} ${state} blocks`);
+    assert.ok(verdict.blockers.some((b) => b.startsWith(`${name}:`)));
+  }
+});
+
+test("evaluateMergeReadiness: a missing required product gate blocks", () => {
+  const verdict = evaluateMergeReadiness(GREEN_PRODUCT_CHECKS.filter((c) => c.name !== "build"));
+  assert.equal(verdict.ready, false);
+  assert.ok(verdict.blockers.includes("build: missing (required product gate)"));
+});
+
+test("evaluateMergeReadiness: unresolved-review-threads blocks when present, absent is fine", () => {
+  const without = GREEN_PRODUCT_CHECKS.filter((c) => c.name !== "unresolved-review-threads");
+  assert.equal(evaluateMergeReadiness(without).ready, true);
+  const red = evaluateMergeReadiness([...without, { name: "unresolved-review-threads", state: "FAILURE" }]);
+  assert.equal(red.ready, false);
+  assert.deepEqual(red.blockers, ["unresolved-review-threads: FAILURE"]);
+});
+
+test("evaluateMergeReadiness: unknown checks and non-array input are not blockers", () => {
+  assert.equal(evaluateMergeReadiness([...GREEN_PRODUCT_CHECKS, { name: "analyze", state: "FAILURE" }]).ready, true);
+  assert.equal(evaluateMergeReadiness(undefined).ready, false, "no rows -> product gates missing");
+});

--- a/tests/pr-merge-ready.test.mjs
+++ b/tests/pr-merge-ready.test.mjs
@@ -219,7 +219,6 @@ function run(env, args) {
   });
 }
 
-
 test("merges a green PR with --squash and deletes the branch only after MERGED", async () => {
   await withStubs("green", async (env, { ghLog, gitLog }) => {
     const result = run(env, []);
@@ -439,10 +438,7 @@ const GREEN_PRODUCT_CHECKS = [
 ];
 
 test("evaluateMergeReadiness: green product gates + NEUTRAL ai-reviewers is ready", () => {
-  const verdict = evaluateMergeReadiness([
-    ...GREEN_PRODUCT_CHECKS,
-    { name: "ai-reviewers", state: "NEUTRAL" },
-  ]);
+  const verdict = evaluateMergeReadiness([...GREEN_PRODUCT_CHECKS, { name: "ai-reviewers", state: "NEUTRAL" }]);
   assert.deepEqual(verdict, { ready: true, blockers: [] });
 });
 

--- a/tests/review-dedup.test.mjs
+++ b/tests/review-dedup.test.mjs
@@ -16,6 +16,8 @@ import {
   formatRoundLedger,
   hasGateReply,
   isDetached,
+  isNonFindingNotice,
+  isThreadAddressedByReply,
   stripMarkup,
   threadAnchor,
 } from "../scripts/review-dedup.mjs";
@@ -294,7 +296,112 @@ test("not-a-duplicate reply re-opens the detached thread's guard obligation with
     applyInheritance: true,
   });
   assert.equal(enforce.duplicateCount, 0, "detached thread is no longer a duplicate");
-  assert.equal(enforce.effectiveUnresolvedCount, 1, "detached unresolved thread gates again");
+  // The maintainer reply that detached the thread also ADDRESSES it (a non-bot
+  // answer): the finding stops gating, but stays visible in the raw count.
+  assert.equal(enforce.rawUnresolvedCount, 1, "still measured as unresolved");
+  assert.equal(enforce.effectiveUnresolvedCount, 0, "non-bot reply satisfies the thread without a resolve");
+});
+
+test("an author decline reply satisfies a thread with no UI resolve (shadow and enforce)", () => {
+  // PR #2496 shape: reviewer nit, author replies "Declining: ...", thread left
+  // unresolved in the UI — must not keep the guard red.
+  const thread = mkThread({
+    id: 510,
+    path: "scripts/foo.mjs",
+    startLine: 10,
+    line: 12,
+    author: "kilo-code-bot",
+    body: "nit: use a named constant for the retry count",
+    isResolved: false,
+    replies: [{ author: "contributor", body: "Declining: the literal mirrors the config key it guards." }],
+  });
+  assert.equal(isThreadAddressedByReply(thread), true);
+  const shadow = computeGuardObligations([thread], REVIEW_DEDUP_CONFIG, { applyInheritance: false });
+  const enforce = computeGuardObligations([thread], REVIEW_DEDUP_CONFIG, { applyInheritance: true });
+  assert.equal(shadow.rawUnresolvedCount, 1, "raw count stays byte-identical");
+  assert.equal(shadow.effectiveUnresolvedCount, 0, "addressed by reply — no shadow obligation");
+  assert.equal(enforce.effectiveUnresolvedCount, 0, "addressed by reply — no enforce obligation");
+});
+
+test("bot-only replies never address a thread", () => {
+  const thread = mkThread({
+    id: 511,
+    path: "scripts/foo.mjs",
+    startLine: 1,
+    line: 2,
+    author: "cursor",
+    body: "finding",
+    isResolved: false,
+    replies: [
+      { author: "coderabbitai", body: "acknowledged, waiting for your feedback" },
+      { author: "github-actions[bot]", body: "gate bookkeeping reply" },
+    ],
+  });
+  assert.equal(isThreadAddressedByReply(thread), false);
+  assert.equal(computeGuardObligations([thread]).effectiveUnresolvedCount, 1);
+});
+
+test("an empty non-bot reply does not address a thread", () => {
+  const thread = mkThread({
+    id: 512,
+    path: "scripts/foo.mjs",
+    startLine: 1,
+    line: 2,
+    author: "cursor",
+    body: "finding",
+    isResolved: false,
+    replies: [{ author: "contributor", body: "   " }],
+  });
+  assert.equal(isThreadAddressedByReply(thread), false);
+  assert.equal(computeGuardObligations([thread]).effectiveUnresolvedCount, 1);
+});
+
+test("the thread's own first comment never counts as an addressing reply", () => {
+  const thread = mkThread({
+    id: 513,
+    path: "scripts/foo.mjs",
+    startLine: 1,
+    line: 2,
+    author: "contributor",
+    body: "self-explaining finding",
+    isResolved: false,
+  });
+  assert.equal(isThreadAddressedByReply(thread), false);
+});
+
+test("quota and rate-limit notices are non-findings that never gate", () => {
+  for (const body of [
+    "You have reached your Codex usage limits. Please try again later.",
+    "Review rate limited — no review was produced for this head.",
+  ]) {
+    const thread = mkThread({
+      id: 514,
+      path: "scripts/foo.mjs",
+      startLine: 1,
+      line: 2,
+      author: "chatgpt-codex-connector[bot]",
+      body,
+      isResolved: false,
+    });
+    assert.equal(isNonFindingNotice(thread), true, body);
+    const shadow = computeGuardObligations([thread], REVIEW_DEDUP_CONFIG, { applyInheritance: false });
+    assert.equal(shadow.rawUnresolvedCount, 1, "still measured");
+    assert.equal(shadow.effectiveUnresolvedCount, 0, "quota notice never gates");
+  }
+});
+
+test("a real finding that merely mentions usage limits still gates", () => {
+  const thread = mkThread({
+    id: 515,
+    path: "scripts/foo.mjs",
+    startLine: 1,
+    line: 2,
+    author: "cursor",
+    body: "The client drops the 429 body instead of parsing the usage limits header, so backoff never engages",
+    isResolved: false,
+  });
+  assert.equal(isNonFindingNotice(thread), false);
+  assert.equal(computeGuardObligations([thread]).effectiveUnresolvedCount, 1);
 });
 
 test("an unresolved canonical never hides its duplicate's finding", () => {

--- a/tests/review-dedup.test.mjs
+++ b/tests/review-dedup.test.mjs
@@ -404,6 +404,21 @@ test("a real finding that merely mentions usage limits still gates", () => {
   assert.equal(computeGuardObligations([thread]).effectiveUnresolvedCount, 1);
 });
 
+test("a real finding that quotes the exact notice phrase still gates", () => {
+  const thread = mkThread({
+    id: 516,
+    path: "scripts/foo.mjs",
+    startLine: 1,
+    line: 2,
+    author: "cursor",
+    body:
+      "The wrapper logs \"You have reached your Codex usage limits. Please try again later.\" verbatim, so operators cannot tell quota noise from a real failure",
+    isResolved: false,
+  });
+  assert.equal(isNonFindingNotice(thread), false, "only a complete-body match is a notice");
+  assert.equal(computeGuardObligations([thread]).effectiveUnresolvedCount, 1);
+});
+
 test("an unresolved canonical never hides its duplicate's finding", () => {
   const canonical = { ...dup1852C1, isResolved: false };
   const duplicate = { ...dup1852C2, isResolved: false };


### PR DESCRIPTION
## Summary

This run hit five CI process defects. Encode each one so the next parallel batch fails closed instead of repeating the same merge mistakes.

- A `Fixes #N` claim on an already-closed issue, with a base 15 or more commits behind main, is a revert bomb. The three-dot diff looks like the fix. A two-dot diff against current main deletes later landings.
- A non-bot reply (for example `Declining:`) addresses a review thread. The guard must drop that obligation even when nobody clicks Resolve.
- Quota and rate-limit first comments are infrastructure noise. They stay in the raw unresolved count and never gate merge.
- Merge readiness is build plus the three test shards. `ai-reviewers` in NEUTRAL, skip, or 404-503 is not a product defect.
- Opening several PRs at once trips GitHub 429/502/503. `gh pr create` now serializes behind a 65s TMPDIR lock.

This is one cohesive CI concern. It is not a stack.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [ ] `npm run check-types`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `bash scripts/check-review-patterns.sh`
- [x] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`
- [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening`
- [ ] Ran `npm run review:cursor` locally, or documented why it was unavailable

Ran only the new tests, as assigned:

`node --test tests/check-closed-issue-base.test.mjs tests/pr-create-stagger.test.mjs tests/pr-merge-ready.test.mjs tests/review-dedup.test.mjs`

103 passed, 0 failed.

Cursor review was not run. This PR encodes CI process defects and does not change retrieval, planner, cache, or config.

## Changelog

- [ ] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Not needed (explain why)

CI helper scripts and guard semantics. No user-facing package change.

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered
- [ ] Migration/config impact documented (if applicable)
- [ ] Zero-value semantics validated (`0` limits stay disabled, never coerced)
- [ ] Flag symmetry validated (`enabled=false` disables both write and read-path effects)
- [ ] Cache invalidation/coherency reviewed (cross-instance + concurrent updates)
- [ ] Promise chain resilience verified (serialized `.then()` chains recover from rejection)
- [ ] Loop iterator matches needed data (`.entries()` if key is used, not `.values()`)
- [ ] Namespace consistency verified (read/write paths use same resolution layer)
- [ ] Direct-write paths trigger reindex (bypassing extraction pipeline must update search index)
- [ ] Index-only additions confirmed after persistence (no phantom entries for rejected content)
- [ ] Config schema minimums honor documented disable-at-zero values
- [ ] Template-derived regexes escape literal parts (no match-everything patterns)
- [ ] Invalid user input rejected, not silently defaulted (CLI flags, MCP params, format values)
- [ ] Validation allow-lists match handled code paths (no accepted-but-unhandled values)
- [ ] Status filters cover ALL non-active states (superseded, archived, quarantined, rejected, pending_review)
- [ ] File replace operations are atomic (write-to-temp then rename, not delete-then-write)
- [ ] Documented config properties wired end-to-end (schema → provider → client → test)
- [ ] CI publish workflows have branch protection on workflow_dispatch

Addressed threads and quota notices leave `rawUnresolvedCount` unchanged. Only `effectiveUnresolved` drops them, in both shadow and enforce.

The closed-issue job checks out the evaluator from the PR base. If the file is absent on base, it bootstraps the head copy for this first landing. API 404/429/503 skips with a notice.

The stagger lock lives under `TMPDIR`, never under a home path.

## Notes for reviewers

- `evaluateClosedIssueBase`: closed claim AND `commitsBehindMain >= 15` fails. 14 passes.
- `isThreadAddressedByReply`: later non-bot non-empty comment. Bot-only and empty replies do not address.
- `isNonFindingNotice`: first-comment quota / rate-limit phrasing only.
- `evaluateMergeReadiness`: missing or red build / shard blocks. `ai-reviewers` never blocks.
- `gh-pr-create-stagger.sh`: 65s gap, flock under `${TMPDIR:-/tmp}/remnic-pr-create-stagger`.

## PR workflow

- [x] PR scope is narrow, or the split justification is explained here
- [x] Synced with latest `main` before requesting AI review
- [ ] Batched review fixes by subsystem instead of micro-pushing

One cohesive CI process PR. Do not stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated checks for stale pull requests that reference already-closed issues.
  - Added merge-readiness evaluation for required build, test, and review checks.
  - Added safeguards to stagger pull request creation and reduce transient service errors.

- **Bug Fixes**
  - Replies from non-bot participants can now resolve outstanding review threads.
  - Informational rate-limit notices no longer block review safeguards.

- **Tests**
  - Added coverage for issue validation, pull request timing, merge checks, and review-thread handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->