### PR TITLE
chore(ci): encode five defects from the 2476-2483 parallel run

### DIFF
--- a/.changeset/ci-this-run-defects-2.md
+++ b/.changeset/ci-this-run-defects-2.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Encode five CI gates from the #2476/#2477/#2478/#2483/#2190 parallel run: hook source-grep tests must target remnic-hook-core.cjs, those tests run in the checks job, last_recall.json load must reject arrays and proto keys, and preflight runs both checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
         run: node scripts/check-package-test-files.mjs
       - name: Shared hook runner sync (issue #2483)
         run: node scripts/check-hook-runner-sync.mjs
+      - name: Hook contract tests target remnic-hook-core.cjs
+        run: node scripts/check-hook-grep-targets.mjs
+      - name: Hook contract source-grep tests
+        run: node --test tests/codex-materialize-consolidation-wiring.test.ts tests/integration/plugin-structure.test.ts
+      - name: last_recall.json load hardening
+        run: node scripts/check-last-recall-json-load.mjs
 
 
       - name: Docs-code parity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Hook contract tests target remnic-hook-core.cjs
         run: node scripts/check-hook-grep-targets.mjs
       - name: Hook contract source-grep tests
-        run: node --test tests/codex-materialize-consolidation-wiring.test.ts tests/integration/plugin-structure.test.ts
+        run: node --import tsx --test tests/codex-materialize-consolidation-wiring.test.ts tests/integration/plugin-structure.test.ts
       - name: last_recall.json load hardening
         run: node scripts/check-last-recall-json-load.mjs
 

--- a/package.json
+++ b/package.json
@@ -989,6 +989,8 @@
     "check:openclaw-plugin-sync": "node scripts/check-openclaw-plugin-sync.mjs",
     "sync:hook-runner": "node scripts/sync-hook-runner.mjs",
     "check:hook-runner-sync": "node scripts/check-hook-runner-sync.mjs",
+    "check:hook-grep-targets": "node scripts/check-hook-grep-targets.mjs",
+    "check:last-recall-json-load": "node scripts/check-last-recall-json-load.mjs",
     "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
     "check:ratchets": "node scripts/check-ratchets.mjs",

--- a/scripts/check-hook-grep-targets.mjs
+++ b/scripts/check-hook-grep-targets.mjs
@@ -1,0 +1,53 @@
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// After #2483 the hook contract lives in remnic-hook-core.cjs.
+// Source-grep tests that still only read the thin wrappers fail in CI
+// (2511 root shard). This check fails if those tests omit the core file.
+
+export const HOOK_CORE_REL = path.join(
+  "packages",
+  "plugin-codex",
+  "hooks",
+  "bin",
+  "remnic-hook-core.cjs",
+);
+
+export const HOOK_CONTRACT_TESTS = [
+  path.join("tests", "codex-materialize-consolidation-wiring.test.ts"),
+  path.join("tests", "integration", "plugin-structure.test.ts"),
+];
+
+export function findHookGrepTargetMisses(root) {
+  const corePath = path.join(root, HOOK_CORE_REL);
+  if (!existsSync(corePath)) return [];
+  const misses = [];
+  for (const rel of HOOK_CONTRACT_TESTS) {
+    const filePath = path.join(root, rel);
+    if (!existsSync(filePath)) {
+      misses.push(`${rel} (missing)`);
+      continue;
+    }
+    const src = readFileSync(filePath, "utf8");
+    if (!src.includes("remnic-hook-core.cjs")) {
+      misses.push(rel);
+    }
+  }
+  return misses;
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const misses = findHookGrepTargetMisses(root);
+  if (misses.length > 0) {
+    console.error(
+      [
+        "Hook contract tests must mention remnic-hook-core.cjs after the shared runner extract (#2483/#2511):",
+        ...misses.map((item) => `  - ${item}`),
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/check-hook-grep-targets.mjs
+++ b/scripts/check-hook-grep-targets.mjs
@@ -30,7 +30,7 @@ export function findHookGrepTargetMisses(root) {
       continue;
     }
     const src = readFileSync(filePath, "utf8");
-    if (!src.includes("remnic-hook-core.cjs")) {
+    if (!/(?:readFile(?:Sync)?|join)\([\s\S]{0,200}remnic-hook-core\.cjs/.test(src)) {
       misses.push(rel);
     }
   }

--- a/scripts/check-last-recall-json-load.mjs
+++ b/scripts/check-last-recall-json-load.mjs
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// #2513 load() of last_recall.json accepted arrays and proto keys.
+// Keep the reject-array + unsafe-key skip in the load path.
+
+export const LAST_RECALL_STATE_REL = path.join(
+  "packages",
+  "remnic-core",
+  "src",
+  "recall-state.ts",
+);
+
+export function findLastRecallLoadHoles(source) {
+  const holes = [];
+  const loadIdx = source.indexOf("async load(): Promise<void>");
+  if (loadIdx < 0) {
+    holes.push("LastRecallStore.load() is missing");
+    return holes;
+  }
+  const loadBody = source.slice(loadIdx, loadIdx + 1200);
+  if (!loadBody.includes("Array.isArray(parsed)")) {
+    holes.push("load() must reject JSON arrays");
+  }
+  const skipsUnsafeKeys =
+    loadBody.includes("isUnsafeStateKey") ||
+    (loadBody.includes("__proto__") &&
+      loadBody.includes("constructor") &&
+      loadBody.includes("prototype"));
+  if (!skipsUnsafeKeys) {
+    holes.push("load() must skip unsafe session keys");
+  }
+  return holes;
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const source = readFileSync(path.join(root, LAST_RECALL_STATE_REL), "utf8");
+  const holes = findLastRecallLoadHoles(source);
+  if (holes.length > 0) {
+    console.error(
+      ["last_recall.json load hardening regresssed (#2513):", ...holes.map((item) => `  - ${item}`)].join(
+        "\n",
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -300,6 +300,8 @@ run bash scripts/check-review-patterns.sh
 run node scripts/check-ratchets.mjs
 run node scripts/check-package-test-files.mjs
 run node scripts/check-hook-runner-sync.mjs
+run node scripts/check-hook-grep-targets.mjs
+run node scripts/check-last-recall-json-load.mjs
 
 run node scripts/check-docs-parity.mjs
 run node scripts/check-dataset-hygiene.mjs

--- a/tests/check-hook-grep-targets.test.mjs
+++ b/tests/check-hook-grep-targets.test.mjs
@@ -38,8 +38,17 @@ test("fails when contract tests omit remnic-hook-core.cjs", () => {
 test("passes when both contract tests name the core file", () => {
   const root = writeTree({
     [HOOK_CORE_REL]: "module.exports = {}",
-    [HOOK_CONTRACT_TESTS[0]]: 'readFileSync(codexHookCore) // remnic-hook-core.cjs',
+    [HOOK_CONTRACT_TESTS[0]]: 'readFileSync("remnic-hook-core.cjs")',
     [HOOK_CONTRACT_TESTS[1]]: 'path.join(PACKAGES, "plugin-codex", "hooks", "bin", "remnic-hook-core.cjs")',
   });
   assert.deepEqual(findHookGrepTargetMisses(root), []);
+});
+
+test("fails when the core filename appears only in a comment", () => {
+  const root = writeTree({
+    [HOOK_CORE_REL]: "module.exports = {}",
+    [HOOK_CONTRACT_TESTS[0]]: "// remnic-hook-core.cjs is the shared runner",
+    [HOOK_CONTRACT_TESTS[1]]: 'path.join(PACKAGES, "plugin-codex", "hooks", "bin", "remnic-hook-core.cjs")',
+  });
+  assert.deepEqual(findHookGrepTargetMisses(root), [HOOK_CONTRACT_TESTS[0]]);
 });

--- a/tests/check-hook-grep-targets.test.mjs
+++ b/tests/check-hook-grep-targets.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  HOOK_CONTRACT_TESTS,
+  HOOK_CORE_REL,
+  findHookGrepTargetMisses,
+} from "../scripts/check-hook-grep-targets.mjs";
+
+function writeTree(files) {
+  const root = mkdtempSync(path.join(tmpdir(), "hook-grep-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, body);
+  }
+  return root;
+}
+
+test("passes when no shared hook core exists", () => {
+  const root = writeTree({
+    [HOOK_CONTRACT_TESTS[0]]: "readFileSync(codexHookRunner)",
+  });
+  assert.deepEqual(findHookGrepTargetMisses(root), []);
+});
+
+test("fails when contract tests omit remnic-hook-core.cjs", () => {
+  const root = writeTree({
+    [HOOK_CORE_REL]: "module.exports = {}",
+    [HOOK_CONTRACT_TESTS[0]]: "readFileSync(codexHookRunner)",
+    [HOOK_CONTRACT_TESTS[1]]: "readFileSync(runner)",
+  });
+  assert.deepEqual(findHookGrepTargetMisses(root), HOOK_CONTRACT_TESTS);
+});
+
+test("passes when both contract tests name the core file", () => {
+  const root = writeTree({
+    [HOOK_CORE_REL]: "module.exports = {}",
+    [HOOK_CONTRACT_TESTS[0]]: 'readFileSync(codexHookCore) // remnic-hook-core.cjs',
+    [HOOK_CONTRACT_TESTS[1]]: 'path.join(PACKAGES, "plugin-codex", "hooks", "bin", "remnic-hook-core.cjs")',
+  });
+  assert.deepEqual(findHookGrepTargetMisses(root), []);
+});

--- a/tests/check-last-recall-json-load.test.mjs
+++ b/tests/check-last-recall-json-load.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { findLastRecallLoadHoles } from "../scripts/check-last-recall-json-load.mjs";
+
+test("flags a load() that accepts any JSON object", () => {
+  const holes = findLastRecallLoadHoles(`
+    async load(): Promise<void> {
+      const parsed = JSON.parse(raw) as LastRecallState;
+      if (parsed && typeof parsed === "object") this.state = parsed;
+    }
+  `);
+  assert.ok(holes.includes("load() must reject JSON arrays"));
+  assert.ok(holes.includes("load() must skip unsafe session keys"));
+});
+
+test("accepts the hardened load() shape", () => {
+  const holes = findLastRecallLoadHoles(`
+    async load(): Promise<void> {
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        this.state = {};
+        return;
+      }
+      for (const [sessionKey, snapshot] of Object.entries(parsed)) {
+        if (isUnsafeStateKey(sessionKey)) continue;
+      }
+    }
+  `);
+  assert.deepEqual(holes, []);
+});


### PR DESCRIPTION
This run shipped #2476, #2477, #2478, #2483, and #2190. Five CI holes
showed up while merging those PRs.

1. Hook source-grep tests still read only the thin wrappers after the
   shared runner extract. The #2511 root shard failed. New check:
   `scripts/check-hook-grep-targets.mjs`.
2. Those same two test files now run in the checks job so they fail in
   seconds, not after the root shard.
3. `last_recall.json` load accepted arrays and proto keys until #2513.
   New check: `scripts/check-last-recall-json-load.mjs`.
4. `preflight:quick` runs both new checks.
5. Unit tests cover the two check scripts.

Merge bar: checks + the three test shards. Missing Cursor or GitHub
404/422/429/503 are not product defects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of recall-state loading to reject JSON arrays and unsafe session keys.
  * Added checks ensuring hook contract tests reference the shared hook core.

* **Tests**
  * Added automated coverage for recall-state validation and hook contract verification.

* **Chores**
  * Integrated the new validations into CI and preflight checks.
  * Added commands for running the validations locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->