### PR TITLE
chore(ci): harden gates this batch actually hit

### DIFF
--- a/.changeset/ci-this-run-5.md
+++ b/.changeset/ci-this-run-5.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+chore(ci): harden gates this batch actually hit

--- a/packages/remnic-core/src/review/frontmatter.test.ts
+++ b/packages/remnic-core/src/review/frontmatter.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseFrontmatterFields, splitMarkdownFrontmatter } from "./frontmatter.js";
+
+test("splitMarkdownFrontmatter uses indexOf, not a ReDoS regex", () => {
+  const split = splitMarkdownFrontmatter("---\nid: a\n---\nbody");
+  assert.deepEqual(split, { fields: "id: a", body: "body" });
+  assert.equal(splitMarkdownFrontmatter("no fence"), null);
+});
+
+test("parseFrontmatterFields reads key: value lines", () => {
+  assert.equal(parseFrontmatterFields("---\nid: mem-1\n---\n").id, "mem-1");
+  assert.deepEqual(parseFrontmatterFields("plain"), {});
+});

--- a/packages/remnic-core/src/review/frontmatter.ts
+++ b/packages/remnic-core/src/review/frontmatter.ts
@@ -1,0 +1,20 @@
+export function splitMarkdownFrontmatter(content: string): { fields: string; body: string } | null {
+  if (!content.startsWith("---\n")) return null;
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) return null;
+  const after = end + "\n---".length;
+  const body = content.startsWith("\n", after) ? content.slice(after + 1) : content.slice(after);
+  return { fields: content.slice(4, end), body };
+}
+
+export function parseFrontmatterFields(content: string): Record<string, string> {
+  const split = splitMarkdownFrontmatter(content);
+  if (!split) return {};
+  const fields: Record<string, string> = {};
+  for (const line of split.fields.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    fields[line.slice(0, colonIdx).trim()] = line.slice(colonIdx + 1).trim();
+  }
+  return fields;
+}

--- a/packages/remnic-core/src/review/review-deck-snapshot.ts
+++ b/packages/remnic-core/src/review/review-deck-snapshot.ts
@@ -6,6 +6,7 @@ import {
   type ReviewDeckSnapshot,
   type ReviewDeckSourceRow,
 } from "./review-deck.js";
+import { parseFrontmatterFields, splitMarkdownFrontmatter } from "./frontmatter.js";
 
 const QUEUE_DIRS = ["suggestions", "review"] as const;
 
@@ -147,30 +148,13 @@ function readFileSafe(filePath: string): string | null {
   }
 }
 
-function splitFrontmatter(content: string): { fields: string; body: string } | null {
-  if (!content.startsWith("---\n")) return null;
-  const end = content.indexOf("\n---", 4);
-  if (end === -1) return null;
-  const after = end + "\n---".length;
-  const body = content.startsWith("\n", after) ? content.slice(after + 1) : content.slice(after);
-  return { fields: content.slice(4, end), body };
-}
-
 function parseFrontmatter(content: string): Record<string, unknown> | null {
-  const split = splitFrontmatter(content);
-  if (!split) return null;
-  const fm: Record<string, unknown> = {};
-  for (const line of split.fields.split("\n")) {
-    const colonIdx = line.indexOf(":");
-    if (colonIdx === -1) continue;
-    fm[line.slice(0, colonIdx).trim()] = line.slice(colonIdx + 1).trim();
-  }
-  return fm;
+  if (!content.startsWith("---\n")) return null;
+  return parseFrontmatterFields(content);
 }
 
 function extractBody(content: string): string {
-  const split = splitFrontmatter(content);
-  return split ? split.body.trim() : content.trim();
+  return splitMarkdownFrontmatter(content)?.body.trim() ?? content.trim();
 }
 
 function parseBoolean(value: unknown): boolean {

--- a/packages/remnic-core/src/review/review-deck.ts
+++ b/packages/remnic-core/src/review/review-deck.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { parseFrontmatterFields } from "./frontmatter.js";
 
 export type ReviewDeckChoice = "keep" | "prepare_fix" | "not_true";
 export type ReviewDeckRisk = "reversible";
@@ -255,18 +256,6 @@ function provenanceFromRow(row: ReviewDeckSourceRow): ReviewDeckEvidence[] {
   return provenance;
 }
 
-function parseFrontmatterFields(content: string): Record<string, string> {
-  if (!content.startsWith("---\n")) return {};
-  const end = content.indexOf("\n---", 4);
-  if (end === -1) return {};
-  const fields: Record<string, string> = {};
-  for (const line of content.slice(4, end).split("\n")) {
-    const colonIdx = line.indexOf(":");
-    if (colonIdx === -1) continue;
-    fields[line.slice(0, colonIdx).trim()] = line.slice(colonIdx + 1).trim();
-  }
-  return fields;
-}
 
 function idList(value: string | undefined): string[] {
   if (value === undefined || value.length === 0) return [];

--- a/tests/pr-create-stagger.test.mjs
+++ b/tests/pr-create-stagger.test.mjs
@@ -58,8 +58,6 @@ test("stagger wrapper sleeps the remainder, execs gh with all args, and writes a
     { mode: 0o755 }
   );
 
-  // Fresh stamp + 2s gap: even if the wrapper starts after the next whole
-  // second ticks, ~2s of gap still remain, so the sleep is deterministic.
   writeFileSync(path.join(lockDir, "stamp"), String(Math.floor(Date.now() / 1000)));
   const startedAt = Date.now();
   const out = execFileSync(
@@ -71,14 +69,14 @@ test("stagger wrapper sleeps the remainder, execs gh with all args, and writes a
         ...process.env,
         PATH: `${binDir}:${process.env.PATH}`,
         TMPDIR: tmpRoot,
-        REMNIC_PR_CREATE_GAP_SEC: "2",
+        REMNIC_PR_CREATE_GAP_SEC: "3",
       },
     }
   );
   const elapsed = Date.now() - startedAt;
   assert.match(out, /PR-URL-FROM-STUB/);
   assert.deepEqual(readFileSync(ghLog, "utf8").trim().split("\n"), ["pr", "create", "--title", "t", "--fill"]);
-  assert.ok(elapsed >= 1500, `expected a stagger sleep, finished in ${elapsed}ms`);
+  assert.ok(elapsed >= 1000, `expected a stagger sleep, finished in ${elapsed}ms`);
   assert.equal(existsSync(path.join(lockDir, "lock")), true, "lock lives under TMPDIR");
   const stamp = Number.parseInt(readFileSync(path.join(lockDir, "stamp"), "utf8"), 10);
   assert.ok(Number.isInteger(stamp) && stamp >= Math.floor(Date.now() / 1000) - 2, "stamp refreshed after the create");

--- a/tests/remnic-server-package-surface.test.ts
+++ b/tests/remnic-server-package-surface.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -30,16 +30,11 @@ test("@remnic/server build emits and advertises TypeScript declarations", async 
   assert.equal(pkg.exports?.["."]?.types, "./dist/index.d.ts");
   assert.equal(pkg.exports?.["."]?.import, "./dist/index.js");
   assert.equal(pkg.exports?.["."]?.["remnic-source"], "./src/index.ts");
-  assert.deepEqual(pkg.files, [
-    "bin/*.js",
-    "dist",
-    "src/index.ts",
-    "src/admin-console-config.ts",
-    "src/oauth.ts",
-    "src/server-env.ts",
-    "src/startup-readiness.ts",
-    "src/support-passport-runtime.ts",
-  ]);
+  const srcTs = readdirSync(path.join(SERVER_DIR, "src"))
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .map((name) => `src/${name}`)
+    .sort();
+  assert.deepEqual([...(pkg.files ?? [])].sort(), ["bin/*.js", "dist", ...srcTs].sort());
   assert.match(pkg.scripts?.build ?? "", /\s--dts(\s|$)/);
 
   const pack = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {


### PR DESCRIPTION
## Why

This batch hit:

1. Forgotten parsed-keys snapshots (#2382, #2369).
2. Hardcoded `@remnic/server` `files[]` list (#2351).
3. ReDoS regex copies in review-deck (#2351).
4. Parallel-PR grandfather ceiling collisions (#2369).
5. Flaky stagger wrapper at a second boundary.

## Change

- Derive server `files[]` from `src/*.ts`.
- Share a regex-free frontmatter splitter.
- Stamp the stagger test so a second tick still sleeps.

Ceiling shrinks stay in the feature PRs that hit them.