### PR TITLE
docs(okf): surface OKF conformance in README and llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,15 @@ The search index lives separately and is rebuildable from these files at any tim
 
 See [docs/importers.md](docs/importers.md) for input formats, provenance metadata, and the full privacy breakdown.
 
+**Open Knowledge Format (OKF).** The memory directory doubles as an OKF v0.1 knowledge bundle: every memory file ships an inert `type` field next to Remnic's canonical `category`, so OKF-aware consumers can read your store without a converter. `category` stays authoritative — `type` is interop metadata and never overrides it on parse. Two commands keep the bundle conformant:
+
+| Command | What it does |
+|---------|--------------|
+| `remnic okf lint` | Report files missing frontmatter or `type`; exit 1 when findings remain (`--json` for machine output) |
+| `remnic okf sweep` | Backfill missing `type` values from `category` without bumping `updated` (opt-in via `okf.sweepEnabled`) |
+
+Config gates, lint finding codes, and the full category-to-type mapping: [docs/okf.md](docs/okf.md).
+
 **Live connectors: Google Drive and Notion.** Beyond one-time imports, Remnic can *continuously* sync external sources into memory. The Google Drive and Notion connectors poll for changed documents on a schedule and ingest them incrementally — connect once (`remnic connectors run google-drive` / `remnic connectors run notion` for a manual sync, `remnic connectors status` to inspect), and your docs stay searchable alongside everything else your agents know. Gmail and GitHub connectors run on the hosted scheduler as well. Setup, OAuth, and polling details: [docs/live-connectors.md](docs/live-connectors.md).
 
 **Wearables.** Three optional connectors ingest AI-wearable recordings, clean and speaker-label the transcripts, apply your personal corrections, store searchable per-day transcript files, and create memories under strict per-source trust gates: `@remnic/connector-limitless` (Limitless Pendant), `@remnic/connector-bee` (Bee bracelet), and `@remnic/connector-omi` (Omi necklace). See [docs/wearables.md](docs/wearables.md).

--- a/docs/okf.md
+++ b/docs/okf.md
@@ -6,8 +6,22 @@ Spec (v0.1 revision): https://github.com/GoogleCloudPlatform/knowledge-catalog/b
 
 ## Commands
 
-- `remnic okf lint` — report missing frontmatter or `type`. Encrypted files are skipped. Exit 1 when findings remain. `--json` prints the result object.
-- `remnic okf sweep` — add missing `type` values without bumping `updated`. Gated by `okf.sweepEnabled`.
+| Command | Behavior |
+|---|---|
+| `remnic okf lint` | Report missing frontmatter or `type`. Encrypted files are skipped. Exit 1 when findings remain. `--json` prints the result object. |
+| `remnic okf sweep` | Add missing `type` values without bumping `updated`. Gated by `okf.sweepEnabled`. |
+
+Lint walks every `.md` file under the memory directory, skipping `state/`, `.git/`, and symlinks. Findings carry a stable code:
+
+| Code | Meaning |
+|---|---|
+| `missing_frontmatter` | File has no YAML frontmatter block. |
+| `missing_type` | Frontmatter has no `type` key. |
+| `empty_type` | `type` is present but empty. |
+| `reserved_basename` | `index.md` or `log.md` at any depth — OKF §6/§7 reserves these basenames for bundle-level files, and Remnic writes targeting them are rejected. |
+| `skipped_encrypted` | File is a secure-store encrypted envelope. Informational; does not affect the exit code. |
+
+Sweep fixes only `missing_type` and `empty_type` findings, deriving the value from the file's `category`.
 
 ## Config
 
@@ -24,4 +38,43 @@ Spec (v0.1 revision): https://github.com/GoogleCloudPlatform/knowledge-catalog/b
 
 ## Mapping
 
-See `packages/remnic-core/src/okf/type-mapping.ts`. `category: fact` → `type: Memory Fact`. Unknown categories → `Memory`. Entity kinds map to Person/Company/Project/Entity. Profile → `Profile`.
+Source of truth: `packages/remnic-core/src/okf/type-mapping.ts`. The tables below mirror it exactly; change both together.
+
+### Memory categories
+
+| `category` | `type` |
+|---|---|
+| `fact` | `Memory Fact` |
+| `decision` | `Decision` |
+| `preference` | `Preference` |
+| `commitment` | `Commitment` |
+| `relationship` | `Relationship` |
+| `principle` | `Principle` |
+| `moment` | `Moment` |
+| `skill` | `Skill` |
+| `correction` | `Correction` |
+| `rule` | `Rule` |
+| any other category | `Memory` |
+
+Memories carrying an `artifactType` report `Artifact` regardless of category.
+
+### Entity kinds
+
+| Entity `kind` | `type` |
+|---|---|
+| `person` | `Person` |
+| `company` | `Company` |
+| `organization` | `Organization` |
+| `project` | `Project` |
+| `topic` | `Topic` |
+| `technology` | `Technology` |
+| `place` | `Place` |
+| `event` | `Event` |
+| any other or missing kind | `Entity` |
+
+### Other written files
+
+| File | `type` |
+|---|---|
+| `profile.md` | `Profile` (frontmatter header on the profile body) |
+| question files | `Question` |

--- a/llms.txt
+++ b/llms.txt
@@ -96,6 +96,19 @@ archived. Episode/note model separates time-specific events from stable
 beliefs. Inline provenance tags carry source attribution in the fact body.
 
 
+
+OKF CONFORMANCE
+
+Memory directories are OKF v0.1 knowledge bundles. Spec (pinned revision):
+https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md
+Every memory file carries an inert `type` field alongside the canonical
+`category`; `type` never overrides `category` on parse. `remnic okf lint`
+reports conformance findings (exit 1 when any remain; --json supported).
+`remnic okf sweep` backfills missing `type` values without bumping
+`updated` (opt-in via okf.sweepEnabled, default false; `type` emission
+itself is gated by okf.conformanceEnabled, default true). Full mapping
+and finding codes: docs/okf.md.
+
 SEARCH BACKENDS
 
 Six backends, selected by `searchBackend`:


### PR DESCRIPTION
Fixes #1951.

#1946 shipped `remnic okf lint` / `remnic okf sweep`. This documents only those commands.

## Change

- README OKF section with a 2-row command table.
- `docs/okf.md` mapping tables match `okf/type-mapping.ts`.
- `llms.txt` OKF section.

Repo topics `okf` and `open-knowledge-format` added. Ecosystem submissions deferred (voice-guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for Open Knowledge Format (OKF) v0.1 conformance.
  - Documented `remnic okf lint` and `remnic okf sweep`, including configuration, output, exit behavior, and timestamp handling.
  - Added details on metadata requirements, category mappings, encrypted files, reserved names, and lint findings.
  - Linked to the OKF reference specification and documented related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->