### PR TITLE
fix(capture-screen): pin OCR to the ax-snapshot window id

### DIFF
--- a/.changeset/2141-ocr-window-id.md
+++ b/.changeset/2141-ocr-window-id.md
@@ -1,0 +1,13 @@
+---
+"@remnic/capture-screen": patch
+---
+
+capture-screen: pin OCR to the ax-snapshot window id (#2141)
+
+`captureFromSnapshot` now targets `ocr-window --window <id>` with the stable
+window id returned by `ax-snapshot` instead of `--frontmost`, closing the
+focus-change TOCTOU where OCR read a different window than the one the
+captured app/windowTitle describe. `AxSnapshot` carries an optional
+`windowId` (string; a numeric CGWindowID is coerced); helpers that do not
+emit one keep the previous frontmost behavior, still guarded by the deny
+preflight.

--- a/packages/capture-screen/package.json
+++ b/packages/capture-screen/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli-bin.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/util.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/replay.test.ts src/scheduler.test.ts src/daemon.test.ts src/cli.test.ts",
+    "test": "tsx --test src/simhash.test.ts src/dedup.test.ts src/daywindow.test.ts src/denylist.test.ts src/axtree.test.ts src/redact.test.ts src/config.test.ts src/validate.test.ts src/util.test.ts src/token.test.ts src/spool.test.ts src/capture.test.ts src/helper.test.ts src/live.test.ts src/replay.test.ts src/scheduler.test.ts src/daemon.test.ts src/cli.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/capture-screen/src/helper.test.ts
+++ b/packages/capture-screen/src/helper.test.ts
@@ -63,6 +63,35 @@ test("ax-snapshot parses window context + tree from the fake helper", async () =
   assert.equal(snap.tree.role, "AXWindow");
 });
 
+const WIN = fakeHelper(
+  "win.js",
+  `const cmd = process.argv[2];
+if (cmd === "ax-snapshot") process.stdout.write(JSON.stringify({ app: "kitty", windowTitle: "shell", windowId: "A", tree: { role: "AXWindow" } }));
+else process.exit(2);`,
+);
+const WINNUM = fakeHelper(
+  "winnum.js",
+  `process.stdout.write(JSON.stringify({ app: "kitty", windowTitle: "shell", windowId: 4242, tree: { role: "AXWindow" } }));`,
+);
+const WINBAD = fakeHelper(
+  "winbad.js",
+  `process.stdout.write(JSON.stringify({ app: "kitty", windowTitle: "shell", windowId: true, tree: { role: "AXWindow" } }));`,
+);
+
+test("ax-snapshot threads the helper window id through to the snapshot", async () => {
+  const snap = await new NativeHelper(WIN).axSnapshot({ frontmost: true });
+  assert.equal(snap.windowId, "A");
+});
+
+test("ax-snapshot coerces a numeric window id (CGWindowID) to string", async () => {
+  const snap = await new NativeHelper(WINNUM).axSnapshot({ frontmost: true });
+  assert.equal(snap.windowId, "4242");
+});
+
+test("ax-snapshot rejects a malformed window id", async () => {
+  await assert.rejects(new NativeHelper(WINBAD).axSnapshot(), CaptureInputError);
+});
+
 test("ocr-window returns the text field", async () => {
   const helper = new NativeHelper(OK);
   assert.equal(await helper.ocrWindow({ frontmost: true }), "terminal ocr text");

--- a/packages/capture-screen/src/helper.ts
+++ b/packages/capture-screen/src/helper.ts
@@ -155,11 +155,14 @@ export interface AxSnapshotOptions {
  * The helper's `ax-snapshot` payload: the frontmost window's context (app,
  * title, optional browser URL) plus its accessibility tree. The tree is
  * permissive (see AxNode); window context lets the daemon build a capture
- * candidate without a separate frontmost-window query.
+ * candidate without a separate frontmost-window query. `windowId` is the
+ * stable native window id (macOS CGWindowID) so follow-up OCR can target
+ * the exact window this tree came from, not whatever is frontmost later.
  */
 export interface AxSnapshot {
   app: string;
   windowTitle: string;
+  windowId?: string;
   browserUrl?: string | null;
   tree: AxNode;
 }
@@ -193,12 +196,21 @@ export class NativeHelper {
     const app: unknown = json.app;
     const windowTitle: unknown = json.windowTitle;
     const browserUrl: unknown = "browserUrl" in json ? json.browserUrl : undefined;
+    const windowIdRaw: unknown = "windowId" in json ? json.windowId : undefined;
     const tree: unknown = json.tree;
     if (typeof app !== "string" || typeof windowTitle !== "string") {
       throw new CaptureInputError("native helper ax-snapshot app/windowTitle must be strings");
     }
     if (tree === null || typeof tree !== "object" || Array.isArray(tree)) {
       throw new CaptureInputError("native helper ax-snapshot tree must be an object");
+    }
+    // CGWindowID may arrive as a JSON number or string; null/absent means the
+    // helper could not resolve an id (OCR falls back to frontmost).
+    let windowId: string | undefined;
+    if (typeof windowIdRaw === "string") windowId = windowIdRaw;
+    else if (typeof windowIdRaw === "number" && Number.isFinite(windowIdRaw)) windowId = String(windowIdRaw);
+    else if (windowIdRaw !== undefined && windowIdRaw !== null) {
+      throw new CaptureInputError("native helper ax-snapshot windowId must be a string or number");
     }
     // Named cast (sanctioned): the tree is structurally an AxNode (all fields
     // optional) and extractAxText tolerates unknown shapes; a schema parse of an
@@ -207,6 +219,7 @@ export class NativeHelper {
     return {
       app,
       windowTitle,
+      ...(windowId !== undefined ? { windowId } : {}),
       ...(typeof browserUrl === "string" ? { browserUrl } : {}),
       tree: axTree,
     };

--- a/packages/capture-screen/src/live.test.ts
+++ b/packages/capture-screen/src/live.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CaptureProcessor } from "./capture.js";
+import { defaultDaemonConfig } from "./config.js";
+import type { AxSnapshot, NativeHelper, OcrWindowOptions } from "./helper.js";
+import { captureFromSnapshot } from "./live.js";
+
+test("focus change between ax-snapshot and OCR: OCR targets the snapshot window id", async () => {
+  const config = defaultDaemonConfig();
+  const processor = new CaptureProcessor(config);
+  const calls: OcrWindowOptions[] = [];
+  // Simulate the focus flip: after the snapshot was taken the frontmost
+  // window became a different one, so the frontmost path would read
+  // WINDOW-B text while the candidate is stored under window A's identity.
+  const helper = {
+    ocrWindow: async (opts: OcrWindowOptions) => {
+      calls.push(opts);
+      return opts.windowId === "A" ? "window A ocr text" : "WINDOW-B TEXT";
+    },
+  } as unknown as NativeHelper;
+  // kitty is terminal-class (DEFAULT_TERMINAL_APPS) and the tree carries no
+  // text, so captureFromSnapshot must take the OCR path.
+  const snap: AxSnapshot = {
+    app: "kitty",
+    windowTitle: "shell",
+    windowId: "A",
+    tree: { role: "AXWindow" },
+  };
+
+  const decision = await captureFromSnapshot(snap, helper, processor, config, "2026-08-17T00:00:00.000Z");
+
+  assert.deepEqual(calls, [{ windowId: "A" }], "OCR must target the snapshot window, not the frontmost");
+  assert.equal(decision.action, "store");
+  if (decision.action === "store") {
+    assert.equal(decision.snapshot.text, "window A ocr text");
+    assert.equal(decision.snapshot.textSource, "ocr");
+    assert.equal(decision.snapshot.app, "kitty");
+  }
+});

--- a/packages/capture-screen/src/live.ts
+++ b/packages/capture-screen/src/live.ts
@@ -58,7 +58,16 @@ export async function captureFromSnapshot(
     // Leave text-less; processor.process denies it below (no OCR ran).
   } else if (isTerminalApp(snap.app, config.terminalApps) || axText.trim() === "") {
     try {
-      const ocrText = await helper.ocrWindow({ frontmost: true });
+      // Pin OCR to the snapshot's window when the helper reported its id: a
+      // focus change between the ax-snapshot and this call must not redirect
+      // OCR at a different window than the one this candidate is stored
+      // under. The deny preflight above ran against this same window
+      // identity, so the resolved OCR target is the window that was checked.
+      // Without an id (legacy helper) frontmost is the only target available
+      // and the preflight against the snap identity remains the guard.
+      const ocrText = await helper.ocrWindow(
+        snap.windowId !== undefined ? { windowId: snap.windowId } : { frontmost: true },
+      );
       if (ocrText.trim() !== "") {
         candidate.text = ocrText;
         candidate.textSource = "ocr";


### PR DESCRIPTION
Fixes #2141.

`captureFromSnapshot` OCR used `--frontmost`. A focus change between the AX snapshot and the OCR call stored another window's text under the snapshot identity.

## Change

- Thread `windowId` through `AxSnapshot`.
- Call `ocrWindow({ windowId })` when the snapshot has an id.
- Keep `{ frontmost: true }` only for legacy helpers with no id.

## Regression

`live.test.ts`: focus flip between snapshot and OCR targets window A.

## Verification

`node --import tsx --test src/live.test.ts src/helper.test.ts` — 14 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OCR now targets the window captured in the accessibility snapshot, improving accuracy when focus changes.
  - Supports stable window identifiers from accessibility data, including numeric identifiers converted to text.
  - Retains frontmost-window OCR behavior when no identifier is available.

- **Bug Fixes**
  - Invalid window identifiers are rejected safely instead of producing unreliable capture results.

- **Tests**
  - Added coverage for window targeting, identifier handling, and focus-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->