### PR TITLE
fix(extraction): add output-language policy to memory prompts

### DIFF
--- a/packages/remnic-core/src/calibration.ts
+++ b/packages/remnic-core/src/calibration.ts
@@ -20,6 +20,7 @@ import type { AgentPersonaModelConfig, GatewayConfig, MemoryFile } from "./types
 import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { isRecord } from "./store-contract.js";
 import { log } from "./logger.js";
+import { OUTPUT_LANGUAGE_POLICY } from "./extraction-prompt.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -193,7 +194,7 @@ async function readCorrectionsImpl(memoryDir: string): Promise<CorrectionMemory[
 
 // ─── LLM-Assisted Clustering and Replay ──────────────────────────────────────
 
-const CLUSTER_PROMPT = `You are analyzing user corrections to an AI assistant. Each correction represents a moment where the assistant's prediction of what the user wanted was WRONG.
+export const CLUSTER_PROMPT = `You are analyzing user corrections to an AI assistant. Each correction represents a moment where the assistant's prediction of what the user wanted was WRONG.
 
 Your job: Group these corrections into clusters where the SAME TYPE of misunderstanding is happening. Then for each cluster, synthesize a CalibrationRule.
 
@@ -205,6 +206,7 @@ A CalibrationRule describes:
 - ruleType: One of "model_tendency", "user_expectation", "scope_boundary", "verification_required"
 
 Focus on PATTERNS, not individual corrections. A cluster needs at least 2 corrections to be worth a rule.
+${OUTPUT_LANGUAGE_POLICY}
 
 Output valid JSON only:
 {

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -20,6 +20,7 @@ import type { LocalLlmClient } from "./local-llm.js";
 import { type FallbackLlmClient, gatewayTaskChainOptions } from "./fallback-llm.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
+import { OUTPUT_LANGUAGE_POLICY } from "./extraction-prompt.js";
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -210,7 +211,7 @@ export interface JudgeVerdictObservation {
 // Prompt (embedded; mirrors prompts/extraction_judge.prompt.md)
 // ---------------------------------------------------------------------------
 
-const JUDGE_SYSTEM_PROMPT = `You are a memory curator evaluating whether extracted facts are **durable** — worth storing for long-term recall across sessions.
+export const JUDGE_SYSTEM_PROMPT = `You are a memory curator evaluating whether extracted facts are **durable** — worth storing for long-term recall across sessions.
 
 A fact is **durable** if it will still be useful 30+ days from now and is relevant across multiple sessions, not just the current task.
 
@@ -252,6 +253,7 @@ Rules:
 2. When in doubt between accept and reject, lean toward accept — false negatives (losing a useful fact) are worse than false positives (keeping a marginal one).
 3. Use defer only when another turn of context would genuinely change the verdict.
 4. Output valid JSON only. No markdown fences, no commentary.
+5. ${OUTPUT_LANGUAGE_POLICY}
 
 Example output:
 [{"index": 0, "kind": "accept", "durable": true, "reason": "Stable personal preference"}, {"index": 1, "kind": "reject", "durable": false, "reason": "Ephemeral build status"}, {"index": 2, "kind": "defer", "durable": false, "reason": "Ambiguous pronoun"}]`;

--- a/packages/remnic-core/src/extraction-output-language.test.ts
+++ b/packages/remnic-core/src/extraction-output-language.test.ts
@@ -77,14 +77,20 @@ test("local extraction of a Japanese conversation keeps the source language and 
       capturedPrompt = messages.map((m) => m.content).join("\n");
       return {
         content: JSON.stringify({
-          facts: [],
+          facts: [
+            {
+              category: "preference",
+              content: "私は毎朝緑茶を飲みます。",
+              confidence: 0.9,
+            },
+          ],
           profileUpdates: [],
           entities: [],
           questions: [],
           relationships: [],
         }),
       };
-    },
+    }
   };
   const modelRegistry = {
     calculateContextSizes: () => ({
@@ -95,8 +101,7 @@ test("local extraction of a Japanese conversation keeps the source language and 
   };
   assert.equal(Reflect.set(engine, "localLlm", localLlm), true);
   assert.equal(Reflect.set(engine, "modelRegistry", modelRegistry), true);
-
-  await engine.extract(JAPANESE_TURNS);
+  const result = await engine.extract(JAPANESE_TURNS);
 
   assert.ok(capturedPrompt.length > 0, "no prompt captured from local extraction");
   assert.ok(
@@ -104,5 +109,8 @@ test("local extraction of a Japanese conversation keeps the source language and 
     "local extraction prompt missing policy",
   );
   assert.ok(capturedPrompt.includes("私は毎朝緑茶を飲みます。"), "Japanese source not in prompt");
-  assert.doesNotMatch(capturedPrompt, ENGLISH_OUTPUT_DIRECTIVE_RE);
+  assert.ok(
+    result.facts.some((fact) => fact.content === "私は毎朝緑茶を飲みます。"),
+    "Japanese fact content altered or dropped by extraction",
+  );
 });

--- a/packages/remnic-core/src/extraction-output-language.test.ts
+++ b/packages/remnic-core/src/extraction-output-language.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { CLUSTER_PROMPT } from "./calibration.js";
+import { ExtractionEngine } from "./extraction.js";
+import { JUDGE_SYSTEM_PROMPT } from "./extraction-judge.js";
+import {
+  OUTPUT_LANGUAGE_POLICY,
+  buildConsolidationSystemPrompt,
+  buildExtractionInstructions,
+  buildProfileConsolidationSystemPrompt,
+} from "./extraction-prompt.js";
+import type { BufferTurn } from "./types.js";
+
+// Issue #2190: prompts that produce memory content must embed the
+// output-language policy so a non-English conversation is not silently
+// translated to English — translated memories fail later lexical recall.
+const ENGLISH_OUTPUT_DIRECTIVE_RE =
+  /\b(?:write|respond|answer|output|produce|always reply)[^.]{0,60}\bin English\b/i;
+
+// Japanese fixture: a non-English conversation that must stay Japanese.
+const JAPANESE_TURNS: BufferTurn[] = [
+  { role: "user", content: "私は毎朝緑茶を飲みます。", timestamp: "2026-08-17T01:00:00.000Z" },
+  { role: "assistant", content: "承知しました。", timestamp: "2026-08-17T01:00:05.000Z" },
+];
+
+function allInstructionPrompts(): string[] {
+  const config = parseConfig({});
+  return [
+    buildExtractionInstructions(config),
+    buildConsolidationSystemPrompt(config),
+    buildProfileConsolidationSystemPrompt(50),
+    JUDGE_SYSTEM_PROMPT,
+    CLUSTER_PROMPT,
+  ];
+}
+
+test("extraction, consolidation, and profile-consolidation prompts embed the output-language policy", () => {
+  const config = parseConfig({});
+  assert.ok(
+    buildExtractionInstructions(config).includes(OUTPUT_LANGUAGE_POLICY),
+    "extraction instructions missing policy",
+  );
+  assert.ok(
+    buildConsolidationSystemPrompt(config).includes(OUTPUT_LANGUAGE_POLICY),
+    "consolidation prompt missing policy",
+  );
+  assert.ok(
+    buildProfileConsolidationSystemPrompt(50).includes(OUTPUT_LANGUAGE_POLICY),
+    "profile-consolidation prompt missing policy",
+  );
+});
+
+test("judge and calibration prompts embed the output-language policy", () => {
+  assert.ok(JUDGE_SYSTEM_PROMPT.includes(OUTPUT_LANGUAGE_POLICY), "judge prompt missing policy");
+  assert.ok(CLUSTER_PROMPT.includes(OUTPUT_LANGUAGE_POLICY), "calibration prompt missing policy");
+});
+
+test("no prompt surface instructs English output", () => {
+  for (const prompt of allInstructionPrompts()) {
+    assert.doesNotMatch(prompt, ENGLISH_OUTPUT_DIRECTIVE_RE);
+  }
+});
+
+test("local extraction of a Japanese conversation keeps the source language and is not told to emit English", async () => {
+  const engine = new ExtractionEngine(
+    parseConfig({
+      localLlmEnabled: true,
+      localLlmModel: "fixture-local",
+      localLlmFallback: false,
+    }),
+  );
+  let capturedPrompt = "";
+  const localLlm = {
+    async chatCompletion(messages: { content: string }[]) {
+      capturedPrompt = messages.map((m) => m.content).join("\n");
+      return {
+        content: JSON.stringify({
+          facts: [],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+          relationships: [],
+        }),
+      };
+    },
+  };
+  const modelRegistry = {
+    calculateContextSizes: () => ({
+      maxInputChars: 8_000,
+      maxOutputTokens: 1_000,
+      description: "fixture",
+    }),
+  };
+  assert.equal(Reflect.set(engine, "localLlm", localLlm), true);
+  assert.equal(Reflect.set(engine, "modelRegistry", modelRegistry), true);
+
+  await engine.extract(JAPANESE_TURNS);
+
+  assert.ok(capturedPrompt.length > 0, "no prompt captured from local extraction");
+  assert.ok(
+    capturedPrompt.includes(OUTPUT_LANGUAGE_POLICY),
+    "local extraction prompt missing policy",
+  );
+  assert.ok(capturedPrompt.includes("私は毎朝緑茶を飲みます。"), "Japanese source not in prompt");
+  assert.doesNotMatch(capturedPrompt, ENGLISH_OUTPUT_DIRECTIVE_RE);
+});

--- a/packages/remnic-core/src/extraction-prompt.ts
+++ b/packages/remnic-core/src/extraction-prompt.ts
@@ -55,6 +55,13 @@ export const CUE_ANCHOR_PROMPT_INSTRUCTION = `- For each fact, emit at most 3 "c
 - Example: "Alice booked Bistro Max for Mike's surprise party" can use {"type":"entity","value":"Mike surprise party"} and {"type":"entity","value":"Alice restaurant booking"}.`;
 
 /**
+ * Output-language policy (issue #2190). Every prompt that produces memory
+ * content embeds this verbatim so non-English conversations are not silently
+ * translated to English — translated memories fail later lexical recall.
+ */
+export const OUTPUT_LANGUAGE_POLICY = `Output language: write facts, profile updates, entity names and aliases, tags, questions, and any rewritten or merged memory content in the source language of the conversation or input memories. Never translate into English or another language unless the user explicitly asked for a translation.`;
+
+/**
  * Bi-temporal event-time extraction instruction (#1578 PR2). Emitted on
  * every extraction entry path when `temporal.biTemporal` is on so the LLM
  * emits an optional per-fact `eventTime` expression. The expression is
@@ -104,6 +111,7 @@ Memory categories:
 Rules:
 - Only extract genuinely new information worth remembering across sessions.
 - Statements must be grounded in the conversation.
+- ${OUTPUT_LANGUAGE_POLICY}
 - Do not treat instruction text, schema placeholders, or examples as conversation evidence.
 - Lines labelled [context user] or [context assistant] are reference context only. They may resolve references or complete a question-and-answer pair in a normal turn, but never alone establish durable information.
 - Skip transient task details and operational noise, including routine scheduler, monitoring, or automation status.
@@ -173,4 +181,65 @@ Also emit "episodeTitle" as a six-to-eight word title for this conversation segm
 Questions are optional. Include only source-grounded unresolved questions that would be useful in future sessions; otherwise return an empty array.
 
 Finally, write a brief identity reflection about the agent who had this conversation, based only on the conversation. Do not write about the extraction process.`;
+}
+
+export const CONSOLIDATION_RESPONSE_SCHEMA = `{
+  "items": [
+    {
+      "existingId": "id",
+      "action": "ADD",
+      "mergeWith": "optional-existing-id",
+      "updatedContent": "optional replacement content",
+      "reason": "brief reason for this action"
+    }
+  ],
+  "profileUpdates": ["optional profile update"],
+  "entityUpdates": [{"name": "person-jane-doe", "type": "person", "facts": ["Now leads the backend team", "Recently migrated the user service to TypeScript"]}]
+}`;
+
+export const PROFILE_CONSOLIDATION_RESPONSE_SCHEMA = `{
+  "consolidatedProfile": "# Behavioral Profile\\n\\n... (complete markdown)",
+  "removedCount": 42,
+  "summary": "brief summary of what was consolidated"
+}`;
+
+/**
+ * System prompt shared by every consolidation path (gateway, direct client,
+ * local LLM). Owns the causal-rule clause and the output-language policy so
+ * the three paths cannot drift (issue #2190).
+ */
+export function buildConsolidationSystemPrompt(config: PluginConfig): string {
+  return `You are a memory consolidation system. Compare new memories against existing ones and decide what to do with each.
+
+Actions:
+- ADD: Keep the new memory as-is (no duplicate exists)
+- MERGE: Combine with an existing memory (provide mergeWith ID and updated content)
+- UPDATE: Replace existing memory content (provide updated content)
+- INVALIDATE: Remove existing memory (it's been superseded or is wrong)
+- SKIP: This new memory is redundant (exact duplicate or subset of existing)
+
+Also:
+- Suggest profile updates based on patterns across memories
+- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(config).causalRuleExtraction ? `
+- When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}
+- ${OUTPUT_LANGUAGE_POLICY}`;
+}
+
+/**
+ * System prompt shared by every profile-consolidation path (gateway, direct
+ * client, local LLM). Owns the output-language policy (issue #2190).
+ */
+export function buildProfileConsolidationSystemPrompt(targetLines: number): string {
+  return `You are a profile consolidation system. You are given a behavioral profile (markdown) that has grown too large. Your job is to produce a CONSOLIDATED version that:
+
+1. PRESERVES all ## section headers and their structure
+2. MERGES duplicate or near-duplicate bullet points into single, clear statements
+3. REMOVES stale information that has been superseded by newer bullets
+4. REMOVES trivial or overly specific operational details that won't be useful across sessions
+5. KEEPS the most important, durable observations about the user's preferences, habits, identity, and working style
+6. Target roughly ${targetLines} lines — this is a soft target, prioritize quality over length
+7. Write in the same style as the existing profile — concise bullets, no fluff
+8. ${OUTPUT_LANGUAGE_POLICY}
+
+The output should be the COMPLETE consolidated profile as valid markdown, starting with "# Behavioral Profile".`;
 }

--- a/packages/remnic-core/src/extraction-prompt.ts
+++ b/packages/remnic-core/src/extraction-prompt.ts
@@ -118,7 +118,7 @@ Rules:
 - Priority: corrections > principles${resolveRecallAuxiliaryCapabilities(config).causalRuleExtraction ? " > rules" : ""} > preferences > commitments > decisions > relationships > entities > moments > skills > facts
 - Corrections get highest confidence.
 - Each fact should be a standalone, self-contained statement.
-- Entity references should use normalized names (lowercase, hyphenated: "jane-doe", "acme-corp")
+- Entity references should use normalized names (lowercase, hyphenated: "jane-doe", "acme-corp"). When the source language is not written in a Latin script, the source-script name IS the normalized form — never transliterate or translate it.
 - CRITICAL: Entity names must be CANONICAL. Always use the hyphenated multi-word form: "acme-corp" NOT "acmecorp" or "acme". "jane-doe" NOT "janedoe" or "jane". If unsure, prefer the most specific full name.
 - Avoid creating entities typed as "other" when a more specific type fits (company, project, tool, person, place)
 ${CUE_ANCHOR_PROMPT_INSTRUCTION}

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -49,7 +49,17 @@ import { applyGroundingWithConnector, headerConnector, renderExtractionConversat
 import { isMemoryCategory } from "./write-envelope.js";
 import { classifyExtractionThrownError, classifyFallbackParseFailure } from "./extraction-error-classification.js";
 import { AMBIENT_CAPTURE_PROMPT_SECTION_COMPACT, clampAmbientCaptureConfidence } from "./ambient-provenance.js";
-import { CUE_ANCHOR_PROMPT_INSTRUCTION, EXTRACTION_RESPONSE_SHAPE, buildExtractionInstructions, eventTimePromptInstruction } from "./extraction-prompt.js";
+import {
+  CONSOLIDATION_RESPONSE_SCHEMA,
+  CUE_ANCHOR_PROMPT_INSTRUCTION,
+  EXTRACTION_RESPONSE_SHAPE,
+  OUTPUT_LANGUAGE_POLICY,
+  PROFILE_CONSOLIDATION_RESPONSE_SCHEMA,
+  buildConsolidationSystemPrompt,
+  buildExtractionInstructions,
+  buildProfileConsolidationSystemPrompt,
+  eventTimePromptInstruction,
+} from "./extraction-prompt.js";
 import {
   containsExtractionPlaceholder,
   extractionAttributes,
@@ -66,19 +76,6 @@ type ExtractedEntityResult = ExtractionResult["entities"][number];
 type ExtractedRelationshipResult = NonNullable<ExtractionResult["relationships"]>[number];
 
 const PROACTIVE_MIN_CONFIDENCE = 0.8;
-const CONSOLIDATION_RESPONSE_SCHEMA = `{
-  "items": [
-    {
-      "existingId": "id",
-      "action": "ADD",
-      "mergeWith": "optional-existing-id",
-      "updatedContent": "optional replacement content",
-      "reason": "brief reason for this action"
-    }
-  ],
-  "profileUpdates": ["optional profile update"],
-  "entityUpdates": [{"name": "person-jane-doe", "type": "person", "facts": ["Now leads the backend team", "Recently migrated the user service to TypeScript"]}]
-}`;
 
 function extractionEntityType(value: unknown): ExtractedEntityResult["type"] | undefined {
   const type = extractionText(value);
@@ -688,6 +685,7 @@ export class ExtractionEngine {
     const prompt = [
       "You are doing a proactive second-pass memory extraction.",
       `Generate up to ${maxAdditional} additional high-value follow-up questions not already covered.${ambientCapture ? AMBIENT_CAPTURE_PROMPT_SECTION_COMPACT : ""}`,
+      OUTPUT_LANGUAGE_POLICY,
       "Return only valid JSON with this shape:",
       '{"questions":[{"question":"...","context":"...","priority":0.0}]}',
       "",
@@ -790,6 +788,7 @@ export class ExtractionEngine {
       "You are answering proactive memory follow-up questions using only the provided buffered conversation.",
       `Return at most ${maxAdditional} additional high-confidence memory candidates that were omitted from the base extraction.`,
       `Only include information directly supported by the conversation. Do not speculate. Do not repeat the base extraction.${ambientCapture ? AMBIENT_CAPTURE_PROMPT_SECTION_COMPACT : ""}`,
+      OUTPUT_LANGUAGE_POLICY,
       "Return only valid JSON with this shape:",
       '{"facts":[{"category":"fact","content":"...","confidence":0.0,"tags":["..."],"entityRef":"optional","promptedByQuestion":"optional","quote":"optional verbatim span from a single turn"}],"profileUpdates":["..."],"entities":[{"name":"...","type":"person","facts":["..."],"structuredSections":[{"key":"beliefs","title":"Beliefs","facts":["..."]}],"promptedByQuestion":"optional"}],"relationships":[{"source":"...","target":"...","label":"...","promptedByQuestion":"optional"}]}',
       this.config.provenance?.enabled
@@ -1423,6 +1422,7 @@ Rules:
 - Use normalized, hyphenated entity names and keep the entity list short.
 - Keep facts standalone. Skip transient task state and operational noise such as routine scheduler, monitoring, or automation status.
 - Add structuredAttributes only for concrete values.
+- ${OUTPUT_LANGUAGE_POLICY}
 ${CUE_ANCHOR_PROMPT_INSTRUCTION}\n- Include at most five durable relationships.${this.config.provenance?.enabled ? `
 - Each fact must include a quote copied verbatim from one contiguous conversation span.` : ""}${lifecycleCaps.extractionScopeClassification ? `
 - Set each fact scope to "global" for cross-project knowledge or "project" for codebase-specific knowledge. Tool, command, or CLI-flag instructions tied to one agent are "project" (the same tool name can mean different things across agents); when keeping one, begin the fact with a leading "In <agent>," clause naming that agent.` : ""}${ambientCapture ? AMBIENT_CAPTURE_PROMPT_SECTION_COMPACT : ""}
@@ -1650,19 +1650,7 @@ ${truncatedConversation}`;
       [
         {
           role: "system",
-          content: `You are a memory consolidation system. Compare new memories against existing ones and decide what to do with each.
-
-Actions:
-- ADD: Keep the new memory as-is (no duplicate exists)
-- MERGE: Combine with an existing memory (provide mergeWith ID and updated content)
-- UPDATE: Replace existing memory content (provide updated content)
-- INVALIDATE: Remove existing memory (it's been superseded or is wrong)
-- SKIP: This new memory is redundant (exact duplicate or subset of existing)
-
-Also:
-- Suggest profile updates based on patterns across memories
-- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
-- When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}`,
+          content: buildConsolidationSystemPrompt(this.config),
         },
         {
           role: "user",
@@ -1696,19 +1684,7 @@ Consolidate the new memories against existing ones.`,
     }
 
     try {
-      const instructionText = `You are a memory consolidation system. Compare new memories against existing ones and decide what to do with each.
-
-Actions:
-- ADD: Keep the new memory as-is (no duplicate exists)
-- MERGE: Combine with an existing memory (provide mergeWith ID and updated content)
-- UPDATE: Replace existing memory content (provide updated content)
-- INVALIDATE: Remove existing memory (it's been superseded or is wrong)
-- SKIP: This new memory is redundant (exact duplicate or subset of existing)
-
-Also:
-- Suggest profile updates based on patterns across memories
-- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
-- When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}
+      const instructionText = `${buildConsolidationSystemPrompt(this.config)}
 
 Current behavioral profile:
 ${currentProfile || "(empty)"}
@@ -1794,19 +1770,7 @@ ${CONSOLIDATION_RESPONSE_SCHEMA}`;
     );
     log.debug(`Consolidation model context: ${contextSizes.description}`);
 
-    const prompt = `You are a memory consolidation system. Compare new memories against existing ones and decide what to do with each.
-
-Actions:
-- ADD: Keep the new memory as-is (no duplicate exists)
-- MERGE: Combine with an existing memory (provide mergeWith ID and updated content)
-- UPDATE: Replace existing memory content (provide updated content)
-- INVALIDATE: Remove existing memory (it's been superseded or is wrong)
-- SKIP: This new memory is redundant (exact duplicate or subset of existing)
-
-Also:
-- Suggest profile updates based on patterns across memories
-- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
-- When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}
+    const prompt = `${buildConsolidationSystemPrompt(this.config)}
 
 Current behavioral profile:
 ${currentProfile || "(empty)"}
@@ -1907,17 +1871,7 @@ ${CONSOLIDATION_RESPONSE_SCHEMA}`;
       [
         {
           role: "system",
-          content: `You are a profile consolidation system. You are given a behavioral profile (markdown) that has grown too large. Your job is to produce a CONSOLIDATED version that:
-
-1. PRESERVES all ## section headers and their structure
-2. MERGES duplicate or near-duplicate bullet points into single, clear statements
-3. REMOVES stale information that has been superseded by newer bullets
-4. REMOVES trivial or overly specific operational details that won't be useful across sessions
-5. KEEPS the most important, durable observations about the user's preferences, habits, identity, and working style
-6. Target roughly ${targetLines} lines — this is a soft target, prioritize quality over length
-7. Write in the same style as the existing profile — concise bullets, no fluff
-
-The output should be the COMPLETE consolidated profile as valid markdown, starting with "# Behavioral Profile".`,
+          content: buildProfileConsolidationSystemPrompt(targetLines),
         },
         { role: "user", content: fullProfileContent },
       ],
@@ -1937,24 +1891,10 @@ The output should be the COMPLETE consolidated profile as valid markdown, starti
     }
 
     try {
-      const instructionText = `You are a profile consolidation system. You are given a behavioral profile (markdown) that has grown too large. Your job is to produce a CONSOLIDATED version that:
-
-1. PRESERVES all ## section headers and their structure
-2. MERGES duplicate or near-duplicate bullet points into single, clear statements
-3. REMOVES stale information that has been superseded by newer bullets
-4. REMOVES trivial or overly specific operational details that won't be useful across sessions
-5. KEEPS the most important, durable observations about the user's preferences, habits, identity, and working style
-6. Target roughly ${targetLines} lines — this is a soft target, prioritize quality over length
-7. Write in the same style as the existing profile — concise bullets, no fluff
-
-The output should be the COMPLETE consolidated profile as valid markdown, starting with "# Behavioral Profile".
+      const instructionText = `${buildProfileConsolidationSystemPrompt(targetLines)}
 
 Respond with valid JSON matching this schema:
-{
-  "consolidatedProfile": "# Behavioral Profile\\n\\n... (complete markdown)",
-  "removedCount": 42,
-  "summary": "brief summary of what was consolidated"
-}`;
+${PROFILE_CONSOLIDATION_RESPONSE_SCHEMA}`;
 
       const response = await this.client.chat.completions.create({
         model: this.config.model,
@@ -2027,25 +1967,13 @@ Respond with valid JSON matching this schema:
     );
     log.debug(`Profile consolidation model context: ${contextSizes.description}`);
 
-    const prompt = `You are a profile consolidation system. You are given a behavioral profile (markdown) that has grown too large. Your job is to produce a CONSOLIDATED version that:
-
-1. PRESERVES all ## section headers and their structure
-2. MERGES duplicate or near-duplicate bullet points into single, clear statements
-3. REMOVES stale information that has been superseded by newer bullets
-4. REMOVES trivial or overly specific operational details that won't be useful across sessions
-5. KEEPS the most important, durable observations about the user's preferences, habits, identity, and working style
-6. Target roughly ${targetLines} lines — this is a soft target, prioritize quality over length
-7. Write in the same style as the existing profile — concise bullets, no fluff
+    const prompt = `${buildProfileConsolidationSystemPrompt(targetLines)}
 
 Profile to consolidate:
 ${fullProfileContent}
 
 Respond with valid JSON matching this schema:
-{
-  "consolidatedProfile": "# Behavioral Profile\\n\\n... (complete markdown)",
-  "removedCount": 42,
-  "summary": "brief summary of what was consolidated"
-}`;
+${PROFILE_CONSOLIDATION_RESPONSE_SCHEMA}`;
 
     const response = await this.localLlm.chatCompletion(
       [

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1419,7 +1419,7 @@ Rules:
 - Lines labelled [context user] or [context assistant] are reference context only. They may resolve references or complete a question-and-answer pair in a normal turn, but never alone establish durable information.
 - Questions are optional. Return an empty array when the conversation does not support a useful unresolved question.
 - Set confidence from source evidence: Explicit (0.95-1.0), Implied (0.70-0.94), Inferred (0.40-0.69), or Speculative (0.00-0.39). Corrections get highest confidence.
-- Use normalized, hyphenated entity names and keep the entity list short.
+- Use normalized, hyphenated entity names and keep the entity list short. When the source language is not written in a Latin script, the source-script name IS the normalized form — never transliterate or translate it.
 - Keep facts standalone. Skip transient task state and operational noise such as routine scheduler, monitoring, or automation status.
 - Add structuredAttributes only for concrete values.
 - ${OUTPUT_LANGUAGE_POLICY}


### PR DESCRIPTION
Fixes #2190.

Extraction, consolidation, profile-consolidation, judge, and calibration
prompts had no output-language policy. Non-English conversations could
be silently translated to English. Those memories then fail later lexical
recall.

One shared `OUTPUT_LANGUAGE_POLICY` constant is now embedded in every
prompt that produces memory content. Facts, profile updates, entity
names, tags, and questions stay in the source language unless the user
asked for a translation.

`extraction.ts` shrank (2827 → 2755) by moving duplicated consolidation
prompt literals into shared builders. That pays the fileSizeGrandfather
ratchet.

Regression: `extraction-output-language.test.ts` checks policy presence
on every prompt surface and drives a Japanese fixture through the local
extraction path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated extraction, consolidation, profiling, judging, and clustering results now follow the source content’s language.
  * Added support for configurable profile summary length and optional causal-rule guidance during consolidation.
  * Improved consistency across local extraction and proactive questioning workflows.

* **Bug Fixes**
  * Prevented prompts from incorrectly requiring English responses when processing content in other languages.
  * Standardized consolidation responses for more reliable structured results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->