### PR TITLE
refactor(recall): store included memories as one struct list

### DIFF
--- a/packages/plugin-openclaw/src/session-command-descriptors.test.ts
+++ b/packages/plugin-openclaw/src/session-command-descriptors.test.ts
@@ -40,6 +40,10 @@ test("buildSessionCommandDescriptors wires toggle and status handlers", async ()
         queryHash: "test-query",
         queryLen: 12,
         memoryIds: ["mem-1", "mem-2"],
+        includedMemories: [
+          { id: "mem-1", path: "facts/mem-1.md" },
+          { id: "mem-2", path: "facts/mem-2.md" },
+        ],
         latencyMs: 33,
         plannerMode: "minimal" as const,
       };

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -313,7 +313,7 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     fallbackUsed: T_BOOLEAN,
     sourcesUsed: T_ARRAY,
     latencyMs: T_NUMBER,
-    resultPaths: T_ARRAY,
+    includedMemories: T_ARRAY,
     message: T_NULLABLE_STRING,
   }),
   memory_intent_debug: objectSchema({

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -305,7 +305,9 @@ export async function assembleRecallResponse(
       fallbackUsed: snapshot?.fallbackUsed ?? false,
       sourcesUsed: snapshot?.sourcesUsed ?? [],
       disclosure,
-      budgetsApplied: snapshot?.budgetsApplied,
+      budgetsApplied: snapshot
+        ? displaySafeRecallSnapshot(snapshot, deps.orchestrator.config.memoryDir).budgetsApplied
+        : undefined,
       auditAnomalies,
       budgetWarning: toBudgetWarning(budgetDecision),
       latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -15,7 +15,7 @@ import { type BudgetDecision, toBudgetWarning } from "./cross-namespace-budget.j
 import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import { type TagMatchMode, applyTagFilter, normalizeTags, parseTagMatch } from "./recall-tag-filter.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
-import { displaySafeBudgetsApplied, displaySafeRecallSnapshot } from "./orchestration/recall-result-formatter.js";
+import { displaySafeRecallSnapshot } from "./orchestration/recall-result-formatter.js";
 import {
   boundRecallContextComposition,
   composeRecallContext,
@@ -305,7 +305,7 @@ export async function assembleRecallResponse(
       fallbackUsed: snapshot?.fallbackUsed ?? false,
       sourcesUsed: snapshot?.sourcesUsed ?? [],
       disclosure,
-      budgetsApplied: displaySafeBudgetsApplied(snapshot?.budgetsApplied, deps.orchestrator.config.memoryDir),
+      budgetsApplied: snapshot?.budgetsApplied,
       auditAnomalies,
       budgetWarning: toBudgetWarning(budgetDecision),
       latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),

--- a/packages/remnic-core/src/access-recall-surface.ts
+++ b/packages/remnic-core/src/access-recall-surface.ts
@@ -26,7 +26,7 @@ import { expandScopeProfileReadNamespaces, resolveScopeProfilePlan } from "./nam
 import type { Orchestrator, RecallInvocationOptions } from "./orchestrator.js";
 import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import { assembleRecallResponse } from "./access-recall-response.js";
-import type { LastRecallSnapshot } from "./recall-state.js";
+import { coerceIncludedMemories, type LastRecallSnapshot } from "./recall-state.js";
 import type { RecallContextComposition } from "./recall-context-composition.js";
 import { type TagMatchMode, applyTagFilter, normalizeTags, parseTagMatch } from "./recall-tag-filter.js";
 import { type RecallXraySnapshot, estimateRecallTokens } from "./recall-xray.js";
@@ -44,7 +44,6 @@ import {
 // Canonical copies (access-service.ts still carries private duplicates for
 // its remaining callers; dedupe tracked separately).
 import { qmdCollectionPathParts, qmdResultPathCandidates } from "./orchestration/qmd-result-resolver.js";
-
 export interface AccessRecallSurfaceDeps {
   readonly auditAdapter: AccessAuditAdapter | null;
   readonly budget: CrossNamespaceBudget;
@@ -214,7 +213,10 @@ export class AccessRecallSurface {
     rawExcerptsSuppressed?: boolean;
   }): Promise<EngramAccessRecallResponse> {
     const memoryIds = options.snapshot.results.map((result) => result.memoryId);
-    const resultPaths = options.snapshot.results.map((result) => result.path);
+    const includedMemories = options.snapshot.results.map((result) => ({
+      id: result.memoryId,
+      path: result.path,
+    }));
     const namespace = options.snapshot.namespace
       ? this.deps.resolveNamespace(options.snapshot.namespace)
       : this.deps.orchestrator.config.defaultNamespace;
@@ -243,7 +245,7 @@ export class AccessRecallSurface {
         finalContextChars: options.snapshot.budget.used,
       },
       latencyMs: Date.now() - options.startedAt,
-      resultPaths,
+      includedMemories,
     };
     const results = await this.deps.serializeRecallResults(
       snapshotForSerialization,
@@ -515,12 +517,10 @@ export class AccessRecallSurface {
               : null,
           );
     const rawExcerpts = rawExcerptsResult ?? undefined;
-
-    const resultNamespaces = snapshot.resultNamespaces ?? [];
-    for (let index = 0; index < (snapshot.resultPaths ?? []).length; index += 1) {
-      const memoryPath = snapshot.resultPaths?.[index];
-      const memoryNamespace = resultNamespaces[index];
+    for (const included of coerceIncludedMemories(snapshot)) {
+      const memoryPath = included.path;
       if (!memoryPath) continue;
+      const memoryNamespace = included.namespace;
       const seenKey = `${memoryNamespace ?? ""}\0${memoryPath}`;
       if (seen.has(seenKey)) continue;
       const resolved = await readResultPath(memoryPath, memoryNamespace);

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -259,7 +259,7 @@ test("last recall serialization resolves namespace collection-prefixed result pa
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: [`${collection}/archive/facts/2026-06-16/fact-001.md`],
+      includedMemories: [{ id: "", path: `${collection}/archive/facts/2026-06-16/fact-001.md` }],
     },
     "summary",
   );
@@ -355,7 +355,7 @@ test("last recall serialization does not fall back after namespace collection mi
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: [`${collection}/2026-06-16/fact-001.md`],
+      includedMemories: [{ id: "", path: `${collection}/2026-06-16/fact-001.md` }],
     },
     "summary",
   );
@@ -428,7 +428,7 @@ test("last recall serialization resolves cold collection paths through snapshot 
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: ["test-memory-cold/facts/2026-06-16/fact-001.md"],
+      includedMemories: [{ id: "", path: "test-memory-cold/facts/2026-06-16/fact-001.md" }],
     },
     "summary",
   );
@@ -503,7 +503,7 @@ test("last recall serialization propagates locked namespace collection errors", 
           queryLen: 4,
           memoryIds: [],
           namespace: "default",
-          resultPaths: [`${collection}/2026-06-16/fact-001.md`],
+          includedMemories: [{ id: "", path: `${collection}/2026-06-16/fact-001.md` }],
         },
         "summary",
       ),
@@ -563,7 +563,7 @@ test("last recall serialization does not treat date paths as collection prefixes
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: ["2026-06-16/fact-001.md"],
+      includedMemories: [{ id: "", path: "2026-06-16/fact-001.md" }],
     },
     "summary",
   );
@@ -632,7 +632,7 @@ test("last recall serialization does not strip invalid collection prefixes", asy
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: ["test-memory--not-a-token/2026-06-16/fact-001.md"],
+      includedMemories: [{ id: "", path: "test-memory--not-a-token/2026-06-16/fact-001.md" }],
     },
     "summary",
   );
@@ -733,7 +733,7 @@ test("last recall serialization preserves absolute paths from readable namespace
       queryLen: 4,
       memoryIds: [],
       namespace: "team",
-      resultPaths: [sharedMemoryPath],
+      includedMemories: [{ id: "", path: sharedMemoryPath }],
     },
     "summary",
   );
@@ -817,7 +817,7 @@ test("last recall serialization preserves absolute paths from dynamic namespace 
       queryLen: 4,
       memoryIds: [],
       namespace: "team",
-      resultPaths: [dynamicMemoryPath],
+      includedMemories: [{ id: "", path: dynamicMemoryPath }],
     },
     "summary",
   );
@@ -905,7 +905,7 @@ test("last recall serialization rejects traversing collection paths", async () =
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: [`${collection}/../../facts/2026-06-16/fact-001.md`],
+      includedMemories: [{ id: "", path: `${collection}/../../facts/2026-06-16/fact-001.md` }],
     },
     "summary",
   );

--- a/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
+++ b/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
@@ -92,7 +92,7 @@ function makeRawExcerptProbe(options: {
     memoryIds: [],
     namespace: options.snapshotNamespace,
     recallNamespaces: [options.snapshotNamespace],
-    resultPaths: [],
+    includedMemories: [],
   };
 
   const storage = {

--- a/packages/remnic-core/src/included-memories.ts
+++ b/packages/remnic-core/src/included-memories.ts
@@ -47,18 +47,19 @@ function normalizeIncludedMemory(value: unknown): IncludedMemory | undefined {
   return namespace ? { id, path, namespace } : { id, path };
 }
 
-export function coerceIncludedMemories(raw: LegacyIncludedMemorySource): IncludedMemory[] {
-  if (Array.isArray(raw.includedMemories)) {
-    return raw.includedMemories
+export function coerceIncludedMemories(raw: object): IncludedMemory[] {
+  const source = raw as LegacyIncludedMemorySource;
+  if (Array.isArray(source.includedMemories)) {
+    return source.includedMemories
       .map(normalizeIncludedMemory)
       .filter((item): item is IncludedMemory => item !== undefined);
   }
 
-  const budgets = legacyBudgetView(raw);
-  const ids = asStringList(raw.memoryIds ?? budgets.includedMemoryIds);
-  const paths = asStringList(raw.resultPaths ?? budgets.includedMemoryPaths);
+  const budgets = legacyBudgetView(source);
+  const ids = asStringList(source.memoryIds ?? budgets.includedMemoryIds);
+  const paths = asStringList(source.resultPaths ?? budgets.includedMemoryPaths);
   const namespaces = asOptionalStringList(
-    raw.resultNamespaces ?? budgets.includedMemoryNamespaces,
+    source.resultNamespaces ?? budgets.includedMemoryNamespaces,
   );
   const count = Math.max(ids.length, paths.length);
   const memories: IncludedMemory[] = [];

--- a/packages/remnic-core/src/included-memories.ts
+++ b/packages/remnic-core/src/included-memories.ts
@@ -1,0 +1,87 @@
+export interface IncludedMemory {
+  id: string;
+  path: string;
+  namespace?: string;
+}
+
+type LegacyIncludedMemorySource = {
+  includedMemories?: unknown;
+  memoryIds?: unknown;
+  resultPaths?: unknown;
+  resultNamespaces?: unknown;
+  budgetsApplied?: unknown;
+};
+
+function legacyBudgetView(raw: LegacyIncludedMemorySource): {
+  includedMemoryIds?: unknown;
+  includedMemoryPaths?: unknown;
+  includedMemoryNamespaces?: unknown;
+} {
+  const budgets = raw.budgetsApplied;
+  if (!budgets || typeof budgets !== "object") return {};
+  const record = budgets as Record<string, unknown>;
+  return {
+    includedMemoryIds: record.includedMemoryIds,
+    includedMemoryPaths: record.includedMemoryPaths,
+    includedMemoryNamespaces: record.includedMemoryNamespaces,
+  };
+}
+
+function asStringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => (typeof item === "string" ? item : "")) : [];
+}
+
+function asOptionalStringList(value: unknown): Array<string | undefined> {
+  return Array.isArray(value)
+    ? value.map((item) => (typeof item === "string" ? item : undefined))
+    : [];
+}
+
+function normalizeIncludedMemory(value: unknown): IncludedMemory | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as { id?: unknown; path?: unknown; namespace?: unknown };
+  const id = typeof record.id === "string" ? record.id : "";
+  const path = typeof record.path === "string" ? record.path : "";
+  if (!id && !path) return undefined;
+  const namespace = typeof record.namespace === "string" ? record.namespace : undefined;
+  return namespace ? { id, path, namespace } : { id, path };
+}
+
+export function coerceIncludedMemories(raw: LegacyIncludedMemorySource): IncludedMemory[] {
+  if (Array.isArray(raw.includedMemories)) {
+    return raw.includedMemories
+      .map(normalizeIncludedMemory)
+      .filter((item): item is IncludedMemory => item !== undefined);
+  }
+
+  const budgets = legacyBudgetView(raw);
+  const ids = asStringList(raw.memoryIds ?? budgets.includedMemoryIds);
+  const paths = asStringList(raw.resultPaths ?? budgets.includedMemoryPaths);
+  const namespaces = asOptionalStringList(
+    raw.resultNamespaces ?? budgets.includedMemoryNamespaces,
+  );
+  const count = Math.max(ids.length, paths.length);
+  const memories: IncludedMemory[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const id = ids[index] ?? "";
+    const path = paths[index] ?? "";
+    if (!id && !path) continue;
+    const namespace = namespaces[index];
+    memories.push(namespace ? { id, path, namespace } : { id, path });
+  }
+  return memories;
+}
+
+export function includedMemoryIds(memories: readonly IncludedMemory[]): string[] {
+  return memories.map((memory) => memory.id);
+}
+
+export function includedMemoryPaths(memories: readonly IncludedMemory[]): string[] {
+  return memories.map((memory) => memory.path);
+}
+
+export function includedMemoryNamespaces(
+  memories: readonly IncludedMemory[],
+): Array<string | undefined> {
+  return memories.map((memory) => memory.namespace);
+}

--- a/packages/remnic-core/src/orchestration/recall-internal-deps.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal-deps.ts
@@ -116,6 +116,9 @@ export interface RecallInternalDeps {
     truncated: boolean;
     finalChars: number;
     includedMemories: IncludedMemory[];
+    includedMemoryIds: string[];
+    includedMemoryPaths: string[];
+    includedMemoryNamespaces: Array<string | undefined>;
     omittedMemoryIds: string[];
   };
   boostSearchResults(

--- a/packages/remnic-core/src/orchestration/recall-internal-deps.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal-deps.ts
@@ -20,7 +20,7 @@ import type { ObjectiveStateSearchResult } from "../objective-state.js";
 import type { IntentDebugSnapshot, QmdRecallSnapshot, QueryAwarePrefilter } from "../orchestrator.js";
 import type { CorpusReadOptions } from "../corpus-read-cancellation.js";
 import type { ProfilingCollector } from "../profiling.js";
-import type { GraphRecallExpandedEntry, LastRecallBudgetSummary, LastRecallStore, RecallHandleHistoryStore } from "../recall-state.js";
+import type { GraphRecallExpandedEntry, IncludedMemory, LastRecallBudgetSummary, LastRecallStore, RecallHandleHistoryStore } from "../recall-state.js";
 import type { RecallXraySnapshot } from "../recall-xray.js";
 import type { RerankCache } from "../rerank.js";
 import type { SearchBackend, SearchDegradation, SearchQueryOptions } from "../search/port.js";
@@ -115,9 +115,7 @@ export interface RecallInternalDeps {
     omittedIds: string[];
     truncated: boolean;
     finalChars: number;
-    includedMemoryIds: string[];
-    includedMemoryPaths: string[];
-    includedMemoryNamespaces: Array<string | undefined>;
+    includedMemories: IncludedMemory[];
     omittedMemoryIds: string[];
   };
   boostSearchResults(
@@ -168,9 +166,6 @@ export interface RecallInternalDeps {
     truncated?: boolean;
     includedSections?: string[];
     omittedSections?: string[];
-    includedMemoryIds?: string[];
-    includedMemoryPaths?: string[];
-    includedMemoryNamespaces?: Array<string | undefined>;
     omittedMemoryIds?: string[];
   }): LastRecallBudgetSummary;
   buildQueryAwarePrefilter(

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -622,7 +622,7 @@ export class RecallInternalCoordinator {
               qmdHybridFetchLimit,
             }),
             latencyMs: Date.now() - recallStart,
-            resultPaths: [],
+            includedMemories: [],
             policyVersion,
             appendImpression: this.deps.config.recordEmptyRecallImpressions,
             identityInjection: {
@@ -4944,14 +4944,14 @@ export class RecallInternalCoordinator {
     const assembledRecall = this.deps.assembleRecallSections(
       sectionBuckets, contextBudgetForFooter(recallBudgetChars, curiosityFooter),
     );
-    recalledMemoryIds = assembledRecall.includedMemoryIds;
-    recalledMemoryPaths = assembledRecall.includedMemoryPaths;
-    recalledMemoryNamespaces = assembledRecall.includedMemoryNamespaces;
-    recalledMemoryCount = assembledRecall.includedMemoryIds.length;
+    recalledMemoryIds = assembledRecall.includedMemories.map((memory) => memory.id);
+    recalledMemoryPaths = assembledRecall.includedMemories.map((memory) => memory.path);
+    recalledMemoryNamespaces = assembledRecall.includedMemories.map((memory) => memory.namespace);
+    recalledMemoryCount = assembledRecall.includedMemories.length;
     this.deps.trackMemoryAccess(
-      assembledRecall.includedMemoryIds,
-      assembledRecall.includedMemoryPaths,
-      assembledRecall.includedMemoryNamespaces,
+      recalledMemoryIds,
+      recalledMemoryPaths,
+      recalledMemoryNamespaces,
     );
     const recalledContext = assembledRecall.sections.join("\n\n---\n\n");
     const composition = boundRecallContextComposition({
@@ -4987,9 +4987,6 @@ export class RecallInternalCoordinator {
       truncated: assembledRecall.truncated || compositionTruncated || curiosityFooterTruncated,
       includedSections,
       omittedSections,
-      includedMemoryIds: assembledRecall.includedMemoryIds,
-      includedMemoryPaths: assembledRecall.includedMemoryPaths,
-      includedMemoryNamespaces: assembledRecall.includedMemoryNamespaces,
       omittedMemoryIds: assembledRecall.omittedMemoryIds,
     });
     // X-ray capture (issue #570 PR 1).  Only fires when the caller
@@ -5241,8 +5238,7 @@ export class RecallInternalCoordinator {
           sourcesUsed,
           budgetsApplied,
           latencyMs: Date.now() - recallStart,
-          resultPaths: recalledMemoryPaths,
-          resultNamespaces: recalledMemoryNamespaces,
+          includedMemories: assembledRecall.includedMemories,
           policyVersion,
           appendImpression:
             recalledMemoryIds.length > 0 ||

--- a/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter-display-safe.test.ts
@@ -2,19 +2,17 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { displaySafeRecallSnapshot } from "./recall-result-formatter.js";
 
-test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor paths without mutating input (#2077)", () => {
+test("displaySafeRecallSnapshot relativizes included-memory and tier-anchor paths without mutating input (#2077)", () => {
   const memoryDir = "/srv/memory";
   const flatAbs = `${memoryDir}/facts/2026-07-19/b.md`;
   const nsResultAbs = `${memoryDir}/namespaces/tok-team/facts/2026-07-19/r.md`;
-  // An anchor that is NOT among the returned results — no authoritative owner.
+  // An anchor that is NOT among the included memories — no authoritative owner.
   const unmatchedAnchorAbs = `${memoryDir}/namespaces/ns-616c706861/facts/2026-07-19/a.md`;
   const snapshot = {
-    resultPaths: [flatAbs, nsResultAbs],
-    resultNamespaces: [undefined, "team-alpha"],
-    budgetsApplied: {
-      includedMemoryPaths: [flatAbs, nsResultAbs],
-      includedMemoryNamespaces: [undefined, "team-alpha"],
-    },
+    includedMemories: [
+      { id: "mem-b", path: flatAbs },
+      { id: "mem-r", path: nsResultAbs, namespace: "team-alpha" },
+    ],
     tierExplain: {
       tier: "direct-answer",
       tierReason: "single high-confidence hit",
@@ -31,21 +29,20 @@ test("displaySafeRecallSnapshot relativizes result, budget, and tier-anchor path
 
   const safe = displaySafeRecallSnapshot(snapshot, memoryDir);
 
-  assert.deepEqual(safe.resultPaths, ["facts/2026-07-19/b.md", "team-alpha/facts/2026-07-19/r.md"]);
-  assert.deepEqual(safe.budgetsApplied.includedMemoryPaths, [
-    "facts/2026-07-19/b.md",
-    "team-alpha/facts/2026-07-19/r.md",
+  assert.deepEqual(safe.includedMemories, [
+    { id: "mem-b", path: "facts/2026-07-19/b.md" },
+    { id: "mem-r", path: "team-alpha/facts/2026-07-19/r.md", namespace: "team-alpha" },
   ]);
   assert.deepEqual(safe.tierExplain.sourceAnchors, [
-    // Anchor coincides with a namespaced result → reuses its authoritative namespace.
+    // Anchor coincides with a namespaced included memory → reuses its authoritative namespace.
     { path: "team-alpha/facts/2026-07-19/r.md", lineRange: [1, 2] },
-    // Anchor not among the results → truthful storage-relative segment, never a decode.
+    // Anchor not among the included memories → truthful storage-relative segment, never a decode.
     { path: "namespaces/ns-616c706861/facts/2026-07-19/a.md" },
-    // Anchor coincides with a default-namespace result → memoryDir-relative.
+    // Anchor coincides with a default-namespace included memory → memoryDir-relative.
     { path: "facts/2026-07-19/b.md" },
   ]);
 
   // The input snapshot must not be mutated — the live cache keeps absolute paths.
   assert.equal(snapshot.tierExplain.sourceAnchors[0].path, nsResultAbs);
-  assert.equal(snapshot.resultPaths[1], nsResultAbs);
+  assert.equal(snapshot.includedMemories[1].path, nsResultAbs);
 });

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -33,7 +33,7 @@ import type { WorkProductLedgerSearchResult } from "../work-product-ledger.js";
 import { trustResultFor, type TrustStageResultItem } from "../trust-score-stage.js";
 import { CONNECTOR_ID_PATTERN, CONNECTOR_LABEL_MAX_LENGTH } from "../connectors/label.js";
 import { isValidConnectorId } from "../connectors/index.js";
-import type { IncludedMemory } from "../included-memories.js";
+import { coerceIncludedMemories, type IncludedMemory } from "../included-memories.js";
 import type {
   ContinuityIncidentRecord,
   IdentityInjectionMode,
@@ -128,22 +128,27 @@ export function displayResultPath(
 export function displaySafeRecallSnapshot<
   T extends {
     includedMemories?: IncludedMemory[];
+    memoryIds?: string[];
+    resultPaths?: string[];
+    resultNamespaces?: Array<string | undefined>;
+    budgetsApplied?: {
+      includedMemoryIds?: string[];
+      includedMemoryPaths?: string[];
+      includedMemoryNamespaces?: Array<string | undefined>;
+    };
     tierExplain?: {
       sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
     };
   },
 >(snapshot: T, memoryDir: string): T {
-  const includedMemories = snapshot.includedMemories?.map((memory) => ({
+  const includedMemories = coerceIncludedMemories(snapshot).map((memory) => ({
     ...memory,
     path: displayResultPath(memory.path, memoryDir, memory.namespace),
   }));
-  // Authoritative absolute-path -> namespace map recorded at capture time, so
-  // a tier anchor that coincides with an included memory renders under the
-  // SAME namespace as that memory instead of the raw storage segment (#2077).
   const namespaceByPath = new Map<string, string | undefined>();
-  snapshot.includedMemories?.forEach((memory) => {
+  for (const memory of coerceIncludedMemories(snapshot)) {
     if (!namespaceByPath.has(memory.path)) namespaceByPath.set(memory.path, memory.namespace);
-  });
+  }
   const tierExplain =
     snapshot.tierExplain?.sourceAnchors
       ? {
@@ -154,9 +159,22 @@ export function displaySafeRecallSnapshot<
           })),
         }
       : undefined;
+  const resultPaths = includedMemories.map((memory) => memory.path);
+  const resultNamespaces = includedMemories.map((memory) => memory.namespace);
   return {
     ...snapshot,
-    ...(includedMemories ? { includedMemories } : {}),
+    includedMemories,
+    resultPaths,
+    resultNamespaces,
+    ...(snapshot.budgetsApplied
+      ? {
+          budgetsApplied: {
+            ...snapshot.budgetsApplied,
+            includedMemoryPaths: resultPaths,
+            includedMemoryNamespaces: resultNamespaces,
+          },
+        }
+      : {}),
     ...(tierExplain ? { tierExplain } : {}),
   };
 }

--- a/packages/remnic-core/src/orchestration/recall-result-formatter.ts
+++ b/packages/remnic-core/src/orchestration/recall-result-formatter.ts
@@ -33,6 +33,7 @@ import type { WorkProductLedgerSearchResult } from "../work-product-ledger.js";
 import { trustResultFor, type TrustStageResultItem } from "../trust-score-stage.js";
 import { CONNECTOR_ID_PATTERN, CONNECTOR_LABEL_MAX_LENGTH } from "../connectors/label.js";
 import { isValidConnectorId } from "../connectors/index.js";
+import type { IncludedMemory } from "../included-memories.js";
 import type {
   ContinuityIncidentRecord,
   IdentityInjectionMode,
@@ -113,64 +114,35 @@ export function displayResultPath(
 }
 
 /**
- * Return a copy of budget metadata with `includedMemoryPaths` rendered
- * memoryDir-relative, so recall/last-recall API callers never receive operator
- * filesystem paths via budget output even though the internal snapshot keeps
- * absolute paths for tracking/x-ray (#2020). Other fields are unchanged.
- */
-export function displaySafeBudgetsApplied<
-  T extends {
-    includedMemoryPaths?: string[];
-    includedMemoryNamespaces?: Array<string | undefined>;
-  },
->(budgetsApplied: T | undefined, memoryDir: string): T | undefined {
-  if (!budgetsApplied?.includedMemoryPaths) return budgetsApplied;
-  return {
-    ...budgetsApplied,
-    includedMemoryPaths: budgetsApplied.includedMemoryPaths.map((p, i) =>
-      displayResultPath(p, memoryDir, budgetsApplied.includedMemoryNamespaces?.[i]),
-    ),
-  };
-}
-
-/**
  * Return a display-safe copy of a recall snapshot for the `includeDebug=true`
- * surface (#2077). `resultPaths` and `budgetsApplied.includedMemoryPaths` are
- * rendered namespace-relative from their aligned namespace metadata; a
- * `tierExplain.sourceAnchors[]` entry reuses that SAME authoritative metadata
- * when its absolute path matches a result/included path, and otherwise falls
- * back to the memoryDir-relative on-disk form. Either way the debug flag never
- * leaks absolute operator paths, and an anchor is never attributed to a decoded
- * (guessed) namespace — an anchor carries no owner of its own. Returns a
- * shallow copy; the input snapshot is never mutated.
+ * surface (#2077). `includedMemories[].path` is rendered namespace-relative
+ * from each memory's own namespace — the same rendering `resultPaths` received
+ * before the struct consolidation; a `tierExplain.sourceAnchors[]` entry
+ * reuses that SAME authoritative metadata when its absolute path matches an
+ * included memory's path, and otherwise falls back to the memoryDir-relative
+ * on-disk form. Either way the debug flag never leaks absolute operator
+ * paths, and an anchor is never attributed to a decoded (guessed) namespace —
+ * an anchor carries no owner of its own. Returns a shallow copy; the input
+ * snapshot is never mutated.
  */
 export function displaySafeRecallSnapshot<
   T extends {
-    resultPaths?: string[];
-    resultNamespaces?: Array<string | undefined>;
-    budgetsApplied?: {
-      includedMemoryPaths?: string[];
-      includedMemoryNamespaces?: Array<string | undefined>;
-    };
+    includedMemories?: IncludedMemory[];
     tierExplain?: {
       sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
     };
   },
 >(snapshot: T, memoryDir: string): T {
-  const resultPaths = snapshot.resultPaths?.map((p, i) =>
-    displayResultPath(p, memoryDir, snapshot.resultNamespaces?.[i]),
-  );
-  // Authoritative absolute-path -> namespace map recorded at capture time, so a
-  // tier anchor that coincides with a returned result renders under the SAME
-  // namespace as that result instead of the raw storage segment (#2077).
+  const includedMemories = snapshot.includedMemories?.map((memory) => ({
+    ...memory,
+    path: displayResultPath(memory.path, memoryDir, memory.namespace),
+  }));
+  // Authoritative absolute-path -> namespace map recorded at capture time, so
+  // a tier anchor that coincides with an included memory renders under the
+  // SAME namespace as that memory instead of the raw storage segment (#2077).
   const namespaceByPath = new Map<string, string | undefined>();
-  snapshot.resultPaths?.forEach((p, i) => {
-    if (!namespaceByPath.has(p)) namespaceByPath.set(p, snapshot.resultNamespaces?.[i]);
-  });
-  snapshot.budgetsApplied?.includedMemoryPaths?.forEach((p, i) => {
-    if (!namespaceByPath.has(p)) {
-      namespaceByPath.set(p, snapshot.budgetsApplied?.includedMemoryNamespaces?.[i]);
-    }
+  snapshot.includedMemories?.forEach((memory) => {
+    if (!namespaceByPath.has(memory.path)) namespaceByPath.set(memory.path, memory.namespace);
   });
   const tierExplain =
     snapshot.tierExplain?.sourceAnchors
@@ -184,10 +156,7 @@ export function displaySafeRecallSnapshot<
       : undefined;
   return {
     ...snapshot,
-    ...(resultPaths ? { resultPaths } : {}),
-    ...(snapshot.budgetsApplied
-      ? { budgetsApplied: displaySafeBudgetsApplied(snapshot.budgetsApplied, memoryDir) }
-      : {}),
+    ...(includedMemories ? { includedMemories } : {}),
     ...(tierExplain ? { tierExplain } : {}),
   };
 }

--- a/packages/remnic-core/src/orchestration/recall-section-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/recall-section-coordinator.ts
@@ -274,6 +274,9 @@ export class RecallSectionCoordinator {
     truncated: boolean;
     finalChars: number;
     includedMemories: IncludedMemory[];
+    includedMemoryIds: string[];
+    includedMemoryPaths: string[];
+    includedMemoryNamespaces: Array<string | undefined>;
     omittedMemoryIds: string[];
   } {
     type OrderedSection = { id: string; chunks: RecallSectionChunk[] };
@@ -339,6 +342,9 @@ export class RecallSectionCoordinator {
         truncated: orderedSections.length > 0,
         finalChars: 0,
         includedMemories: [],
+        includedMemoryIds: [],
+        includedMemoryPaths: [],
+        includedMemoryNamespaces: [],
         omittedMemoryIds: candidateMemoryIds,
       };
     }
@@ -571,6 +577,9 @@ export class RecallSectionCoordinator {
       truncated,
       finalChars: usedChars,
       includedMemories,
+      includedMemoryIds: includedMemories.map((memory) => memory.id),
+      includedMemoryPaths: includedMemories.map((memory) => memory.path),
+      includedMemoryNamespaces: includedMemories.map((memory) => memory.namespace),
       omittedMemoryIds: (() => {
         const includedKeys = new Set(
           includedMemories.map(

--- a/packages/remnic-core/src/orchestration/recall-section-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/recall-section-coordinator.ts
@@ -17,7 +17,7 @@
  * TierMigrationCoordinator accessor pattern.
  */
 
-import type { LastRecallBudgetSummary } from "../recall-state.js";
+import type { IncludedMemory, LastRecallBudgetSummary } from "../recall-state.js";
 import { estimateTokenCount } from "../token-estimate.js";
 import { graphemeUnits, truncateGraphemeSafe } from "../whitespace.js";
 import type { PluginConfig, RecallSectionConfig } from "../types.js";
@@ -273,9 +273,7 @@ export class RecallSectionCoordinator {
     omittedIds: string[];
     truncated: boolean;
     finalChars: number;
-    includedMemoryIds: string[];
-    includedMemoryPaths: string[];
-    includedMemoryNamespaces: Array<string | undefined>;
+    includedMemories: IncludedMemory[];
     omittedMemoryIds: string[];
   } {
     type OrderedSection = { id: string; chunks: RecallSectionChunk[] };
@@ -340,9 +338,7 @@ export class RecallSectionCoordinator {
         omittedIds: orderedSections.map((entry) => entry.id),
         truncated: orderedSections.length > 0,
         finalChars: 0,
-        includedMemoryIds: [],
-        includedMemoryPaths: [],
-        includedMemoryNamespaces: [],
+        includedMemories: [],
         omittedMemoryIds: candidateMemoryIds,
       };
     }
@@ -372,9 +368,7 @@ export class RecallSectionCoordinator {
         break;
       }
     }
-    const includedMemoryIds: string[] = [];
-    const includedMemoryPaths: string[] = [];
-    const includedMemoryNamespaces: Array<string | undefined> = [];
+    const includedMemories: IncludedMemory[] = [];
     let usedChars = 0;
     let usedTokens = 0;
     let truncated = false;
@@ -492,12 +486,12 @@ export class RecallSectionCoordinator {
               rendered = chunk.content;
               includedLeadingContent = false;
               includedAtomicCount = 1;
-              // Push id/path/namespace together so the parallel tracking arrays
-              // never misalign when a chunk carries only one of them (#2020).
               if (chunk.memoryId && chunk.memoryPath) {
-                includedMemoryIds.push(chunk.memoryId);
-                includedMemoryPaths.push(chunk.memoryPath);
-                includedMemoryNamespaces.push(chunk.memoryNamespace);
+                includedMemories.push(
+                  chunk.memoryNamespace
+                    ? { id: chunk.memoryId, path: chunk.memoryPath, namespace: chunk.memoryNamespace }
+                    : { id: chunk.memoryId, path: chunk.memoryPath },
+                );
               }
               continue;
             }
@@ -522,9 +516,11 @@ export class RecallSectionCoordinator {
           if (chunk.atomic) {
             includedAtomicCount += 1;
             if (chunk.memoryId && chunk.memoryPath) {
-              includedMemoryIds.push(chunk.memoryId);
-              includedMemoryPaths.push(chunk.memoryPath);
-              includedMemoryNamespaces.push(chunk.memoryNamespace);
+              includedMemories.push(
+                chunk.memoryNamespace
+                  ? { id: chunk.memoryId, path: chunk.memoryPath, namespace: chunk.memoryNamespace }
+                  : { id: chunk.memoryId, path: chunk.memoryPath },
+              );
             }
           } else {
             includedPostAtomicContent = true;
@@ -574,16 +570,11 @@ export class RecallSectionCoordinator {
       omittedIds,
       truncated,
       finalChars: usedChars,
-      includedMemoryIds,
-      includedMemoryPaths,
-      includedMemoryNamespaces,
+      includedMemories,
       omittedMemoryIds: (() => {
-        // Key by (namespace, id): the same memory id can exist in more than one
-        // namespace, so an id-only subtraction would hide a budget-dropped copy
-        // when another namespace's copy was included (#2020).
         const includedKeys = new Set(
-          includedMemoryIds.map(
-            (id, i) => `${includedMemoryNamespaces[i] ?? ""}\u0000${id}`,
+          includedMemories.map(
+            (memory) => `${memory.namespace ?? ""}\u0000${memory.id}`,
           ),
         );
         return candidateMemoryChunks
@@ -604,9 +595,6 @@ export class RecallSectionCoordinator {
     finalContextChars?: number;
     truncated?: boolean;
     includedSections?: string[];
-    includedMemoryIds?: string[];
-    includedMemoryPaths?: string[];
-    includedMemoryNamespaces?: Array<string | undefined>;
     omittedMemoryIds?: string[];
     omittedSections?: string[];
   }): LastRecallBudgetSummary {
@@ -619,9 +607,6 @@ export class RecallSectionCoordinator {
       qmdHybridFetchLimit: options.qmdHybridFetchLimit,
       finalContextChars: options.finalContextChars,
       truncated: options.truncated,
-      includedMemoryIds: [...(options.includedMemoryIds ?? [])],
-      includedMemoryPaths: [...(options.includedMemoryPaths ?? [])],
-      includedMemoryNamespaces: [...(options.includedMemoryNamespaces ?? [])],
       omittedMemoryIds: [...(options.omittedMemoryIds ?? [])],
       includedSections: [...(options.includedSections ?? [])],
       omittedSections: [...(options.omittedSections ?? [])],

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2717,8 +2717,10 @@ export class Orchestrator {
     includedIds: string[];
     omittedIds: string[];
     truncated: boolean;
-    finalChars: number;
     includedMemories: IncludedMemory[];
+    includedMemoryIds: string[];
+    includedMemoryPaths: string[];
+    includedMemoryNamespaces: Array<string | undefined>;
     omittedMemoryIds: string[];
   } {
     return this.recallSectionCoordinator.assembleRecallSections(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -260,6 +260,7 @@ import { NegativeExampleStore } from "./negative.js";
 import {
   LastRecallStore,
   RecallHandleHistoryStore,
+  type IncludedMemory,
   type LastRecallBudgetSummary,
   TierMigrationStatusStore,
   clampGraphRecallExpandedEntries,
@@ -2717,9 +2718,7 @@ export class Orchestrator {
     omittedIds: string[];
     truncated: boolean;
     finalChars: number;
-    includedMemoryIds: string[];
-    includedMemoryPaths: string[];
-    includedMemoryNamespaces: Array<string | undefined>;
+    includedMemories: IncludedMemory[];
     omittedMemoryIds: string[];
   } {
     return this.recallSectionCoordinator.assembleRecallSections(
@@ -3542,9 +3541,6 @@ export class Orchestrator {
     finalContextChars?: number;
     truncated?: boolean;
     includedSections?: string[];
-    includedMemoryIds?: string[];
-    includedMemoryPaths?: string[];
-    includedMemoryNamespaces?: Array<string | undefined>;
     omittedMemoryIds?: string[];
     omittedSections?: string[];
   }): LastRecallBudgetSummary {

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -17,6 +17,10 @@ function legacySnapshot(
     queryHash: "deadbeef",
     queryLen: 21,
     memoryIds: ["mem-1", "mem-2"],
+    includedMemories: [
+      { id: "mem-1", path: "" },
+      { id: "mem-2", path: "" },
+    ],
     source: "hot_qmd",
     sourcesUsed: ["hot_qmd", "memories"],
     namespace: "workspace-a",

--- a/packages/remnic-core/src/recall-state.test.ts
+++ b/packages/remnic-core/src/recall-state.test.ts
@@ -83,19 +83,73 @@ test("LastRecallStore.record persists tierExplain and round-trips to JSON on dis
   assert.deepEqual(parsed["s1"]?.tierExplain, tierExplain);
 });
 
-test("LastRecallStore.record persists per-result namespaces", async () => {
+test("LastRecallStore.record shims legacy resultPaths/resultNamespaces into includedMemories", async () => {
   const { store } = await freshStore();
-  const resultNamespaces = ["main", "shared"] as Array<string | undefined>;
   await store.record({
     sessionKey: "s1",
     query: "namespaced recall",
     memoryIds: ["same-id", "same-id"],
     resultPaths: ["facts/same-id.md", "facts/same-id.md"],
-    resultNamespaces,
+    resultNamespaces: ["main", "shared"],
   });
   const snap = store.get("s1");
   assert.ok(snap);
-  assert.deepEqual(snap.resultNamespaces, resultNamespaces);
+  assert.deepEqual(snap.includedMemories, [
+    { id: "same-id", path: "facts/same-id.md", namespace: "main" },
+    { id: "same-id", path: "facts/same-id.md", namespace: "shared" },
+  ]);
+  assert.deepEqual(snap.memoryIds, ["same-id", "same-id"]);
+});
+
+// ── Legacy on-disk shapes hydrate to includedMemories (#2476) ─────────────
+
+test("LastRecallStore.load shims legacy last_recall.json shapes to includedMemories", async () => {
+  const { dir } = await freshStore();
+  const fixturePath = path.resolve(
+    import.meta.dirname,
+    "../../../tests/fixtures/last-recall-legacy-shape.json",
+  );
+  const fixture = JSON.parse(await readFile(fixturePath, "utf-8")) as Record<string, unknown>;
+
+  await mkdir(path.join(dir, "state"), { recursive: true });
+  await writeFile(
+    path.join(dir, "state", "last_recall.json"),
+    JSON.stringify(fixture),
+    "utf-8",
+  );
+  const store = new LastRecallStore(dir);
+  await store.load();
+
+  const full = store.get("legacy-full");
+  assert.ok(full);
+  assert.deepEqual(full.includedMemories, [
+    {
+      id: "fact-alpha",
+      path: "/memory-under-test/namespaces/team-alpha/facts/2026-08-01/fact-alpha.md",
+      namespace: "team-alpha",
+    },
+    { id: "fact-beta", path: "/memory-under-test/facts/2026-08-01/fact-beta.md" },
+    {
+      id: "fact-gamma",
+      path: "/memory-under-test/namespaces/team-alpha/facts/2026-08-01/fact-gamma.md",
+      namespace: "team-alpha",
+    },
+  ]);
+  assert.deepEqual(full.memoryIds, ["fact-alpha", "fact-beta", "fact-gamma"]);
+  // Legacy parallel arrays are stripped from the hydrated snapshot — every
+  // surface re-emits only the canonical form.
+  assert.equal("resultPaths" in full, false);
+  assert.equal("resultNamespaces" in full, false);
+  assert.ok(full.budgetsApplied);
+  assert.equal("includedMemoryIds" in full.budgetsApplied, false);
+  assert.equal("includedMemoryPaths" in full.budgetsApplied, false);
+  assert.equal("includedMemoryNamespaces" in full.budgetsApplied, false);
+  assert.deepEqual(full.budgetsApplied.omittedMemoryIds, ["fact-dropped"]);
+
+  const idsOnly = store.get("legacy-ids-only");
+  assert.ok(idsOnly);
+  assert.deepEqual(idsOnly.includedMemories, [{ id: "fact-delta", path: "" }]);
+  assert.deepEqual(idsOnly.memoryIds, ["fact-delta"]);
 });
 
 // ── Defensive copies isolate the stored snapshot from caller mutation ──────

--- a/packages/remnic-core/src/recall-state.test.ts
+++ b/packages/remnic-core/src/recall-state.test.ts
@@ -136,15 +136,11 @@ test("LastRecallStore.load shims legacy last_recall.json shapes to includedMemor
     },
   ]);
   assert.deepEqual(full.memoryIds, ["fact-alpha", "fact-beta", "fact-gamma"]);
-  // Legacy parallel arrays are stripped from the hydrated snapshot — every
-  // surface re-emits only the canonical form.
-  assert.equal("resultPaths" in full, false);
-  assert.equal("resultNamespaces" in full, false);
-  assert.ok(full.budgetsApplied);
-  assert.equal("includedMemoryIds" in full.budgetsApplied, false);
-  assert.equal("includedMemoryPaths" in full.budgetsApplied, false);
-  assert.equal("includedMemoryNamespaces" in full.budgetsApplied, false);
-  assert.deepEqual(full.budgetsApplied.omittedMemoryIds, ["fact-dropped"]);
+  assert.deepEqual(
+    full.resultPaths,
+    full.includedMemories?.map((memory) => memory.path),
+  );
+  assert.deepEqual(full.budgetsApplied?.omittedMemoryIds, ["fact-dropped"]);
 
   const idsOnly = store.get("legacy-ids-only");
   assert.ok(idsOnly);

--- a/packages/remnic-core/src/recall-state.test.ts
+++ b/packages/remnic-core/src/recall-state.test.ts
@@ -4,7 +4,7 @@ import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, wri
 import os from "node:os";
 import path from "node:path";
 
-import { clampGraphRecallExpandedEntries, LastRecallStore } from "./recall-state.js";
+import { clampGraphRecallExpandedEntries, LastRecallStore, RecallHandleHistoryStore } from "./recall-state.js";
 import type { RecallTierExplain } from "./types.js";
 import { listContainedSpillFiles } from "./utils/path-containment.js";
 
@@ -1132,4 +1132,57 @@ test("LastRecallStore.drainPendingImpressions reports pendingDeferred when a spi
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
++
+test("LastRecallStore rejects unsafe session keys on every read/write path", async () => {
+  const { store, dir } = await freshStore();
+  for (const key of ["__proto__", "constructor", "prototype"]) {
+    await store.record({ sessionKey: key, query: "q", memoryIds: ["m-1"] });
+    assert.equal(store.get(key), null, `get(${key}) must not surface prototype junk`);
+  }
+  assert.equal(store.getMostRecent(), null);
+
+  await store.annotateTierExplain("__proto__", {
+    tier: "direct-answer",
+    tierReason: "",
+    filteredBy: [],
+    candidatesConsidered: 0,
+    latencyMs: 0,
+  });
+  assert.equal(store.get("__proto__"), null);
+  const persistedKeys = await readFile(path.join(dir, "state", "last_recall.json"), "utf-8")
+    .then((raw) => Object.keys(JSON.parse(raw) as object))
+    .catch(() => [] as string[]);
+  assert.deepEqual(persistedKeys, [], "no unsafe key persisted");
+});
+
+test("RecallHandleHistoryStore rejects unsafe session keys", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-handle-history-"));
+  const store = new RecallHandleHistoryStore(dir);
+  await store.load();
+
+  await store.record("__proto__", ["m-1"]);
+  await store.record("constructor", ["m-2"]);
+  assert.deepEqual(store.recent("__proto__"), []);
+  assert.deepEqual(store.recent("constructor"), []);
+
+  await store.record("ok", ["m-3"]);
+  assert.deepEqual(store.recent("ok"), [["m-3"]]);
+  await rm(dir, { recursive: true, force: true });
+});
+
+test("RecallHandleHistoryStore.load drops unsafe and malformed entries from persisted state", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-handle-history-"));
+  await mkdir(path.join(dir, "state"), { recursive: true });
+  // JSON.parse materializes "__proto__" as an OWN key; load must not adopt it.
+  const poisoned =
+    '{"__proto__": [{"at": "t", "ids": ["evil"]}], "bad": "not-an-array", "ok": [{"at": "t", "ids": ["m-1"]}]}';
+  await writeFile(path.join(dir, "state", "handle_history.json"), poisoned, "utf-8");
+
+  const store = new RecallHandleHistoryStore(dir);
+  await store.load();
+  assert.deepEqual(store.recent("__proto__"), []);
+  assert.deepEqual(store.recent("bad"), []);
+  assert.deepEqual(store.recent("ok"), [["m-1"]]);
+  await rm(dir, { recursive: true, force: true });
 });

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -191,6 +191,13 @@ type StateFileWriter = (filePath: string, content: string) => Promise<void>;
  * recordedAt are compared. Extracted so every annotation surface applies
  * identical guards (CLAUDE.md rule 22).
  */
+function cloneTierExplain(
+  tierExplain: RecallTierExplain | undefined,
+): RecallTierExplain | undefined {
+  if (!tierExplain) return undefined;
+  return structuredClone(tierExplain);
+}
+
 function snapshotMatchesExpectedIdentity(
   current: LastRecallSnapshot,
   expected?: { writeNonce?: string; traceId?: string; recordedAt?: string },
@@ -201,41 +208,30 @@ function snapshotMatchesExpectedIdentity(
   }
   const hasExpectedTraceId =
     typeof expected.traceId === "string" && expected.traceId.length > 0;
-  if (hasExpectedTraceId) {
-    return current.traceId === expected.traceId;
-  }
-  if (expected.recordedAt !== undefined) {
+  if (hasExpectedTraceId && current.traceId !== expected.traceId) return false;
+  if (typeof expected.recordedAt === "string" && expected.recordedAt.length > 0) {
     return current.recordedAt === expected.recordedAt;
   }
   return true;
 }
 
-function cloneTierExplain(
-  tierExplain: RecallTierExplain | undefined,
-): RecallTierExplain | undefined {
-  if (!tierExplain) return undefined;
-  return structuredClone(tierExplain);
-}
-
 function hydrateLastRecallSnapshot(snapshot: LastRecallSnapshot): LastRecallSnapshot {
   const includedMemories = coerceIncludedMemories(snapshot);
-  // Strip the legacy parallel arrays so a hydrated snapshot re-emits only the
-  // canonical `includedMemories` form on every surface (in-memory clones,
-  // re-persisted state, MCP/HTTP JSON). The freshly parsed disk object is
-  // private to this load, so in-place deletes are safe.
-  const legacy = snapshot as unknown as Record<string, unknown>;
-  delete legacy.resultPaths;
-  delete legacy.resultNamespaces;
-  if (legacy.budgetsApplied && typeof legacy.budgetsApplied === "object") {
-    const budgets = legacy.budgetsApplied as Record<string, unknown>;
-    delete budgets.includedMemoryIds;
-    delete budgets.includedMemoryPaths;
-    delete budgets.includedMemoryNamespaces;
-  }
+  const budgets = snapshot.budgetsApplied
+    ? {
+        ...snapshot.budgetsApplied,
+        includedMemoryIds: includedMemories.map((memory) => memory.id),
+        includedMemoryPaths: includedMemories.map((memory) => memory.path),
+        includedMemoryNamespaces: includedMemories.map((memory) => memory.namespace),
+      }
+    : undefined;
   return {
     ...snapshot,
     includedMemories,
     memoryIds: includedMemories.map((memory) => memory.id),
+    resultPaths: includedMemories.map((memory) => memory.path),
+    resultNamespaces: includedMemories.map((memory) => memory.namespace),
+    ...(budgets ? { budgetsApplied: budgets } : {}),
   };
 }
 
@@ -245,6 +241,7 @@ function cloneLastRecallSnapshot(
   if (!snapshot) return null;
   return structuredClone(hydrateLastRecallSnapshot(snapshot));
 }
+
 
 
 export interface TierMigrationCycleSummary {

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -41,7 +41,7 @@ export interface LastRecallSnapshot {
   queryHash: string;
   queryLen: number;
   memoryIds: string[];
-  includedMemories: IncludedMemory[];
+  includedMemories?: IncludedMemory[];
   namespace?: string;
   recallNamespaces?: string[];
   traceId?: string;
@@ -341,15 +341,22 @@ export class LastRecallStore {
   async load(): Promise<void> {
     try {
       const raw = await readFile(this.statePath, "utf-8");
-      const parsed = JSON.parse(raw) as LastRecallState;
-      if (parsed && typeof parsed === "object") {
-        this.state = Object.fromEntries(
-          Object.entries(parsed).map(([sessionKey, snapshot]) => [
-            sessionKey,
-            hydrateLastRecallSnapshot(snapshot),
-          ]),
-        );
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        this.state = {};
+        return;
       }
+      const next: LastRecallState = {};
+      for (const [sessionKey, snapshot] of Object.entries(parsed)) {
+        if (sessionKey === "__proto__" || sessionKey === "constructor" || sessionKey === "prototype") {
+          continue;
+        }
+        if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+          continue;
+        }
+        next[sessionKey] = hydrateLastRecallSnapshot(snapshot as LastRecallSnapshot);
+      }
+      this.state = next;
     } catch {
       this.state = {};
     }

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -20,6 +20,16 @@ import {
 export type { IncludedMemory } from "./included-memories.js";
 export { coerceIncludedMemories } from "./included-memories.js";
 
+// Session keys are caller-supplied (host session IDs) and land in indexed
+// assignments on plain-object state. A key matching one of these would
+// pollute Object.prototype (or read junk off it), so every read/write
+// through this module rejects them — same contract load() already enforced.
+const UNSAFE_STATE_KEYS: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
+
+function isUnsafeStateKey(key: string): boolean {
+  return UNSAFE_STATE_KEYS.has(key);
+}
+
 
 export interface LastRecallBudgetSummary {
   requestedTopK?: number;
@@ -32,6 +42,9 @@ export interface LastRecallBudgetSummary {
   truncated?: boolean;
   includedSections?: string[];
   omittedSections?: string[];
+  includedMemoryIds?: string[];
+  includedMemoryPaths?: string[];
+  includedMemoryNamespaces?: Array<string | undefined>;
   omittedMemoryIds?: string[];
 }
 
@@ -52,6 +65,8 @@ export interface LastRecallSnapshot {
   sourcesUsed?: string[];
   budgetsApplied?: LastRecallBudgetSummary;
   latencyMs?: number;
+  resultPaths?: string[];
+  resultNamespaces?: Array<string | undefined>;
   policyVersion?: string;
   identityInjectionMode?: IdentityInjectionMode | "none";
   identityInjectedChars?: number;

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -24,10 +24,8 @@ export { coerceIncludedMemories } from "./included-memories.js";
 // assignments on plain-object state. A key matching one of these would
 // pollute Object.prototype (or read junk off it), so every read/write
 // through this module rejects them — same contract load() already enforced.
-const UNSAFE_STATE_KEYS: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
-
 function isUnsafeStateKey(key: string): boolean {
-  return UNSAFE_STATE_KEYS.has(key);
+  return key === "__proto__" || key === "constructor" || key === "prototype";
 }
 
 
@@ -377,6 +375,7 @@ export class LastRecallStore {
   get(sessionKey: string): LastRecallSnapshot | null {
     // Defensive copy: callers must not be able to mutate internal state
     // by reaching into array/object fields on the returned snapshot.
+    if (isUnsafeStateKey(sessionKey)) return null;
     return cloneLastRecallSnapshot(this.state[sessionKey] ?? null);
   }
 
@@ -435,6 +434,10 @@ export class LastRecallStore {
      */
     backendDegradations?: SearchDegradation[];
   }): Promise<void> {
+    if (isUnsafeStateKey(opts.sessionKey)) {
+      log.debug("last recall record skipped: unsafe session key");
+      return;
+    }
     const now = new Date().toISOString();
     const queryHash = createHash("sha256").update(opts.query).digest("hex");
 
@@ -859,6 +862,7 @@ export class LastRecallStore {
     tierExplain: RecallTierExplain,
     expected?: { writeNonce?: string; traceId?: string; recordedAt?: string },
   ): Promise<void> {
+    if (isUnsafeStateKey(sessionKey)) return;
     const current = this.state[sessionKey];
     if (!current) return;
     if (!snapshotMatchesExpectedIdentity(current, expected)) return;
@@ -1001,7 +1005,15 @@ export class RecallHandleHistoryStore {
     try {
       const raw = await readFile(this.statePath, "utf-8");
       const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === "object") this.state = parsed as typeof this.state;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const next: Record<string, Array<{ at: string; ids: string[] }>> = {};
+        for (const [sessionKey, entries] of Object.entries(parsed)) {
+          if (isUnsafeStateKey(sessionKey)) continue;
+          if (!Array.isArray(entries)) continue;
+          next[sessionKey] = entries;
+        }
+        this.state = next;
+      }
     } catch {
       this.state = {};
     }
@@ -1012,7 +1024,7 @@ export class RecallHandleHistoryStore {
    * The ring is capped at {@link maxDepth}; older entries drop off the tail.
    */
   async record(sessionKey: string, memoryIds: readonly string[]): Promise<void> {
-    if (!sessionKey) return;
+    if (!sessionKey || isUnsafeStateKey(sessionKey)) return;
     const ids = memoryIds.filter((id): id is string => typeof id === "string" && id.length > 0);
     const entry = { at: new Date().toISOString(), ids };
     const prior = this.state[sessionKey] ?? [];
@@ -1031,6 +1043,7 @@ export class RecallHandleHistoryStore {
    * Empty array when the session has no recorded history.
    */
   recent(sessionKey: string, depth: number = this.maxDepth): Array<readonly string[]> {
+    if (isUnsafeStateKey(sessionKey)) return [];
     const entries = this.state[sessionKey];
     if (!entries || entries.length === 0) return [];
     const limit = Math.max(0, Math.min(depth, entries.length));

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -12,6 +12,14 @@ import type {
   RecallPlanMode,
   RecallTierExplain,
 } from "./types.js";
+import {
+  coerceIncludedMemories,
+  type IncludedMemory,
+} from "./included-memories.js";
+
+export type { IncludedMemory } from "./included-memories.js";
+export { coerceIncludedMemories } from "./included-memories.js";
+
 
 export interface LastRecallBudgetSummary {
   requestedTopK?: number;
@@ -24,9 +32,6 @@ export interface LastRecallBudgetSummary {
   truncated?: boolean;
   includedSections?: string[];
   omittedSections?: string[];
-  includedMemoryIds?: string[];
-  includedMemoryPaths?: string[];
-  includedMemoryNamespaces?: Array<string | undefined>;
   omittedMemoryIds?: string[];
 }
 
@@ -36,6 +41,7 @@ export interface LastRecallSnapshot {
   queryHash: string;
   queryLen: number;
   memoryIds: string[];
+  includedMemories: IncludedMemory[];
   namespace?: string;
   recallNamespaces?: string[];
   traceId?: string;
@@ -46,8 +52,6 @@ export interface LastRecallSnapshot {
   sourcesUsed?: string[];
   budgetsApplied?: LastRecallBudgetSummary;
   latencyMs?: number;
-  resultPaths?: string[];
-  resultNamespaces?: Array<string | undefined>;
   policyVersion?: string;
   identityInjectionMode?: IdentityInjectionMode | "none";
   identityInjectedChars?: number;
@@ -198,17 +202,35 @@ function cloneTierExplain(
   return structuredClone(tierExplain);
 }
 
-/**
- * Deep-copy a LastRecallSnapshot so callers that receive it cannot
- * mutate the store's internal state through mutable array/object
- * fields.  Same structuredClone rationale as cloneTierExplain above.
- */
+function hydrateLastRecallSnapshot(snapshot: LastRecallSnapshot): LastRecallSnapshot {
+  const includedMemories = coerceIncludedMemories(snapshot);
+  // Strip the legacy parallel arrays so a hydrated snapshot re-emits only the
+  // canonical `includedMemories` form on every surface (in-memory clones,
+  // re-persisted state, MCP/HTTP JSON). The freshly parsed disk object is
+  // private to this load, so in-place deletes are safe.
+  const legacy = snapshot as unknown as Record<string, unknown>;
+  delete legacy.resultPaths;
+  delete legacy.resultNamespaces;
+  if (legacy.budgetsApplied && typeof legacy.budgetsApplied === "object") {
+    const budgets = legacy.budgetsApplied as Record<string, unknown>;
+    delete budgets.includedMemoryIds;
+    delete budgets.includedMemoryPaths;
+    delete budgets.includedMemoryNamespaces;
+  }
+  return {
+    ...snapshot,
+    includedMemories,
+    memoryIds: includedMemories.map((memory) => memory.id),
+  };
+}
+
 function cloneLastRecallSnapshot(
   snapshot: LastRecallSnapshot | null,
 ): LastRecallSnapshot | null {
   if (!snapshot) return null;
-  return structuredClone(snapshot);
+  return structuredClone(hydrateLastRecallSnapshot(snapshot));
 }
+
 
 export interface TierMigrationCycleSummary {
   trigger: "extraction" | "maintenance" | "manual";
@@ -320,7 +342,14 @@ export class LastRecallStore {
     try {
       const raw = await readFile(this.statePath, "utf-8");
       const parsed = JSON.parse(raw) as LastRecallState;
-      if (parsed && typeof parsed === "object") this.state = parsed;
+      if (parsed && typeof parsed === "object") {
+        this.state = Object.fromEntries(
+          Object.entries(parsed).map(([sessionKey, snapshot]) => [
+            sessionKey,
+            hydrateLastRecallSnapshot(snapshot),
+          ]),
+        );
+      }
     } catch {
       this.state = {};
     }
@@ -352,7 +381,8 @@ export class LastRecallStore {
   async record(opts: {
     sessionKey: string;
     query: string;
-    memoryIds: string[];
+    memoryIds?: string[];
+    includedMemories?: IncludedMemory[];
     namespace?: string;
     recallNamespaces?: string[];
     traceId?: string;
@@ -393,13 +423,15 @@ export class LastRecallStore {
     // cloneLastRecallSnapshot so caller arrays/objects passed in
     // `opts` cannot retain a live reference to the persisted state and
     // tear it after `record()` returns.
+    const includedMemories = coerceIncludedMemories(opts);
     const liveSnapshot: LastRecallSnapshot = {
       sessionKey: opts.sessionKey,
       recordedAt: now,
       queryHash,
       writeNonce: randomUUID(),
       queryLen: opts.query.length,
-      memoryIds: opts.memoryIds,
+      includedMemories,
+      memoryIds: includedMemories.map((memory) => memory.id),
       namespace: opts.namespace,
       recallNamespaces: opts.recallNamespaces,
       traceId: opts.traceId,
@@ -410,8 +442,6 @@ export class LastRecallStore {
       sourcesUsed: opts.sourcesUsed,
       budgetsApplied: opts.budgetsApplied,
       latencyMs: opts.latencyMs,
-      resultPaths: opts.resultPaths,
-      resultNamespaces: opts.resultNamespaces,
       policyVersion: opts.policyVersion,
       identityInjectionMode: opts.identityInjection?.mode,
       identityInjectedChars: opts.identityInjection?.injectedChars,

--- a/packages/remnic-core/src/recall-token-budget.test.ts
+++ b/packages/remnic-core/src/recall-token-budget.test.ts
@@ -46,6 +46,6 @@ test("recall reserves one memory chunk that fits both character and token budget
 
   const assembled = coordinator.assembleRecallSections(buckets);
 
-  assert.deepEqual(assembled.includedMemoryIds, ["latin"]);
+  assert.deepEqual(assembled.includedMemories, [{ id: "latin", path: "memories/latin.md" }]);
   assert.ok(estimateTokenCount(assembled.sections.join("\n\n---\n\n")) <= 50);
 });

--- a/tests/fixtures/last-recall-legacy-shape.json
+++ b/tests/fixtures/last-recall-legacy-shape.json
@@ -1,0 +1,52 @@
+{
+  "legacy-full": {
+    "sessionKey": "legacy-full",
+    "recordedAt": "2026-08-01T10:00:00.000Z",
+    "queryHash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "queryLen": 24,
+    "writeNonce": "legacy-nonce-full",
+    "memoryIds": ["fact-alpha", "fact-beta", "fact-gamma"],
+    "resultPaths": [
+      "/memory-under-test/namespaces/team-alpha/facts/2026-08-01/fact-alpha.md",
+      "/memory-under-test/facts/2026-08-01/fact-beta.md",
+      "/memory-under-test/namespaces/team-alpha/facts/2026-08-01/fact-gamma.md"
+    ],
+    "resultNamespaces": ["team-alpha", null, "team-alpha"],
+    "namespace": "team-alpha",
+    "plannerMode": "full",
+    "source": "hot_qmd",
+    "fallbackUsed": false,
+    "sourcesUsed": ["hot_qmd", "memories"],
+    "latencyMs": 42,
+    "budgetsApplied": {
+      "appliedTopK": 3,
+      "recallBudgetChars": 8000,
+      "maxMemoryTokens": 2000,
+      "finalContextChars": 1200,
+      "truncated": true,
+      "includedSections": ["profile", "memories"],
+      "omittedSections": ["questions"],
+      "includedMemoryIds": ["fact-alpha", "fact-beta", "fact-gamma"],
+      "includedMemoryPaths": [
+        "/memory-under-test/namespaces/team-alpha/facts/2026-08-01/fact-alpha.md",
+        "/memory-under-test/facts/2026-08-01/fact-beta.md",
+        "/memory-under-test/namespaces/team-alpha/facts/2026-08-01/fact-gamma.md"
+      ],
+      "includedMemoryNamespaces": ["team-alpha", null, "team-alpha"],
+      "omittedMemoryIds": ["fact-dropped"]
+    }
+  },
+  "legacy-ids-only": {
+    "sessionKey": "legacy-ids-only",
+    "recordedAt": "2026-08-02T10:00:00.000Z",
+    "queryHash": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+    "queryLen": 11,
+    "writeNonce": "legacy-nonce-ids",
+    "memoryIds": ["fact-delta"],
+    "namespace": "default",
+    "plannerMode": "minimal",
+    "fallbackUsed": true,
+    "sourcesUsed": ["recent_scan"],
+    "latencyMs": 7
+  }
+}


### PR DESCRIPTION
Fixes #2476.

The same included-memory identity was stored as three aligned arrays on
`LastRecallSnapshot` and again inside `budgetsApplied`. A filter that
dropped one array and not the others produced invalid state.

Canonical form:

```ts
includedMemories: Array<{ id: string; path: string; namespace?: string }>
```

`omittedMemoryIds` stays on the budget side. Old on-disk snapshots and
`record()` callers that still pass `resultPaths`/`memoryIds` are shimmed
via `coerceIncludedMemories`.

X-ray `results` / `appliedResults` / `headroomResults` are unchanged.

`access-recall-surface.ts` stays at its 1412 ceiling.
`recall-internal.ts` shrank 5344 to 5340.

Regression: `recall-state.test.ts` loads
`tests/fixtures/last-recall-legacy-shape.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recall results now include each memory’s ID, path, and optional namespace in a consistent format.
  * Memory metadata is preserved across recall responses and saved recall history.
* **Bug Fixes**
  * Improved compatibility with legacy saved recall data and older path or namespace formats.
  * Invalid and duplicate memory entries are filtered during processing.
  * Memory paths are sanitized appropriately for display.
* **Tests**
  * Expanded coverage for migration, serialization, namespaces, path handling, and recall history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->