### PR TITLE
fix(surfaces): i18n commitment detection, confirmations, and RTL isolation

### DIFF
--- a/packages/remnic-core/src/briefing.test.ts
+++ b/packages/remnic-core/src/briefing.test.ts
@@ -17,6 +17,7 @@ import {
   buildActiveThreads,
   buildBriefing,
   buildChainFollowupGenerator,
+  buildOpenCommitments,
   BRIEFING_FOLLOWUP_DEFAULT_MODEL,
 } from "./briefing.js";
 import type {
@@ -1669,4 +1670,53 @@ test("buildActiveThreads: primary sort by updatedAt overrides id tiebreaker", ()
   const threads = buildActiveThreads([olderAlpha, newerBeta]);
   assert.equal(threads[0]!.id, "entity:beta", "newer timestamp must rank first, overriding id tiebreaker");
   assert.equal(threads[1]!.id, "entity:alpha");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// buildOpenCommitments — non-English content (issue #2198)
+// ──────────────────────────────────────────────────────────────────────────
+function makeCommitmentMemory(overrides: {
+  content: string;
+  category?: MemoryFile["frontmatter"]["category"];
+  tags?: string[];
+}): MemoryFile {
+  return {
+    path: "/synthetic/mem.md",
+    frontmatter: {
+      id: "synthetic-commitment",
+      category: overrides.category ?? "fact",
+      created: "2026-08-17T00:00:00.000Z",
+      updated: "2026-08-17T00:00:00.000Z",
+      source: "test",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: overrides.tags ?? [],
+    },
+    content: overrides.content,
+  };
+}
+
+test("buildOpenCommitments: fullwidth and Arabic question marks surface questions (issue #2198)", () => {
+  const fullwidth = makeCommitmentMemory({ content: "このAPIのレート制限はいくつですか？" });
+  const arabic = makeCommitmentMemory({ content: "ما هو موعد الاجتماع؟" });
+  const english = makeCommitmentMemory({ content: "What is the rate limit?" });
+
+  const commitments = buildOpenCommitments([fullwidth, arabic, english]);
+  assert.equal(commitments.length, 3);
+  assert.ok(commitments.every((c) => c.kind === "question"));
+});
+
+test("buildOpenCommitments: structured category is language-neutral (issue #2198)", () => {
+  const japanese = makeCommitmentMemory({
+    content: "金曜日までにレビューを提出する",
+    category: "commitment",
+  });
+  const commitments = buildOpenCommitments([japanese]);
+  assert.equal(commitments.length, 1);
+  assert.equal(commitments[0]!.kind, "commitment");
+});
+
+test("buildOpenCommitments: plain non-English statement without markers is not flagged", () => {
+  const plain = makeCommitmentMemory({ content: "会議は終わりました" });
+  assert.equal(buildOpenCommitments([plain]).length, 0);
 });

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -1114,14 +1114,15 @@ export function buildRecentEntities(
     .slice(0, MAX_RECENT_ENTITIES);
 }
 
-function buildOpenCommitments(memories: MemoryFile[]): BriefingOpenCommitment[] {
+/** @internal — exported for testing only. */
+export function buildOpenCommitments(memories: MemoryFile[]): BriefingOpenCommitment[] {
   const commitments: BriefingOpenCommitment[] = [];
 
   for (const memory of memories) {
     const tags = memory.frontmatter.tags ?? [];
     const isPending = tags.some((t) => t.toLowerCase() === "pending");
     const isCommitment = memory.frontmatter.category === "commitment";
-    const isUnresolvedQuestion = /(?:\?$|\bfollow[- ]up\b|\btodo\b)/i.test(memory.content);
+    const isUnresolvedQuestion = /(?:[?？؟]$|\bfollow[- ]up\b|\btodo\b)/i.test(memory.content);
 
     if (isPending || isCommitment || isUnresolvedQuestion) {
       const kind: BriefingOpenCommitment["kind"] = isCommitment

--- a/packages/remnic-core/src/chat/chat-engine.test.ts
+++ b/packages/remnic-core/src/chat/chat-engine.test.ts
@@ -123,6 +123,21 @@ test("confirmation protocol: isConfirmationMessage recognizes exact-match keywor
   assert.ok(!isConfirmationMessage("please apply"));
 });
 
+test("confirmation protocol: non-English exact-match confirmations (issue #2198)", () => {
+  assert.ok(isConfirmationMessage("はい"));
+  assert.ok(isConfirmationMessage("sí"));
+  assert.ok(isConfirmationMessage("ja"));
+  assert.ok(isConfirmationMessage("نعم"));
+  assert.ok(isConfirmationMessage("  JA  "));
+  assert.ok(isConfirmationMessage("Sí"));
+  // Exact match only — partial or hedged text keeps the no-apply default.
+  assert.ok(!isConfirmationMessage("si")); // missing accent, not exact
+  assert.ok(!isConfirmationMessage("jam"));
+  assert.ok(!isConfirmationMessage("ja, aber"));
+  assert.ok(!isConfirmationMessage("نعم لا"));
+  assert.ok(!isConfirmationMessage("はい、しかし"));
+});
+
 test("citation guard: uncited memory assertion gets warning", async () => {
   const executor = makeStubExecutor();
   // The LLM makes an assertion without calling any tools first.

--- a/packages/remnic-core/src/chat/chat-engine.ts
+++ b/packages/remnic-core/src/chat/chat-engine.ts
@@ -85,10 +85,21 @@ export interface ChatEngineOptions {
 // Confirmation keywords — deterministic, not LLM-interpreted
 // ---------------------------------------------------------------------------
 
-const CONFIRMATION_KEYWORDS = new Set(["yes", "y", "apply", "confirm"]);
+// Exact-match confirmations. Unrecognized text keeps the conservative
+// no-apply default, so this stays a small fixed set (issue #2198).
+const CONFIRMATION_KEYWORDS: Record<string, true> = {
+  yes: true,
+  y: true,
+  apply: true,
+  confirm: true,
+  "はい": true, // Japanese
+  "sí": true, // Spanish
+  ja: true, // German/Dutch
+  "نعم": true, // Arabic
+};
 
 export function isConfirmationMessage(text: string): boolean {
-  return CONFIRMATION_KEYWORDS.has(text.trim().toLowerCase());
+  return CONFIRMATION_KEYWORDS[text.trim().toLowerCase()] === true;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/day-summary.test.ts
+++ b/packages/remnic-core/src/day-summary.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Day-summary composition tests — bidi isolation of user content (issue #2198).
+ * All fixtures are synthetic — no real user data.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatDaySummaryMemories } from "./day-summary.js";
+import type { MemoryFile } from "./types.js";
+
+const FSI = "\u2068";
+const PDI = "\u2069";
+
+function makeMemory(content: string): MemoryFile {
+  return {
+    path: "/synthetic/mem.md",
+    frontmatter: {
+      id: "synthetic-mem",
+      category: "fact",
+      created: "2026-08-17T00:00:00.000Z",
+      updated: "2026-08-17T00:00:00.000Z",
+      source: "test",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: [],
+    },
+    content,
+  };
+}
+
+test("formatDaySummaryMemories wraps RTL content in FSI/PDI isolates (issue #2198)", () => {
+  const rtl = makeMemory("اجتماع الفريق غدا في العاشرة");
+  const out = formatDaySummaryMemories([rtl]);
+
+  const expected = `[synthetic-mem] (fact, 2026-08-17T00:00:00.000Z)\n${FSI}اجتماع الفريق غدا في العاشرة${PDI}`;
+  assert.equal(out, expected);
+});
+
+test("formatDaySummaryMemories isolates LTR content too — labels stay outside the isolate", () => {
+  const out = formatDaySummaryMemories([makeMemory("standup at ten")]);
+
+  assert.ok(out.includes(`${FSI}standup at ten${PDI}`), "content wrapped in FSI/PDI");
+  assert.ok(out.startsWith("[synthetic-mem] (fact,"), "Latin label precedes the isolate");
+  assert.ok(!out.includes(`${PDI}[`), "label not inside the isolate");
+});
+
+test("formatDaySummaryMemories isolates each memory's content independently", () => {
+  const out = formatDaySummaryMemories([
+    makeMemory("first item"),
+    makeMemory("عنصر ثان"),
+  ]);
+
+  const parts = out.split("\n\n");
+  assert.equal(parts.length, 2);
+  assert.ok(parts[0]!.includes(`${FSI}first item${PDI}`));
+  assert.ok(parts[1]!.includes(`${FSI}عنصر ثان${PDI}`));
+});
+
+test("formatDaySummaryMemories raw-string passthrough is not wrapped", () => {
+  const out = formatDaySummaryMemories("  plain string input  ");
+  assert.equal(out, "plain string input");
+});

--- a/packages/remnic-core/src/day-summary.ts
+++ b/packages/remnic-core/src/day-summary.ts
@@ -93,6 +93,18 @@ export async function loadDaySummaryPrompt(): Promise<string> {
   return EMBEDDED_DAY_SUMMARY_PROMPT;
 }
 
+const FSI = "\u2068"; // FIRST STRONG ISOLATE
+const PDI = "\u2069"; // POP DIRECTIONAL ISOLATE
+
+/**
+ * Wrap user content in Unicode bidi isolates so RTL text (Arabic, Hebrew)
+ * cannot reorder the surrounding Latin labels on the same composed line.
+ * No visible change for LTR content (issue #2198).
+ */
+function bidiIsolate(text: string): string {
+  return `${FSI}${text}${PDI}`;
+}
+
 export function formatDaySummaryMemories(memories: string | MemoryFile[]): string {
   if (typeof memories === "string") {
     return memories.trim();
@@ -102,7 +114,7 @@ export function formatDaySummaryMemories(memories: string | MemoryFile[]): strin
     .map((memory) => {
       const category = memory.frontmatter.category || "fact";
       const created = memory.frontmatter.created || "unknown";
-      return `[${memory.frontmatter.id}] (${category}, ${created})\n${memory.content}`;
+      return `[${memory.frontmatter.id}] (${category}, ${created})\n${bidiIsolate(memory.content)}`;
     })
     .join("\n\n")
     .trim();


### PR DESCRIPTION
Fixes #2198.

Briefing commitment detection missed fullwidth `？`. Chat confirmations
were English-only. Day-summary concatenated RTL user content with Latin
labels without bidi isolation.

Surfaces now accept `？`, a small confirmation set (はい / sí / ja / نعم),
and isolate user content for RTL.

Regression: briefing, chat-engine, and day-summary tests cover those
cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing confirmations in Japanese, Spanish, German, Dutch, and Arabic.
  * Improved detection of open questions ending with fullwidth or Arabic question marks.
  * Improved day summaries for mixed right-to-left and left-to-right text, keeping labels and content properly ordered.

* **Bug Fixes**
  * Fixed multilingual commitment and question detection to avoid missing valid entries or misclassifying ordinary statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->