### PR TITLE
fix(openclaw): pin flush-plan snapshot directory by descriptor

### DIFF
--- a/.changeset/2380-flush-plan-directory-pin.md
+++ b/.changeset/2380-flush-plan-directory-pin.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Pin flush-plan snapshot I/O to a held directory descriptor.

--- a/packages/plugin-openclaw/src/delegate-flush-plan-directory.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-directory.ts
@@ -1,0 +1,171 @@
+/**
+ * Directory-relative I/O for the flush-plan snapshot files (issue #2380).
+ *
+ * The ingester walks the plan file, its sidecars, and every directory down to
+ * the workspace root and refuses a symlink anywhere on the way — once before
+ * the lock wait and again inside the lock. That answers for the tree as it was
+ * at check time, and `O_NOFOLLOW` constrains only the FINAL path component. A
+ * local process that can write the gateway's plugin-state directory can
+ * therefore replace a checked PARENT directory with a symlink after the check,
+ * and the temp-file create, rename, and unlink that follow all resolve through
+ * the swap.
+ *
+ * Node exposes no `openat`, `renameat`, or `unlinkat`, but the kernel offers
+ * the same guarantee through the per-process descriptor directory: a path under
+ * `/proc/self/fd/<fd>/` (Linux) or `/dev/fd/<fd>/` (macOS and the BSDs)
+ * resolves through the OPEN descriptor's inode instead of re-walking the
+ * textual path. Opening the snapshot directory once and holding that handle for
+ * the whole ingestion therefore makes every snapshot create, rename, and unlink
+ * directory-relative: a parent swapped afterwards is simply not the directory
+ * the writes land in.
+ */
+
+import { constants, type Stats } from "node:fs";
+import { type FileHandle, lstat, open, stat } from "node:fs/promises";
+import path from "node:path";
+
+/** Every file one flush-plan ingestion touches. All share one directory. */
+export interface SnapshotPaths {
+  plan: string;
+  inflight: string;
+  rotating: string;
+  oversized: string;
+  /**
+   * The cross-process lock. Acquired before the directory is pinned, so it
+   * stays a real filesystem path; a parent swap can only make its refresh
+   * report lost ownership, which declines the flush instead of writing.
+   */
+  lock: string;
+  /**
+   * Real path of `oversized`, for log lines. The I/O paths above may be
+   * descriptor-anchored, which means nothing to whoever reads the warning.
+   */
+  oversizedLabel: string;
+}
+
+export function buildSnapshotPaths(planPath: string): SnapshotPaths {
+  return {
+    plan: planPath,
+    inflight: `${planPath}.inflight`,
+    rotating: `${planPath}.rotating`,
+    oversized: `${planPath}.oversized`,
+    lock: `${planPath}.lock`,
+    oversizedLabel: `${planPath}.oversized`,
+  };
+}
+
+/**
+ * Where this platform exposes open descriptors as path components, or
+ * `undefined` when it exposes none and path-based I/O is the only option.
+ */
+export function descriptorDirectoryRoot(platform: NodeJS.Platform = process.platform): string | undefined {
+  if (platform === "linux") return "/proc/self/fd";
+  if (platform === "darwin" || platform === "freebsd" || platform === "openbsd") return "/dev/fd";
+  return undefined;
+}
+
+export type PinnedSnapshotDirectory =
+  | {
+      kind: "pinned";
+      /** The same file set, addressed through the held directory descriptor. */
+      paths: SnapshotPaths;
+      close(): Promise<void>;
+    }
+  /** No descriptor directory to anchor against; the caller keeps real paths. */
+  | { kind: "unsupported" }
+  /** The directory is a symlink or changed identity: refuse, never guess. */
+  | { kind: "unstable" };
+
+/**
+ * Open the snapshot directory and return the same paths addressed through that
+ * descriptor.
+ *
+ * `unstable` and `unsupported` are deliberately distinct: the first is an
+ * attack or a race and must stop the flush, the second is a platform without a
+ * descriptor directory and leaves the pre-existing path-based behavior.
+ */
+export async function pinSnapshotDirectory(
+  paths: SnapshotPaths,
+  options: { descriptorRoot?: string | undefined } = {}
+): Promise<PinnedSnapshotDirectory> {
+  const descriptorRoot = options.descriptorRoot ?? descriptorDirectoryRoot();
+  if (descriptorRoot === undefined) return { kind: "unsupported" };
+  const directory = path.dirname(paths.plan);
+
+  let before: Stats;
+  try {
+    before = await lstat(directory);
+  } catch {
+    return { kind: "unstable" };
+  }
+  if (before.isSymbolicLink() || !before.isDirectory()) return { kind: "unstable" };
+
+  let handle: FileHandle;
+  try {
+    handle = await open(directory, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  } catch {
+    // ELOOP means a symlink was swapped in between the lstat and the open;
+    // ENOENT and ENOTDIR mean the directory went away under us. All refuse.
+    return { kind: "unstable" };
+  }
+  try {
+    // The handle now pins an inode. Confirm it is the inode the walk checked:
+    // a swap already in place fails the lstat compare, and one reverted after
+    // the open fails the descriptor compare below.
+    const opened = await handle.stat();
+    const after = await lstat(directory);
+    if (
+      !opened.isDirectory() ||
+      after.isSymbolicLink() ||
+      !after.isDirectory() ||
+      !isSameInode(before, opened) ||
+      !isSameInode(after, opened)
+    ) {
+      await closeQuietly(handle);
+      return { kind: "unstable" };
+    }
+
+    // Prove the descriptor directory actually resolves to the pinned inode
+    // before trusting it for writes: a host without procfs mounted must fall
+    // back to path-based I/O rather than write to a path that means nothing.
+    const pinnedDirectory = path.join(descriptorRoot, String(handle.fd));
+    let anchored: Stats;
+    try {
+      anchored = await stat(pinnedDirectory);
+    } catch {
+      await closeQuietly(handle);
+      return { kind: "unsupported" };
+    }
+    if (!anchored.isDirectory() || !isSameInode(anchored, opened)) {
+      await closeQuietly(handle);
+      return { kind: "unsupported" };
+    }
+
+    return {
+      kind: "pinned",
+      paths: {
+        ...paths,
+        plan: anchoredChild(pinnedDirectory, paths.plan),
+        inflight: anchoredChild(pinnedDirectory, paths.inflight),
+        rotating: anchoredChild(pinnedDirectory, paths.rotating),
+        oversized: anchoredChild(pinnedDirectory, paths.oversized),
+      },
+      close: () => closeQuietly(handle),
+    };
+  } catch (err) {
+    await closeQuietly(handle);
+    throw err;
+  }
+}
+
+function anchoredChild(pinnedDirectory: string, realPath: string): string {
+  return path.join(pinnedDirectory, path.basename(realPath));
+}
+
+function isSameInode(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function closeQuietly(handle: FileHandle): Promise<void> {
+  await handle.close().catch(() => undefined);
+}

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
@@ -1,12 +1,24 @@
 import assert from "node:assert/strict";
-import { appendFile, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import type { DelegateDaemonTarget } from "./bridge.js";
 import { ingestFlushPlanNotes } from "./delegate-flush-plan-ingest.js";
+import { descriptorDirectoryRoot } from "./delegate-flush-plan-directory.js";
 
 interface ObserveServer {
   port: number;
@@ -93,6 +105,53 @@ test("stops after lock loss during a flush instead of posting another chunk", as
     assert.equal(await readIfPresent(files.inflight), notes, "the new owner receives the untouched snapshot");
   } finally {
     await server?.close();
+    await rm(files.workspaceDir, { recursive: true, force: true });
+  }
+});
+
+test("keeps snapshot writes in the pinned directory when a parent is swapped mid-flush", async (t) => {
+  if (descriptorDirectoryRoot() === undefined) {
+    t.skip("no descriptor directory on this platform; path-based I/O is the only option");
+    return;
+  }
+  const files = await createFlushPlanFiles("parent-swap");
+  const stateDir = path.dirname(files.plan);
+  const movedStateDir = `${stateDir}.moved`;
+  const decoyDir = path.join(files.workspaceDir, "decoy");
+  const lockName = path.basename(files.lock);
+  // Two chunks, so a snapshot write still happens AFTER the swap below.
+  const notes = Array.from({ length: 2_000 }, (_, index) => `- note ${index} ${"x".repeat(70)}\n`).join("");
+  const observed: string[] = [];
+  let server: ObserveServer | undefined;
+  try {
+    await mkdir(stateDir, { recursive: true });
+    await mkdir(decoyDir, { recursive: true });
+    await writeFile(files.plan, notes, "utf8");
+    server = await startObserveServer(async (content) => {
+      observed.push(content);
+      if (observed.length !== 1) return;
+      // A local process with write access to the plugin-state directory copies
+      // the live lock, so our ownership checks keep passing, then replaces the
+      // checked PARENT directory with a symlink of its own. Path-based writes
+      // would now resolve into `decoyDir`; descriptor-anchored writes cannot.
+      await copyFile(files.lock, path.join(decoyDir, lockName));
+      await rename(stateDir, movedStateDir);
+      await symlink(decoyDir, stateDir);
+    });
+
+    await ingestFlushPlanNotes(optionsFor(server.port, files.workspaceDir, "parent-swap"));
+
+    assert.ok(observed.length > 1, "the flush keeps draining through the pinned directory");
+    assert.equal(observed.join(""), notes, "every note reaches the daemon exactly once");
+    assert.deepEqual(
+      (await readdir(decoyDir)).filter((entry) => entry !== lockName),
+      [],
+      "no snapshot file may land in the swapped-in directory",
+    );
+    assert.equal(await readIfPresent(path.join(movedStateDir, path.basename(files.inflight))), undefined);
+  } finally {
+    await server?.close();
+    await rm(stateDir, { force: true });
     await rm(files.workspaceDir, { recursive: true, force: true });
   }
 });

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.test.ts
@@ -18,7 +18,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { ingestFlushPlanNotes } from "./delegate-flush-plan-ingest.js";
-import { descriptorDirectoryRoot } from "./delegate-flush-plan-directory.js";
+import { buildSnapshotPaths, pinSnapshotDirectory } from "./delegate-flush-plan-directory.js";
 
 interface ObserveServer {
   port: number;
@@ -110,37 +110,33 @@ test("stops after lock loss during a flush instead of posting another chunk", as
 });
 
 test("keeps snapshot writes in the pinned directory when a parent is swapped mid-flush", async (t) => {
-  if (descriptorDirectoryRoot() === undefined) {
-    t.skip("no descriptor directory on this platform; path-based I/O is the only option");
-    return;
-  }
   const files = await createFlushPlanFiles("parent-swap");
   const stateDir = path.dirname(files.plan);
+  await mkdir(stateDir, { recursive: true });
+  const probe = await pinSnapshotDirectory(buildSnapshotPaths(files.plan));
+  if (probe.kind !== "pinned") {
+    t.skip("descriptor directory does not resolve the held fd; path-based I/O is the only option");
+    await rm(files.workspaceDir, { recursive: true, force: true });
+    return;
+  }
+  await probe.close();
   const movedStateDir = `${stateDir}.moved`;
   const decoyDir = path.join(files.workspaceDir, "decoy");
   const lockName = path.basename(files.lock);
-  // Two chunks, so a snapshot write still happens AFTER the swap below.
   const notes = Array.from({ length: 2_000 }, (_, index) => `- note ${index} ${"x".repeat(70)}\n`).join("");
   const observed: string[] = [];
   let server: ObserveServer | undefined;
   try {
-    await mkdir(stateDir, { recursive: true });
     await mkdir(decoyDir, { recursive: true });
     await writeFile(files.plan, notes, "utf8");
     server = await startObserveServer(async (content) => {
       observed.push(content);
       if (observed.length !== 1) return;
-      // A local process with write access to the plugin-state directory copies
-      // the live lock, so our ownership checks keep passing, then replaces the
-      // checked PARENT directory with a symlink of its own. Path-based writes
-      // would now resolve into `decoyDir`; descriptor-anchored writes cannot.
       await copyFile(files.lock, path.join(decoyDir, lockName));
       await rename(stateDir, movedStateDir);
       await symlink(decoyDir, stateDir);
     });
-
     await ingestFlushPlanNotes(optionsFor(server.port, files.workspaceDir, "parent-swap"));
-
     assert.ok(observed.length > 1, "the flush keeps draining through the pinned directory");
     assert.equal(observed.join(""), notes, "every note reaches the daemon exactly once");
     assert.deepEqual(

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -21,6 +21,10 @@
  *  3. Recovery is part of the claim. A `.rotating` or `.inflight` file found
  *     while holding the lock is residue from a dead run and is merged ahead of
  *     the newly claimed notes, preserving write order.
+ *
+ * Every snapshot create, rename, and unlink is finally addressed through a held
+ * descriptor for the snapshot directory (issue #2380), so a parent directory
+ * swapped in after the link-free walk cannot redirect them.
  */
 
 import { constants } from "node:fs";
@@ -31,6 +35,11 @@ import { log } from "@remnic/core/logger";
 import { withHeldFileLock, type HeldFileLockController } from "@remnic/core/utils/serialize-mutations";
 
 import type { DelegateDaemonTarget } from "./bridge.js";
+import {
+  buildSnapshotPaths,
+  pinSnapshotDirectory,
+  type SnapshotPaths,
+} from "./delegate-flush-plan-directory.js";
 import { buildMemoryFlushPlan } from "./memory-flush-plan.js";
 import { postJsonWithStatus } from "./delegate-http.js";
 
@@ -51,14 +60,6 @@ const LOCK_STALE_MS = 60_000;
  */
 const MAX_RECLAIM_PASSES = 4;
 
-interface SnapshotPaths {
-  plan: string;
-  inflight: string;
-  rotating: string;
-  oversized: string;
-  lock: string;
-}
-
 export async function ingestFlushPlanNotes(options: {
   target: DelegateDaemonTarget;
   serviceId: string;
@@ -74,13 +75,7 @@ export async function ingestFlushPlanNotes(options: {
     workspaceDir,
     ...buildMemoryFlushPlan({ serviceId: options.serviceId }).relativePath.split("/"),
   );
-  const paths: SnapshotPaths = {
-    plan: planPath,
-    inflight: `${planPath}.inflight`,
-    rotating: `${planPath}.rotating`,
-    oversized: `${planPath}.oversized`,
-    lock: `${planPath}.lock`,
-  };
+  const paths = buildSnapshotPaths(planPath);
   // The embedded processor refuses a symlinked plan file or parent, and so must
   // this one: following a link would send another file's contents to the daemon
   // and then truncate that file. EVERY path this module reads or writes is
@@ -124,7 +119,22 @@ export async function ingestFlushPlanNotes(options: {
         );
         return;
       }
-      await ingestUnderLock(options, paths, lock);
+      // The walk above answers for the tree as it was; `O_NOFOLLOW` covers only
+      // final components. Pin the snapshot directory by descriptor so a parent
+      // swapped in from here on cannot redirect a create, rename, or unlink
+      // (issue #2380).
+      const pinned = await pinSnapshotDirectory(paths);
+      if (pinned.kind === "unstable") {
+        log.warn(
+          `[${options.serviceId}] flush-plan ingestion skipped: the snapshot directory changed identity while it was being opened`,
+        );
+        return;
+      }
+      try {
+        await ingestUnderLock(options, pinned.kind === "pinned" ? pinned.paths : paths, lock);
+      } finally {
+        if (pinned.kind === "pinned") await pinned.close();
+      }
     },
   );
 }
@@ -424,7 +434,7 @@ async function quarantineOversizedLine(
     await handle.close();
   }
   log.warn(
-    `[${serviceId}] a flush-plan note exceeds the daemon's body limit; moved it to ${paths.oversized} so the remaining notes can drain`,
+    `[${serviceId}] a flush-plan note exceeds the daemon's body limit; moved it to ${paths.oversizedLabel} so the remaining notes can drain`,
   );
   return rest;
 }


### PR DESCRIPTION
Fixes #2380.

## Change

After the link-free walk, pin the snapshot directory by a held descriptor.
Create, rename, and unlink go through that descriptor so a parent swap cannot redirect them.

On hosts without a descriptor directory, ingest keeps path-based I/O.

## Regression

`delegate-flush-plan-ingest.test.ts` covers pin/unstable/unsupported behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flush-plan reliability when the snapshot directory is replaced or redirected during processing.
  * Ensured snapshot files remain in the original state directory, preventing writes to unintended locations.
  * Improved handling and reporting of unstable or unsupported snapshot directories.
  * Enhanced oversized-note warnings with clearer directory labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->