### PR TITLE
refactor(core): share reconcile ordering and census validators

### DIFF
--- a/packages/remnic-core/src/census-validation.ts
+++ b/packages/remnic-core/src/census-validation.ts
@@ -1,0 +1,25 @@
+/**
+ * Census field acceptance shared by offline-sync and the reconcile planner
+ * (issue #2477). Both surfaces parse untrusted peer censuses and must accept
+ * and reject exactly the same values; when these checks lived as two copies
+ * they could drift silently and break convergence. Each surface keeps only a
+ * thin wrapper that picks its own error type and message.
+ */
+
+/** 64-character sha256 hex, either case; the canonical stored form is lowercase. */
+export const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
+
+/** Largest `mtimeMs` a census may carry: `new Date(ms)` must stay a valid Date. */
+export const CENSUS_MAX_MTIME_MS = 8_640_000_000_000_000;
+
+export function isSha256Hex(value: unknown): value is string {
+  return typeof value === "string" && SHA256_HEX_PATTERN.test(value);
+}
+
+/**
+ * Fractional values are valid: `fs.stat()` reports sub-millisecond mtimes on
+ * common filesystems, so this deliberately does not require an integer.
+ */
+export function isCensusMtimeMs(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= CENSUS_MAX_MTIME_MS;
+}

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -33,7 +33,7 @@ import {
   type OfflineSyncExcludeFile,
   type OfflineSyncFileTarget,
 } from "./offline-sync-file-io.js";
-
+import { CENSUS_MAX_MTIME_MS, isCensusMtimeMs, isSha256Hex } from "./census-validation.js";
 export type { OfflineSyncExcludeFile, OfflineSyncFileTarget } from "./offline-sync-file-io.js";
 
 export const OFFLINE_SYNC_SNAPSHOT_FORMAT = "remnic.offline-sync.snapshot.v1";
@@ -43,7 +43,7 @@ export const OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES = 64 * 1024 * 1024;
 export const OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES = 8 * 1024 * 1024;
 export const OFFLINE_SYNC_APPLY_MAX_BODY_BYTES = 16 * 1024 * 1024;
 export const OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES = 64 * 1024 * 1024;
-export const OFFLINE_SYNC_MAX_MTIME_MS = 8_640_000_000_000_000;
+export const OFFLINE_SYNC_MAX_MTIME_MS = CENSUS_MAX_MTIME_MS;
 
 export interface OfflineSyncFileState {
   path: string;
@@ -288,7 +288,7 @@ function compareByPath<T extends { path: string }>(left: T, right: T): number {
 }
 
 function assertSha256(value: unknown, field: string): string {
-  if (typeof value !== "string" || !/^[a-f0-9]{64}$/i.test(value)) {
+  if (!isSha256Hex(value)) {
     throw new Error(`${field} must be a 64-character sha256 hex string`);
   }
   return value.toLowerCase();
@@ -315,7 +315,7 @@ function assertNonNegativeFinite(value: unknown, field: string): number {
 
 function assertOfflineSyncMtimeMs(value: unknown, field: string): number {
   const mtimeMs = assertNonNegativeFinite(value, field);
-  if (mtimeMs > OFFLINE_SYNC_MAX_MTIME_MS) {
+  if (!isCensusMtimeMs(mtimeMs)) {
     throw new Error(`${field} must be within JavaScript Date range`);
   }
   return mtimeMs;

--- a/packages/remnic-core/src/reconcile/census-parity.test.ts
+++ b/packages/remnic-core/src/reconcile/census-parity.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  OFFLINE_SYNC_MAX_MTIME_MS,
+  OFFLINE_SYNC_SNAPSHOT_FORMAT,
+  normalizeOfflineSyncSnapshot,
+} from "../offline-sync.js";
+import {
+  type ReconcilePlanEntry,
+  ReconcilePlanInputError,
+  compareReconcilePlanEntries,
+  planNamespaceReconciliation,
+  planReconciliation,
+  semanticAgreementKey,
+} from "./plan.js";
+
+/**
+ * Issue #2477: offline-sync and the reconcile planner validate the same peer
+ * census fields, and cursor/manifest order and key plan entries the same way.
+ * These tests fail the moment one surface drifts from the other, which was
+ * previously a silent convergence bug.
+ */
+
+const PATH = "facts/2026-03-01/a.md";
+const GOOD_SHA = "a".repeat(64);
+
+type CensusOutcome = { accepted: boolean; digest?: string };
+
+/** Validate one census file record through the offline-sync snapshot surface. */
+function offlineSyncOutcome(overrides: Record<string, unknown>): CensusOutcome {
+  try {
+    const snapshot = normalizeOfflineSyncSnapshot({
+      format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+      schemaVersion: 1,
+      createdAt: "2026-08-17T00:00:00.000Z",
+      sourceId: "peer",
+      includeTranscripts: false,
+      files: [{ path: PATH, bytes: 1, mtimeMs: 0, sha256: GOOD_SHA, ...overrides }],
+    });
+    return { accepted: true, digest: snapshot.files[0]?.sha256 };
+  } catch {
+    return { accepted: false };
+  }
+}
+
+/** Validate the same record through the reconcile planner's census surface. */
+function reconcileOutcome(overrides: Record<string, unknown>): CensusOutcome {
+  try {
+    const entries = planNamespaceReconciliation({
+      namespace: "default",
+      local: [{ path: PATH, sha256: GOOD_SHA, mtimeMs: 0, ...overrides }],
+      peer: [],
+    });
+    return { accepted: true, digest: entries.find((e) => e.path === PATH)?.localSha256 };
+  } catch (err) {
+    assert.ok(err instanceof ReconcilePlanInputError, "plan census rejects must stay ReconcilePlanInputError");
+    return { accepted: false };
+  }
+}
+
+const SHA256_FIXTURES: unknown[] = [
+  "b".repeat(64), // accepted, already canonical
+  "B".repeat(64), // accepted, canonicalized to lowercase
+  "b".repeat(63), // too short
+  "b".repeat(65), // too long
+  "z".repeat(64), // not hex
+  "",
+  42,
+  null,
+  { length: 64 },
+];
+
+const MTIME_FIXTURES: unknown[] = [
+  0,
+  1.25, // fractional mtimes are valid
+  OFFLINE_SYNC_MAX_MTIME_MS,
+  OFFLINE_SYNC_MAX_MTIME_MS + 1,
+  -1,
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  "100",
+  null,
+];
+
+test("sha256 census fixtures accept and canonicalize identically on both surfaces", () => {
+  const offline = SHA256_FIXTURES.map((sha256) => offlineSyncOutcome({ sha256 }));
+  const reconcile = SHA256_FIXTURES.map((sha256) => reconcileOutcome({ sha256 }));
+  assert.deepEqual(reconcile, offline);
+  assert.deepEqual(
+    offline.map((o) => o.accepted),
+    [true, true, false, false, false, false, false, false, false]
+  );
+  assert.equal(offline[1].digest, "b".repeat(64));
+});
+
+test("mtimeMs census fixtures accept and reject identically on both surfaces", () => {
+  const offline = MTIME_FIXTURES.map((mtimeMs) => offlineSyncOutcome({ mtimeMs }));
+  const reconcile = MTIME_FIXTURES.map((mtimeMs) => reconcileOutcome({ mtimeMs }));
+  assert.deepEqual(reconcile, offline);
+  assert.deepEqual(
+    offline.map((o) => o.accepted),
+    [true, true, true, false, false, false, false, false, false]
+  );
+});
+
+test("compareReconcilePlanEntries is the total order plan output itself uses", () => {
+  const entry = (namespace: string, path: string): ReconcilePlanEntry => ({
+    path,
+    namespace,
+    action: "identical",
+    reason: "same_content",
+  });
+  const a = entry("alpha", "facts/a.md");
+  const b = entry("beta", "facts/a.md");
+  const c = entry("beta", "facts/b.md");
+  const sorted = [c, { ...a }, b, a].sort(compareReconcilePlanEntries);
+  assert.deepEqual(
+    sorted.map((e) => [e.namespace, e.path]),
+    [
+      ["alpha", "facts/a.md"],
+      ["alpha", "facts/a.md"],
+      ["beta", "facts/a.md"],
+      ["beta", "facts/b.md"],
+    ]
+  );
+  assert.equal(compareReconcilePlanEntries(a, { ...a }), 0);
+
+  const plan = planReconciliation([
+    { namespace: "beta", local: [], peer: [] },
+    { namespace: "alpha", local: [{ path: "facts/z.md", sha256: GOOD_SHA }], peer: [] },
+  ]);
+  assert.ok(plan.entries.length > 0);
+  for (let i = 1; i < plan.entries.length; i += 1) {
+    assert.ok(compareReconcilePlanEntries(plan.entries[i - 1], plan.entries[i]) <= 0);
+  }
+});
+
+test("semanticAgreementKey pins the ordered path-pair identity shared by cursor and manifest", () => {
+  const localFirst = semanticAgreementKey({
+    local: { path: "facts/local.md", sha256: GOOD_SHA },
+    peer: { path: "facts/peer.md", sha256: GOOD_SHA },
+  });
+  assert.equal(localFirst, "facts/local.md\0facts/peer.md");
+  assert.notEqual(
+    localFirst,
+    semanticAgreementKey({
+      local: { path: "facts/peer.md", sha256: GOOD_SHA },
+      peer: { path: "facts/local.md", sha256: GOOD_SHA },
+    })
+  );
+});

--- a/packages/remnic-core/src/reconcile/cursor.ts
+++ b/packages/remnic-core/src/reconcile/cursor.ts
@@ -1,7 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { ReconcilePlanEntry, ReconcileSemanticAgreement } from "./plan.js";
+import {
+  type ReconcilePlanEntry,
+  type ReconcileSemanticAgreement,
+  semanticAgreementKey,
+} from "./plan.js";
 
 export type ConvergeRefreshTarget = "local" | "receiver";
 
@@ -74,10 +78,6 @@ function digestAfterReconcile(entry: ReconcilePlanEntry): string | undefined {
   if (entry.action !== "identical") return undefined;
   if (entry.localSha256 && entry.peerSha256 && entry.localSha256 !== entry.peerSha256) return undefined;
   return entry.localSha256 ?? entry.peerSha256;
-}
-
-function semanticAgreementKey(agreement: ReconcileSemanticAgreement): string {
-  return `${agreement.local.path}\0${agreement.peer.path}`;
 }
 
 export function deriveConvergeCursorBase(

--- a/packages/remnic-core/src/reconcile/manifest.ts
+++ b/packages/remnic-core/src/reconcile/manifest.ts
@@ -12,6 +12,8 @@ import {
   type ReconcilePlanEntry,
   type ReconcileSemanticAgreement,
   type ReconcileSemanticChange,
+  compareReconcilePlanEntries,
+  semanticAgreementKey,
   summarizeReconcilePlan,
 } from "./plan.js";
 
@@ -218,15 +220,6 @@ function contentHashRows(
   return rows;
 }
 
-function comparePlanEntries(left: ReconcilePlanEntry, right: ReconcilePlanEntry): number {
-  if (left.namespace !== right.namespace) return left.namespace < right.namespace ? -1 : 1;
-  return left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
-}
-
-function semanticAgreementKey(agreement: ReconcileSemanticAgreement): string {
-  return `${agreement.local.path}\0${agreement.peer.path}`;
-}
-
 function classifySemanticChange(
   current: ReconcileSemanticAgreement,
   prior: ReconcileSemanticAgreement | undefined
@@ -396,13 +389,13 @@ export function collapseActiveFactDuplicates(
     if (removed.size > 0 || replacements.length > 0) {
       entriesByNamespace.set(
         namespace,
-        [...entries.filter((entry) => !removed.has(entry)), ...replacements].sort(comparePlanEntries)
+        [...entries.filter((entry) => !removed.has(entry)), ...replacements].sort(compareReconcilePlanEntries)
       );
     }
   }
 
   if (!changed) return plan;
-  const entries = [...entriesByNamespace.values()].flat().sort(comparePlanEntries);
+  const entries = [...entriesByNamespace.values()].flat().sort(compareReconcilePlanEntries);
   return {
     entries,
     byNamespace: summarizeReconcilePlan(entries),

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -1,5 +1,5 @@
+import { CENSUS_MAX_MTIME_MS, isCensusMtimeMs, isSha256Hex } from "../census-validation.js";
 import { normalizeNamespaceIdentity } from "../namespaces/identity.js";
-import { OFFLINE_SYNC_MAX_MTIME_MS } from "../offline-sync.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
 import {
@@ -197,8 +197,7 @@ export class ReconcilePlanInputError extends Error {
   }
 }
 
-/** Matches `assertSha256` in offline-sync so both surfaces reject the same values (§40). */
-const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
+/** Shared with offline-sync's census validation (issue #2477): one acceptance set. */
 
 /**
  * Validate a census record's identity fields.
@@ -247,14 +246,9 @@ function assertCensusRecord(
  * deliberately does not require an integer.
  */
 function assertMtimeMs(value: unknown, context: string): number {
-  if (
-    typeof value !== "number"
-    || !Number.isFinite(value)
-    || value < 0
-    || value > OFFLINE_SYNC_MAX_MTIME_MS
-  ) {
+  if (!isCensusMtimeMs(value)) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${context} has an out-of-range mtimeMs; expected a finite value between 0 and ${OFFLINE_SYNC_MAX_MTIME_MS}`,
+      `reconcile: ${context} has an out-of-range mtimeMs; expected a finite value between 0 and ${CENSUS_MAX_MTIME_MS}`,
     );
   }
   return value;
@@ -267,7 +261,7 @@ function assertMtimeMs(value: unknown, context: string): number {
  * and tombstone lookups would silently miss.
  */
 function assertDigest(value: unknown, context: string): string {
-  if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
+  if (!isSha256Hex(value)) {
     throw new ReconcilePlanInputError(
       `reconcile: ${context} must carry a 64-character sha256 hex digest`,
     );
@@ -503,14 +497,23 @@ function assertConflictPolicy(value: ConvergeConflictPolicy | undefined): Conver
  * Total ordering for plan entries (§12): namespace, then path. Both are unique
  * per entry, so equal keys are impossible and the comparator never has to
  * return 0 for distinct rows — the output is byte-identical across runs, which
- * is what makes a convergence report diffable.
+ * is what makes a convergence report diffable. Cursor and manifest sort with
+ * this same export; a local copy on either side is how ordering drifts (§2477).
  */
-function compareEntries(a: ReconcilePlanEntry, b: ReconcilePlanEntry): number {
+export function compareReconcilePlanEntries(a: ReconcilePlanEntry, b: ReconcilePlanEntry): number {
   if (a.namespace !== b.namespace) return a.namespace < b.namespace ? -1 : 1;
   if (a.path !== b.path) return a.path < b.path ? -1 : 1;
   return 0;
 }
 
+/**
+ * Identity of a semantic-duplicate pair: the ordered (local, peer) path pair.
+ * Cursor derivation and manifest collapse must key prior agreements with this
+ * same export or a stored cursor stops matching the plan that wrote it.
+ */
+export function semanticAgreementKey(agreement: ReconcileSemanticAgreement): string {
+  return `${agreement.local.path}\0${agreement.peer.path}`;
+}
 
 function resolveConflict(
   policy: ConvergeConflictPolicy,
@@ -795,7 +798,7 @@ export function planNamespaceReconciliation(
     });
   }
 
-  return entries.sort(compareEntries);
+  return entries.sort(compareReconcilePlanEntries);
 }
 
 /** Aggregate entries into the per-namespace convergence report (#2150). */
@@ -852,7 +855,7 @@ export function planReconciliation(
     seenNamespaces.add(name);
     entries.push(...planNamespaceReconciliation(namespace, options));
   }
-  entries.sort(compareEntries);
+  entries.sort(compareReconcilePlanEntries);
   return {
     entries,
     byNamespace: summarizeReconcilePlan(entries),


### PR DESCRIPTION
Fixes #2477.

Reconcile plan ordering and semantic-agreement keys were copied across
`plan.ts`, `cursor.ts`, and `manifest.ts`. Census sha256/mtimeMs
acceptance was copied between `offline-sync.ts` and `reconcile/plan.ts`.
Drift between those copies is a silent converge bug.

`compareReconcilePlanEntries` and `semanticAgreementKey` now live in
`reconcile/plan.ts`. Cursor and manifest import them.

Shared census predicates live in `census-validation.ts`. Offline-sync
and reconcile keep their error types via thin wrappers.

Regression: `reconcile/census-parity.test.ts` runs the same fixture
order through both surfaces.

`offline-sync.ts` did not grow (grandfathered).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized validation for census SHA-256 hashes and modification times.
  * Improved consistency when comparing and ordering reconciliation results, manifests, and synchronization data.
  * Ensured stable agreement keys and deterministic output ordering across reconciliation workflows.

* **Tests**
  * Added coverage for accepted and rejected census values, canonicalization, ordering, and consistency between synchronization and reconciliation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->