### PR TITLE
feat(recall): language hint and cross-script planner

### DIFF
--- a/.changeset/2197-cross-lingual-recall.md
+++ b/.changeset/2197-cross-lingual-recall.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Cross-lingual recall: stamp a dominant-script hint (ISO 15924, e.g. `latn`/`jpan`) into memory frontmatter `language` at write time, and teach the recall planner to compare the query's script against the corpus's. On a mismatch the lexical page is supplemented with vector-tier hits regardless of lexical fill, so an English query can retrieve a Japanese memory (and the reverse) when a multilingual embedding model is configured. When the scripts differ and no vector tier exists, recall records a `vector_tier_unavailable` degradation on the snapshot instead of returning an unexplained empty result. Legacy memories without the `language` field are tolerated — they simply do not vote for the corpus script. Closes #2197.

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -508,9 +508,8 @@ Remnic plans for this explicitly (issue #2197):
    When they differ, the lexical page is supplemented with vector-tier hits
    from the embedding fallback — regardless of how full the lexical page is,
    because token overlap across scripts is near zero.
-3. **Degradation signal.** When the scripts differ and no vector tier is
-   configured (embedding fallback disabled, and QMD either unavailable or
-   pinned to `qmdSearchStrategy: "lex"`), recall records a
+3. **Degradation signal.** When the scripts differ and embedding fallback
+   is disabled, recall records a
    `vector_tier_unavailable` degradation on the recall snapshot instead of
    silently returning nothing. Read it with `remnic recall explain` or the
    `memory_last_recall` tool: an empty cross-lingual recall then reads as

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -486,13 +486,38 @@ To restore the pre-#2187 stock English tokenizer:
 }
 ```
 
-### Cross-script recall rides on embeddings
+### Multilingual deployments (cross-script recall)
 
 Whatever the backend, matching a query in one script against memories written
 in another (Japanese query against English memories, or the reverse) is a
 semantic task that the lexical tier cannot perform — it depends on the
 embedding model's multilingual coverage. Configure an embedding provider
 (see the Orama and LanceDB embedding sections) for cross-script recall.
+
+Remnic plans for this explicitly (issue #2197):
+
+1. **Write time.** Every memory is stamped with a dominant-script hint in
+   frontmatter `language`, using ISO 15924 codes (`latn`, `jpan`, `kore`,
+   `hani`, `cyrl`, `grek`, `arab`, `hebr`, `thai`, `deva`). Detection is a
+   codepoint scan, not a language model: kana anywhere means `jpan`, Hangul
+   means `kore`, and otherwise the most frequent script wins. Memories written
+   before this shipped have no `language` field; they are simply ignored when
+   the corpus script is sampled.
+2. **Recall time.** The planner compares the query's dominant script against
+   the corpus's (sampled from those hints, memoized per corpus generation).
+   When they differ, the lexical page is supplemented with vector-tier hits
+   from the embedding fallback — regardless of how full the lexical page is,
+   because token overlap across scripts is near zero.
+3. **Degradation signal.** When the scripts differ and no vector tier is
+   configured (embedding fallback disabled, and QMD either unavailable or
+   pinned to `qmdSearchStrategy: "lex"`), recall records a
+   `vector_tier_unavailable` degradation on the recall snapshot instead of
+   silently returning nothing. Read it with `remnic recall explain` or the
+   `memory_last_recall` tool: an empty cross-lingual recall then reads as
+   "vectors missing", not "no such memory".
+
+A monolingual deployment never triggers any of this — the query and corpus
+scripts match, so the lexical path is unchanged.
 
 ## Global Search
 

--- a/packages/remnic-core/src/cross-lingual-recall.test.ts
+++ b/packages/remnic-core/src/cross-lingual-recall.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  corpusDominantLanguage,
+  detectLanguageHint,
+  planCrossScript,
+} from "./cross-lingual-recall.js";
+
+test("detectLanguageHint distinguishes Latin and Japanese", () => {
+  assert.equal(detectLanguageHint("what did we decide about the deployment?"), "latn");
+  assert.equal(detectLanguageHint("これはテストです"), "jpan");
+  assert.equal(detectLanguageHint("デプロイは金曜に延期と決定"), "jpan");
+});
+
+test("legacy memories without a language hint do not vote", () => {
+  assert.equal(corpusDominantLanguage([undefined, undefined, "jpan", "jpan", "latn"]), "jpan");
+  assert.equal(corpusDominantLanguage([undefined, undefined]), undefined);
+});
+
+test("cross-script plan leans on vector and signals when embeddings are missing", () => {
+  const withVector = planCrossScript({
+    queryLanguage: "latn",
+    corpusLanguage: "jpan",
+    vectorTierAvailable: true,
+  });
+  assert.equal(withVector.crossScript, true);
+  assert.equal(withVector.degradation, undefined);
+
+  const withoutVector = planCrossScript({
+    queryLanguage: "latn",
+    corpusLanguage: "jpan",
+    vectorTierAvailable: false,
+  });
+  assert.equal(withoutVector.crossScript, true);
+  assert.equal(withoutVector.degradation?.code, "vector_tier_unavailable");
+});
+
+test("same-script query does not degrade", () => {
+  const plan = planCrossScript({
+    queryLanguage: "latn",
+    corpusLanguage: "latn",
+    vectorTierAvailable: false,
+  });
+  assert.equal(plan.crossScript, false);
+  assert.equal(plan.degradation, undefined);
+});

--- a/packages/remnic-core/src/cross-lingual-recall.ts
+++ b/packages/remnic-core/src/cross-lingual-recall.ts
@@ -14,9 +14,14 @@
  * legacy files without the field simply do not vote for the corpus script.
  */
 
-import type { StorageManager } from "./storage.js";
 import type { MemoryFile } from "./types.js";
 import type { SearchDegradation } from "./search/port.js";
+
+type CorpusLanguageStorage = {
+  dir: string;
+  readAllMemories: () => Promise<MemoryFile[]>;
+  getCorpusScanVersion: () => string;
+};
 
 /** Script classes the cheap detector can distinguish. ISO 15924 codes. */
 export type LanguageHint =
@@ -162,7 +167,7 @@ const corpusLanguageCache = new Map<string, { version: string; language: Languag
  * Read failures degrade to `undefined` — never break recall.
  */
 export async function dominantCorpusLanguage(
-  storage: Pick<StorageManager, "dir" | "readAllMemories" | "getCorpusScanVersion">,
+  storage: CorpusLanguageStorage,
 ): Promise<LanguageHint | undefined> {
   try {
     const version = storage.getCorpusScanVersion();

--- a/packages/remnic-core/src/cross-lingual-recall.ts
+++ b/packages/remnic-core/src/cross-lingual-recall.ts
@@ -1,0 +1,181 @@
+/**
+ * Cross-lingual recall planner (issue #2197).
+ *
+ * Lexical tiers (BM25/FTS) match on shared surface tokens, so a query whose
+ * dominant script differs from the corpus's cannot retrieve lexically — an
+ * English query never token-overlaps a Japanese fact. When the planner
+ * detects that mismatch it leans on the vector tier (the embedding-fallback
+ * supplement in the recall search pipeline), and when NO vector tier exists
+ * it emits a {@link SearchDegradation} so "no results" stays distinguishable
+ * from "cross-script query, vectors unavailable" (rule 34).
+ *
+ * The write-time half is a dominant-script hint stamped into frontmatter
+ * `language` by `StorageManager.writeMemory` (ISO 15924 script codes);
+ * legacy files without the field simply do not vote for the corpus script.
+ */
+
+import type { StorageManager } from "./storage.js";
+import type { MemoryFile } from "./types.js";
+import type { SearchDegradation } from "./search/port.js";
+
+/** Script classes the cheap detector can distinguish. ISO 15924 codes. */
+export type LanguageHint =
+  | "latn"
+  | "jpan"
+  | "kore"
+  | "hani"
+  | "cyrl"
+  | "grek"
+  | "arab"
+  | "hebr"
+  | "thai"
+  | "deva";
+
+/** Inclusive codepoint ranges per script class. `kana` folds into `jpan` at detection. */
+const SCRIPT_RANGES: ReadonlyArray<readonly [LanguageHint | "kana", number, number]> = [
+  ["latn", 0x41, 0x5a],
+  ["latn", 0x61, 0x7a],
+  ["latn", 0xc0, 0x24f],
+  ["grek", 0x370, 0x3ff],
+  ["cyrl", 0x400, 0x4ff],
+  ["cyrl", 0x500, 0x52f],
+  ["hebr", 0x590, 0x5ff],
+  ["arab", 0x600, 0x6ff],
+  ["arab", 0x750, 0x77f],
+  ["deva", 0x900, 0x97f],
+  ["thai", 0xe00, 0xe7f],
+  ["kore", 0x1100, 0x11ff],
+  ["latn", 0x1e00, 0x1eff],
+  ["kana", 0x3040, 0x309f],
+  ["kana", 0x30a0, 0x30ff],
+  ["kana", 0x31f0, 0x31ff],
+  ["hani", 0x3400, 0x4dbf],
+  ["hani", 0x4e00, 0x9fff],
+  ["kore", 0xac00, 0xd7a3],
+  ["kana", 0xff66, 0xff9d],
+];
+
+/**
+ * Dominant-script hint for a text. Codepoint-range counting (no regex):
+ * kana anywhere maps to `jpan` — kana is unique to Japanese and disambiguates
+ * it from `hani` (Chinese, or kanji-only Japanese). Returns `undefined` when
+ * the text contains no lettered script class.
+ */
+export function detectLanguageHint(text: string): LanguageHint | undefined {
+  const counts = new Map<LanguageHint | "kana", number>();
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    for (const [script, low, high] of SCRIPT_RANGES) {
+      if (code < low) break;
+      if (code <= high) {
+        counts.set(script, (counts.get(script) ?? 0) + 1);
+        break;
+      }
+    }
+  }
+  // SCRIPT_RANGES is sorted by start codepoint, so `break` on the first
+  // range starting past the codepoint is exact — one range test per char.
+  if (counts.has("kana")) return "jpan";
+  let best: LanguageHint | undefined;
+  let bestCount = 0;
+  for (const [script, count] of counts) {
+    if (script === "kana") continue;
+    if (count > bestCount) {
+      best = script;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** Dominant hint over a corpus sample; `undefined` entries (legacy files) never vote. */
+export function corpusDominantLanguage(
+  hints: Iterable<string | undefined>,
+): LanguageHint | undefined {
+  const counts = new Map<string, number>();
+  for (const hint of hints) {
+    if (hint === undefined || hint === "") continue;
+    counts.set(hint, (counts.get(hint) ?? 0) + 1);
+  }
+  let best: string | undefined;
+  let bestCount = 0;
+  for (const [hint, count] of counts) {
+    if (count > bestCount) {
+      best = hint;
+      bestCount = count;
+    }
+  }
+  return best as LanguageHint | undefined;
+}
+
+/** Planner decision for one recall query. */
+export interface CrossScriptPlan {
+  queryLanguage: LanguageHint | undefined;
+  corpusLanguage: LanguageHint | undefined;
+  /** True when both hints resolved and differ — lexical tiers cannot serve this query. */
+  crossScript: boolean;
+  /** Emitted when `crossScript` is true and no vector tier can compensate. */
+  degradation?: SearchDegradation;
+}
+
+/**
+ * Pure planner core: compare query/corpus hints and, on a mismatch without a
+ * vector tier, build the visible degradation signal.
+ */
+export function planCrossScript(input: {
+  queryLanguage: LanguageHint | undefined;
+  corpusLanguage: LanguageHint | undefined;
+  vectorTierAvailable: boolean;
+}): CrossScriptPlan {
+  const crossScript =
+    input.queryLanguage !== undefined &&
+    input.corpusLanguage !== undefined &&
+    input.queryLanguage !== input.corpusLanguage;
+  return {
+    queryLanguage: input.queryLanguage,
+    corpusLanguage: input.corpusLanguage,
+    crossScript,
+    degradation:
+      crossScript && !input.vectorTierAvailable
+        ? {
+            backend: "qmd",
+            code: "vector_tier_unavailable",
+            detail:
+              `cross-script query (${input.queryLanguage}) over a ${input.corpusLanguage} corpus: ` +
+              "lexical recall cannot match across scripts — enable a multilingual embedding model " +
+              "(embedding fallback) so the vector tier can serve it",
+          }
+        : undefined,
+  };
+}
+
+/** Corpus sample cap: dominant script stabilizes well below the full corpus. */
+const CORPUS_SAMPLE_CAP = 500;
+
+/** Memoized dominant corpus language per storage dir, keyed by corpus scan version. */
+const corpusLanguageCache = new Map<string, { version: string; language: LanguageHint | undefined }>();
+
+/**
+ * Dominant corpus language for a storage manager, sampled from the newest
+ * frontmatter `language` hints (capped, memoized on the corpus scan version so
+ * recurring recalls pay one pass per corpus generation, not per query).
+ * Read failures degrade to `undefined` — never break recall.
+ */
+export async function dominantCorpusLanguage(
+  storage: Pick<StorageManager, "dir" | "readAllMemories" | "getCorpusScanVersion">,
+): Promise<LanguageHint | undefined> {
+  try {
+    const version = storage.getCorpusScanVersion();
+    const cached = corpusLanguageCache.get(storage.dir);
+    if (cached?.version === version) return cached.language;
+    const memories = await storage.readAllMemories();
+    const language = corpusDominantLanguage(
+      memories.slice(0, CORPUS_SAMPLE_CAP).map((memory: MemoryFile) => memory.frontmatter.language),
+    );
+    if (corpusLanguageCache.size > 8) corpusLanguageCache.clear();
+    corpusLanguageCache.set(storage.dir, { version, language });
+    return language;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/remnic-core/src/orchestration/recall-internal-deps.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal-deps.ts
@@ -219,6 +219,8 @@ export interface RecallInternalDeps {
       searchOptions?: SearchQueryOptions;
       onDebugSnapshot?: (snapshot: QmdRecallSnapshot) => Promise<void>;
       /** Backend degradation observer, threaded into every QMD call (#1536). */
+      /** Cross-lingual plan flag (#2197): supplement the lexical page with vector-tier hits. */
+      crossScript?: boolean;
       onDegradation?: (degradation: SearchDegradation) => void;
       abortSignal?: AbortSignal;
     },

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -25,6 +25,7 @@ import path from "node:path";
 import { type BoxFrontmatter } from "../boxes.js";
 import { type CapabilitySet, type GraphConstructionCapabilitySet, type MemoryLifecycleCapabilitySet, type SecurityCapabilitySet, resolveCapabilities, resolveCompressionCapabilities, resolveConsolidationCapabilities, resolveConversationContextCapabilities, resolveCreationMemoryCapabilities, resolveGraphConstructionCapabilities, resolveIdentityContinuityCapabilities, resolveIndexingCapabilities, resolveMemoryLifecycleCapabilities, resolveNamespaceCapabilities, resolveObjectiveStateCapabilities, resolvePipelineProcessingCapabilities, resolvePresentationCapabilities, resolveQmdCapabilities, resolveRecallAuxiliaryCapabilities, resolveRecallEnhancementCapabilities, resolveSecurityCapabilities } from "../capabilities.js";
 import { searchCausalTrajectories } from "../causal-trajectory.js";
+import { detectLanguageHint, dominantCorpusLanguage, planCrossScript } from "../cross-lingual-recall.js";
 import { buildEntityRecallSection, entityRecentTranscriptLookbackHours, readRecentEntityTranscriptEntries } from "../entity-retrieval.js";
 import { buildEventOrderRecallSection, shouldRecallEventOrderEvidence } from "../event-order-recall.js";
 import { buildExplicitCueRecallSection } from "../explicit-cue-recall.js";
@@ -261,34 +262,22 @@ export class RecallInternalCoordinator {
     // per-result explain data (e.g. reinforcementBoost) from the result that
     // was actually served.
     let xrayRecalledResults: QmdSearchResult[] = [];
-    // Issue #1577 — per-recall trust map (admitted + quarantined items).
-    // A LOCAL, not instance state, so concurrent recalls on the same
-    // orchestrator cannot race on it (review: shared-trust-map concurrency).
-    // Populated by applyTrustScoreRerank on whichever recall path runs;
-    // consumed by formatQmdResults (epistemic hedge), publishRecallResults
-    // (quarantine filtering on ALL paths), and the X-ray capture (trust
-    // projection + quarantined-item visibility — rule 34).
+    // Issue #1577 — per-recall trust map (admitted + quarantined). LOCAL, not
+    // instance state, so concurrent recalls cannot race on it. Consumed by
+    // formatQmdResults, publishRecallResults (quarantine filtering on ALL
+    // paths), and the X-ray capture (rule 34).
     let recallTrustByPath: Map<string, TrustStageResultItem> | null = null;
-    // Issue #1577 — sink for the cold-fallback pipeline's trust map. The cold
-    // pipeline scores internally (applyColdFallbackPipeline) and writes its
-    // per-path trust map here; each cold caller reads it back into
-    // recallTrustByPath so cold/embedding/recent paths feed the same X-ray +
-    // epistemic-rendering + publisher-quarantine consumers the hot path uses
-    // (rule 41: the feature gate applies across ALL parallel recall paths).
+    // Issue #1577 — sink for the cold pipeline's trust map: cold callers read
+    // it back into recallTrustByPath so every path feeds the same consumers
+    // (rule 41 parity).
     const trustByPathSink: { trustByPath: Map<string, TrustStageResultItem> | null } = {
       trustByPath: null,
     };
     const lcmStructuredXrayResults: RecallXrayResult[] = [];
-    // Per-branch pre-limit candidate pool size for the X-ray filter
-    // trace (issue #570 PR 1).  `recalledMemoryCount` is assigned
-    // AFTER MMR + truncation so using it alone would make the
-    // `recall-result-limit` trace report `considered == admitted`
-    // even when many candidates were dropped.  Each entry captures
-    // the pool size BEFORE truncation at that branch.  The X-ray
-    // capture block picks the pool that corresponds to the branch
-    // that actually produced the admitted results (via `recallSource`)
-    // so a pool from a branch whose candidates were killed by an
-    // earlier gate cannot leak into the `considered` count.
+    // Per-branch PRE-truncation pool size for the X-ray filter trace
+    // (issue #570 PR 1): `recalledMemoryCount` is post-truncation, so the
+    // trace would otherwise report considered == admitted. The capture block
+    // picks the branch that produced the admitted results via `recallSource`.
     const xrayBranchPoolSize: Record<
       "hot_qmd" | "hot_embedding" | "cold_fallback" | "recent_scan",
       number
@@ -298,11 +287,9 @@ export class RecallInternalCoordinator {
       cold_fallback: 0,
       recent_scan: 0,
     };
-    // Shared out-parameter sink the cold-fallback pipeline writes
-    // its pre-truncation pool size into (issue #570 PR 1).  Declared
-    // once so every call to `applyColdFallbackPipeline` (four call
-    // sites) updates the same counter; the X-ray capture block
-    // reads this as the cold-fallback pool.
+    // Sink the cold-fallback pipeline (four call sites) writes its
+    // pre-truncation pool size into (issue #570 PR 1); the X-ray capture
+    // block reads it as the cold-fallback pool.
     const xrayColdPoolSink = { size: 0 };
     let selectedResultPartition: RecallResultPartition | null = null;
     let identityInjectionModeUsed: IdentityInjectionMode | "none" = "none";
@@ -1908,6 +1895,21 @@ export class RecallInternalCoordinator {
       degradations?: SearchDegradation[];
     } | null;
 
+    // Cross-lingual recall (#2197): computed beside the prefilter; never
+    // throws — a failed corpus sample only skips the plan.
+    const crossScriptPlanPromise = (async () => {
+      const queryLanguage = detectLanguageHint(retrievalQuery);
+      if (queryLanguage === undefined) return null;
+      const corpusLanguage = await dominantCorpusLanguage(this.deps.storage);
+      if (corpusLanguage === undefined) return null;
+      return planCrossScript({
+        queryLanguage,
+        corpusLanguage,
+        vectorTierAvailable:
+          resolveMemoryLifecycleCapabilities(this.deps.config).embeddingFallback ||
+          (this.deps.qmd.isAvailable() && this.deps.config.qmdSearchStrategy !== "lex"),
+      });
+    })().catch(() => null);
     const qmdEnrichmentAbort = createEnrichmentAbortHandle(options.abortSignal);
     const qmdPromise = observeEnrichmentPromise(
       (async (): Promise<QmdPhaseResult> => {
@@ -1989,7 +1991,11 @@ export class RecallInternalCoordinator {
           }
           return cachedQmd.value;
         }
-
+        const crossScriptPlan = await crossScriptPlanPromise;
+        if (crossScriptPlan?.degradation) {
+          backendDegradations.push(crossScriptPlan.degradation);
+        }
+        const crossScript = crossScriptPlan?.crossScript === true;
         if (!this.deps.qmd.isAvailable()) {
           const now = Date.now();
           const QMD_REPROBE_COOLDOWN_MS = 60_000;
@@ -2141,6 +2147,7 @@ export class RecallInternalCoordinator {
                 resolveNamespace: (p) => this.deps.namespaceFromPath(p),
                 queryAwarePrefilter,
                 searchOptions: qmdSearchOptions,
+                crossScript,
                 abortSignal: qmdEnrichmentAbort.signal,
                 onDegradation: (degradation) => {
                   backendDegradations.push(degradation);
@@ -4105,8 +4112,6 @@ export class RecallInternalCoordinator {
               undefined,
               { asOfMs, requestingConnector: options.sourceConnector },
             );
-            // MMR runs on the pre-truncation pool so diverse candidates just
-            // below the cutoff can be promoted into the injected set.
             xrayBranchPoolSize.hot_embedding = Math.max(
               xrayBranchPoolSize.hot_embedding,
               boostedScoped.length,
@@ -4319,8 +4324,7 @@ export class RecallInternalCoordinator {
               undefined,
               { asOfMs, requestingConnector: options.sourceConnector },
             );
-            // MMR runs on the pre-truncation pool so diverse candidates just
-            // below the cutoff can be promoted into the injected set.
+            // MMR runs on the pre-truncation pool (see the hot-embedding branch).
             xrayBranchPoolSize.hot_embedding = Math.max(
               xrayBranchPoolSize.hot_embedding,
               boostedScoped.length,

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -1905,9 +1905,7 @@ export class RecallInternalCoordinator {
       return planCrossScript({
         queryLanguage,
         corpusLanguage,
-        vectorTierAvailable:
-          resolveMemoryLifecycleCapabilities(this.deps.config).embeddingFallback ||
-          (this.deps.qmd.isAvailable() && this.deps.config.qmdSearchStrategy !== "lex"),
+        vectorTierAvailable: resolveMemoryLifecycleCapabilities(this.deps.config).embeddingFallback,
       });
     })().catch(() => null);
     const qmdEnrichmentAbort = createEnrichmentAbortHandle(options.abortSignal);

--- a/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
+++ b/packages/remnic-core/src/orchestration/recall-search-pipeline.ts
@@ -281,6 +281,8 @@ export class RecallSearchPipelineCoordinator {
       searchOptions?: SearchQueryOptions;
       onDebugSnapshot?: (snapshot: QmdRecallSnapshot) => Promise<void>;
       /** Backend degradation observer, threaded into every QMD call (#1536). */
+      /** Cross-lingual plan flag (#2197): supplement the lexical page with vector-tier hits. */
+      crossScript?: boolean;
       onDegradation?: (degradation: SearchDegradation) => void;
       abortSignal?: AbortSignal;
     },
@@ -334,6 +336,12 @@ export class RecallSearchPipelineCoordinator {
     const debugSearchOptions = backendHonorsQmdSearchSignals
       ? resolvedSearchOptions
       : undefined;
+    // Cross-lingual recall (#2197): lexical tiers cannot match a query whose
+    // dominant script differs from the corpus's, whatever the page fill.
+    // Supplement with the embedding-fallback tier ONCE, before widening.
+    const crossScriptVectorHits = options.crossScript
+      ? await this.searchEmbeddingFallback(prompt, fetchLimit)
+      : [];
     let bestFiltered = filterRecallCandidates(scopedSeedResults, {
       namespacesEnabled: options.namespacesEnabled,
       recallNamespaces: options.recallNamespaces,
@@ -475,6 +483,14 @@ export class RecallSearchPipelineCoordinator {
         }
       }
 
+      if (crossScriptVectorHits.length > 0) {
+        mergedResults = dedupeResultsByNamespace(
+          [...mergedResults, ...crossScriptVectorHits],
+          this.deps.namespaceFromPath,
+          fetchLimit,
+          { filter: recallable },
+        );
+      }
       if (scopedSeedResults.length > 0) {
         mergedResults = dedupeResultsByNamespace(
           [...scopedSeedResults, ...mergedResults],

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -27,7 +27,8 @@ export interface SearchDegradation {
     | "daemon_loading"
     | "subprocess_error"
     | "deadline_exceeded"
-    | "remote_error";
+    | "remote_error"
+    | "vector_tier_unavailable";
   detail?: string;
 }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -244,6 +244,7 @@ import { normalizeProjectionPreview, normalizeProjectionTags } from "./memory-pr
 import { isSupportPassportPrivateMemory } from "./support-passport/card-projection.js";
 import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
 import { parseOriginClass } from "./security/origin-authority.js";
+import { detectLanguageHint } from "./cross-lingual-recall.js";
 import {
   composeMemoryEnvelope,
   isSealedMemoryEnvelope,
@@ -322,6 +323,7 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
     `tags: [${fm.tags.map((t) => `"${t}"`).join(", ")}]`,
   ];
   // OKF v0.1 interop (issue #1946): inert presentation metadata; `category` stays canonical.
+  if (fm.language) lines.push(`language: ${fm.language}`);
   if (fm.type !== undefined) lines.push(`type: ${fm.type}`);
   if (fm.origin) lines.push(`origin: ${/^[A-Za-z0-9:_.*-]+$/.test(fm.origin) ? fm.origin : JSON.stringify(fm.origin)}`);
   if (fm.entityRef) lines.push(`entityRef: ${fm.entityRef}`);
@@ -859,8 +861,9 @@ export function parseFrontmatter(raw: string): { frontmatter: MemoryFrontmatter;
     frontmatter: {
       id: fm.id ?? "",
       category: (fm.category ?? "fact") as MemoryCategory,
-      type: parseFrontmatterStringValue(fm.type),
       created: fm.created ?? new Date().toISOString(),
+      language: fm.language || undefined,
+      type: parseFrontmatterStringValue(fm.type),
       updated: fm.updated ?? new Date().toISOString(),
       source: fm.source ?? "unknown",
       confidence: conf,
@@ -3729,6 +3732,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
       category,
       created: now.toISOString(),
       updated: now.toISOString(),
+      language: detectLanguageHint(content),
       source: options.source ?? "extraction",
       confidence: conf,
       confidenceTier: tier,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -2807,6 +2807,8 @@ export interface MemoryFrontmatter extends SourceConnectorProvenance, OriginMeta
   category: MemoryCategory;
   /** OKF v0.1 interop metadata (issue #1946). Inert: presentation only, never overrides `category`. */
   type?: string;
+  /** Dominant-script hint (ISO 15924, e.g. `latn`/`jpan`) for cross-lingual recall (#2197). Absent on legacy files. */
+  language?: string;
   created: string;
   updated: string;
   source: string;


### PR DESCRIPTION
Fixes #2197.

## Change

- Write-time `language` hint (ISO 15924 script).
- Planner leans on the vector tier when query and corpus scripts differ.
- `vector_tier_unavailable` degradation when embeddings are missing.
- Docs in `docs/search-backends.md`.

Legacy memories without `language` are ignored when sampling the corpus.

## Regression

`cross-lingual-recall.test.ts`: Latin vs Japanese detection, legacy votes, degradation signal.