### PR TITLE
fix(core): keep grounded CJK facts and entity names in source grounding

### DIFF
--- a/packages/remnic-core/src/extraction-source-grounding-helpers.ts
+++ b/packages/remnic-core/src/extraction-source-grounding-helpers.ts
@@ -334,9 +334,9 @@ export interface GroundingLexeme {
 }
 
 export function groundingLexemes(text: string): GroundingLexeme[] {
-  const rawTokens = text.normalize("NFKC").match(
+  const rawTokens = (text.normalize("NFKC").match(
     /[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)?(?:\+\+[\p{L}\p{N}]*|#[\p{L}\p{N}]*)?/gu,
-  ) ?? [];
+  ) ?? []).flatMap(splitSpacelessScriptToken);
   const tokens = rawTokens.map((rawToken) =>
     rawToken.replaceAll("’", "'").toLocaleLowerCase());
   let predicateIndex = tokens.findIndex((token, index) => {
@@ -498,6 +498,116 @@ export function tokenize(text: string): Set<string> {
     if (GROUNDING_STOPWORDS[token] !== true) tokens.add(stemToken(token, preserveTerminalS, true));
   }
   return tokens;
+}
+
+const SPACELESS_SCRIPT_CHARACTER_PATTERN = new RegExp(
+  "[\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}"
+    + "\\p{Script=Thai}\\p{Script=Lao}\\p{Script=Khmer}\\p{Script=Myanmar}]",
+  "u",
+);
+const SPACELESS_SCRIPT_LCS_SOURCE_LIMIT = 4096;
+
+function containsSpacelessScriptCharacter(text: string): boolean {
+  return SPACELESS_SCRIPT_CHARACTER_PATTERN.test(text);
+}
+
+/**
+ * Scripts without word separators (CJK, Hangul, Thai, ...) must not become one
+ * whitespace-delimited token: a paraphrase never matches a whole-run token, so
+ * grounded CJK facts and entity names were dropped. Split those runs into
+ * per-character lexemes so contiguous-token matching behaves as substring
+ * matching for these scripts.
+ */
+function splitSpacelessScriptToken(rawToken: string): string[] {
+  if (!containsSpacelessScriptCharacter(rawToken)) return [rawToken];
+  const parts: string[] = [];
+  let otherScriptRun = "";
+  for (const character of rawToken) {
+    if (containsSpacelessScriptCharacter(character)) {
+      if (otherScriptRun.length > 0) {
+        parts.push(otherScriptRun);
+        otherScriptRun = "";
+      }
+      parts.push(character);
+    } else {
+      otherScriptRun += character;
+    }
+  }
+  if (otherScriptRun.length > 0) parts.push(otherScriptRun);
+  return parts;
+}
+
+function spacelessScriptCharacterSequence(text: string): string[] {
+  const characters: string[] = [];
+  for (const character of text.normalize("NFKC")) {
+    if (containsSpacelessScriptCharacter(character)) characters.push(character);
+  }
+  return characters;
+}
+
+function spacelessScriptCharacterNgrams(text: string): Set<string> {
+  const grams = new Set<string>();
+  let previousCharacter = "";
+  for (const character of spacelessScriptCharacterSequence(text)) {
+    if (previousCharacter !== "") grams.add(previousCharacter + character);
+    previousCharacter = character;
+  }
+  return grams;
+}
+
+function longestCommonSubstringLength(
+  left: ReadonlyArray<string>,
+  right: ReadonlyArray<string>,
+): number {
+  if (left.length === 0 || right.length === 0) return 0;
+  let longest = 0;
+  let previousRow = new Array<number>(right.length).fill(0);
+  for (const leftCharacter of left) {
+    const currentRow = new Array<number>(right.length).fill(0);
+    for (let index = 0; index < right.length; index += 1) {
+      if (leftCharacter !== right[index]) continue;
+      currentRow[index] = (index > 0 ? previousRow[index - 1] : 0) + 1;
+      if (currentRow[index] > longest) longest = currentRow[index];
+    }
+    previousRow = currentRow;
+  }
+  return longest;
+}
+
+/**
+ * Script-aware grounding score for candidates written in scripts without word
+ * separators. Returns null when the candidate has no such characters, so
+ * whitespace-delimited candidates keep the default scorer. The longest-common-
+ * span gate rejects topical overlap that shares mostly function characters.
+ * ponytail: n-grams and the common-span gate ignore argument order; swap in a
+ * segmentation-aware matcher if CJK role confusion surfaces.
+ */
+export function spacelessScriptGroundedTokenScore(candidate: string, source: string): number | null {
+  const candidateGrams = spacelessScriptCharacterNgrams(candidate);
+  if (candidateGrams.size === 0) return null;
+  const sourceGrams = spacelessScriptCharacterNgrams(source);
+  let sharedGrams = 0;
+  for (const gram of candidateGrams) {
+    if (sourceGrams.has(gram)) sharedGrams += 1;
+  }
+  if (sharedGrams < GROUNDING_MIN_SHARED_TOKENS) return 0;
+  const coverage = sharedGrams / candidateGrams.size;
+  if (coverage < GROUNDING_MIN_COVERAGE) return 0;
+  const candidateCharacters = spacelessScriptCharacterSequence(candidate);
+  const sourceCharacters = spacelessScriptCharacterSequence(source);
+  if (sourceCharacters.length <= SPACELESS_SCRIPT_LCS_SOURCE_LIMIT) {
+    const anchoredFraction = longestCommonSubstringLength(candidateCharacters, sourceCharacters)
+      / candidateCharacters.length;
+    if (anchoredFraction < GROUNDING_MIN_COVERAGE) return 0;
+  }
+  const sourceTokens = tokenize(source);
+  for (const token of tokenize(candidate)) {
+    if (containsSpacelessScriptCharacter(token)) continue;
+    if (![...sourceTokens].some((sourceToken) => areGroundingTokensCompatible(token, sourceToken))) {
+      return 0;
+    }
+  }
+  return coverage;
 }
 
 export function normalizeForExactMatch(text: string): string {

--- a/packages/remnic-core/src/extraction-source-grounding-rules.ts
+++ b/packages/remnic-core/src/extraction-source-grounding-rules.ts
@@ -14,12 +14,12 @@ import {
   groundingTokenSequence,
   hasContradictoryPolarity,
   hasExplicitRoleSubjectToken,
-  isAttachedNegatedAuxiliary,
   isInterrogativeSourceSentence,
   normalizeForExactMatch,
   normalizedGroundingAlignmentTokenSequence,
   normalizedGroundingTokenSequence,
   sourceSentences,
+  spacelessScriptGroundedTokenScore,
   splitGroundingClauses,
   stemToken,
   tokenize,
@@ -229,6 +229,8 @@ function groundedTokenScore(
   requireAlignedArguments = true,
   requireAllCandidateTokensGrounded = true,
 ): number {
+  const scriptAwareScore = spacelessScriptGroundedTokenScore(candidate, source);
+  if (scriptAwareScore !== null) return scriptAwareScore;
   const candidateTokens = tokenize(candidate);
   if (candidateTokens.size === 0) return 0;
   const sourceTokens = tokenize(source);

--- a/packages/remnic-core/src/extraction-source-grounding.test.ts
+++ b/packages/remnic-core/src/extraction-source-grounding.test.ts
@@ -2665,3 +2665,55 @@ test("grounding preserves plural identifiers after a proper-name copular subject
     assert.deepEqual(result.facts, []);
   }
 });
+
+const JAPANESE_OBSERVED_TURN = {
+  role: "user" as const,
+  content: "田中さんは東京に住んでいます。毎日電車で会社に行きます。",
+  timestamp: "2026-07-25T12:00:00.000Z",
+};
+
+test("script-aware grounding keeps CJK paraphrased facts and embedded entity names", async () => {
+  const engine = fixtureEngine({
+    localLlmEnabled: true,
+    localLlmModel: "fixture-local",
+    localLlmFallback: false,
+  });
+  Object.assign(engine, {
+    localLlm: {
+      async chatCompletion() {
+        return {
+          content: JSON.stringify({
+            facts: [
+              {
+                category: "fact",
+                content: "田中さんは東京に住んでいる",
+                confidence: 0.9,
+                tags: [],
+              },
+              {
+                category: "fact",
+                content: "田中さんは大阪に住んでいる",
+                confidence: 0.9,
+                tags: [],
+              },
+            ],
+            profileUpdates: [],
+            entities: [{
+              name: "田中",
+              type: "person",
+              facts: ["東京に住んでいる"],
+            }],
+            questions: [],
+          }),
+        };
+      },
+    },
+  });
+
+  const result = await engine.extract([JAPANESE_OBSERVED_TURN]);
+
+  assert.deepEqual(result.facts.map((fact) => fact.content), ["田中さんは東京に住んでいる"]);
+  assert.equal(result.entities.length, 1);
+  assert.equal(result.entities[0]?.name, "田中");
+  assert.deepEqual(result.entities[0]?.facts, ["東京に住んでいる"]);
+});


### PR DESCRIPTION
Fixes #2512.

Source grounding tokenizes on whitespace. Japanese, Chinese, and Korean
facts were dropped even when the source turn contained them. Entity
names embedded in a CJK sentence never matched as standalone tokens.

Script-aware matching now keeps paraphrased CJK facts and embedded
names when they are grounded in the source turn. Grounding stays on.

Regression: `extraction-source-grounding.test.ts` covers a Japanese
paraphrase and an embedded name.