### PR TITLE
fix(entity): non-English follow-up coreference and query modes

### DIFF
--- a/packages/remnic-core/src/entity-retrieval-i18n.test.ts
+++ b/packages/remnic-core/src/entity-retrieval-i18n.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { normalizeEntityText } from "./entity-schema.js";
+import { buildEntityRecallSection } from "./entity-retrieval.js";
+import { detectNonEnglishEntityQueryMode } from "./entity-retrieval-i18n.js";
+import { StorageManager } from "./storage.js";
+import type { PluginConfig, TranscriptEntry } from "./types.js";
+
+function dialogueTurn(content: string): TranscriptEntry[] {
+  return [{
+    timestamp: new Date().toISOString(),
+    role: "user",
+    content,
+    sessionKey: "test-session",
+    turnId: "test-turn-1",
+  }];
+}
+
+function recallBase(
+  config: PluginConfig,
+  storage: StorageManager,
+  transcriptEntries: TranscriptEntry[],
+): Parameters<typeof buildEntityRecallSection>[0] {
+  return {
+    config,
+    storage,
+    query: "",
+    recentTurns: 2,
+    maxHints: 2,
+    maxSupportingFacts: 2,
+    maxRelatedEntities: 2,
+    maxChars: 10_000,
+    transcriptEntries,
+  };
+}
+
+test("non-English follow-ups resolve the recently discussed entity like the English pronoun follow-up (#2193)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-i18n-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    const entityRef = await storage.writeEntity("Alice", "person", []);
+    await storage.writeMemory("fact", "Alice leads the platform launch review.", {
+      source: "test",
+      entityRef,
+    });
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+    });
+    const dialogue = dialogueTurn("I spoke with Alice about the launch review yesterday.");
+
+    // English pronoun follow-up and its Japanese/Chinese equivalents must
+    // resolve to the same recently-discussed entity.
+    for (const query of ["What about her?", "それで、どうなった？", "彼はどうなった？", "然后呢？"]) {
+      const section = await buildEntityRecallSection({
+        ...recallBase(config, storage, dialogue),
+        query,
+      });
+      assert.ok(section, `expected an entity hint section for query: ${query}`);
+      assert.match(section, /alice/i);
+    }
+
+    // Without recent dialogue both decline identically — no entity to carry.
+    for (const query of ["What about him?", "それで、どうなった？"]) {
+      const section = await buildEntityRecallSection({
+        ...recallBase(config, storage, []),
+        query,
+      });
+      assert.equal(section, null, `expected no entity section without dialogue: ${query}`);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("zero-pronoun Japanese follow-up retrieves a CJK entity from a particle-bound mention (#2193)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-i18n-cjk-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    const entityRef = await storage.writeEntity("田中", "person", []);
+    await storage.writeMemory("fact", "田中は来週の発表を準備している。", {
+      source: "test",
+      entityRef,
+    });
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+    });
+
+    for (const query of ["それで、どうなった？", "彼女はどうなった？"]) {
+      const section = await buildEntityRecallSection({
+        ...recallBase(config, storage, dialogueTurn("田中とは昨日打ち合わせをした。")),
+        query,
+      });
+      assert.ok(section, `expected an entity hint section for query: ${query}`);
+      assert.match(section, /田中/);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("non-English query-mode cue table classification (#2193)", () => {
+  assert.equal(detectNonEnglishEntityQueryMode(normalizeEntityText("彼はどうなった")), "follow_up");
+  assert.equal(detectNonEnglishEntityQueryMode(normalizeEntityText("¿y ella?")), "follow_up");
+  assert.equal(detectNonEnglishEntityQueryMode(normalizeEntityText("田中さんの最近の状況")), "timeline");
+  assert.equal(detectNonEnglishEntityQueryMode(normalizeEntityText("了解しました")), null);
+});

--- a/packages/remnic-core/src/entity-retrieval-i18n.ts
+++ b/packages/remnic-core/src/entity-retrieval-i18n.ts
@@ -5,12 +5,15 @@ import { normalizeEntityText } from "./entity-schema.js";
  *
  * #2161 made explicit entity mentions language-independent, but follow-up /
  * pronoun coreference and timeline phrasing still classify through English
- * word lists in `detectEntityQueryMode`. These cue tables plus the
- * structural follow-up signal below close that gap without building a full
- * coreference engine: the structural layer covers every script (including
- * zero-pronoun languages like Japanese, Chinese, and Korean, which omit the
- * subject entirely and can never trip a pronoun word list), and the tables
- * add precision for queries without a question mark.
+ * word lists in `detectEntityQueryMode`. These cue tables plus the structural
+ * follow-up signal below close that gap without building a full coreference
+ * engine: the structural layer covers zero-pronoun scripts (Japanese,
+ * Chinese, Korean — languages that omit the subject entirely and can never
+ * trip a pronoun word list), and the tables add precision for other scripts,
+ * including Latin-script languages whose pronoun follow-ups carry their
+ * pronoun explicitly. Latin-script queries never use the structural layer:
+ * their generic technical questions ("what does this error mean?") are
+ * indistinguishable from subject-less follow-ups by shape alone.
  */
 
 export type EntityQueryMode = "direct" | "timeline" | "follow_up";
@@ -20,8 +23,13 @@ export type EntityQueryMode = "direct" | "timeline" | "follow_up";
 const FOLLOW_UP_MAX_TOKENS = 8;
 const FOLLOW_UP_MAX_GRAPHEMES = 48;
 
-/** Latin / question marks: ASCII `?`, fullwidth `？` (CJK), Arabic `؟`. */
-const QUESTION_MARK_RE = /[?？؟]/;
+/** Latin letters mark a script with explicit pronouns; structural fallback
+ * never applies there (English "what does this error mean?" and its
+ * relatives keep the technical-question guard in detectEntityQueryMode). */
+const LATIN_LETTER_RE = /\p{Script=Latin}/u;
+
+ /** Latin / question marks: ASCII `?`, fullwidth `？` (CJK), Arabic `؟`. */
+ const QUESTION_MARK_RE = /[?？؟]/;
 
 /**
  * CJK cues and normalized multi-word phrases match by containment; single
@@ -106,12 +114,48 @@ export function detectNonEnglishEntityQueryMode(normalizedQuery: string): Entity
 /**
  * Structural follow-up signal, independent of pronoun vocabulary: a short
  * question carrying no entity name, asked while recent dialogue exists, is a
- * coreference cue in any language. Recent-turn candidate resolution (and its
- * empty result → section absent) remains the real gate, so this only routes
- * the query into the follow-up path; it never invents an entity.
+ * coreference cue in zero-pronoun scripts (Latin-script queries are excluded
+ * above — their follow-ups carry pronouns that the cue tables and English
+ * rules classify). Recent-turn candidate resolution (and its empty result →
+ * section absent) remains the real gate, so this only routes the query into
+ * the follow-up path; it never invents an entity.
  */
 export function isStructuralEntityFollowUpQuery(query: string, hasRecentDialogue: boolean): boolean {
   if (!hasRecentDialogue) return false;
+  if (LATIN_LETTER_RE.test(query)) return false;
   const normalized = normalizeEntityText(query);
   return isShortFollowUpShaped(normalized) && QUESTION_MARK_RE.test(query);
 }
+
+const ENTITY_PRONOUN_RE = /\b(he|him|his|she|her|they|them|their|it|its)\b/i;
+
+export function detectEntityQueryMode(query: string): EntityQueryMode | null {
+  const normalized = normalizeEntityText(query);
+  if (!normalized) return null;
+  if (
+    /^(what about|and what about|how about|what happened (with|to) (he|him|his|she|her|they|them|their|it|its)|did (he|she|they|it)|is (he|she|they|it)|was (he|she|they|it))\b/.test(normalized)
+  ) {
+    return "follow_up";
+  }
+  if (
+    /^(who is|who s|what do we know about|what does|tell me about|what can you tell me about|what s new with|what happened with|what happened to|status of|where is|how is)\b/.test(normalized)
+  ) {
+    if (/^what does\b/.test(normalized)) {
+      if (/^what does (?:this|that|it|the|a|an|my|our|your|their)\b/.test(normalized)) {
+        return null;
+      }
+      if (
+        /^what does [a-z0-9-]+ (?:error|warning|exception|failure|stack|trace|code|message|log)\b/.test(normalized)
+        && /\b(mean|means|indicate|indicates|imply|implies)\b/.test(normalized)
+      ) {
+        return null;
+      }
+    }
+    return /what happened|what s new|status of|how is|where is/.test(normalized) ? "timeline" : "direct";
+  }
+  if (ENTITY_PRONOUN_RE.test(normalized) && normalized.split(/\s+/).length <= 8) {
+    return "follow_up";
+  }
+  return detectNonEnglishEntityQueryMode(normalized);
+}
+

--- a/packages/remnic-core/src/entity-retrieval-i18n.ts
+++ b/packages/remnic-core/src/entity-retrieval-i18n.ts
@@ -1,0 +1,117 @@
+import { normalizeEntityText } from "./entity-schema.js";
+
+/**
+ * Non-English query-mode cues for entity retrieval (#2193).
+ *
+ * #2161 made explicit entity mentions language-independent, but follow-up /
+ * pronoun coreference and timeline phrasing still classify through English
+ * word lists in `detectEntityQueryMode`. These cue tables plus the
+ * structural follow-up signal below close that gap without building a full
+ * coreference engine: the structural layer covers every script (including
+ * zero-pronoun languages like Japanese, Chinese, and Korean, which omit the
+ * subject entirely and can never trip a pronoun word list), and the tables
+ * add precision for queries without a question mark.
+ */
+
+export type EntityQueryMode = "direct" | "timeline" | "follow_up";
+
+/** Shared short-question bound. Whitespace tokens are a poor length proxy
+ * for unspaced scripts, so bound graphemes too (48 graphemes ≈ 8 words). */
+const FOLLOW_UP_MAX_TOKENS = 8;
+const FOLLOW_UP_MAX_GRAPHEMES = 48;
+
+/** Latin / question marks: ASCII `?`, fullwidth `？` (CJK), Arabic `؟`. */
+const QUESTION_MARK_RE = /[?？؟]/;
+
+/**
+ * CJK cues and normalized multi-word phrases match by containment; single
+ * Latin/Cyrillic/Arabic words match with a script-agnostic letter boundary
+ * so `él` never matches `el` and `il` never matches `famille`.
+ */
+const FOLLOW_UP_CONTAINS_CUES = [
+  // ja
+  "彼", "彼女", "あの人", "その人", "それで", "ちなみに",
+  // zh (simplified + traditional)
+  "他", "她", "它", "他们", "她们", "他們", "她們", "然后呢", "然後呢",
+  // ko
+  "그녀", "그 사람", "걔",
+] as const;
+
+const FOLLOW_UP_WORD_CUES = [
+  // es
+  "él", "ella", "ellos", "ellas",
+  // fr
+  "elle", "eux",
+  // de
+  "sie",
+  // pt
+  "ele", "ela",
+  // it
+  "lui", "lei",
+  // ru
+  "он", "она", "они",
+  // ar
+  "هو", "هي", "هم",
+] as const;
+
+const TIMELINE_CONTAINS_CUES = [
+  // ja
+  "最近", "その後", "どうなった", "何があった",
+  // zh (simplified + traditional)
+  "怎么样了", "怎麼樣了", "后来", "後來", "最新", "近况", "近況", "什么情况", "什麼情況",
+  // ko
+  "요즘", "요새", "최근",
+  // multi-word phrases, already in normalized form (punctuation → space)
+  "qué hay de nuevo", "qué pasó con", "quoi de neuf", "что нового",
+  "что случилось", "ما الجديد", "ماذا حدث", "was gibt s neues",
+] as const;
+
+function wordCueRegex(cues: readonly string[]): RegExp {
+  const alternation = cues
+    .map((cue) => cue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|");
+  return new RegExp(`(?<![\\p{L}\\p{N}])(?:${alternation})(?![\\p{L}\\p{N}])`, "u");
+}
+
+const FOLLOW_UP_WORD_RE = wordCueRegex(FOLLOW_UP_WORD_CUES);
+
+function isShortFollowUpShaped(normalized: string): boolean {
+  if (!normalized) return false;
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+  if (tokens.length > FOLLOW_UP_MAX_TOKENS) return false;
+  return Array.from(normalized).length <= FOLLOW_UP_MAX_GRAPHEMES;
+}
+
+/**
+ * Classify already-normalized non-English queries. Returns null when no
+ * table cue matches; callers keep their English rules untouched.
+ */
+export function detectNonEnglishEntityQueryMode(normalizedQuery: string): EntityQueryMode | null {
+  if (!normalizedQuery) return null;
+  if (
+    isShortFollowUpShaped(normalizedQuery)
+    && (
+      FOLLOW_UP_CONTAINS_CUES.some((cue) => normalizedQuery.includes(cue))
+      || FOLLOW_UP_WORD_RE.test(normalizedQuery)
+    )
+  ) {
+    return "follow_up";
+  }
+  if (TIMELINE_CONTAINS_CUES.some((cue) => normalizedQuery.includes(cue))) {
+    return "timeline";
+  }
+  return null;
+}
+
+/**
+ * Structural follow-up signal, independent of pronoun vocabulary: a short
+ * question carrying no entity name, asked while recent dialogue exists, is a
+ * coreference cue in any language. Recent-turn candidate resolution (and its
+ * empty result → section absent) remains the real gate, so this only routes
+ * the query into the follow-up path; it never invents an entity.
+ */
+export function isStructuralEntityFollowUpQuery(query: string, hasRecentDialogue: boolean): boolean {
+  if (!hasRecentDialogue) return false;
+  const normalized = normalizeEntityText(query);
+  return isShortFollowUpShaped(normalized) && QUESTION_MARK_RE.test(query);
+}

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -10,6 +10,11 @@ import { normalizeEntityText, resolveRequestedEntitySectionKeys } from "./entity
 import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry } from "./types.js";
 import { truncateGraphemeSafe } from "./whitespace.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
+import {
+  detectNonEnglishEntityQueryMode,
+  isStructuralEntityFollowUpQuery,
+  type EntityQueryMode,
+} from "./entity-retrieval-i18n.js";
 import { buildOriginStructuredSections, sanitizeOriginatedFacts, type EntityOriginStructuredSection } from "./entity-origin-fields.js";
 import {
   checkEntityRecallAbort,
@@ -24,7 +29,6 @@ const METADATA_WRAPPER_RE = /^(source|context|metadata|notes?):/i;
 const ENTITY_PRONOUN_RE = /\b(he|him|his|she|her|they|them|their|it|its)\b/i;
 const BELIEF_LEDGER_SECTION_KEY = "belief_ledger";
 const BELIEF_LEDGER_FACT_RE = /^claim=([^;]+);\s*status=([^;]+);\s*updatedAt=([^;]+);\s*(.+)$/;
-type EntityQueryMode = "direct" | "timeline" | "follow_up";
 type EntityMentionIndexEntry = {
   canonicalId: string;
   name: string;
@@ -198,7 +202,7 @@ function detectEntityQueryMode(query: string): EntityQueryMode | null {
   if (ENTITY_PRONOUN_RE.test(normalized) && normalized.split(/\s+/).length <= 8) {
     return "follow_up";
   }
-  return null;
+  return detectNonEnglishEntityQueryMode(normalized);
 }
 function scoreAliasMatch(query: string, alias: string): number {
   const normalizedQuery = normalizeEntityText(query);
@@ -1061,7 +1065,17 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   // during a scan is observed here (issue #2291).
   checkEntityRecallAbort(options.abortSignal);
   const prefixedMode = detectEntityQueryMode(options.query);
-  const persistedIndex = prefixedMode
+  // #2193: a short question with no entity name is a structural follow-up
+  // cue in any language (zero-pronoun languages never trip a pronoun word
+  // list), so it enters the same coreference path as an English "what about
+  // him?". Recent-turn resolution stays the gate — this only routes.
+  const structuralFollowUp = prefixedMode === null
+    && isStructuralEntityFollowUpQuery(
+      options.query,
+      options.recentTurns > 0 && options.transcriptEntries.length > 0,
+    );
+  const earlyMode = prefixedMode ?? (structuralFollowUp ? "follow_up" : null);
+  const persistedIndex = earlyMode
     ? null
     : await readCurrentPersistedEntityIndex(
       options.storage,
@@ -1072,7 +1086,7 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   checkEntityRecallAbort(options.abortSignal);
   let nativeChunks: NativeKnowledgeChunk[] | undefined;
   if (
-    !prefixedMode &&
+    !earlyMode &&
     persistedIndex &&
     resolveLanguageIndependentExplicitCandidates(persistedIndex, options.query).length === 0
   ) {
@@ -1129,7 +1143,15 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   const queryCandidates = prefixedMode
     ? explicitCandidates
     : resolveLanguageIndependentExplicitCandidates(index, options.query);
-  const mode = prefixedMode ?? (queryCandidates.length > 0 ? "direct" : null);
+  // Explicit mentions keep #2161 behavior (direct mode) even when the
+  // structural follow-up signal also fired; only name-less short questions
+  // fall through to coreference.
+  const mode = prefixedMode
+    ?? (queryCandidates.length > 0
+      ? "direct"
+      : structuralFollowUp
+        ? "follow_up"
+        : null);
   if (!mode) return entityRecallSectionAbsent(options.abortSignal);
 
   const candidates = queryCandidates.length > 0

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -11,7 +11,7 @@ import type { EntityStructuredSection, MemoryFile, PluginConfig, TranscriptEntry
 import { truncateGraphemeSafe } from "./whitespace.js";
 import { containsPhrase } from "./entity-retrieval-boundaries.js";
 import {
-  detectNonEnglishEntityQueryMode,
+  detectEntityQueryMode,
   isStructuralEntityFollowUpQuery,
   type EntityQueryMode,
 } from "./entity-retrieval-i18n.js";
@@ -26,7 +26,6 @@ const ENTITY_INDEX_VERSION = 3;
 const RECENT_TRANSCRIPT_LOOKBACK_HOURS = 24;
 const INSTRUCTION_LIKE_RE = /\b(always|never|must|should|remember to|do not|don't|process|workflow|template|checklist|instruction)\b/i;
 const METADATA_WRAPPER_RE = /^(source|context|metadata|notes?):/i;
-const ENTITY_PRONOUN_RE = /\b(he|him|his|she|her|they|them|their|it|its)\b/i;
 const BELIEF_LEDGER_SECTION_KEY = "belief_ledger";
 const BELIEF_LEDGER_FACT_RE = /^claim=([^;]+);\s*status=([^;]+);\s*updatedAt=([^;]+);\s*(.+)$/;
 type EntityMentionIndexEntry = {
@@ -174,35 +173,6 @@ function relationLine(entry: EntityMentionIndexEntry, relationship: { target: st
   const normalizedLabel = relationship.label.replace(/\s+/g, " ").trim();
   if (normalizedLabel.length === 0) return `${entry.name} is connected to ${relationship.target}`;
   return `${entry.name} ${normalizedLabel} ${relationship.target}`;
-}
-function detectEntityQueryMode(query: string): EntityQueryMode | null {
-  const normalized = normalizeEntityText(query);
-  if (!normalized) return null;
-  if (
-    /^(what about|and what about|how about|what happened (with|to) (he|him|his|she|her|they|them|their|it|its)|did (he|she|they|it)|is (he|she|they|it)|was (he|she|they|it))\b/.test(normalized)
-  ) {
-    return "follow_up";
-  }
-  if (
-    /^(who is|who s|what do we know about|what does|tell me about|what can you tell me about|what s new with|what happened with|what happened to|status of|where is|how is)\b/.test(normalized)
-  ) {
-    if (/^what does\b/.test(normalized)) {
-      if (/^what does (?:this|that|it|the|a|an|my|our|your|their)\b/.test(normalized)) {
-        return null;
-      }
-      if (
-        /^what does [a-z0-9-]+ (?:error|warning|exception|failure|stack|trace|code|message|log)\b/.test(normalized)
-        && /\b(mean|means|indicate|indicates|imply|implies)\b/.test(normalized)
-      ) {
-        return null;
-      }
-    }
-    return /what happened|what s new|status of|how is|where is/.test(normalized) ? "timeline" : "direct";
-  }
-  if (ENTITY_PRONOUN_RE.test(normalized) && normalized.split(/\s+/).length <= 8) {
-    return "follow_up";
-  }
-  return detectNonEnglishEntityQueryMode(normalized);
 }
 function scoreAliasMatch(query: string, alias: string): number {
   const normalizedQuery = normalizeEntityText(query);
@@ -1065,10 +1035,11 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   // during a scan is observed here (issue #2291).
   checkEntityRecallAbort(options.abortSignal);
   const prefixedMode = detectEntityQueryMode(options.query);
-  // #2193: a short question with no entity name is a structural follow-up
-  // cue in any language (zero-pronoun languages never trip a pronoun word
-  // list), so it enters the same coreference path as an English "what about
-  // him?". Recent-turn resolution stays the gate — this only routes.
+  // #2193: in zero-pronoun scripts a short question with no entity name
+  // never trips a pronoun word list, so the structural signal routes it
+  // into the same coreference path as an English "what about him?".
+  // Latin-script queries stay on the cue tables / English rules so the
+  // generic technical-question guard keeps working. Resolution gates.
   const structuralFollowUp = prefixedMode === null
     && isStructuralEntityFollowUpQuery(
       options.query,
@@ -1143,6 +1114,13 @@ export async function buildEntityRecallSection(options: BuildEntityRecallSection
   const queryCandidates = prefixedMode
     ? explicitCandidates
     : resolveLanguageIndependentExplicitCandidates(index, options.query);
+  if (
+    queryCandidates.length === 0
+    && /^what does (?:this|that|it|the|a|an|my|our|your|their)\b/i.test(normalizeEntityText(options.query))
+  ) {
+    return entityRecallSectionAbsent(options.abortSignal);
+  }
+
   // Explicit mentions keep #2161 behavior (direct mode) even when the
   // structural follow-up signal also fired; only name-less short questions
   // fall through to coreference.


### PR DESCRIPTION
Fixes #2193.

Entity retrieval follow-up and pronoun coreference were still
English-gated after #2161. A Japanese or Chinese follow-up missed the
entity path.

Non-English follow-up and query-mode cues now reach the same entity
retrieval path. No full coreference engine.

Regression: `entity-retrieval-i18n.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved entity retrieval for Japanese, Chinese, Spanish, and other non-English queries.
  * Recognizes localized direct, timeline, and follow-up questions.
  * Supports short follow-up questions based on recent conversation context, including particle-bound entity mentions.

* **Bug Fixes**
  * Prevents unsupported generic questions from retrieving unrelated entities.
  * Preserves accurate handling of explicit entity references and technical questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->