### PR TITLE
feat(connector-reitti): optional Reitti location provider

### DIFF
--- a/.changeset/2045-connector-reitti.md
+++ b/.changeset/2045-connector-reitti.md
@@ -1,0 +1,6 @@
+---
+"@remnic/connector-reitti": minor
+"@remnic/core": minor
+---
+
+Add the optional `@remnic/connector-reitti` location provider (issue #2045): a read-only Reitti API client and normalizer for the core location pipeline. Uses only current-user `/api/v1/timeline` and `/api/v1/visits` endpoints, supports both documented token header forms (one configured mode, never both), distinguishes empty days from auth/rate-limit/server/network/timeout/JSON/size/schema failures, honors `AbortSignal`, bounds response size, and never logs tokens. Registers through the core location registry; `@remnic/core` gains a `./location` subpath export so adapters consume the provider contract without growing the frozen root index. Closes #2045.

--- a/packages/connector-reitti/README.md
+++ b/packages/connector-reitti/README.md
@@ -23,9 +23,9 @@ location registry — ideally via a computed-specifier dynamic import so
 bundlers cannot statically resolve the optional package:
 
 ```ts
-import { registerLocationProvider } from "@remnic/core/location";
+import { getLocationProvider } from "@remnic/core/location";
 
-const mod = await import("@remnic/connector-reitti");
+const mod = await import("@remnic/" + "connector-reitti");
 mod.ensureReittiProviderRegistered({
   baseUrl: "https://reitti.example.invalid",
   token: resolvedToken, // from Remnic's secret reference mechanism

--- a/packages/connector-reitti/README.md
+++ b/packages/connector-reitti/README.md
@@ -1,0 +1,80 @@
+# @remnic/connector-reitti
+
+Optional location provider adapter that reads a self-hosted
+[Reitti](https://github.com/dedicatedcode/reitti) instance and feeds the core
+location pipeline (`@remnic/core` ≥ 9.64, issue #2044). Read-only, opt-in,
+current-user endpoints only — no memory writes, no Reitti mutations, no raw
+GPS/track storage, no telemetry.
+
+## Install
+
+```bash
+npm install @remnic/connector-reitti
+```
+
+`@remnic/core` works without this package: a configured `reitti` source whose
+provider is not registered is skipped with `provider-not-registered`, never an
+error.
+
+## Usage
+
+The adapter is an API client and normalizer. Register it through the core
+location registry — ideally via a computed-specifier dynamic import so
+bundlers cannot statically resolve the optional package:
+
+```ts
+import { registerLocationProvider } from "@remnic/core/location";
+
+const mod = await import("@remnic/connector-reitti");
+mod.ensureReittiProviderRegistered({
+  baseUrl: "https://reitti.example.invalid",
+  token: resolvedToken, // from Remnic's secret reference mechanism
+  authMode: "x-api-token", // or "bearer" — exactly one header is sent
+  timezone: "Europe/Berlin", // from location config; used for day bucketing
+});
+
+// Later, per day window (half-open [startUtc, endUtc)):
+const provider = getLocationProvider("reitti");
+const page = await provider.fetchObservations({ startUtc, endUtc });
+```
+
+## Endpoints used
+
+- `GET /api/v1/timeline?date=YYYY-MM-DD&timezone=<IANA>` — primary
+  chronological source (VISIT and TRIP entries).
+- `GET /api/v1/visits?date=YYYY-MM-DD&timezone=<IANA>` — optional fallback
+  (`visitsFallback: true`) when the timeline day is empty; served as a second
+  page through the `visits` cursor.
+
+Never `/api/v1/visits/{userId}` or raw location-point endpoints.
+
+## Normalization
+
+Each timeline interval becomes two observations (start + end instants)
+carrying its place; core's `observationSegments` merges them back into
+half-open `[start, end)` segments. Named places keep their Reitti id
+(`reitti:place:<id>`); trips carry the transport mode and distance in the
+label (`Trip (TRAIN · 12.3 km)`, kind `transit`); unresolved places are
+labeled `Unnamed place` without inventing names or coordinates. Instants are
+clamped into the requested day window. Encoded paths are ignored.
+
+## Failure behavior
+
+Empty day (`[]`) and provider failure are distinct. Errors are typed
+`ReittiApiError` kinds: `auth` (401/403), `rate-limit` (429), `server` (5xx),
+`network`, `timeout`, `invalid-json`, `response-too-large`, `schema`, `http`.
+Transient GET failures retry with bounded exponential backoff (Retry-After
+honored), always preserving the caller's `AbortSignal`; an aborted caller
+propagates unwrapped and unretried. Response bodies are size-bounded. The
+token never appears in errors, URLs, or logs.
+
+## Privacy
+
+Coordinates are never emitted by this adapter — coordinate retention stays a
+core config decision (`location.retainCoordinates`, default off). Place
+labels, addresses, and cities are treated as sensitive data by the core
+pipeline. No request beyond the configured instance is ever made.
+
+## License
+
+MIT

--- a/packages/connector-reitti/package.json
+++ b/packages/connector-reitti/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@remnic/connector-reitti",
+  "version": "9.64.2",
+  "description": "Reitti location connector for Remnic — read a self-hosted Reitti instance as a location provider",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.64.2"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-reitti"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "reitti",
+    "location",
+    "self-hosted"
+  ]
+}

--- a/packages/connector-reitti/src/client.test.ts
+++ b/packages/connector-reitti/src/client.test.ts
@@ -1,0 +1,382 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  REITTI_AUTH_MODES,
+  ReittiApiError,
+  ReittiClient,
+  assertValidIanaTimezone,
+  normalizeReittiBaseUrl,
+} from "./client.js";
+
+const TOKEN = "rtt_secret_token_9f1c";
+
+function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+type CapturedRequest = { url: string; headers: Headers };
+
+function capturingFetch(
+  handler: (request: CapturedRequest, call: number) => Response | Promise<Response>,
+): { fetchImpl: typeof fetch; requests: CapturedRequest[] } {
+  const requests: CapturedRequest[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const request = { url: String(url), headers: new Headers(init?.headers) };
+    requests.push(request);
+    return handler(request, requests.length);
+  }) as typeof fetch;
+  return { fetchImpl, requests };
+}
+
+const noSleep = async () => {};
+
+function baseOptions(overrides: Partial<ConstructorParameters<typeof ReittiClient>[0]> = {}) {
+  return { baseUrl: "https://reitti.example.invalid", token: TOKEN, sleep: noSleep, ...overrides };
+}
+
+test("constructor rejects a missing or blank token", () => {
+  assert.throws(() => new ReittiClient(baseOptions({ token: "" })), TypeError);
+  assert.throws(() => new ReittiClient(baseOptions({ token: "   " })), TypeError);
+});
+
+test("baseUrl must be an absolute http(s) URL; trailing slashes strip without changing the path", () => {
+  assert.throws(() => normalizeReittiBaseUrl("not a url"), RangeError);
+  assert.throws(() => normalizeReittiBaseUrl("ftp://host/"), RangeError);
+  assert.equal(normalizeReittiBaseUrl("https://host/"), "https://host");
+  assert.equal(normalizeReittiBaseUrl("https://host/reitti/"), "https://host/reitti");
+  assert.equal(normalizeReittiBaseUrl("https://host:8443/reitti///"), "https://host:8443/reitti");
+});
+
+test("default auth mode sends exactly X-API-Token; bearer sends exactly Authorization", async () => {
+  const tokenAuth = capturingFetch(() => jsonResponse([]));
+  await new ReittiClient(baseOptions({ fetchImpl: tokenAuth.fetchImpl })).fetchTimeline({
+    date: "2026-08-17",
+    timezone: "UTC",
+  });
+  assert.equal(tokenAuth.requests[0]?.headers.get("x-api-token"), TOKEN);
+  assert.equal(tokenAuth.requests[0]?.headers.get("authorization"), null);
+
+  const bearerAuth = capturingFetch(() => jsonResponse([]));
+  await new ReittiClient(
+    baseOptions({ authMode: "bearer", fetchImpl: bearerAuth.fetchImpl }),
+  ).fetchTimeline({ date: "2026-08-17", timezone: "UTC" });
+  assert.equal(bearerAuth.requests[0]?.headers.get("authorization"), `Bearer ${TOKEN}`);
+  assert.equal(bearerAuth.requests[0]?.headers.get("x-api-token"), null);
+});
+
+test("an unknown auth mode is rejected against the allow-list", () => {
+  assert.throws(
+    () => new ReittiClient(baseOptions({ authMode: "both" as never })),
+    (err: unknown) => err instanceof RangeError && err.message.includes(REITTI_AUTH_MODES.join(", ")),
+  );
+});
+
+test("fetchTimeline forwards date and IANA timezone in the query", async () => {
+  const { fetchImpl, requests } = capturingFetch(() => jsonResponse([]));
+  await new ReittiClient(baseOptions({ fetchImpl })).fetchTimeline({
+    date: "2026-08-17",
+    timezone: "Europe/Berlin",
+  });
+  assert.match(requests[0]?.url ?? "", /\/api\/v1\/timeline\?date=2026-08-17&timezone=Europe%2FBerlin$/);
+});
+
+test("fetchTimeline validates the date and timezone before any request", async () => {
+  const { fetchImpl, requests } = capturingFetch(() => jsonResponse([]));
+  const client = new ReittiClient(baseOptions({ fetchImpl }));
+  await assert.rejects(client.fetchTimeline({ date: "2026-13-40", timezone: "UTC" }), RangeError);
+  await assert.rejects(client.fetchTimeline({ date: "2026-08-17", timezone: "Not/AZone" }), RangeError);
+  assert.equal(requests.length, 0);
+  assert.throws(() => assertValidIanaTimezone("Also/Bogus"), RangeError);
+});
+
+const visitRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "tl-1",
+  resourceId: 11,
+  type: "VISIT",
+  place: { id: 7, name: "Home", address: null, city: null, type: "HOME" },
+  path: "encoded-polyline-ignore",
+  startTime: "2026-08-17T08:00:00Z",
+  endTime: "2026-08-17T09:00:00Z",
+  formattedDuration: "1h",
+  distanceMeters: null,
+  transportMode: null,
+  editable: false,
+  ...overrides,
+});
+
+test("a valid timeline payload parses into validated entries", async () => {
+  const { fetchImpl } = capturingFetch(() => jsonResponse([visitRow()]));
+  const entries = await new ReittiClient(baseOptions({ fetchImpl })).fetchTimeline({
+    date: "2026-08-17",
+    timezone: "UTC",
+  });
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]?.type, "VISIT");
+  assert.equal(entries[0]?.place?.name, "Home");
+});
+
+test("an empty timeline array is a valid empty result, not an error", async () => {
+  const { fetchImpl } = capturingFetch(() => jsonResponse([]));
+  const entries = await new ReittiClient(baseOptions({ fetchImpl })).fetchTimeline({
+    date: "2026-08-17",
+    timezone: "UTC",
+  });
+  assert.deepEqual(entries, []);
+});
+
+test("malformed timeline payloads fail with a typed schema error", async () => {
+  const cases: Array<[string, unknown]> = [
+    ["non-array body", { entries: [] }],
+    ["row is not an object", ["nope"]],
+    ["missing id", [{ type: "VISIT", startTime: "2026-08-17T08:00:00Z", endTime: "2026-08-17T09:00:00Z" }]],
+    ["bad type enum", [visitRow({ type: "STOP" })]],
+    ["bad transport mode enum", [visitRow({ type: "TRIP", transportMode: "TELEPORT" })]],
+    ["bad place type enum", [visitRow({ place: { id: 1, name: "X", type: "CASTLE" } })]],
+    ["non-ISO startTime", [visitRow({ startTime: "yesterday" })]],
+    ["negative distance", [visitRow({ distanceMeters: -5 })]],
+    ["place is a string", [visitRow({ place: "home" })]],
+  ];
+  for (const [name, body] of cases) {
+    const { fetchImpl } = capturingFetch(() => jsonResponse(body));
+    const client = new ReittiClient(baseOptions({ fetchImpl }));
+    await assert.rejects(
+      client.fetchTimeline({ date: "2026-08-17", timezone: "UTC" }),
+      (err: unknown) => err instanceof ReittiApiError && err.kind === "schema",
+      `case "${name}" must reject with kind schema`,
+    );
+  }
+});
+
+test("fetchVisits parses place summaries and validates the shape", async () => {
+  const payload = {
+    places: [
+      {
+        placeInfo: { id: 7, name: "Home", address: null, city: "Berlin", type: "HOME" },
+        visits: [{ id: 99, startTime: "2026-08-17T08:00:00Z", endTime: "2026-08-17T09:00:00Z", durationSeconds: 3600 }],
+        totalDurationMs: 3_600_000,
+        visitCount: 1,
+        color: "#3388ff",
+      },
+    ],
+  };
+  const { fetchImpl, requests } = capturingFetch(() => jsonResponse(payload));
+  const summaries = await new ReittiClient(baseOptions({ fetchImpl })).fetchVisits({
+    date: "2026-08-17",
+    timezone: "UTC",
+  });
+  assert.equal(summaries.length, 1);
+  assert.equal(summaries[0]?.visits.length, 1);
+  assert.match(requests[0]?.url ?? "", /\/api\/v1\/visits\?date=2026-08-17&timezone=UTC$/);
+
+  const broken = capturingFetch(() => jsonResponse({ places: "yes" }));
+  await assert.rejects(
+    new ReittiClient(baseOptions({ fetchImpl: broken.fetchImpl })).fetchVisits({ date: "2026-08-17", timezone: "UTC" }),
+    (err: unknown) => err instanceof ReittiApiError && err.kind === "schema",
+  );
+});
+
+test("401 and 403 map to a non-retryable auth error and are fetched exactly once", async () => {
+  for (const status of [401, 403]) {
+    const { fetchImpl, requests } = capturingFetch(() => jsonResponse({ error: "denied" }, status));
+    const client = new ReittiClient(baseOptions({ fetchImpl, sleep: noSleep }));
+    await assert.rejects(
+      client.fetchTimeline({ date: "2026-08-17", timezone: "UTC" }),
+      (err: unknown) => err instanceof ReittiApiError && err.kind === "auth" && err.status === status,
+    );
+    assert.equal(requests.length, 1, `status ${status} must not be retried`);
+  }
+});
+
+test("429 retries with the injected sleep, then surfaces a rate-limit error with the status", async () => {
+  const { fetchImpl, requests } = capturingFetch(() => jsonResponse({}, 429));
+  const sleeps: number[] = [];
+  const client = new ReittiClient({
+    ...baseOptions({ fetchImpl }),
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  await assert.rejects(
+    client.fetchTimeline({ date: "2026-08-17", timezone: "UTC" }),
+    (err: unknown) => err instanceof ReittiApiError && err.kind === "rate-limit" && err.status === 429,
+  );
+  assert.equal(requests.length, 4);
+  assert.equal(sleeps.length, 3);
+});
+
+test("5xx is retried with backoff, then succeeds without advancing state", async () => {
+  const { fetchImpl, requests } = capturingFetch((_req, call) =>
+    call < 3 ? jsonResponse({ error: "boom" }, 503) : jsonResponse([visitRow()]),
+  );
+  const sleeps: number[] = [];
+  const entries = await new ReittiClient({
+    ...baseOptions({ fetchImpl }),
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  }).fetchTimeline({ date: "2026-08-17", timezone: "UTC" });
+  assert.equal(entries.length, 1);
+  assert.equal(requests.length, 3);
+  assert.deepEqual(sleeps, [1_000, 2_000]);
+});
+
+test("Retry-After seconds override the exponential backoff", async () => {
+  const sleeps: number[] = [];
+  const { fetchImpl } = capturingFetch((_req, call) =>
+    call === 1 ? new Response("busy", { status: 429, headers: { "retry-after": "7" } }) : jsonResponse([]),
+  );
+  await new ReittiClient({
+    ...baseOptions({ fetchImpl }),
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  }).fetchTimeline({ date: "2026-08-17", timezone: "UTC" });
+  assert.deepEqual(sleeps, [7_000]);
+});
+
+test("a non-JSON body fails with kind invalid-json and no retry", async () => {
+  const { fetchImpl, requests } = capturingFetch(() => new Response("<html/>", { status: 200 }));
+  await assert.rejects(
+    new ReittiClient(baseOptions({ fetchImpl })).fetchTimeline({ date: "2026-08-17", timezone: "UTC" }),
+    (err: unknown) => err instanceof ReittiApiError && err.kind === "invalid-json",
+  );
+  assert.equal(requests.length, 1);
+});
+
+test("a request timeout is a retryable timeout error, distinct from the caller's abort", async () => {
+  // The fetch hangs until the client's own timeout signal aborts it. The
+  // ref'd fallback timer keeps the event loop alive across attempts —
+  // AbortSignal.timeout timers are unref'd and alone would drain the loop.
+  const requests: string[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    requests.push(String(url));
+    const { promise, reject } = Promise.withResolvers<never>();
+    const abort = () => reject(new DOMException("The operation was aborted", "AbortError"));
+    const fallback = setTimeout(abort, 5_000);
+    init?.signal?.addEventListener("abort", () => {
+      clearTimeout(fallback);
+      abort();
+    });
+    return promise;
+  }) as typeof fetch;
+  await assert.rejects(
+    new ReittiClient(baseOptions({ fetchImpl, timeoutMs: 10 })).fetchTimeline({
+      date: "2026-08-17",
+      timezone: "UTC",
+    }),
+    (err: unknown) => err instanceof ReittiApiError && err.kind === "timeout",
+  );
+  assert.equal(requests.length, 4, "timeout is retried up to the bound");
+});
+
+test("the caller's abort propagates unwrapped, unretried, and before any request", async () => {
+  const { promise, reject } = Promise.withResolvers<never>();
+  reject(new DOMException("This operation was aborted", "AbortError"));
+  const { fetchImpl, requests } = capturingFetch(() => promise as Promise<Response>);
+  const controller = new AbortController();
+  controller.abort();
+  const client = new ReittiClient(baseOptions({ fetchImpl }));
+  await assert.rejects(
+    client.fetchTimeline({ date: "2026-08-17", timezone: "UTC", signal: controller.signal }),
+    (err: unknown) => err instanceof DOMException && err.name === "AbortError",
+  );
+  assert.equal(requests.length, 0, "an aborted caller must not fire even one request");
+  void promise.catch(() => {});
+});
+
+test("an abort mid-flight rethrows the caller's error raw and is never retried", async () => {
+  const controller = new AbortController();
+  const requests: string[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    requests.push(String(url));
+    const { promise, reject } = Promise.withResolvers<never>();
+    init?.signal?.addEventListener("abort", () =>
+      reject(new DOMException("This operation was aborted", "AbortError")),
+    );
+    return promise;
+  }) as typeof fetch;
+  const pending = new ReittiClient(baseOptions({ fetchImpl })).fetchTimeline({
+    date: "2026-08-17",
+    timezone: "UTC",
+    signal: controller.signal,
+  });
+  controller.abort();
+  await assert.rejects(
+    pending,
+    (err: unknown) => err instanceof DOMException && err.name === "AbortError",
+  );
+  assert.equal(requests.length, 1, "a mid-flight abort must not be retried");
+});
+
+test("a declared content-length over the bound rejects without reading the body", async () => {
+  const { fetchImpl, requests } = capturingFetch(
+    () => jsonResponse({ padding: "x".repeat(64) }, 200, { "content-length": "999999999" }),
+  );
+  await assert.rejects(
+    new ReittiClient(baseOptions({ fetchImpl, maxResponseBytes: 1024 })).fetchTimeline({
+      date: "2026-08-17",
+      timezone: "UTC",
+    }),
+    (err: unknown) => err instanceof ReittiApiError && err.kind === "response-too-large",
+  );
+  assert.equal(requests.length, 1);
+});
+
+test("a streaming body over the bound rejects mid-read", async () => {
+  const bigBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(4096).fill(65));
+      controller.enqueue(new Uint8Array(4096).fill(66));
+      controller.close();
+    },
+  });
+  const oversized = new Response(bigBody, { status: 200, headers: { "content-length": "8192" } });
+  const fetchImpl = (async () => oversized) as typeof fetch;
+  await assert.rejects(
+    new ReittiClient(baseOptions({ fetchImpl, maxResponseBytes: 1024 })).fetchTimeline({
+      date: "2026-08-17",
+      timezone: "UTC",
+    }),
+    (err: unknown) => err instanceof ReittiApiError && err.kind === "response-too-large",
+  );
+});
+
+test("the token never appears in any error message", async () => {
+  const messages: string[] = [];
+  const record = (err: unknown) => {
+    if (err instanceof Error) messages.push(err.message);
+  };
+  const failing: Array<() => Promise<unknown>> = [
+    () =>
+      new ReittiClient(baseOptions({ fetchImpl: capturingFetch(() => jsonResponse({}, 401)).fetchImpl })).fetchTimeline({
+        date: "2026-08-17",
+        timezone: "UTC",
+      }),
+    () =>
+      new ReittiClient(baseOptions({ fetchImpl: capturingFetch(() => jsonResponse({}, 429)).fetchImpl, sleep: noSleep }))
+        .fetchTimeline({ date: "2026-08-17", timezone: "UTC" }),
+    () =>
+      new ReittiClient(baseOptions({ fetchImpl: capturingFetch(() => new Response("nope")).fetchImpl })).fetchTimeline({
+        date: "2026-08-17",
+        timezone: "UTC",
+      }),
+    () =>
+      new ReittiClient(baseOptions({ fetchImpl: capturingFetch(() => jsonResponse({ places: 3 })).fetchImpl }))
+        .fetchVisits({ date: "2026-08-17", timezone: "UTC" }),
+    () =>
+      new ReittiClient(baseOptions({ fetchImpl: capturingFetch(() => jsonResponse("not-an-array")).fetchImpl }))
+        .fetchTimeline({ date: "2026-08-17", timezone: "UTC" }),
+  ];
+  for (const attempt of failing) {
+    try {
+      await attempt();
+    } catch (err) {
+      record(err);
+    }
+  }
+  assert.equal(messages.length, failing.length);
+  for (const message of messages) {
+    assert.equal(message.includes(TOKEN), false, `token leaked into: ${message}`);
+  }
+});

--- a/packages/connector-reitti/src/client.test.ts
+++ b/packages/connector-reitti/src/client.test.ts
@@ -273,6 +273,7 @@ test("a request timeout is a retryable timeout error, distinct from the caller's
 test("the caller's abort propagates unwrapped, unretried, and before any request", async () => {
   const { promise, reject } = Promise.withResolvers<never>();
   reject(new DOMException("This operation was aborted", "AbortError"));
+  void promise.catch(() => {});
   const { fetchImpl, requests } = capturingFetch(() => promise as Promise<Response>);
   const controller = new AbortController();
   controller.abort();
@@ -282,7 +283,6 @@ test("the caller's abort propagates unwrapped, unretried, and before any request
     (err: unknown) => err instanceof DOMException && err.name === "AbortError",
   );
   assert.equal(requests.length, 0, "an aborted caller must not fire even one request");
-  void promise.catch(() => {});
 });
 
 test("an abort mid-flight rethrows the caller's error raw and is never retried", async () => {

--- a/packages/connector-reitti/src/client.ts
+++ b/packages/connector-reitti/src/client.ts
@@ -101,7 +101,7 @@ export interface ReittiVisitDetail {
 
 /** A validated `/api/v1/visits` place summary. */
 export interface ReittiPlaceVisitSummary {
-  place: ReittiSignificantPlace;
+  place: ReittiSignificantPlace | null;
   visits: ReittiVisitDetail[];
 }
 
@@ -202,7 +202,7 @@ export function normalizeReittiBaseUrl(raw: string): string {
 
 function assertFiniteInstant(iso: unknown, what: string): string {
   if (typeof iso !== "string" || iso.length === 0 || !Number.isFinite(Date.parse(iso))) {
-    throw new ReittiApiError(`Reitti timeline entry has an invalid ${what}`, "schema");
+    throw new ReittiApiError(`Reitti response has an invalid ${what}`, "schema");
   }
   return iso;
 }
@@ -295,13 +295,7 @@ function parseVisitSummary(value: unknown): ReittiPlaceVisitSummary {
       endTime: assertFiniteInstant(visit.endTime, "visit endTime"),
     };
   });
-  return { place: parsePlace(value.placeInfo, "visit summary") ?? {
-    id: null,
-    name: null,
-    address: null,
-    city: null,
-    type: null,
-  }, visits };
+  return { place: parsePlace(value.placeInfo, "visit summary"), visits };
 }
 
 export class ReittiClient {
@@ -474,7 +468,7 @@ function discardBody(response: Response): void {
 }
 
 
-/** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */
+/** Exponential retry delay for a transient GET, capped at MAX_RETRY_DELAY_MS. */
 function backoffMs(attempt: number): number {
   return Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt);
 }

--- a/packages/connector-reitti/src/client.ts
+++ b/packages/connector-reitti/src/client.ts
@@ -1,0 +1,488 @@
+/**
+ * Minimal Reitti API client (raw fetch, no SDK).
+ *
+ * Read-only, current-user endpoints only (issue #2045):
+ *   GET /api/v1/timeline?date=YYYY-MM-DD&timezone=<IANA>
+ *   GET /api/v1/visits?date=YYYY-MM-DD&timezone=<IANA>
+ * Never /api/v1/visits/{userId} and never raw location-point endpoints.
+ *
+ * Auth uses exactly ONE configured header form — `X-API-Token` or
+ * `Authorization: Bearer` — never both. The token never appears in any
+ * error message, URL, or log line produced here.
+ *
+ * Transport distinguishes empty results from failures (§22): a valid empty
+ * day is `[]`, while auth, rate-limit, server, network, timeout, JSON, size,
+ * and schema problems are distinct `ReittiApiError` kinds. Retries apply to
+ * transient GET failures only, always preserve the caller's abort signal,
+ * and never advance any state (the client is stateless).
+ */
+
+import { isValidLocationDate } from "@remnic/core/location";
+
+export type ReittiAuthMode = "x-api-token" | "bearer";
+
+export const REITTI_AUTH_MODES = ["x-api-token", "bearer"] as const;
+
+/** Reitti `TransportMode` values the normalizer preserves in trip labels. */
+export const REITTI_TRANSPORT_MODES = [
+  "WALKING",
+  "CYCLING",
+  "DRIVING",
+  "TRAIN",
+  "TRANSIT",
+  "MOTORCYCLE",
+  "SCOOTER",
+  "AIRPLANE",
+  "UNKNOWN",
+] as const;
+
+/** Reitti `SignificantPlace.PlaceType` values (upstream main, 2026-08). */
+export const REITTI_PLACE_TYPES = [
+  "RESTAURANT",
+  "PARK",
+  "SHOP",
+  "HOME",
+  "WORK",
+  "HOSPITAL",
+  "SCHOOL",
+  "AIRPORT",
+  "TRAIN_STATION",
+  "GAS_STATION",
+  "HOTEL",
+  "BANK",
+  "PHARMACY",
+  "GYM",
+  "LIBRARY",
+  "CHURCH",
+  "CINEMA",
+  "CAFE",
+  "MUSEUM",
+  "LANDMARK",
+  "TOURIST_ATTRACTION",
+  "HISTORIC_SITE",
+  "MONUMENT",
+  "SHOPPING_MALL",
+  "MARKET",
+  "GALLERY",
+  "THEATER",
+  "GROCERY_STORE",
+  "ATM",
+  "OTHER",
+] as const;
+
+export type ReittiTransportMode = (typeof REITTI_TRANSPORT_MODES)[number];
+export type ReittiPlaceType = (typeof REITTI_PLACE_TYPES)[number];
+
+/** The place fields this connector consumes; other upstream fields are ignored. */
+export interface ReittiSignificantPlace {
+  id: number | string | null;
+  name: string | null;
+  address: string | null;
+  city: string | null;
+  type: ReittiPlaceType | null;
+}
+
+/** A validated `/api/v1/timeline` row (VISIT or TRIP). */
+export interface ReittiTimelineEntry {
+  id: string;
+  type: "VISIT" | "TRIP";
+  startTime: string;
+  endTime: string;
+  place: ReittiSignificantPlace | null;
+  transportMode: ReittiTransportMode | null;
+  distanceMeters: number | null;
+}
+
+/** A validated visit interval inside a `/api/v1/visits` place summary. */
+export interface ReittiVisitDetail {
+  startTime: string;
+  endTime: string;
+}
+
+/** A validated `/api/v1/visits` place summary. */
+export interface ReittiPlaceVisitSummary {
+  place: ReittiSignificantPlace;
+  visits: ReittiVisitDetail[];
+}
+
+export type ReittiErrorKind =
+  | "auth"
+  | "rate-limit"
+  | "server"
+  | "network"
+  | "timeout"
+  | "invalid-json"
+  | "response-too-large"
+  | "schema"
+  | "http";
+
+const RETRYABLE_KINDS: readonly ReittiErrorKind[] = ["rate-limit", "server", "network", "timeout"];
+
+export class ReittiApiError extends Error {
+  readonly kind: ReittiErrorKind;
+  readonly status?: number;
+
+  constructor(message: string, kind: ReittiErrorKind, status?: number) {
+    super(message);
+    this.name = "ReittiApiError";
+    this.kind = kind;
+    this.status = status;
+  }
+
+  get retryable(): boolean {
+    return RETRYABLE_KINDS.includes(this.kind);
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const MAX_RETRY_DELAY_MS = 30_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+export interface ReittiClientOptions {
+  /** Absolute HTTP(S) base URL of the self-hosted Reitti instance. */
+  baseUrl: string;
+  /** Pre-resolved API token (from the secret store); never a placeholder. */
+  token: string;
+  /** Which documented header form to use; exactly one is sent. */
+  authMode?: ReittiAuthMode;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface ReittiDayRequest {
+  date: string;
+  timezone: string;
+  signal?: AbortSignal;
+}
+
+/** Canonical boundary guard for this package: a non-null plain object (arrays are caught by field checks). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+/** Validate an IANA timezone by constructing a formatter (throws RangeError). */
+export function assertValidIanaTimezone(timezone: string): void {
+  if (typeof timezone !== "string" || timezone.length === 0) {
+    throw new TypeError("Reitti timezone must be a non-empty IANA zone string");
+  }
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: timezone });
+  } catch {
+    throw new RangeError(`Reitti timezone "${timezone}" is not a valid IANA zone`);
+  }
+}
+
+/**
+ * Validate and normalize the base URL: absolute HTTP(S), trailing slashes
+ * stripped without touching path semantics (a sub-path install keeps its
+ * prefix). Loop instead of a `/\/+$/` regex — CodeQL polynomial-redos.
+ */
+export function normalizeReittiBaseUrl(raw: string): string {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new TypeError("Reitti baseUrl must be a non-empty string");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new RangeError(`Reitti baseUrl "${raw}" is not a valid absolute URL`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new RangeError(`Reitti baseUrl must be http(s), got "${parsed.protocol}"`);
+  }
+  let path = parsed.pathname;
+  while (path.length > 1 && path.endsWith("/")) {
+    path = path.slice(0, -1);
+  }
+  return `${parsed.protocol}//${parsed.host}${path === "/" ? "" : path}`;
+}
+
+function assertFiniteInstant(iso: unknown, what: string): string {
+  if (typeof iso !== "string" || iso.length === 0 || !Number.isFinite(Date.parse(iso))) {
+    throw new ReittiApiError(`Reitti timeline entry has an invalid ${what}`, "schema");
+  }
+  return iso;
+}
+
+function parsePlace(value: unknown, context: string): ReittiSignificantPlace | null {
+  if (value === null || value === undefined) return null;
+  if (!isRecord(value)) {
+    throw new ReittiApiError(`Reitti ${context} place must be an object or null`, "schema");
+  }
+  const id = value.id;
+  if (id !== null && id !== undefined && typeof id !== "number" && typeof id !== "string") {
+    throw new ReittiApiError(`Reitti ${context} place.id must be a number, string, or null`, "schema");
+  }
+  for (const field of ["name", "address", "city"] as const) {
+    const raw = value[field];
+    if (raw !== null && raw !== undefined && typeof raw !== "string") {
+      throw new ReittiApiError(`Reitti ${context} place.${field} must be a string or null`, "schema");
+    }
+  }
+  const type = value.type;
+  if (type !== null && type !== undefined && !(REITTI_PLACE_TYPES as readonly string[]).includes(type as string)) {
+    throw new ReittiApiError(`Reitti ${context} place.type "${String(type)}" is not a known Reitti place type`, "schema");
+  }
+  return {
+    id: (id ?? null) as ReittiSignificantPlace["id"],
+    name: (value.name ?? null) as string | null,
+    address: (value.address ?? null) as string | null,
+    city: (value.city ?? null) as string | null,
+    type: (type ?? null) as ReittiPlaceType | null,
+  };
+}
+
+function parseTimelineEntry(value: unknown): ReittiTimelineEntry {
+  if (!isRecord(value)) {
+    throw new ReittiApiError("Reitti timeline row must be an object", "schema");
+  }
+  if (value.id === undefined || typeof value.id !== "string" || value.id.length === 0) {
+    throw new ReittiApiError("Reitti timeline row requires a non-empty string id", "schema");
+  }
+  if (value.type !== "VISIT" && value.type !== "TRIP") {
+    throw new ReittiApiError(
+      `Reitti timeline row type "${String(value.type)}" must be VISIT or TRIP`,
+      "schema",
+    );
+  }
+  const distance = value.distanceMeters;
+  if (
+    distance !== null &&
+    distance !== undefined &&
+    (typeof distance !== "number" || !Number.isFinite(distance) || distance < 0)
+  ) {
+    throw new ReittiApiError("Reitti timeline row distanceMeters must be a non-negative number or null", "schema");
+  }
+  const mode = value.transportMode;
+  if (
+    mode !== null &&
+    mode !== undefined &&
+    !(REITTI_TRANSPORT_MODES as readonly string[]).includes(mode as string)
+  ) {
+    throw new ReittiApiError(
+      `Reitti timeline row transportMode "${String(mode)}" is not a known Reitti transport mode`,
+      "schema",
+    );
+  }
+  return {
+    id: value.id,
+    type: value.type,
+    startTime: assertFiniteInstant(value.startTime, "startTime"),
+    endTime: assertFiniteInstant(value.endTime, "endTime"),
+    place: parsePlace(value.place, "timeline"),
+    transportMode: (mode ?? null) as ReittiTransportMode | null,
+    distanceMeters: (distance ?? null) as number | null,
+  };
+}
+
+function parseVisitSummary(value: unknown): ReittiPlaceVisitSummary {
+  if (!isRecord(value)) {
+    throw new ReittiApiError("Reitti visit summary must be an object", "schema");
+  }
+  const rawVisits = value.visits;
+  if (!Array.isArray(rawVisits)) {
+    throw new ReittiApiError("Reitti visit summary requires a visits array", "schema");
+  }
+  const visits: ReittiVisitDetail[] = rawVisits.map((visit) => {
+    if (!isRecord(visit)) {
+      throw new ReittiApiError("Reitti visit detail must be an object", "schema");
+    }
+    return {
+      startTime: assertFiniteInstant(visit.startTime, "visit startTime"),
+      endTime: assertFiniteInstant(visit.endTime, "visit endTime"),
+    };
+  });
+  return { place: parsePlace(value.placeInfo, "visit summary") ?? {
+    id: null,
+    name: null,
+    address: null,
+    city: null,
+    type: null,
+  }, visits };
+}
+
+export class ReittiClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+  private readonly authMode: ReittiAuthMode;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly maxResponseBytes: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: ReittiClientOptions) {
+    if (typeof options.token !== "string" || options.token.trim().length === 0) {
+      throw new TypeError("Reitti token must be a non-empty string (resolve the secret reference first)");
+    }
+    this.token = options.token.trim();
+    this.baseUrl = normalizeReittiBaseUrl(options.baseUrl);
+    const authMode = options.authMode ?? "x-api-token";
+    if (!(REITTI_AUTH_MODES as readonly string[]).includes(authMode)) {
+      throw new RangeError(`Reitti authMode "${String(authMode)}" must be one of ${REITTI_AUTH_MODES.join(", ")}`);
+    }
+    this.authMode = authMode;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  /** Every VISIT/TRIP entry overlapping the local day (primary source). */
+  async fetchTimeline(request: ReittiDayRequest): Promise<ReittiTimelineEntry[]> {
+    assertValidIanaTimezone(request.timezone);
+    if (!isValidLocationDate(request.date)) {
+      throw new RangeError(`Reitti date "${request.date}" must be a real YYYY-MM-DD day`);
+    }
+    const payload = await this.requestJson(
+      `/api/v1/timeline?date=${encodeURIComponent(request.date)}&timezone=${encodeURIComponent(request.timezone)}`,
+      request.signal,
+    );
+    if (!Array.isArray(payload)) {
+      throw new ReittiApiError("Reitti /api/v1/timeline returned a non-array body", "schema");
+    }
+    return payload.map(parseTimelineEntry);
+  }
+
+  /** Processed visits grouped by place (fallback/enrichment source). */
+  async fetchVisits(request: ReittiDayRequest): Promise<ReittiPlaceVisitSummary[]> {
+    assertValidIanaTimezone(request.timezone);
+    if (!isValidLocationDate(request.date)) {
+      throw new RangeError(`Reitti date "${request.date}" must be a real YYYY-MM-DD day`);
+    }
+    const payload = await this.requestJson(
+      `/api/v1/visits?date=${encodeURIComponent(request.date)}&timezone=${encodeURIComponent(request.timezone)}`,
+      request.signal,
+    );
+    if (!isRecord(payload) || !Array.isArray(payload.places)) {
+      throw new ReittiApiError("Reitti /api/v1/visits returned an unexpected body (missing places array)", "schema");
+    }
+    return payload.places.map(parseVisitSummary);
+  }
+
+  private async requestJson(pathAndQuery: string, signal?: AbortSignal): Promise<unknown> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
+      signal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${this.baseUrl}${pathAndQuery}`, {
+          method: "GET",
+          headers: this.authHeaders(),
+          signal: combined,
+        });
+      } catch (err) {
+        // The caller's abort always propagates unwrapped and unretried.
+        if (signal?.aborted) throw err;
+        lastError = timeoutSignal.aborted
+          ? new ReittiApiError(`Reitti request timed out after ${this.timeoutMs}ms`, "timeout")
+          : new ReittiApiError(`Reitti request failed: ${err instanceof Error ? err.name : String(err)}`, "network");
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw lastError;
+      }
+
+      if (response.status === 429 || response.status >= 500) {
+        discardBody(response);
+        lastError = new ReittiApiError(`Reitti API responded ${response.status}`, kindForStatus(response.status), response.status);
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(await retryDelayMs(response, attempt));
+          continue;
+        }
+        throw lastError;
+      }
+      if (!response.ok) {
+        discardBody(response);
+        throw new ReittiApiError(
+          `Reitti API responded ${response.status} for ${pathAndQuery.split("?")[0]}`,
+          kindForStatus(response.status),
+          response.status,
+        );
+      }
+      const text = await this.readBounded(response);
+      try {
+        return JSON.parse(text) as unknown;
+      } catch {
+        throw new ReittiApiError("Reitti API returned a non-JSON body", "invalid-json");
+      }
+    }
+    throw lastError instanceof Error ? lastError : new ReittiApiError("Reitti API request failed", "network");
+  }
+
+  /** Exactly one auth header, per the configured mode — never both. */
+  private authHeaders(): Record<string, string> {
+    return this.authMode === "bearer"
+      ? { Authorization: `Bearer ${this.token}`, Accept: "application/json" }
+      : { "X-API-Token": this.token, Accept: "application/json" };
+  }
+
+  private async readBounded(response: Response): Promise<string> {
+    const declared = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declared) && declared > this.maxResponseBytes) {
+      discardBody(response);
+      throw new ReittiApiError(
+        `Reitti response exceeds the ${this.maxResponseBytes}-byte bound (${declared} bytes declared)`,
+        "response-too-large",
+      );
+    }
+    const reader = response.body?.getReader();
+    if (reader === undefined) {
+      const text = await response.text();
+      if (Buffer.byteLength(text, "utf8") > this.maxResponseBytes) {
+        throw new ReittiApiError(`Reitti response exceeds the ${this.maxResponseBytes}-byte bound`, "response-too-large");
+      }
+      return text;
+    }
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value?.byteLength ?? 0;
+      if (total > this.maxResponseBytes) {
+        await reader.cancel().catch(() => {});
+        throw new ReittiApiError(`Reitti response exceeds the ${this.maxResponseBytes}-byte bound`, "response-too-large");
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  }
+}
+
+function kindForStatus(status: number): ReittiErrorKind {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429) return "rate-limit";
+  if (status >= 500) return "server";
+  return "http";
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+/** Release the socket back to the pool on error paths (unconsumed bodies pin it). */
+function discardBody(response: Response): void {
+  void response.body?.cancel().catch(() => {});
+}
+
+
+/** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt);
+}
+
+async function retryDelayMs(response: Response, attempt: number): Promise<number> {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter !== null && /^\d+$/.test(retryAfter)) {
+    return Math.min(MAX_RETRY_DELAY_MS, Number(retryAfter) * 1_000);
+  }
+  return backoffMs(attempt);
+}

--- a/packages/connector-reitti/src/index.test.ts
+++ b/packages/connector-reitti/src/index.test.ts
@@ -206,3 +206,15 @@ test("observations always fall inside the requested window", async () => {
   assert.ok(page.observations.every((o) => o.observedAtUtc >= "2026-08-17T00:00:00.000Z"));
   assert.ok(page.observations.every((o) => o.observedAtUtc < "2026-08-18T00:00:00.000Z"));
 });
+
+test("verify rethrows a caller abort instead of reporting the provider unavailable", async () => {
+  const controller = new AbortController();
+  const { provider } = providerWith(() => {
+    controller.abort();
+    throw new DOMException("This operation was aborted", "AbortError");
+  });
+  await assert.rejects(
+    provider.verify(controller.signal),
+    (err: unknown) => err instanceof Error && err.name === "AbortError",
+  );
+});

--- a/packages/connector-reitti/src/index.test.ts
+++ b/packages/connector-reitti/src/index.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  clearLocationProviders,
+  getLocationProvider,
+  listLocationProviders,
+  registerLocationProvider,
+} from "@remnic/core/location";
+
+import {
+  REITTI_PROVIDER_ID,
+  REITTI_VISITS_CURSOR,
+  createReittiProvider,
+  ensureReittiProviderRegistered,
+} from "./index.js";
+
+const TOKEN = "rtt_secret_token_3d7a";
+const BASE = "https://reitti.example.invalid";
+
+afterEach(() => {
+  clearLocationProviders();
+});
+
+type Captured = { url: string; headers: Headers };
+
+function providerWith(
+  handler: (request: Captured, call: number) => Response,
+  options: Partial<Parameters<typeof createReittiProvider>[0]> = {},
+) {
+  const requests: Captured[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const request = { url: String(url), headers: new Headers(init?.headers) };
+    requests.push(request);
+    return handler(request, requests.length);
+  }) as typeof fetch;
+  const provider = createReittiProvider({
+    baseUrl: BASE,
+    token: TOKEN,
+    timezone: "UTC",
+    fetchImpl,
+    sleep: async () => {},
+    ...options,
+  });
+  return { provider, requests };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+const TIMELINE_ROW = {
+  id: "v1",
+  type: "VISIT",
+  place: { id: 7, name: "Home", address: null, city: null, type: "HOME" },
+  startTime: "2026-08-17T08:00:00Z",
+  endTime: "2026-08-17T09:00:00Z",
+  transportMode: null,
+  distanceMeters: null,
+};
+
+const BERLIN_DAY_WINDOW = {
+  startUtc: "2026-08-17T22:00:00.000Z",
+  endUtc: "2026-08-18T22:00:00.000Z",
+};
+
+test("invalid provider config throws: token, baseUrl, timezone, visitsFallback", () => {
+  const valid = { baseUrl: BASE, token: TOKEN, timezone: "UTC" };
+  assert.throws(() => createReittiProvider({ ...valid, token: " " }), TypeError);
+  assert.throws(() => createReittiProvider({ ...valid, baseUrl: "nope" }), RangeError);
+  assert.throws(() => createReittiProvider({ ...valid, baseUrl: "file://host" }), RangeError);
+  assert.throws(() => createReittiProvider({ ...valid, timezone: "Bogus/Zone" }), RangeError);
+  assert.throws(() => createReittiProvider({ ...valid, visitsFallback: "yes" as never }), TypeError);
+});
+
+test("the provider satisfies the core registry contract and registers idempotently", () => {
+  const { provider } = providerWith(() => json([]));
+  assert.equal(provider.id, REITTI_PROVIDER_ID);
+  assert.equal(provider.displayName, "Reitti");
+
+  assert.equal(ensureReittiProviderRegistered({ baseUrl: BASE, token: TOKEN, timezone: "UTC", fetchImpl: (async () => json([])) as typeof fetch, sleep: async () => {} }), true);
+  assert.deepEqual(listLocationProviders(), ["reitti"]);
+  assert.equal(
+    ensureReittiProviderRegistered({ baseUrl: BASE, token: TOKEN, timezone: "UTC", fetchImpl: (async () => json([])) as typeof fetch, sleep: async () => {} }),
+    false,
+    "a second registration is a no-op, not a duplicate-id error",
+  );
+  assert.ok(getLocationProvider("reitti"));
+  assert.throws(() => registerLocationProvider(provider), /already registered/);
+});
+
+test("fetchObservations derives the local date from the window and forwards date + timezone", async () => {
+  const { provider, requests } = providerWith(
+    () => json([{ ...TIMELINE_ROW, startTime: "2026-08-18T08:00:00Z", endTime: "2026-08-18T09:00:00Z" }]),
+    { timezone: "Europe/Berlin" },
+  );
+  const page = await provider.fetchObservations(BERLIN_DAY_WINDOW);
+  assert.match(requests[0]?.url ?? "", /\/api\/v1\/timeline\?date=2026-08-18&timezone=Europe%2FBerlin$/);
+  assert.equal(page.observations.length, 2);
+  assert.equal(page.nextCursor, null);
+});
+
+test("an empty timeline day is an explicit empty page, not an error or a fallback", async () => {
+  const { provider, requests } = providerWith((_req, call) => (call === 1 ? json([]) : json({ places: [] })), {
+    visitsFallback: true,
+  });
+  const page = await provider.fetchObservations({
+    startUtc: "2026-08-17T00:00:00.000Z",
+    endUtc: "2026-08-18T00:00:00.000Z",
+  });
+  assert.deepEqual(page, { observations: [], nextCursor: REITTI_VISITS_CURSOR });
+  assert.equal(requests.length, 1);
+
+  const second = await provider.fetchObservations({
+    startUtc: "2026-08-17T00:00:00.000Z",
+    endUtc: "2026-08-18T00:00:00.000Z",
+    cursor: REITTI_VISITS_CURSOR,
+  });
+  assert.match(requests[1]?.url ?? "", /\/api\/v1\/visits\?/);
+  assert.equal(second.nextCursor, null);
+});
+
+test("without the fallback, an empty timeline day terminates immediately", async () => {
+  const { provider, requests } = providerWith(() => json([]), { visitsFallback: false });
+  const page = await provider.fetchObservations({
+    startUtc: "2026-08-17T00:00:00.000Z",
+    endUtc: "2026-08-18T00:00:00.000Z",
+  });
+  assert.deepEqual(page, { observations: [], nextCursor: null });
+  assert.equal(requests.length, 1);
+});
+
+test("a visits fallback page normalizes intervals under the summary place", async () => {
+  const visitsPayload = {
+    places: [
+      {
+        placeInfo: { id: 7, name: "Home", address: null, city: null, type: "HOME" },
+        visits: [{ startTime: "2026-08-17T08:00:00Z", endTime: "2026-08-17T09:00:00Z" }],
+      },
+    ],
+  };
+  let call = 0;
+  const { provider } = providerWith(() => {
+    call += 1;
+    return call === 1 ? json([]) : json(visitsPayload);
+  }, { visitsFallback: true });
+  const window = { startUtc: "2026-08-17T00:00:00.000Z", endUtc: "2026-08-18T00:00:00.000Z" };
+  await provider.fetchObservations(window);
+  const fallback = await provider.fetchObservations({ ...window, cursor: REITTI_VISITS_CURSOR });
+  assert.equal(fallback.observations.length, 2);
+  assert.ok(fallback.observations.every((o) => o.place.id === "reitti:place:7"));
+});
+
+test("an unknown cursor is rejected loudly", async () => {
+  const { provider } = providerWith(() => json([]));
+  await assert.rejects(
+    provider.fetchObservations({
+      startUtc: "2026-08-17T00:00:00.000Z",
+      endUtc: "2026-08-18T00:00:00.000Z",
+      cursor: "page-9",
+    }),
+    TypeError,
+  );
+});
+
+test("an invalid window is rejected before any request", async () => {
+  const { provider, requests } = providerWith(() => json([]));
+  await assert.rejects(
+    provider.fetchObservations({ startUtc: "2026-08-18T00:00:00.000Z", endUtc: "2026-08-17T00:00:00.000Z" }),
+    RangeError,
+  );
+  assert.equal(requests.length, 0);
+});
+
+test("verify reports ok on a reachable instance and auth failure on 401/403 without the token", async () => {
+  const ok = await providerWith(() => json([])).provider.verify();
+  assert.deepEqual(ok, { ok: true });
+
+  for (const status of [401, 403]) {
+    const result = await providerWith(() => json({}, status)).provider.verify();
+    assert.equal(result.ok, false);
+    assert.match(result.detail ?? "", /rejected the token/);
+    assert.equal((result.detail ?? "").includes(TOKEN), false);
+  }
+});
+
+test("provider errors are typed and never carry the token", async () => {
+  const { provider } = providerWith(() => json({}, 500));
+  await assert.rejects(
+    provider.fetchObservations({ startUtc: "2026-08-17T00:00:00.000Z", endUtc: "2026-08-18T00:00:00.000Z" }),
+    (err: unknown) => {
+      assert.equal(err instanceof Error && err.message.includes(TOKEN), false);
+      return err instanceof Error && err.name === "ReittiApiError";
+    },
+  );
+});
+
+test("observations always fall inside the requested window", async () => {
+  const spillRow = { ...TIMELINE_ROW, startTime: "2026-08-16T20:00:00Z", endTime: "2026-08-17T01:30:00Z" };
+  const { provider } = providerWith(() => json([spillRow]));
+  const page = await provider.fetchObservations({
+    startUtc: "2026-08-17T00:00:00.000Z",
+    endUtc: "2026-08-18T00:00:00.000Z",
+  });
+  assert.equal(page.observations.length, 2);
+  assert.ok(page.observations.every((o) => o.observedAtUtc >= "2026-08-17T00:00:00.000Z"));
+  assert.ok(page.observations.every((o) => o.observedAtUtc < "2026-08-18T00:00:00.000Z"));
+});

--- a/packages/connector-reitti/src/index.ts
+++ b/packages/connector-reitti/src/index.ts
@@ -1,0 +1,181 @@
+/**
+ * @remnic/connector-reitti — Reitti location provider (issue #2045).
+ *
+ * Optional adapter around the core location contract (#2044): an API client
+ * and normalizer only. No file I/O, memory writes, config parsing, host SDK
+ * imports, or LLM calls. `@remnic/core` never imports this package — hosts
+ * register the provider through the core location registry, ideally via a
+ * computed-specifier dynamic import so bundlers cannot statically resolve it:
+ *
+ *   const mod = await import("@remnic/" + "connector-reitti");
+ *   mod.ensureReittiProviderRegistered({ baseUrl, token, timezone });
+ *
+ * Gates: the master `location.enabled=false` and source `enabled=false`
+ * short-circuits live in core config and the core pipeline — the provider is
+ * never consulted for a disabled source. Tokens arrive pre-resolved from
+ * Remnic's secret reference mechanism and never reach logs or error text.
+ */
+
+import {
+  getLocationProvider,
+  isValidLocationDate,
+  registerLocationProvider,
+  type LocationObservationPage,
+  type LocationProvider,
+} from "@remnic/core/location";
+
+import {
+  ReittiApiError,
+  ReittiClient,
+  assertValidIanaTimezone,
+  normalizeReittiBaseUrl,
+  type ReittiAuthMode,
+} from "./client.js";
+import { timelineObservations, visitSummaryObservations } from "./normalize.js";
+
+export {
+  ReittiApiError,
+  ReittiClient,
+  REITTI_AUTH_MODES,
+  REITTI_PLACE_TYPES,
+  REITTI_TRANSPORT_MODES,
+  assertValidIanaTimezone,
+  normalizeReittiBaseUrl,
+} from "./client.js";
+export type {
+  ReittiAuthMode,
+  ReittiClientOptions,
+  ReittiDayRequest,
+  ReittiErrorKind,
+  ReittiPlaceType,
+  ReittiPlaceVisitSummary,
+  ReittiSignificantPlace,
+  ReittiTimelineEntry,
+  ReittiTransportMode,
+  ReittiVisitDetail,
+} from "./client.js";
+export { timelineObservations, visitSummaryObservations } from "./normalize.js";
+export type { LocationWindow } from "./normalize.js";
+
+export const REITTI_PROVIDER_ID = "reitti";
+export const REITTI_PROVIDER_DISPLAY_NAME = "Reitti";
+
+/** Second-page cursor the provider offers when the visits fallback fires. */
+export const REITTI_VISITS_CURSOR = "visits";
+
+export interface ReittiProviderOptions {
+  /** Absolute HTTP(S) base URL of the self-hosted instance. */
+  baseUrl: string;
+  /** Pre-resolved API token from Remnic's secret reference mechanism. */
+  token: string;
+  /** Which documented header form to use; exactly one is sent. */
+  authMode?: ReittiAuthMode;
+  /** IANA zone used to bucket observations into local days (from location config). */
+  timezone: string;
+  /**
+   * When `true`, an empty timeline day falls back to `/api/v1/visits` as the
+   * place/visit source (second page, `REITTI_VISITS_CURSOR`). Default `false`.
+   */
+  visitsFallback?: boolean;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => Date;
+}
+
+export function createReittiProvider(options: ReittiProviderOptions): LocationProvider {
+  normalizeReittiBaseUrl(options.baseUrl);
+  if (typeof options.token !== "string" || options.token.trim().length === 0) {
+    throw new TypeError("Reitti provider requires a non-empty token (resolve the secret reference first)");
+  }
+  assertValidIanaTimezone(options.timezone);
+  if (options.visitsFallback !== undefined && typeof options.visitsFallback !== "boolean") {
+    throw new TypeError("Reitti visitsFallback must be a boolean");
+  }
+  const client = new ReittiClient({
+    baseUrl: options.baseUrl,
+    token: options.token,
+    authMode: options.authMode,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.timeoutMs,
+    maxResponseBytes: options.maxResponseBytes,
+    sleep: options.sleep,
+  });
+  const timezone = options.timezone;
+  const visitsFallback = options.visitsFallback ?? false;
+  const dayFormatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const localDate = (ms: number): string => dayFormatter.format(new Date(ms));
+  const now = options.now ?? (() => new Date());
+
+  return {
+    id: REITTI_PROVIDER_ID,
+    displayName: REITTI_PROVIDER_DISPLAY_NAME,
+
+    async verify(signal) {
+      try {
+        const date = localDate(now().getTime());
+        if (!isValidLocationDate(date)) {
+          return { ok: false, detail: `could not derive a valid local date in ${timezone}` };
+        }
+        await client.fetchTimeline({ date, timezone, signal });
+        return { ok: true };
+      } catch (error) {
+        if (error instanceof ReittiApiError && error.kind === "auth") {
+          return {
+            ok: false,
+            detail: "Reitti rejected the token (401/403) — check the token value and authMode",
+          };
+        }
+        return { ok: false, detail: error instanceof Error ? error.name : "Reitti probe failed" };
+      }
+    },
+
+    async fetchObservations(opts): Promise<LocationObservationPage> {
+      const startMs = Date.parse(opts.startUtc);
+      const endMs = Date.parse(opts.endUtc);
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs >= endMs) {
+        throw new RangeError(
+          `Reitti window must satisfy finite startUtc < endUtc, got [${opts.startUtc}, ${opts.endUtc})`,
+        );
+      }
+      if (opts.cursor !== null && opts.cursor !== undefined && opts.cursor !== REITTI_VISITS_CURSOR) {
+        throw new TypeError(`Reitti provider received an unknown cursor "${opts.cursor}"`);
+      }
+      const date = localDate(startMs);
+      if (!isValidLocationDate(date)) {
+        throw new RangeError(`Reitti provider could not derive a valid local date from "${opts.startUtc}" in ${timezone}`);
+      }
+      const window = { startUtc: opts.startUtc, endUtc: opts.endUtc };
+
+      if (opts.cursor === REITTI_VISITS_CURSOR) {
+        const summaries = await client.fetchVisits({ date, timezone, signal: opts.signal });
+        return { observations: visitSummaryObservations(summaries, window), nextCursor: null };
+      }
+      const entries = await client.fetchTimeline({ date, timezone, signal: opts.signal });
+      const observations = timelineObservations(entries, window);
+      // Empty day vs failure (§22): a valid empty timeline is an explicit
+      // empty result; the visits fallback, when enabled, is a second page.
+      if (visitsFallback && observations.length === 0) {
+        return { observations, nextCursor: REITTI_VISITS_CURSOR };
+      }
+      return { observations, nextCursor: null };
+    },
+  };
+}
+
+/**
+ * Idempotently register the Reitti provider with the core location registry.
+ * Returns `true` when this call performed the registration, `false` when a
+ * provider with this id was already registered.
+ */
+export function ensureReittiProviderRegistered(options: ReittiProviderOptions): boolean {
+  if (getLocationProvider(REITTI_PROVIDER_ID) !== undefined) return false;
+  registerLocationProvider(createReittiProvider(options));
+  return true;
+}

--- a/packages/connector-reitti/src/index.ts
+++ b/packages/connector-reitti/src/index.ts
@@ -126,6 +126,8 @@ export function createReittiProvider(options: ReittiProviderOptions): LocationPr
         await client.fetchTimeline({ date, timezone, signal });
         return { ok: true };
       } catch (error) {
+        // A caller-driven abort is cancellation, not provider unavailability.
+        if (error instanceof Error && error.name === "AbortError") throw error;
         if (error instanceof ReittiApiError && error.kind === "auth") {
           return {
             ok: false,

--- a/packages/connector-reitti/src/normalize.test.ts
+++ b/packages/connector-reitti/src/normalize.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ReittiPlaceVisitSummary, ReittiTimelineEntry } from "./client.js";
+import { timelineObservations, visitSummaryObservations } from "./normalize.js";
+
+/** 2026-08-17 UTC day window. */
+const WINDOW = { startUtc: "2026-08-17T00:00:00.000Z", endUtc: "2026-08-18T00:00:00.000Z" };
+
+function visit(
+  id: string,
+  startUtc: string,
+  endUtc: string,
+  place: ReittiTimelineEntry["place"],
+): ReittiTimelineEntry {
+  return { id, type: "VISIT", startTime: startUtc, endTime: endUtc, place, transportMode: null, distanceMeters: null };
+}
+
+function trip(
+  id: string,
+  startUtc: string,
+  endUtc: string,
+  transportMode: ReittiTimelineEntry["transportMode"],
+  distanceMeters: number | null,
+): ReittiTimelineEntry {
+  return { id, type: "TRIP", startTime: startUtc, endTime: endUtc, place: null, transportMode, distanceMeters };
+}
+
+const HOME = { id: 7, name: "Home", address: null, city: null, type: "HOME" as const };
+const OFFICE = { id: 12, name: "Office", address: "1 Main St", city: "Berlin", type: "WORK" as const };
+
+test("a VISIT-TRIP-VISIT day round-trips into paired observations per interval", () => {
+  const entries = [
+    visit("v1", "2026-08-17T08:00:00Z", "2026-08-17T09:00:00Z", HOME),
+    trip("t1", "2026-08-17T09:00:00Z", "2026-08-17T10:00:00Z", "TRAIN", 12_345),
+    visit("v2", "2026-08-17T10:00:00Z", "2026-08-17T11:00:00Z", OFFICE),
+  ];
+  const observations = timelineObservations(entries, WINDOW);
+  assert.equal(observations.length, 6);
+  assert.deepEqual(
+    observations.map((o) => o.observedAtUtc),
+    [
+      "2026-08-17T08:00:00.000Z",
+      "2026-08-17T09:00:00.000Z",
+      "2026-08-17T09:00:00.000Z",
+      "2026-08-17T10:00:00.000Z",
+      "2026-08-17T10:00:00.000Z",
+      "2026-08-17T11:00:00.000Z",
+    ],
+  );
+  assert.equal(observations[0]?.place.id, "reitti:place:7");
+  assert.equal(observations[0]?.place.label, "Home");
+  assert.equal(observations[0]?.place.kind, "home");
+  assert.equal(observations[2]?.place.id, "reitti:trip:t1");
+  assert.equal(observations[2]?.place.label, "Trip (TRAIN · 12.3 km)");
+  assert.equal(observations[2]?.place.kind, "transit");
+  assert.equal(observations[4]?.place.id, "reitti:place:12");
+  assert.equal(observations[4]?.place.kind, "work");
+});
+
+test("a trip without distance omits the km suffix; unknown mode stays explicit", () => {
+  const noDistance = timelineObservations([trip("t1", "2026-08-17T08:00:00Z", "2026-08-17T08:30:00Z", "WALKING", null)], WINDOW);
+  assert.equal(noDistance[0]?.place.label, "Trip (WALKING)");
+  const noMode = timelineObservations([trip("t2", "2026-08-17T08:00:00Z", "2026-08-17T08:30:00Z", null, 900)], WINDOW);
+  assert.equal(noMode[0]?.place.label, "Trip (UNKNOWN · 0.9 km)");
+});
+
+test("a nullable place is preserved without inventing a name or coordinates", () => {
+  const [visitObs] = timelineObservations([visit("v9", "2026-08-17T08:00:00Z", "2026-08-17T09:00:00Z", null)], WINDOW);
+  assert.equal(visitObs?.place.id, "reitti:visit:v9");
+  assert.equal(visitObs?.place.label, "Unnamed place");
+  assert.equal(visitObs?.place.kind, "other");
+  assert.equal("latitude" in (visitObs?.place ?? {}), false);
+  assert.equal("longitude" in (visitObs?.place ?? {}), false);
+});
+
+test("place labels fall back name > address > city > opaque id", () => {
+  const cases: Array<[ReittiTimelineEntry["place"], string]> = [
+    [{ id: 1, name: "Gym", address: "2 Oak Ave", city: "Leeds", type: "GYM" }, "Gym"],
+    [{ id: 2, name: null, address: "2 Oak Ave", city: "Leeds", type: "OTHER" }, "2 Oak Ave"],
+    [{ id: 3, name: null, address: null, city: "Leeds", type: "OTHER" }, "Leeds"],
+    [{ id: 4, name: null, address: null, city: null, type: null }, "Place 4"],
+  ];
+  for (const [place, expected] of cases) {
+    const [observation] = timelineObservations([visit("v", "2026-08-17T08:00:00Z", "2026-08-17T09:00:00Z", place)], WINDOW);
+    assert.equal(observation?.place.label, expected);
+  }
+});
+
+test("a non-HOME/WORK place type maps to poi", () => {
+  const cafe = { id: 9, name: "Cafe", address: null, city: null, type: "CAFE" as const };
+  const [observation] = timelineObservations([visit("v", "2026-08-17T08:00:00Z", "2026-08-17T09:00:00Z", cafe)], WINDOW);
+  assert.equal(observation?.place.kind, "poi");
+});
+
+test("entries spilling across the window boundary clamp into the window", () => {
+  const entries = [
+    // Started the previous day, ends inside the window: one observation at its end.
+    visit("v1", "2026-08-16T23:00:00Z", "2026-08-17T01:00:00Z", HOME),
+    // Entirely outside the window: dropped.
+    visit("v2", "2026-08-18T05:00:00Z", "2026-08-18T06:00:00Z", HOME),
+    // Spans the whole day: observations at the window edges.
+    visit("v3", "2026-08-16T12:00:00Z", "2026-08-18T12:00:00Z", OFFICE),
+  ];
+  const observations = timelineObservations(entries, WINDOW);
+  assert.deepEqual(
+    observations.map((o) => o.observedAtUtc),
+    [
+      "2026-08-17T00:00:00.000Z",
+      "2026-08-17T00:00:00.000Z",
+      "2026-08-17T01:00:00.000Z",
+      "2026-08-17T23:59:59.999Z",
+    ],
+  );
+  assert.deepEqual(
+    observations.map((o) => o.place.id),
+    ["reitti:place:7", "reitti:place:12", "reitti:place:7", "reitti:place:12"],
+  );
+});
+
+test("a zero-duration entry yields a single observation", () => {
+  const observations = timelineObservations([visit("v1", "2026-08-17T08:00:00Z", "2026-08-17T08:00:00Z", HOME)], WINDOW);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0]?.observedAtUtc, "2026-08-17T08:00:00.000Z");
+});
+
+test("an invalid window throws instead of normalizing", () => {
+  assert.throws(() => timelineObservations([], { startUtc: "2026-08-17T00:00:00Z", endUtc: "2026-08-17T00:00:00Z" }), RangeError);
+  assert.throws(() => timelineObservations([], { startUtc: "later", endUtc: "2026-08-17T00:00:00Z" }), RangeError);
+});
+
+test("visit summaries normalize per visit interval under the summary's place", () => {
+  const summaries: ReittiPlaceVisitSummary[] = [
+    {
+      place: { id: 7, name: "Home", address: null, city: null, type: "HOME" },
+      visits: [
+        { startTime: "2026-08-17T08:00:00Z", endTime: "2026-08-17T09:00:00Z" },
+        { startTime: "2026-08-17T20:00:00Z", endTime: "2026-08-17T21:00:00Z" },
+      ],
+    },
+  ];
+  const observations = visitSummaryObservations(summaries, WINDOW);
+  assert.equal(observations.length, 4);
+  assert.ok(observations.every((o) => o.place.id === "reitti:place:7"));
+  assert.deepEqual(
+    observations.map((o) => o.observedAtUtc),
+    [
+      "2026-08-17T08:00:00.000Z",
+      "2026-08-17T09:00:00.000Z",
+      "2026-08-17T20:00:00.000Z",
+      "2026-08-17T21:00:00.000Z",
+    ],
+  );
+});

--- a/packages/connector-reitti/src/normalize.test.ts
+++ b/packages/connector-reitti/src/normalize.test.ts
@@ -152,3 +152,22 @@ test("visit summaries normalize per visit interval under the summary's place", (
     ],
   );
 });
+
+test("two unresolved visit places keep distinct identities", () => {
+  const summaries: ReittiPlaceVisitSummary[] = [
+    { place: null, visits: [{ startTime: "2026-08-17T08:00:00Z", endTime: "2026-08-17T09:00:00Z" }] },
+    { place: null, visits: [{ startTime: "2026-08-17T20:00:00Z", endTime: "2026-08-17T21:00:00Z" }] },
+  ];
+  const ids = new Set(visitSummaryObservations(summaries, WINDOW).map((o) => o.place.id));
+  assert.equal(ids.size, 2, "distinct unresolved places must not merge into one segment");
+});
+
+test("a place Reitti left without an id does not collapse with another", () => {
+  const nameless = { id: null, name: null, address: null, city: null, type: null } as const;
+  const summaries: ReittiPlaceVisitSummary[] = [
+    { place: { ...nameless }, visits: [{ startTime: "2026-08-17T08:00:00Z", endTime: "2026-08-17T09:00:00Z" }] },
+    { place: { ...nameless }, visits: [{ startTime: "2026-08-17T20:00:00Z", endTime: "2026-08-17T21:00:00Z" }] },
+  ];
+  const ids = new Set(visitSummaryObservations(summaries, WINDOW).map((o) => o.place.id));
+  assert.equal(ids.size, 2, "a null upstream id must not become one shared identity");
+});

--- a/packages/connector-reitti/src/normalize.ts
+++ b/packages/connector-reitti/src/normalize.ts
@@ -1,0 +1,145 @@
+/**
+ * Reitti payload normalization (issue #2045).
+ *
+ * Maps validated `/api/v1/timeline` entries (VISIT/TRIP) and `/api/v1/visits`
+ * place summaries onto the core `LocationObservation` instant model.
+ *
+ * Encoding: each interval becomes two observations — one at its start, one at
+ * its end, both carrying the interval's place. Core's `observationSegments`
+ * merges consecutive same-place observations back into half-open segments,
+ * so this is the exact inverse: `A[8,9] T[9,10] B[10,11]` round-trips as
+ * place-day segments without gaps.
+ *
+ * Preservation rules (the core observation type is intentionally narrow):
+ * - place ids: `reitti:place:<placeId>` for named places; the entry id is
+ *   embedded for synthetic ids (`reitti:trip:<id>`, `reitti:visit:<id>`)
+ *   so source identifiers survive.
+ * - nullable places: a TRIP (or a VISIT Reitti could not resolve) never
+ *   invents a place name. TRIP becomes a `transit`-kind observation whose
+ *   label carries the transport mode and distance; an unresolved VISIT
+ *   becomes an `other`-kind observation labeled "Unnamed place".
+ * - duration is start→end, reconstructible from the two instants.
+ * - encoded paths (`path`) are ignored by design (no track storage).
+ * - coordinates are never emitted; retention is a core config decision.
+ *
+ * Instants are clamped into the requested half-open [startUtc, endUtc)
+ * window: Reitti returns day-overlapping entries, while core requires every
+ * observation to fall inside the window it asked for.
+ */
+
+import type { LocationObservation, LocationPlace } from "@remnic/core/location";
+
+import type {
+  ReittiPlaceVisitSummary,
+  ReittiSignificantPlace,
+  ReittiTimelineEntry,
+} from "./client.js";
+
+export interface LocationWindow {
+  startUtc: string;
+  endUtc: string;
+}
+
+const PLACE_KIND_BY_REITTI_TYPE: Record<string, LocationPlace["kind"]> = {
+  HOME: "home",
+  WORK: "work",
+};
+
+function placeLabel(place: ReittiSignificantPlace): string {
+  return place.name ?? place.address ?? place.city ?? `Place ${place.id ?? "?"}`;
+}
+
+function namedPlace(place: ReittiSignificantPlace): LocationPlace {
+  return {
+    id: `reitti:place:${place.id ?? "unknown"}`,
+    label: placeLabel(place),
+    kind: PLACE_KIND_BY_REITTI_TYPE[place.type ?? ""] ?? "poi",
+  };
+}
+
+function tripPlace(entry: ReittiTimelineEntry): LocationPlace {
+  const mode = entry.transportMode ?? "UNKNOWN";
+  const km = entry.distanceMeters !== null && entry.distanceMeters > 0 ? ` · ${(entry.distanceMeters / 1000).toFixed(1)} km` : "";
+  return { id: `reitti:trip:${entry.id}`, label: `Trip (${mode}${km})`, kind: "transit" };
+}
+
+function unnamedVisitPlace(entry: ReittiTimelineEntry): LocationPlace {
+  return { id: `reitti:visit:${entry.id}`, label: "Unnamed place", kind: "other" };
+}
+
+function entryPlace(entry: ReittiTimelineEntry): LocationPlace {
+  if (entry.type === "TRIP") return tripPlace(entry);
+  return entry.place !== null ? namedPlace(entry.place) : unnamedVisitPlace(entry);
+}
+
+/**
+ * Observations for one interval, clamped to the window. A whole-window entry
+ * (started before the day, ends after it) yields observations at the window
+ * edges so its occupancy still lands in the day document.
+ */
+function intervalObservations(
+  startMs: number,
+  endMs: number,
+  place: LocationPlace,
+  window: { startMs: number; endMs: number },
+): LocationObservation[] {
+  const clampedStart = Math.max(startMs, window.startMs);
+  const clampedEnd = Math.min(endMs, window.endMs - 1);
+  if (clampedStart > clampedEnd) return [];
+  const instants = clampedStart === clampedEnd ? [clampedStart] : [clampedStart, clampedEnd];
+  return instants.map((ms) => ({ observedAtUtc: new Date(ms).toISOString(), place }));
+}
+
+function windowBounds(window: LocationWindow): { startMs: number; endMs: number } {
+  const startMs = Date.parse(window.startUtc);
+  const endMs = Date.parse(window.endUtc);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs >= endMs) {
+    throw new RangeError(`Reitti window must satisfy finite startUtc < endUtc, got [${window.startUtc}, ${window.endUtc})`);
+  }
+  return { startMs, endMs };
+}
+
+function sortByInstant(observations: LocationObservation[]): LocationObservation[] {
+  return observations.sort((a, b) =>
+    a.observedAtUtc === b.observedAtUtc ? 0 : a.observedAtUtc < b.observedAtUtc ? -1 : 1,
+  );
+}
+
+/** Normalize validated timeline entries (primary source) into observations. */
+export function timelineObservations(
+  entries: readonly ReittiTimelineEntry[],
+  window: LocationWindow,
+): LocationObservation[] {
+  const bounds = windowBounds(window);
+  const observations: LocationObservation[] = [];
+  for (const entry of entries) {
+    const startMs = Date.parse(entry.startTime);
+    const endMs = Date.parse(entry.endTime);
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+      throw new RangeError(`Reitti timeline entry "${entry.id}" has non-finite instants`);
+    }
+    observations.push(...intervalObservations(startMs, endMs, entryPlace(entry), bounds));
+  }
+  return sortByInstant(observations);
+}
+
+/** Normalize validated visit summaries (fallback source) into observations. */
+export function visitSummaryObservations(
+  summaries: readonly ReittiPlaceVisitSummary[],
+  window: LocationWindow,
+): LocationObservation[] {
+  const bounds = windowBounds(window);
+  const observations: LocationObservation[] = [];
+  for (const summary of summaries) {
+    const place = namedPlace(summary.place);
+    for (const visit of summary.visits) {
+      const startMs = Date.parse(visit.startTime);
+      const endMs = Date.parse(visit.endTime);
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+        throw new RangeError("Reitti visit detail has non-finite instants");
+      }
+      observations.push(...intervalObservations(startMs, endMs, place, bounds));
+    }
+  }
+  return sortByInstant(observations);
+}

--- a/packages/connector-reitti/src/normalize.ts
+++ b/packages/connector-reitti/src/normalize.ts
@@ -49,9 +49,13 @@ function placeLabel(place: ReittiSignificantPlace): string {
   return place.name ?? place.address ?? place.city ?? `Place ${place.id ?? "?"}`;
 }
 
-function namedPlace(place: ReittiSignificantPlace): LocationPlace {
+/**
+ * `fallbackKey` discriminates places Reitti left without an id: a shared
+ * `unknown` id would let core's segment merging join two distinct places.
+ */
+function namedPlace(place: ReittiSignificantPlace, fallbackKey: string): LocationPlace {
   return {
-    id: `reitti:place:${place.id ?? "unknown"}`,
+    id: place.id !== null ? `reitti:place:${place.id}` : `reitti:place:unresolved:${fallbackKey}`,
     label: placeLabel(place),
     kind: PLACE_KIND_BY_REITTI_TYPE[place.type ?? ""] ?? "poi",
   };
@@ -63,13 +67,13 @@ function tripPlace(entry: ReittiTimelineEntry): LocationPlace {
   return { id: `reitti:trip:${entry.id}`, label: `Trip (${mode}${km})`, kind: "transit" };
 }
 
-function unnamedVisitPlace(entry: ReittiTimelineEntry): LocationPlace {
-  return { id: `reitti:visit:${entry.id}`, label: "Unnamed place", kind: "other" };
+function unnamedPlace(key: string): LocationPlace {
+  return { id: `reitti:visit:${key}`, label: "Unnamed place", kind: "other" };
 }
 
 function entryPlace(entry: ReittiTimelineEntry): LocationPlace {
   if (entry.type === "TRIP") return tripPlace(entry);
-  return entry.place !== null ? namedPlace(entry.place) : unnamedVisitPlace(entry);
+  return entry.place !== null ? namedPlace(entry.place, entry.id) : unnamedPlace(entry.id);
 }
 
 /**
@@ -131,7 +135,8 @@ export function visitSummaryObservations(
   const bounds = windowBounds(window);
   const observations: LocationObservation[] = [];
   for (const summary of summaries) {
-    const place = namedPlace(summary.place);
+    const fallbackKey = summary.visits[0]?.startTime ?? "";
+    const place = summary.place !== null ? namedPlace(summary.place, fallbackKey) : unnamedPlace(fallbackKey);
     for (const visit of summary.visits) {
       const startMs = Date.parse(visit.startTime);
       const endMs = Date.parse(visit.endTime);

--- a/packages/connector-reitti/tsconfig.json
+++ b/packages/connector-reitti/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1365,6 +1365,16 @@
       "remnic-source": "./src/local-llm.ts",
       "import": "./dist/local-llm.js"
     },
+    "./location": {
+      "types": "./dist/location/index.d.ts",
+      "remnic-source": "./src/location/index.ts",
+      "import": "./dist/location/index.js"
+    },
+    "./location.js": {
+      "types": "./dist/location/index.d.ts",
+      "remnic-source": "./src/location/index.ts",
+      "import": "./dist/location/index.js"
+    },
     "./logger": {
       "types": "./dist/logger.d.ts",
       "remnic-source": "./src/logger.ts",

--- a/packages/remnic-core/src/location/adapter-isolation.test.ts
+++ b/packages/remnic-core/src/location/adapter-isolation.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+
+/**
+ * Architecture boundary (issue #2045): `@remnic/core` must never statically
+ * depend on an optional provider package. Provider implementations register
+ * through the location registry at runtime; the connector package consumes
+ * core, never the reverse. A static import here would break à-la-carte
+ * installs (`npm install @remnic/core` alone must work) and drag a network
+ * adapter into every base install.
+ */
+const FORBIDDEN_SPECIFIERS = ["@remnic/connector-reitti", "connector-reitti/src"];
+
+// Production sources only: this test file itself names the banned specifier.
+function collectSourceFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "dist" || entry.name === "node_modules") continue;
+      collectSourceFiles(path, files);
+    } else if (entry.isFile() && /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+test("core source never statically imports @remnic/connector-reitti", () => {
+  const coreSrc = join(import.meta.dirname);
+  const offenders: string[] = [];
+  for (const file of collectSourceFiles(coreSrc)) {
+    const content = readFileSync(file, "utf8");
+    for (const specifier of FORBIDDEN_SPECIFIERS) {
+      if (content.includes(specifier)) {
+        offenders.push(`${file} references ${specifier}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, []);
+});

--- a/packages/remnic-core/src/location/adapter-isolation.test.ts
+++ b/packages/remnic-core/src/location/adapter-isolation.test.ts
@@ -28,7 +28,9 @@ function collectSourceFiles(dir: string, files: string[] = []): string[] {
 }
 
 test("core source never statically imports @remnic/connector-reitti", () => {
-  const coreSrc = join(import.meta.dirname);
+  // The whole core tree, not just src/location: a static import anywhere in
+  // core would break a base install.
+  const coreSrc = join(import.meta.dirname, "..");
   const offenders: string[] = [];
   for (const file of collectSourceFiles(coreSrc)) {
     const content = readFileSync(file, "utf8");

--- a/packages/remnic-core/src/location/index.ts
+++ b/packages/remnic-core/src/location/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Location context subsystem — public surface (issues #2044, #2045).
+ *
+ * Consumed by host adapters and optional provider packages via the
+ * `@remnic/core/location` subpath export; the root index stays frozen at its
+ * ratchet ceiling, and core never statically imports a provider package
+ * (register implementations through `registerLocationProvider` instead).
+ */
+
+export * from "./types.js";
+export * from "./registry.js";
+export * from "./config.js";
+export * from "./intervals.js";
+export * from "./store.js";
+export * from "./pipeline.js";
+export * from "./cli.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connector-reitti:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/connector-replit:
     devDependencies:
       tsup:
@@ -666,7 +681,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.0.0)
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
@@ -2956,6 +2971,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.0.0)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.29)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.29
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.0.0
+      zod-to-json-schema: 3.25.2(zod@4.0.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@msgpack/msgpack@3.1.3': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -4399,6 +4436,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.0.0):
+    dependencies:
+      zod: 4.0.0
 
   zod@3.25.76: {}
 

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -29,6 +29,7 @@ const expectedPublishDirs = [
   "packages/connector-fireflies",
   "packages/connector-granola",
   "packages/connector-droid",
+  "packages/connector-reitti",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
Fixes #2045.

Optional `@remnic/connector-reitti` adapter. `@remnic/core` does not import it.

## Change

- Read-only Reitti timeline/visits client with typed errors.
- `createReittiProvider` + `ensureReittiProviderRegistered`.
- Isolation test: core has no static import of the connector.

## Validation

41 connector tests + 44 location tests (implementer receipt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Reitti location provider for read-only timeline and visit data.
  * Supports token authentication, timezone-aware date ranges, pagination, cancellation, retries, and response-size safeguards.
  * Added observation normalization and clear handling for authentication, rate limits, network issues, timeouts, and invalid responses.
  * Added public location provider exports through `@remnic/core/location`.
* **Documentation**
  * Added setup, usage, endpoint, privacy, security, error-handling, and licensing documentation.
* **Bug Fixes**
  * Prevented sensitive tokens from appearing in errors or logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->