### PR TITLE
feat(bench): deterministic staged-memory benchmark

### DIFF
--- a/.changeset/2346-staged-memory-bench.md
+++ b/.changeset/2346-staged-memory-bench.md
@@ -1,0 +1,5 @@
+---
+"@remnic/bench": minor
+---
+
+Add a deterministic staged-memory benchmark.

--- a/packages/bench/src/benchmarks/remnic/staged-memory/fixture.test.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/fixture.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Behavior-focused tests for the staged-memory fixture (issue #2346):
+ * byte determinism per seed, hash/structure tamper rejection, path-safety
+ * rejection, distractor counts 3/5/7, and dataset hygiene on generated
+ * fixtures.
+ */
+
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { generateDriftCorpus } from "../../../generators/drift-gen/index.js";
+import {
+  buildStagedMemoryFixture,
+  generateStagedMemoryFixture,
+  runStagedMemoryCliCommand,
+  validateStagedMemoryFixture,
+} from "./fixture.js";
+import { type StagedMemoryCaseV1, StagedMemoryCaseV1Schema, assertSafeSourceManifestName } from "./schema.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../../../../");
+const canonicalDriftDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../../../fixtures/drift-gen-core");
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+async function makeTempDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "staged-memory-fixture-"));
+}
+
+/** Generate a fresh drift corpus in a temp dir so tests never share state. */
+async function makeDriftDir(seed = 11): Promise<string> {
+  const dir = await makeTempDir();
+  await generateDriftCorpus({ users: 2, epochs: 4, seed, outDir: dir });
+  return dir;
+}
+
+async function cleanup(...dirs: string[]): Promise<void> {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+}
+
+test("same seed produces byte-identical fixtures in two directories", async () => {
+  const driftDir = await makeDriftDir();
+  const outA = await makeTempDir();
+  const outB = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: outA,
+    casesPerUser: 4,
+    distractorCount: 3,
+  });
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: outB,
+    casesPerUser: 4,
+    distractorCount: 3,
+  });
+  const casesA = await readFile(path.join(outA, "cases.jsonl"), "utf8");
+  const casesB = await readFile(path.join(outB, "cases.jsonl"), "utf8");
+  assert.equal(casesA, casesB, "cases.jsonl must be byte-identical");
+  assert.equal(
+    await readFile(path.join(outA, "manifest.json"), "utf8"),
+    await readFile(path.join(outB, "manifest.json"), "utf8"),
+    "manifest.json must be byte-identical"
+  );
+  assert.equal(sha256(casesA), sha256(casesB));
+  await cleanup(driftDir, outA, outB);
+});
+
+test("a fresh fixture validates and carries the required manifest fields", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  const fixture = await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 4,
+    distractorCount: 3,
+  });
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, true, report.errors.join("; "));
+  assert.equal(fixture.manifest.schemaVersion, 1);
+  assert.equal(fixture.manifest.name, "staged-memory-synthetic");
+  assert.equal(fixture.manifest.createdAt, "1970-01-01T00:00:00.000Z");
+  assert.ok(fixture.manifest.namespaces.length >= 2);
+  assert.ok(fixture.cases.length > 0);
+  for (const fixtureCase of fixture.cases) {
+    assert.ok(fixture.manifest.namespaces.includes(fixtureCase.namespace));
+    assert.equal(fixtureCase.namespace, fixtureCase.scope.allowedNamespace);
+    assert.equal(fixtureCase.exposure.goldMemories.length, fixtureCase.exposure.goldFacts.length);
+    assert.equal(fixtureCase.task.answerFormat, "exact");
+  }
+  await cleanup(driftDir, out);
+});
+
+test("distractor counts 3, 5, and 7 all generate and validate", async () => {
+  const driftDir = await makeDriftDir();
+  for (const distractorCount of [3, 5, 7]) {
+    const out = await makeTempDir();
+    const fixture = await generateStagedMemoryFixture({
+      driftDir,
+      seed: 11,
+      outDir: out,
+      casesPerUser: 3,
+      distractorCount,
+    });
+    const report = await validateStagedMemoryFixture(out);
+    assert.equal(report.ok, true, `count ${distractorCount}: ${report.errors.join("; ")}`);
+    assert.ok(fixture.cases.every((c) => c.distractors.length === distractorCount));
+    await rm(out, { recursive: true, force: true });
+  }
+  await rm(driftDir, { recursive: true, force: true });
+});
+
+test("a tampered cases file fails its manifest hash", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  const casesPath = path.join(out, "cases.jsonl");
+  const original = await readFile(casesPath, "utf8");
+  await writeFile(casesPath, `${original}{"tampered":true}\n`, "utf8");
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) => error.includes("fails its manifest hash")),
+    report.errors.join("; ")
+  );
+  await cleanup(driftDir, out);
+});
+
+test("a symlinked cases file is rejected", async (t) => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  const casesPath = path.join(out, "cases.jsonl");
+  await rm(casesPath);
+  try {
+    await symlink("elsewhere.jsonl", casesPath);
+  } catch (error) {
+    t.skip(`symlink creation unavailable: ${(error as Error).message}`);
+    return;
+  }
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) => error.includes("symlink")),
+    report.errors.join("; ")
+  );
+  await cleanup(driftDir, out);
+});
+
+/** Re-hash a tampered fixture so structural checks (not hash checks) fire. */
+async function tamperAndRehash(out: string, tamper: (fixtureCases: StagedMemoryCaseV1[]) => void): Promise<void> {
+  const casesPath = path.join(out, "cases.jsonl");
+  const rows = (await readFile(casesPath, "utf8"))
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => StagedMemoryCaseV1Schema.parse(JSON.parse(line)));
+  tamper(rows);
+  const rewritten = `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
+  await writeFile(casesPath, rewritten, "utf8");
+  const manifestPath = path.join(out, "manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    files: Record<string, string>;
+  };
+  manifest.files["cases.jsonl"] = sha256(rewritten);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+test("duplicate case IDs are rejected", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  await tamperAndRehash(out, (rows) => {
+    rows[1].caseId = rows[0].caseId;
+  });
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) => error.includes("duplicate caseId")),
+    report.errors.join("; ")
+  );
+  await cleanup(driftDir, out);
+});
+
+test("cross-user fact references are rejected", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  await tamperAndRehash(out, (rows) => {
+    const foreignCase = rows.find((row) => row.userId !== rows[0].userId);
+    assert.ok(foreignCase, "fixture must contain more than one user");
+    const foreignId = foreignCase.task.requiredFactIds[0];
+    const target = rows[0];
+    target.task.requiredFactIds = [foreignId];
+    target.exposure.salientFactIds = [foreignId, ...target.exposure.salientFactIds];
+    target.exposure.goldFacts = [...target.exposure.goldFacts, { ...target.exposure.goldFacts[0], factId: foreignId }];
+  });
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) => error.includes("cross-user")),
+    report.errors.join("; ")
+  );
+  await cleanup(driftDir, out);
+});
+
+test("goldMemories that disagree with goldFacts are rejected", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  await tamperAndRehash(out, (rows) => {
+    rows[0].exposure.goldMemories[0] = "tampered gold statement";
+  });
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) => error.includes("goldMemories disagree")),
+    report.errors.join("; ")
+  );
+  await cleanup(driftDir, out);
+});
+
+test("unknown manifest fields are rejected by the strict schema", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  const manifestPath = path.join(out, "manifest.json");
+  const manifest: Record<string, unknown> = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.surpriseField = true;
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  const report = await validateStagedMemoryFixture(out);
+  assert.equal(report.ok, false);
+  assert.ok(
+    report.errors.some((error) => error.includes("surpriseField")),
+    report.errors.join("; ")
+  );
+  await cleanup(driftDir, out);
+});
+
+test("home-like, absolute, and .. source manifest names are rejected", () => {
+  assert.throws(() => assertSafeSourceManifestName("/home/user/fixture/source-manifest.json"), /repo-relative/);
+  assert.throws(() => assertSafeSourceManifestName("/Users/JaneDoe/datasets/manifest.json"), /repo-relative/);
+  assert.throws(() => assertSafeSourceManifestName("a/../../etc/passwd"), /\.\./);
+  assert.throws(() => assertSafeSourceManifestName(""), /empty/);
+  assert.doesNotThrow(() => assertSafeSourceManifestName("drift-gen-core"));
+});
+
+test("unverified drift source fails fixture preflight", async () => {
+  const driftDir = await makeDriftDir();
+  const factsPath = path.join(driftDir, "11", "gold", "facts.jsonl");
+  const facts = await readFile(factsPath, "utf8");
+  await writeFile(factsPath, `${facts}\n`, "utf8");
+  await assert.rejects(buildStagedMemoryFixture({ driftDir, seed: 11, casesPerUser: 3 }), /manifest hash/);
+  await rm(driftDir, { recursive: true, force: true });
+});
+
+test("generated fixtures pass the repo dataset hygiene scanner", async () => {
+  const driftDir = await makeDriftDir();
+  const out = await makeTempDir();
+  await generateStagedMemoryFixture({
+    driftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 3,
+  });
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "check-dataset-hygiene.mjs")],
+    { env: { ...process.env, REMNIC_HYGIENE_ROOTS: out } }
+  );
+  assert.equal(
+    /violation|FAIL/i.test(`${stdout}${stderr}`),
+    false,
+    `hygiene scanner flagged the fixture: ${stdout}${stderr}`
+  );
+  await cleanup(driftDir, out);
+});
+
+test("generate/validate commands round-trip on the committed corpus", async () => {
+  const out = await makeTempDir();
+  const result = await runStagedMemoryCliCommand({
+    action: "generate",
+    driftDir: canonicalDriftDir,
+    seed: 11,
+    casesPerUser: 4,
+    out,
+    distractorCount: 3,
+  });
+  assert.equal(result.exitCode, 0, result.output);
+  const validation = await runStagedMemoryCliCommand({
+    action: "validate",
+    dir: out,
+  });
+  assert.equal(validation.exitCode, 0, validation.output);
+  assert.match(validation.output, /VALID/);
+  await rm(out, { recursive: true, force: true });
+});
+
+test("generate without --out is rejected", async () => {
+  const result = await runStagedMemoryCliCommand({ action: "generate" });
+  assert.equal(result.exitCode, 1);
+  assert.match(result.output, /--out/);
+});

--- a/packages/bench/src/benchmarks/remnic/staged-memory/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/fixture.ts
@@ -465,9 +465,20 @@ export async function validateStagedMemoryFixture(fixtureDir: string): Promise<S
       stats: { users: 0, cases: 0, distractorsPerCase: 0, transitions: 0 },
     };
   }
-  const manifestParse = StagedMemoryFixtureManifestV1Schema.safeParse(
-    typeof rawManifest === "string" ? JSON.parse(rawManifest) : rawManifest
-  );
+  let parsedManifest: unknown = rawManifest;
+  if (typeof rawManifest === "string") {
+    try {
+      parsedManifest = JSON.parse(rawManifest);
+    } catch {
+      return {
+        ok: false,
+        errors: ["fixture manifest.json is not valid JSON"],
+        warnings,
+        stats: { users: 0, cases: 0, distractorsPerCase: 0, transitions: 0 },
+      };
+    }
+  }
+  const manifestParse = StagedMemoryFixtureManifestV1Schema.safeParse(parsedManifest);
   if (!manifestParse.success) {
     return {
       ok: false,
@@ -583,7 +594,7 @@ export async function validateStagedMemoryFixture(fixtureDir: string): Promise<S
     ) {
       errors.push(`case ${fixtureCase.caseId} goldMemories disagree with goldFacts`);
     }
-    if (new Set([...goldFactIds]).size !== goldFactIds.size) {
+    if (fixtureCase.exposure.goldFacts.length !== goldFactIds.size) {
       errors.push(`case ${fixtureCase.caseId} goldFacts contain duplicate fact IDs`);
     }
     for (const factId of fixtureCase.exposure.salientFactIds) {

--- a/packages/bench/src/benchmarks/remnic/staged-memory/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/fixture.ts
@@ -1,0 +1,762 @@
+/**
+ * Staged-memory synthetic fixture (issue #2346).
+ *
+ * Derives `staged-memory-synthetic` cases from a verified drift-gen corpus
+ * (issue #1954): references rows by stable ID, never copies or regenerates
+ * them, and never creates a second fact store. Byte-identical for the same
+ * inputs (fixed sentinel timestamp, sorted rows, seeded distractor pick).
+ */
+
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DRIFT_GEN_VERSION } from "../../../generators/drift-gen/index.js";
+import { ATTRIBUTE_SPECS, formatFactStatement } from "../../../generators/drift-gen/schedule.js";
+import type { DriftSession, GoldFact } from "../../../generators/drift-gen/types.js";
+import { contentWords, questionAnswerLeakage } from "../../../generators/drift-gen/validate.js";
+import { createSeededRandom, shuffled } from "../../../seeded-random.js";
+import {
+  STAGED_MEMORY_CREATED_AT,
+  STAGED_MEMORY_FIXTURE_NAME,
+  STAGED_MEMORY_GENERATOR_VERSION,
+  STAGED_MEMORY_NAMESPACES,
+  STAGED_MEMORY_TRUSTED_PRINCIPAL,
+  type StagedMemoryCaseV1,
+  StagedMemoryCaseV1Schema,
+  type StagedMemoryDistractorV1,
+  type StagedMemoryFixtureManifestV1,
+  StagedMemoryFixtureManifestV1Schema,
+  assertSafeSourceManifestName,
+} from "./schema.js";
+
+const MAX_QUESTION_ANSWER_LEAKAGE = 0.6;
+const MANIFEST_FILE = "manifest.json";
+const CASES_FILE = "cases.jsonl";
+
+/** Repo-relative logical name for the canonical committed smoke corpus. */
+export const CANONICAL_DRIFT_SOURCE = "drift-gen-core";
+
+export function canonicalDriftDir(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../fixtures/drift-gen-core");
+}
+
+export interface StagedMemoryFixtureOptions {
+  /** Verified drift-gen corpus directory (contains dataset.manifest.json). */
+  driftDir: string;
+  seed: number;
+  /** Number of users to cover; capped at the corpus user count. */
+  users?: number;
+  /** Task cases generated per user; capped at available current facts. */
+  casesPerUser?: number;
+  /** Distractors per case; the paper's configuration examples are 3, 5, 7. */
+  distractorCount?: number;
+}
+
+export interface StagedMemoryFixture {
+  manifest: StagedMemoryFixtureManifestV1;
+  cases: StagedMemoryCaseV1[];
+}
+
+/**
+ * Fixed deterministic distractor templates (issue #2346: no LLM distractor
+ * generator). Synthetic entities only; clause shapes mirror the drift
+ * attribute templates so distractors compete for retrieval rank without
+ * carrying any target entity, value, or answer token.
+ */
+const DISTRACTOR_TEMPLATES: readonly { templateId: string; text: string }[] = Object.freeze([
+  { templateId: "dist-employer-1", text: "Marlow Petrov works at Quill Optical." },
+  { templateId: "dist-employer-2", text: "Indira Calloway works at Ferroline Logistics." },
+  { templateId: "dist-employer-3", text: "Otto Brandt works at Halyard Foods." },
+  { templateId: "dist-role-1", text: "Priya Sundaram is a lighting technician." },
+  { templateId: "dist-role-2", text: "Gustav Reyes is an archivist." },
+  { templateId: "dist-role-3", text: "Nell Okafor is a hydrologist." },
+  { templateId: "dist-city-1", text: "Tomas Lindqvist lives in Copper Hollow." },
+  { templateId: "dist-city-2", text: "Yara Bennet lives in Port Saline." },
+  { templateId: "dist-city-3", text: "Felix Amari lives in Greyfield." },
+  { templateId: "dist-hobby-1", text: "Dessa Vidal has gotten into woodblock printing." },
+  { templateId: "dist-hobby-2", text: "Ruben Castile has gotten into falconry." },
+  { templateId: "dist-hobby-3", text: "Mira Holt has gotten into bonsai." },
+  { templateId: "dist-pet-1", text: "Casper Iwu has a pair of canaries." },
+  { templateId: "dist-pet-2", text: "Lotte Vermeer has a tarantula." },
+  { templateId: "dist-pet-3", text: "Anya Petrova has a ferret." },
+  { templateId: "dist-tool-1", text: "Silas Marsh relies on the cobalt ledger for daily planning." },
+  { templateId: "dist-tool-2", text: "Juno Farrow relies on the paper compass for daily planning." },
+  { templateId: "dist-tool-3", text: "Emeric Vale relies on the quiet almanac for daily planning." },
+  { templateId: "dist-project-1", text: "Talía Ríos is leading the meadow inventory." },
+  { templateId: "dist-project-2", text: "Bo Kwan is leading the harbor census." },
+  { templateId: "dist-project-3", text: "Wren Osei is leading the lantern retrofit." },
+  { templateId: "dist-noise-1", text: "Delphine Aron keeps spare pens in the blue drawer." },
+  { templateId: "dist-noise-2", text: "Kit Serrano waters the office fern on Tuesdays." },
+  { templateId: "dist-noise-3", text: "Petra Nyman alphabetizes the spice rack each month." },
+]);
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function toStrictJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function activeFactsAtEpoch(facts: readonly GoldFact[], epoch: number): GoldFact[] {
+  return facts.filter(
+    (fact) => fact.introducedEpoch <= epoch && (fact.supersededEpoch === null || fact.supersededEpoch > epoch)
+  );
+}
+
+function isCurrentAtEpoch(fact: GoldFact, epoch: number): boolean {
+  return fact.introducedEpoch <= epoch && (fact.supersededEpoch === null || fact.supersededEpoch > epoch);
+}
+
+function factUserPrefixOk(factId: string, userId: string): boolean {
+  return factId.startsWith(`gf-${userId}-`);
+}
+
+interface LoadedDriftCorpus {
+  manifestName: string;
+  manifestSha256: string;
+  facts: GoldFact[];
+  sessions: DriftSession[];
+  seed: number;
+}
+
+async function readJsonlFile(filePath: string): Promise<unknown[]> {
+  const raw = await readFile(filePath, "utf8");
+  const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+  return lines.map((line) => JSON.parse(line) as unknown);
+}
+
+/**
+ * Load and hash-verify the drift source corpus. A tampered or unverified
+ * dataset fails preflight here — the staged fixture never builds on top of
+ * unverified rows.
+ */
+async function loadVerifiedDriftCorpus(driftDir: string, seed: number): Promise<LoadedDriftCorpus> {
+  // Error messages carry the basename only: the resolved drift directory can
+  // be an operator home path and this is a public repo.
+  const label = path.basename(driftDir);
+  const manifestPath = path.join(driftDir, "dataset.manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Record<string, unknown> & {
+    name?: unknown;
+    seeds?: unknown;
+    files?: unknown;
+  };
+  if (typeof manifest.name !== "string" || manifest.name.length === 0) {
+    throw new Error(`drift corpus ${label} has no manifest name`);
+  }
+  if (!Array.isArray(manifest.seeds) || !manifest.seeds.includes(seed)) {
+    throw new Error(`drift corpus ${label} does not carry seed ${seed}; generate it with drift-gen first`);
+  }
+  const files = (manifest.files ?? {}) as Record<string, string>;
+  const seedDir = String(seed);
+  const wanted = [path.posix.join(seedDir, "gold", "facts.jsonl"), path.posix.join(seedDir, "gold", "probes.jsonl")];
+  for (const relPath of wanted) {
+    const expected = files[relPath];
+    if (typeof expected !== "string") {
+      throw new Error(`drift manifest is missing a hash for ${relPath}`);
+    }
+    if (sha256(await readFile(path.join(driftDir, relPath), "utf8")) !== expected) {
+      throw new Error(`drift corpus file ${relPath} fails its manifest hash`);
+    }
+  }
+  const factRows = await readJsonlFile(path.join(driftDir, wanted[0] as string));
+  const facts = factRows.map((row) => {
+    const fact = row as Partial<GoldFact>;
+    if (
+      typeof fact.id !== "string" ||
+      typeof fact.userId !== "string" ||
+      typeof fact.statement !== "string" ||
+      typeof fact.subject !== "string" ||
+      typeof fact.attribute !== "string" ||
+      typeof fact.value !== "string" ||
+      typeof fact.introducedEpoch !== "number"
+    ) {
+      throw new Error(`drift corpus ${label} has a malformed gold fact row`);
+    }
+    return row as GoldFact;
+  });
+  const sessionFiles = Object.keys(files)
+    .filter((relPath) => relPath.startsWith(`${seedDir}/users/`))
+    .sort(compareStrings);
+  const sessions: DriftSession[] = [];
+  for (const relPath of sessionFiles) {
+    const expected = files[relPath];
+    if (sha256(await readFile(path.join(driftDir, relPath), "utf8")) !== expected) {
+      throw new Error(`drift corpus file ${relPath} fails its manifest hash`);
+    }
+    sessions.push(...((await readJsonlFile(path.join(driftDir, relPath))) as DriftSession[]));
+  }
+  sessions.sort((a, b) => a.epoch - b.epoch || compareStrings(a.sessionId, b.sessionId));
+  return {
+    manifestName: manifest.name,
+    manifestSha256: sha256(await readFile(manifestPath, "utf8")),
+    facts,
+    sessions,
+    seed,
+  };
+}
+
+/** Total string order: equality returns 0 so equal keys stay stable. */
+function compareStrings(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+function forbiddenDistractorTokens(fact: GoldFact, relatedFacts: readonly GoldFact[]): Set<string> {
+  const tokens = new Set<string>();
+  for (const word of contentWords(fact.subject)) tokens.add(word);
+  for (const word of contentWords(fact.value)) tokens.add(word);
+  for (const word of contentWords(fact.statement)) tokens.add(word);
+  for (const related of relatedFacts) {
+    if (related.subject === fact.subject) {
+      for (const word of contentWords(related.value)) tokens.add(word);
+    }
+  }
+  return tokens;
+}
+
+function pickDistractors(
+  rngOptions: { seed: number; caseOrdinal: number },
+  count: number,
+  forbidden: ReadonlySet<string>,
+  requiredFactIds: readonly string[],
+  sessionId: string
+): StagedMemoryDistractorV1[] {
+  const rng = createSeededRandom((rngOptions.seed ^ (rngOptions.caseOrdinal * 0x9e3779b1)) >>> 0);
+  const candidates = shuffled(rng, [...DISTRACTOR_TEMPLATES]);
+  const distractors: StagedMemoryDistractorV1[] = [];
+  for (const template of candidates) {
+    if (distractors.length >= count) break;
+    const words = [...contentWords(template.text)];
+    if (words.some((word) => forbidden.has(word))) continue;
+    distractors.push({
+      id: `${template.templateId}-${rngOptions.caseOrdinal}`,
+      sessionId,
+      text: template.text,
+      forbiddenFactIds: [...requiredFactIds],
+      templateId: template.templateId,
+    });
+  }
+  if (distractors.length < count) {
+    throw new Error(`only ${distractors.length} of ${count} requested distractors pass target-overlap checks`);
+  }
+  return distractors;
+}
+
+/**
+ * Build the staged-memory fixture in memory from a verified drift corpus.
+ * Pure: no filesystem writes (see `generateStagedMemoryFixture`).
+ */
+export async function buildStagedMemoryFixture(options: StagedMemoryFixtureOptions): Promise<StagedMemoryFixture> {
+  const distractorCount = options.distractorCount ?? 3;
+  if (!Number.isSafeInteger(distractorCount) || distractorCount < 1 || distractorCount > 7) {
+    throw new Error("distractorCount must be an integer in [1, 7]");
+  }
+  const corpus = await loadVerifiedDriftCorpus(options.driftDir, options.seed);
+  const userIds = [...new Set(corpus.facts.map((fact) => fact.userId))].sort();
+  const users = Math.min(options.users ?? userIds.length, userIds.length);
+  if (users < 1) {
+    throw new Error("drift corpus has no users");
+  }
+  const casesPerUser = options.casesPerUser ?? 12;
+
+  const cases: StagedMemoryCaseV1[] = [];
+  let caseOrdinal = 0;
+  for (let userIndex = 0; userIndex < users; userIndex += 1) {
+    const userId = userIds[userIndex] as string;
+    const userFacts = corpus.facts.filter((fact) => fact.userId === userId).sort((a, b) => compareStrings(a.id, b.id));
+    const userSessions = corpus.sessions
+      .filter((session) => session.userId === userId)
+      .sort((a, b) => a.epoch - b.epoch || compareStrings(a.sessionId, b.sessionId));
+    const exposureEpoch = userSessions.at(-1)?.epoch ?? 0;
+    if (exposureEpoch < 1) {
+      throw new Error(`drift user ${userId} has no exposure sessions`);
+    }
+    const active = activeFactsAtEpoch(userFacts, exposureEpoch);
+    const salientFactIds = active.map((fact) => fact.id);
+    // Gold rows cover the whole exposure window: current facts plus facts
+    // superseded inside it (transitions need both sides).
+    const goldFacts = userFacts
+      .filter((fact) => fact.introducedEpoch <= exposureEpoch)
+      .map((fact) => ({
+        factId: fact.id,
+        subject: fact.subject,
+        attribute: fact.attribute,
+        value: fact.value,
+        statement: fact.statement,
+        introducedEpoch: fact.introducedEpoch,
+      }));
+    const goldMemories = goldFacts.map((fact) => fact.statement);
+    const transitions = userFacts
+      .filter(
+        (fact) => fact.supersededEpoch !== null && fact.supersededEpoch <= exposureEpoch && fact.supersededBy !== null
+      )
+      .map((fact) => {
+        const successor = userFacts.find((candidate) => candidate.id === fact.supersededBy);
+        // A supersession pointer without a live successor is a broken link:
+        // reject it instead of silently dropping the transition.
+        if (!successor || !isCurrentAtEpoch(successor, exposureEpoch)) {
+          throw new Error(`fact ${fact.id} supersession link is broken at epoch ${exposureEpoch}`);
+        }
+        return {
+          oldFactId: fact.id,
+          newFactId: fact.supersededBy as string,
+          epoch: fact.supersededEpoch as number,
+          kind: fact.kind === "contradicted" ? ("contradicted" as const) : ("drifting" as const),
+        };
+      });
+    const sourceSessionRefs = userSessions.map((session) => session.sessionId);
+    const namespace = STAGED_MEMORY_NAMESPACES[userIndex % STAGED_MEMORY_NAMESPACES.length] as string;
+    const lastSession = userSessions.at(-1);
+    if (!lastSession || lastSession.date.length === 0) {
+      throw new Error(`drift user ${userId} has no pinned effective timestamp`);
+    }
+    const effectiveTimestamp = lastSession.date;
+
+    const taskFacts = active.slice(0, Math.min(casesPerUser, active.length));
+    for (const fact of taskFacts) {
+      caseOrdinal += 1;
+      const spec = ATTRIBUTE_SPECS.find((candidate) => candidate.attribute === fact.attribute);
+      if (!spec) {
+        throw new Error(`fact ${fact.id} carries an unknown attribute ${fact.attribute}`);
+      }
+      const forbiddenFactIds = userFacts
+        .filter((candidate) => candidate.supersededBy === fact.id)
+        .map((candidate) => candidate.id);
+      const question = spec.questionCurrent(fact.subject);
+      const leakage = questionAnswerLeakage(question, fact.value);
+      if (leakage > MAX_QUESTION_ANSWER_LEAKAGE) {
+        throw new Error(`task for fact ${fact.id} leaks its answer into the question (${leakage.toFixed(2)})`);
+      }
+      const caseId = `sm-${userId}-${String(caseOrdinal).padStart(4, "0")}`;
+      const exposureSessionId = `staged-${caseId}`;
+      cases.push({
+        schemaVersion: 1,
+        caseId,
+        userId,
+        namespace,
+        seed: options.seed,
+        exposure: {
+          sessionId: exposureSessionId,
+          sourceSessionRefs,
+          salientFactIds,
+          goldFacts,
+          goldMemories,
+          exposureEpoch,
+          effectiveTimestamp,
+        },
+        transitions,
+        distractors: pickDistractors(
+          { seed: options.seed, caseOrdinal },
+          distractorCount,
+          forbiddenDistractorTokens(fact, userFacts),
+          [fact.id],
+          `${exposureSessionId}-stage2`
+        ),
+        task: {
+          question,
+          expectedAnswer: fact.value,
+          requiredFactIds: [fact.id],
+          forbiddenFactIds,
+          answerFormat: "exact",
+        },
+        scope: {
+          principal: STAGED_MEMORY_TRUSTED_PRINCIPAL,
+          allowedUserId: userId,
+          allowedNamespace: namespace,
+        },
+      });
+    }
+  }
+  if (cases.length === 0) {
+    throw new Error("staged-memory fixture derived zero cases from the drift corpus");
+  }
+
+  const files: Record<string, string> = {
+    [CASES_FILE]: sha256(toCaseJsonl(cases)),
+  };
+  const manifest: StagedMemoryFixtureManifestV1 = {
+    schemaVersion: 1,
+    name: STAGED_MEMORY_FIXTURE_NAME,
+    version: STAGED_MEMORY_GENERATOR_VERSION,
+    generatorVersion: DRIFT_GEN_VERSION,
+    seeds: [options.seed],
+    source: {
+      kind: "drift-gen",
+      manifestName: corpus.manifestName,
+      manifestSha256: corpus.manifestSha256,
+    },
+    counts: {
+      users,
+      cases: cases.length,
+      distractors: distractorCount,
+    },
+    files,
+    createdAt: STAGED_MEMORY_CREATED_AT,
+    licenses: [{ source: "synthetic", license: "MIT (repo)" }],
+    namespaces: [...STAGED_MEMORY_NAMESPACES],
+  };
+  assertSafeSourceManifestName(manifest.source.manifestName);
+  return { manifest, cases };
+}
+
+function toCaseJsonl(cases: readonly StagedMemoryCaseV1[]): string {
+  return `${cases.map((row) => JSON.stringify(row)).join("\n")}\n`;
+}
+
+/** Write the fixture to `outDir` deterministically (staged write + rename). */
+export async function generateStagedMemoryFixture(
+  options: StagedMemoryFixtureOptions & { outDir: string }
+): Promise<StagedMemoryFixture> {
+  const fixture = await buildStagedMemoryFixture(options);
+  const staging = `${options.outDir}.staging`;
+  await rm(staging, { recursive: true, force: true });
+  await mkdir(staging, { recursive: true });
+  await writeFile(path.join(staging, CASES_FILE), toCaseJsonl(fixture.cases), "utf8");
+  await writeFile(path.join(staging, MANIFEST_FILE), toStrictJson(fixture.manifest), "utf8");
+  await rm(options.outDir, { recursive: true, force: true });
+  await rename(staging, options.outDir);
+  return fixture;
+}
+
+export interface StagedMemoryValidationStats {
+  users: number;
+  cases: number;
+  distractorsPerCase: number;
+  transitions: number;
+}
+
+export interface StagedMemoryValidationReport {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  stats: StagedMemoryValidationStats;
+}
+
+/**
+ * Validate an on-disk fixture against the strict v1 schemas plus the issue's
+ * integrity rules: file hashes, symlinks, duplicate IDs, namespace binding,
+ * cross-user fact references, broken supersession links, question/answer
+ * leakage, and distractor target overlap.
+ */
+export async function validateStagedMemoryFixture(fixtureDir: string): Promise<StagedMemoryValidationReport> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const dirStat = await lstat(fixtureDir).catch(() => undefined);
+  if (!dirStat?.isDirectory()) {
+    return {
+      ok: false,
+      errors: [`fixture directory not found: ${path.basename(fixtureDir)}`],
+      warnings,
+      stats: { users: 0, cases: 0, distractorsPerCase: 0, transitions: 0 },
+    };
+  }
+  if (dirStat.isSymbolicLink()) {
+    errors.push("fixture directory must not be a symlink");
+  }
+
+  const manifestPath = path.join(fixtureDir, MANIFEST_FILE);
+  const rawManifest: unknown = await readFile(manifestPath, "utf8").catch(() => undefined);
+  if (rawManifest === undefined) {
+    return {
+      ok: false,
+      errors: ["fixture manifest.json is missing"],
+      warnings,
+      stats: { users: 0, cases: 0, distractorsPerCase: 0, transitions: 0 },
+    };
+  }
+  const manifestParse = StagedMemoryFixtureManifestV1Schema.safeParse(
+    typeof rawManifest === "string" ? JSON.parse(rawManifest) : rawManifest
+  );
+  if (!manifestParse.success) {
+    return {
+      ok: false,
+      errors: manifestParse.error.issues.map(
+        (issue) => `manifest: ${issue.path.join(".") || "<root>"} ${issue.message}`
+      ),
+      warnings,
+      stats: { users: 0, cases: 0, distractorsPerCase: 0, transitions: 0 },
+    };
+  }
+  const manifest = manifestParse.data;
+  try {
+    assertSafeSourceManifestName(manifest.source.manifestName);
+  } catch (error) {
+    errors.push((error as Error).message);
+  }
+  const namespaceSet = new Set(manifest.namespaces);
+  if (namespaceSet.size < 2) {
+    errors.push("manifest.namespaces must contain at least two distinct values");
+  }
+  for (const namespace of manifest.namespaces) {
+    if (!(STAGED_MEMORY_NAMESPACES as readonly string[]).includes(namespace)) {
+      errors.push(`namespace is outside the benchmark allowlist: ${namespace}`);
+    }
+  }
+  if (!(CASES_FILE in manifest.files)) {
+    errors.push(`manifest.files must hash ${CASES_FILE}`);
+  }
+  for (const [relPath, expectedHash] of Object.entries(manifest.files)) {
+    const filePath = path.join(fixtureDir, relPath);
+    const stat = await lstat(filePath).catch(() => undefined);
+    if (!stat) {
+      errors.push(`fixture file listed in manifest is missing: ${relPath}`);
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      errors.push(`fixture file must not be a symlink: ${relPath}`);
+      continue;
+    }
+    if (sha256(await readFile(filePath, "utf8")) !== expectedHash) {
+      errors.push(`fixture file fails its manifest hash: ${relPath}`);
+    }
+  }
+
+  const rawCases = await readFile(path.join(fixtureDir, CASES_FILE), "utf8").catch(() => undefined);
+  if (rawCases === undefined) {
+    return {
+      ok: false,
+      errors: [...errors, "fixture cases.jsonl is missing"],
+      warnings,
+      stats: { users: 0, cases: 0, distractorsPerCase: 0, transitions: 0 },
+    };
+  }
+  const seenCaseIds = new Set<string>();
+  const cases: StagedMemoryCaseV1[] = [];
+  for (const [index, line] of rawCases
+    .split("\n")
+    .filter((l) => l.trim())
+    .entries()) {
+    let row: unknown;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      errors.push(`cases.jsonl line ${index + 1} is not valid JSON`);
+      continue;
+    }
+    const parsed = StagedMemoryCaseV1Schema.safeParse(row);
+    if (!parsed.success) {
+      errors.push(
+        `case at line ${index + 1}: ${parsed.error.issues
+          .map((issue) => `${issue.path.join(".") || "<root>"} ${issue.message}`)
+          .join("; ")}`
+      );
+      continue;
+    }
+    const fixtureCase = parsed.data;
+    if (seenCaseIds.has(fixtureCase.caseId)) {
+      errors.push(`duplicate caseId: ${fixtureCase.caseId}`);
+    }
+    seenCaseIds.add(fixtureCase.caseId);
+    cases.push(fixtureCase);
+
+    if (!namespaceSet.has(fixtureCase.namespace)) {
+      errors.push(`case ${fixtureCase.caseId} binds an unallowlisted namespace`);
+    }
+    if (fixtureCase.namespace !== fixtureCase.scope.allowedNamespace) {
+      errors.push(`case ${fixtureCase.caseId} namespace disagrees with scope.allowedNamespace`);
+    }
+    if (fixtureCase.scope.principal !== STAGED_MEMORY_TRUSTED_PRINCIPAL) {
+      errors.push(`case ${fixtureCase.caseId} uses a non-benchmark principal`);
+    }
+    if (fixtureCase.scope.allowedUserId !== fixtureCase.userId) {
+      errors.push(`case ${fixtureCase.caseId} scope user does not match its user`);
+    }
+    const referencedIds = [
+      ...fixtureCase.exposure.salientFactIds,
+      ...fixtureCase.transitions.flatMap((t) => [t.oldFactId, t.newFactId]),
+      ...fixtureCase.task.requiredFactIds,
+      ...fixtureCase.task.forbiddenFactIds,
+    ];
+    for (const factId of referencedIds) {
+      if (!factUserPrefixOk(factId, fixtureCase.userId)) {
+        errors.push(`case ${fixtureCase.caseId} references cross-user fact ${factId}`);
+      }
+    }
+    const salient = new Set(fixtureCase.exposure.salientFactIds);
+    const goldFactIds = new Set(fixtureCase.exposure.goldFacts.map((gold) => gold.factId));
+    if (
+      fixtureCase.exposure.goldMemories.length !== fixtureCase.exposure.goldFacts.length ||
+      fixtureCase.exposure.goldMemories.some(
+        (statement, index) => statement !== (fixtureCase.exposure.goldFacts[index]?.statement ?? "")
+      )
+    ) {
+      errors.push(`case ${fixtureCase.caseId} goldMemories disagree with goldFacts`);
+    }
+    if (new Set([...goldFactIds]).size !== goldFactIds.size) {
+      errors.push(`case ${fixtureCase.caseId} goldFacts contain duplicate fact IDs`);
+    }
+    for (const factId of fixtureCase.exposure.salientFactIds) {
+      if (!goldFactIds.has(factId)) {
+        errors.push(`case ${fixtureCase.caseId} salient fact ${factId} is missing from goldFacts`);
+      }
+    }
+    for (const transition of fixtureCase.transitions) {
+      if (!goldFactIds.has(transition.oldFactId) || !goldFactIds.has(transition.newFactId)) {
+        errors.push(`case ${fixtureCase.caseId} transition references a fact outside goldFacts`);
+      }
+    }
+    for (const transition of fixtureCase.transitions) {
+      if (salient.has(transition.oldFactId)) {
+        errors.push(`case ${fixtureCase.caseId} transition lists superseded fact ${transition.oldFactId} as salient`);
+      }
+      if (!salient.has(transition.newFactId)) {
+        errors.push(
+          `case ${fixtureCase.caseId} transition successor ${transition.newFactId} is missing from salient facts`
+        );
+      }
+    }
+    for (const requiredId of fixtureCase.task.requiredFactIds) {
+      if (!salient.has(requiredId)) {
+        errors.push(`case ${fixtureCase.caseId} task requires non-salient fact ${requiredId}`);
+      }
+    }
+    if (
+      questionAnswerLeakage(fixtureCase.task.question, fixtureCase.task.expectedAnswer) > MAX_QUESTION_ANSWER_LEAKAGE
+    ) {
+      errors.push(`case ${fixtureCase.caseId} task question leaks its answer`);
+    }
+    const answerTokens = contentWords(fixtureCase.task.expectedAnswer);
+    // Target tokens: subject, value, and statement words of the task's
+    // required AND forbidden (superseded) facts — the entities, attributes,
+    // and values a distractor must not carry. Unrelated gold statements that
+    // merely share a clause verb ("gotten into", "lives in") are not target
+    // overlap; the deterministic templates intentionally reuse clause shapes.
+    const goldByFactId = new Map(fixtureCase.exposure.goldFacts.map((row) => [row.factId, row]));
+    const targetTokens = new Set<string>();
+    for (const factId of [...fixtureCase.task.requiredFactIds, ...fixtureCase.task.forbiddenFactIds]) {
+      const row = goldByFactId.get(factId);
+      if (!row) continue;
+      for (const word of [...contentWords(row.subject), ...contentWords(row.value), ...contentWords(row.statement)]) {
+        targetTokens.add(word);
+      }
+    }
+    for (const distractor of fixtureCase.distractors) {
+      const distractorWords = contentWords(distractor.text);
+      let overlapsGold = false;
+      let carriesAnswer = false;
+      for (const word of distractorWords) {
+        if (targetTokens.has(word)) overlapsGold = true;
+        if (answerTokens.has(word)) carriesAnswer = true;
+      }
+      if (overlapsGold) {
+        errors.push(
+          `case ${fixtureCase.caseId} distractor ${distractor.id} carries target entity, attribute, or value tokens`
+        );
+      }
+      if (carriesAnswer) {
+        errors.push(`case ${fixtureCase.caseId} distractor ${distractor.id} carries answer tokens`);
+      }
+      if (!fixtureCase.task.requiredFactIds.every((id) => distractor.forbiddenFactIds.includes(id))) {
+        errors.push(`case ${fixtureCase.caseId} distractor ${distractor.id} does not forbid all required facts`);
+      }
+    }
+  }
+
+  const perCaseDistractors = new Set(cases.map((c) => c.distractors.length));
+  if (perCaseDistractors.size > 1) {
+    warnings.push("distractor counts vary across cases");
+  }
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    stats: {
+      users: new Set(cases.map((c) => c.userId)).size,
+      cases: cases.length,
+      distractorsPerCase: cases[0]?.distractors.length ?? 0,
+      transitions: cases.reduce((sum, c) => sum + c.transitions.length, 0),
+    },
+  };
+}
+
+/** Load a fixture for execution: validation failure is a preflight failure. */
+export async function loadStagedMemoryFixture(
+  fixtureDir: string
+): Promise<StagedMemoryFixture & { fixtureHash: string }> {
+  const report = await validateStagedMemoryFixture(fixtureDir);
+  if (!report.ok) {
+    throw new Error(`staged-memory fixture failed preflight:\n${report.errors.map((e) => `  - ${e}`).join("\n")}`);
+  }
+  const rawManifest = JSON.parse(
+    await readFile(path.join(fixtureDir, MANIFEST_FILE), "utf8")
+  ) as StagedMemoryFixtureManifestV1;
+  const rawCases = await readFile(path.join(fixtureDir, CASES_FILE), "utf8");
+  const cases = rawCases
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as StagedMemoryCaseV1);
+  return {
+    manifest: rawManifest,
+    cases,
+    fixtureHash: sha256(rawCases),
+  };
+}
+
+export interface StagedMemoryCliOptions {
+  action: "generate" | "validate";
+  dir?: string;
+  driftDir?: string;
+  users?: number;
+  casesPerUser?: number;
+  seed?: number;
+  distractorCount?: number;
+  out?: string;
+  json?: boolean;
+}
+
+export async function runStagedMemoryCliCommand(
+  options: StagedMemoryCliOptions
+): Promise<{ exitCode: number; output: string }> {
+  if (options.action === "validate") {
+    if (!options.dir) {
+      return {
+        exitCode: 1,
+        output: "staged-memory validate requires a fixture directory",
+      };
+    }
+    const report = await validateStagedMemoryFixture(options.dir);
+    const lines = [
+      report.ok ? "staged-memory fixture: VALID" : "staged-memory fixture: INVALID",
+      `  users=${report.stats.users} cases=${report.stats.cases} distractorsPerCase=${report.stats.distractorsPerCase} transitions=${report.stats.transitions}`,
+      ...report.warnings.map((warning) => `  warning: ${warning}`),
+      ...report.errors.map((error) => `  error: ${error}`),
+    ];
+    return {
+      exitCode: report.ok ? 0 : 1,
+      output: options.json ? JSON.stringify(report, null, 2) : lines.join("\n"),
+    };
+  }
+
+  if (!options.out) {
+    return {
+      exitCode: 1,
+      output: "staged-memory generate requires --out <dir>",
+    };
+  }
+  const driftDir = options.driftDir ?? canonicalDriftDir();
+  const fixture = await generateStagedMemoryFixture({
+    driftDir,
+    seed: options.seed ?? 11,
+    users: options.users,
+    casesPerUser: options.casesPerUser,
+    distractorCount: options.distractorCount,
+    outDir: options.out,
+  });
+  if (options.json) {
+    return { exitCode: 0, output: JSON.stringify(fixture.manifest, null, 2) };
+  }
+  return {
+    exitCode: 0,
+    output: [
+      `staged-memory v${STAGED_MEMORY_GENERATOR_VERSION}: wrote fixture to ${options.out}`,
+      `  users=${fixture.manifest.counts.users} cases=${fixture.manifest.counts.cases} distractors=${fixture.manifest.counts.distractors} seed=${fixture.manifest.seeds[0]}`,
+      `  source=${fixture.manifest.source.manifestName}@${fixture.manifest.source.manifestSha256.slice(0, 12)}`,
+      `  run with: remnic bench run staged-memory-synthetic-v1 --dataset-dir ${options.out}`,
+    ].join("\n"),
+  };
+}
+
+// formatFactStatement is re-exported for the runner's oracle arm, which must
+// render gold evidence exactly as drift-gen rendered it into sessions.
+export { formatFactStatement };

--- a/packages/bench/src/benchmarks/remnic/staged-memory/metrics.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/metrics.ts
@@ -82,7 +82,7 @@ export function ratioMetric(
 export function holmAdjust(
   pValues: ReadonlyMap<string, number | "NA">,
   primaryMetrics: readonly string[]
-): { adjustedPValues: Record<string, number | "NA"> } {
+): { adjustedPValues: Record<string, number | "NA">; primaryMetrics: string[] } {
   const adjusted: Record<string, number | "NA"> = {};
   const testable = [...pValues.entries()]
     .filter((entry): entry is [string, number] => entry[1] !== "NA")
@@ -107,5 +107,5 @@ export function holmAdjust(
       adjusted[metric] = "NA";
     }
   }
-  return { adjustedPValues: adjusted };
+  return { adjustedPValues: adjusted, primaryMetrics: [...primaryMetrics] };
 }

--- a/packages/bench/src/benchmarks/remnic/staged-memory/metrics.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/metrics.ts
@@ -1,0 +1,111 @@
+/**
+ * Statistics extensions for the staged-memory benchmark (issue #2346):
+ * paired sign-flip permutation p-values, Holm correction across declared
+ * primary metrics, and zero-denominator `NA` accounting. `NA` values are
+ * excluded from every mean, interval, permutation test, and correction —
+ * they are recorded, never averaged around.
+ */
+
+import { createSeededRandom } from "../../../seeded-random.js";
+
+export const STAGED_MEMORY_PERMUTATION_SAMPLES = 10_000;
+/** Pinned so repeated runs reproduce identical p-values (no Math.random). */
+export const STAGED_MEMORY_STATISTICS_SEED = 0x5eed5;
+
+export interface PairedPermutationResult {
+  pValue: number;
+  samples: number;
+}
+
+/**
+ * Two-sided paired permutation test on sign flips. Differences are paired by
+ * case; pairs where either side is `NA` are excluded before testing. When
+ * every difference is exactly zero the p-value is 1 (no observable
+ * difference), which is descriptive evidence only — never a significance
+ * claim.
+ */
+export function pairedPermutationTest(
+  differences: readonly number[],
+  options: { samples?: number; seed?: number } = {}
+): PairedPermutationResult {
+  const samples = options.samples ?? STAGED_MEMORY_PERMUTATION_SAMPLES;
+  const rng = createSeededRandom((options.seed ?? STAGED_MEMORY_STATISTICS_SEED) >>> 0);
+  const diffs = differences.filter((value) => Number.isFinite(value));
+  if (diffs.length === 0) {
+    return { pValue: 1, samples };
+  }
+  const observed = Math.abs(diffs.reduce((sum, value) => sum + value, 0));
+  let extreme = 0;
+  for (let iteration = 0; iteration < samples; iteration += 1) {
+    let flipped = 0;
+    for (const difference of diffs) {
+      // Deterministic coin per pair; comparisons never touch Math.random.
+      flipped += rng() < 0.5 ? difference : -difference;
+    }
+    if (Math.abs(flipped) >= observed) {
+      extreme += 1;
+    }
+  }
+  return { pValue: (extreme + 1) / (samples + 1), samples };
+}
+
+export interface NaMetricEntry {
+  denominator: number;
+  reason: string;
+}
+
+/**
+ * Ratio metric with zero-denominator `NA` semantics. Returns either the
+ * ratio or an `NA` record carrying the denominator and reason; callers put
+ * the reason in `naMetrics` and skip the value in every aggregate.
+ */
+export function ratioMetric(
+  numerator: number,
+  denominator: number,
+  naReason: string
+): { value: number; na?: NaMetricEntry } | { value: "NA"; na: NaMetricEntry } {
+  if (denominator === 0) {
+    return {
+      value: "NA",
+      na: { denominator: 0, reason: naReason },
+    };
+  }
+  return { value: numerator / denominator };
+}
+
+/**
+ * Holm-Bonferroni step-down adjustment across the declared primary metrics.
+ * Metrics whose p-value is `NA` (excluded pairs or zero denominator) are
+ * skipped and reported as `NA`; they never consume correction budget.
+ * pAdj is clamped to be monotone and <= 1.
+ */
+export function holmAdjust(
+  pValues: ReadonlyMap<string, number | "NA">,
+  primaryMetrics: readonly string[]
+): { adjustedPValues: Record<string, number | "NA"> } {
+  const adjusted: Record<string, number | "NA"> = {};
+  const testable = [...pValues.entries()]
+    .filter((entry): entry is [string, number] => entry[1] !== "NA")
+    .map(([metric, pValue]) => ({ metric, pValue }))
+    // Total order: p-value first, metric name as the tiebreaker so equal
+    // p-values sort identically across runs.
+    .sort((left, right) => {
+      if (left.pValue !== right.pValue) return left.pValue - right.pValue;
+      return left.metric < right.metric ? -1 : left.metric > right.metric ? 1 : 0;
+    });
+
+  const family = testable.length;
+  let runningMax = 0;
+  for (let index = 0; index < family; index += 1) {
+    const { metric, pValue } = testable[index] as { metric: string; pValue: number };
+    const step = Math.min(1, (family - index) * pValue);
+    runningMax = Math.max(runningMax, step);
+    adjusted[metric] = runningMax;
+  }
+  for (const metric of primaryMetrics) {
+    if (pValues.get(metric) === "NA") {
+      adjusted[metric] = "NA";
+    }
+  }
+  return { adjustedPValues: adjusted };
+}

--- a/packages/bench/src/benchmarks/remnic/staged-memory/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/runner.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Behavior-focused tests for the staged-memory runner (issue #2346):
+ * staged invariants (persistence across resets, zero leakage, zero scope
+ * violations, supersession), arm separation, NA accounting, paired
+ * statistics, gate enforcement, determinism, and the sanitized public
+ * projection. Controller modes beyond "off" are explicit refusals until
+ * the #2348 coordinator lands.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { getRegisteredBenchmark } from "../../../registry.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+import { generateStagedMemoryFixture } from "./fixture.js";
+import {
+  DeterministicStagedMemory,
+  runStagedMemoryBenchmark,
+  stagedMemorySyntheticV1Definition,
+  toStagedMemoryPublicResults,
+} from "./runner.js";
+import {
+  STAGED_MEMORY_NAMESPACES,
+  STAGED_MEMORY_TRUSTED_PRINCIPAL,
+  type StagedMemoryPublicResultV1,
+} from "./schema.js";
+
+const canonicalDriftDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../../../fixtures/drift-gen-core");
+
+const scope = {
+  trustedPrincipal: STAGED_MEMORY_TRUSTED_PRINCIPAL,
+  namespace: STAGED_MEMORY_NAMESPACES[0] as string,
+};
+
+function runOptions(overrides: Partial<ResolvedRunBenchmarkOptions> = {}): ResolvedRunBenchmarkOptions {
+  return {
+    mode: "quick",
+    benchmark: stagedMemorySyntheticV1Definition,
+    system: null as unknown as ResolvedRunBenchmarkOptions["system"],
+    ...overrides,
+  };
+}
+
+test("the benchmark is registered with a runnable definition", () => {
+  const registered = getRegisteredBenchmark("staged-memory-synthetic-v1");
+  assert.ok(registered, "benchmark must be registered");
+  assert.equal(typeof registered.run, "function");
+});
+
+test("quick mode runs all five arms and passes every deterministic gate", async () => {
+  const result = await runStagedMemoryBenchmark(runOptions());
+  const stagedOptions = result.config.benchmarkOptions as Record<string, unknown>;
+  const armMeans = stagedOptions.armMeans as Record<string, Record<string, number | "NA">>;
+  for (const arm of ["empty", "persist-only", "static-context", "staged-memory", "oracle-retrieval"]) {
+    assert.ok(armMeans[arm], `arm ${arm} must be summarized`);
+  }
+  const staged = armMeans["staged-memory"] as Record<string, number | "NA">;
+  assert.equal(staged.construction_recall, 1);
+  assert.ok((staged.supersession_accuracy as number) >= 0.95);
+  assert.ok((staged.retrieval_recall_at_5 as number) >= 0.9);
+  assert.ok((staged.task_success as number) >= 0.85);
+  assert.equal(staged.distractor_rejection, 1);
+  assert.equal(staged.context_reset_leakage, 0);
+  assert.equal(staged.scope_violation, 0);
+  assert.equal(staged.persistent_survival, 1);
+  assert.equal(staged.stale_answer, 0);
+  const gates = stagedOptions.gates as Record<string, boolean>;
+  assert.ok(
+    Object.values(gates).every((pass) => pass),
+    `all gates pass: ${JSON.stringify(gates)}`
+  );
+});
+
+test("the oracle arm calibrates the scorer and the empty arm floors it", async () => {
+  const result = await runStagedMemoryBenchmark(runOptions());
+  const armMeans = (result.config.benchmarkOptions as Record<string, unknown>).armMeans as Record<
+    string,
+    Record<string, number | "NA">
+  >;
+  assert.equal(
+    armMeans["oracle-retrieval"].task_success,
+    1,
+    "oracle retrieval must calibrate the scorer to exact-match"
+  );
+  assert.equal(armMeans.empty.task_success, 0);
+});
+
+test("resetContext removes appended distractors; static-context keeps them", async () => {
+  const result = await runStagedMemoryBenchmark(runOptions());
+  const tasksByArm = new Map<string, typeof result.results.tasks>();
+  for (const arm of ["static-context", "staged-memory"]) {
+    tasksByArm.set(
+      arm,
+      result.results.tasks.filter((task) => task.taskId.endsWith(`::${arm}`))
+    );
+  }
+  const staticTasks = tasksByArm.get("static-context") as typeof result.results.tasks;
+  const stagedTasks = tasksByArm.get("staged-memory") as typeof result.results.tasks;
+  assert.ok(staticTasks.length > 0);
+  // Distractors were demonstrably present in Stage 2 active context.
+  for (const task of [...staticTasks, ...stagedTasks]) {
+    const details = task.details as { distractorPresenceDuringStage2?: number };
+    assert.ok((details.distractorPresenceDuringStage2 ?? 0) > 0, "distractors must be present in the Stage 2 context");
+  }
+  const staticResidue = staticTasks.filter((task) => task.scores.distractor_rejection === 0);
+  assert.ok(staticResidue.length > 0, "static-context must show distractor residue in at least one case");
+  for (const task of stagedTasks) {
+    assert.equal(task.scores.distractor_rejection, 1);
+    assert.equal(task.scores.context_reset_leakage, 0);
+  }
+});
+
+test("appendContext never writes core memory and resetContext never deletes it", async () => {
+  const engine = new DeterministicStagedMemory(STAGED_MEMORY_NAMESPACES);
+  const sessionId = "staged-sm-engine-test";
+  await engine.store(scope, sessionId, ["Riley Marsh works at Norvig Dynamics."], 2);
+  await engine.appendContext(scope, sessionId, ["Marlow Petrov works at Quill Optical."]);
+  assert.equal(engine.currentTuples(scope).length, 1);
+  assert.deepEqual(engine.contextSnapshot(scope, sessionId), ["Marlow Petrov works at Quill Optical."]);
+  await engine.resetContext(scope, sessionId);
+  assert.deepEqual(engine.contextSnapshot(scope, sessionId), []);
+  assert.equal(engine.currentTuples(scope).length, 1, "resetContext must preserve persistent tuples");
+});
+
+test("missing or unallowlisted scope fields fail for every scoped method", async () => {
+  const engine = new DeterministicStagedMemory(STAGED_MEMORY_NAMESPACES);
+  const badScopes = [
+    { trustedPrincipal: "someone-else", namespace: scope.namespace },
+    { trustedPrincipal: scope.trustedPrincipal, namespace: "rogue-namespace" },
+    { trustedPrincipal: "", namespace: "" },
+  ];
+  for (const bad of badScopes) {
+    await assert.rejects(() => engine.reset(bad), /not allowlisted/);
+    await assert.rejects(() => engine.store(bad, "s", ["x"], 1), /not allowlisted/);
+    await assert.rejects(() => engine.appendContext(bad, "s", ["x"]), /not allowlisted/);
+    await assert.rejects(() => engine.resetContext(bad, "s"), /not allowlisted/);
+    assert.throws(() => engine.currentTuples(bad), /not allowlisted/);
+    assert.throws(() => engine.recall(bad, "s", "q"), /not allowlisted/);
+  }
+});
+
+test("same-session and same-ID collisions stay isolated across namespaces", async () => {
+  const engine = new DeterministicStagedMemory(STAGED_MEMORY_NAMESPACES);
+  const other = {
+    trustedPrincipal: STAGED_MEMORY_TRUSTED_PRINCIPAL,
+    namespace: STAGED_MEMORY_NAMESPACES[1] as string,
+  };
+  const sessionId = "shared-session-id";
+  // Same principal, same session ID, same statement — different namespaces.
+  await engine.store(scope, sessionId, ["Riley Marsh works at Norvig Dynamics."], 2);
+  await engine.appendContext(scope, sessionId, ["alpha context line"]);
+  await engine.store(other, sessionId, ["Lux Bannister lives in Cinder Falls."], 2);
+  await engine.appendContext(other, sessionId, ["beta context line"]);
+  const recallAlpha = engine.recall(scope, sessionId, "Where does Riley Marsh work these days?");
+  const recallBeta = engine.recall(other, sessionId, "Where does Riley Marsh work these days?");
+  assert.match(recallAlpha.text, /Riley Marsh/);
+  assert.ok(!recallAlpha.text.includes("Lux Bannister"));
+  assert.match(recallBeta.text, /Lux Bannister lives/);
+  assert.ok(!recallBeta.text.includes("Riley Marsh"));
+  // A context reset in one namespace cannot clear the other.
+  await engine.resetContext(other, sessionId);
+  assert.deepEqual(engine.contextSnapshot(scope, sessionId), ["alpha context line"]);
+  assert.deepEqual(engine.contextSnapshot(other, sessionId), []);
+});
+
+test("transition scoring uses the pinned epoch, never wall-clock time", async () => {
+  const engine = new DeterministicStagedMemory(STAGED_MEMORY_NAMESPACES);
+  const sessionId = "staged-transition-test";
+  await engine.store(scope, sessionId, ["Riley Marsh works at Norvig Dynamics."], 1);
+  await engine.store(scope, sessionId, ["Riley Marsh works at Halcyon Foundry."], 3);
+  await engine.correct(scope, { subject: "Riley Marsh", attribute: "employer", epoch: 3 });
+  const values = engine
+    .currentTuples(scope)
+    .filter((tuple) => tuple.subject === "Riley Marsh")
+    .map((tuple) => tuple.value);
+  assert.ok(values.includes("Halcyon Foundry"));
+  assert.ok(!values.includes("Norvig Dynamics"));
+});
+
+test("NA metrics are recorded with reasons and excluded from aggregates", async () => {
+  const result = await runStagedMemoryBenchmark(runOptions());
+  const stagedOptions = result.config.benchmarkOptions as Record<string, unknown>;
+  const naMetrics = stagedOptions.naMetrics as Record<string, { denominator: number; reason: string }>;
+  assert.ok(naMetrics["empty:construction_recall"], "empty-arm construction recall must be NA with a reason");
+  const armMeans = stagedOptions.armMeans as Record<string, Record<string, number | "NA">>;
+  assert.equal(armMeans.empty.construction_recall, "NA");
+  // NA values never contaminate numeric means.
+  assert.equal(typeof armMeans["staged-memory"].task_success, "number");
+  // NA metrics are excluded from bootstrap intervals.
+  const statistics = result.results.statistics;
+  assert.ok(statistics);
+  assert.ok(!Object.keys(statistics.confidenceIntervals).includes("staged-memory:construction_recall_empty"));
+});
+
+test("paired permutation and Holm fields are present and shaped", async () => {
+  const result = await runStagedMemoryBenchmark(runOptions());
+  const stagedOptions = result.config.benchmarkOptions as Record<string, unknown>;
+  const paired = stagedOptions.pairedPermutation as Record<string, { pValue: number; samples: number } | "NA">;
+  assert.equal(stagedOptions.permutationSamples, 10_000);
+  for (const key of [
+    "distractor_rejection:staged-vs-static",
+    "task_success:staged-vs-static",
+    "input_tokens:staged-vs-persist",
+  ]) {
+    const entry = paired[key];
+    assert.ok(entry !== undefined, `${key} must exist`);
+    if (entry !== "NA") {
+      assert.ok(entry.pValue > 0 && entry.pValue <= 1);
+      assert.equal(entry.samples, 10_000);
+    }
+  }
+  const holm = stagedOptions.holmCorrection as {
+    adjustedPValues: Record<string, number | "NA">;
+  };
+  for (const value of Object.values(holm.adjustedPValues)) {
+    if (value !== "NA") assert.ok(value > 0 && value <= 1);
+  }
+});
+
+test("replaying the same seed reproduces every statistic without hand edits", async () => {
+  const first = await runStagedMemoryBenchmark(runOptions());
+  const second = await runStagedMemoryBenchmark(runOptions());
+  assert.deepEqual(
+    first.config.benchmarkOptions,
+    second.config.benchmarkOptions,
+    "statistical payload must be identical across runs"
+  );
+  assert.deepEqual(
+    first.results.tasks.map((task) => [task.taskId, task.actual, task.scores]),
+    second.results.tasks.map((task) => [task.taskId, task.actual, task.scores]),
+    "task order, answers, and scores must be identical"
+  );
+  assert.deepEqual(first.results.aggregates, second.results.aggregates);
+  assert.deepEqual(first.results.statistics?.confidenceIntervals, second.results.statistics?.confidenceIntervals);
+});
+
+test("public projection omits questions, answers, recalled and gold text", async () => {
+  const result = await runStagedMemoryBenchmark(runOptions());
+  const projections = toStagedMemoryPublicResults(result);
+  assert.equal(projections.length, 5);
+  const serialized = JSON.stringify(projections);
+  for (const task of result.results.tasks) {
+    assert.ok(!serialized.includes(JSON.stringify(task.question)));
+    assert.ok(!serialized.includes(JSON.stringify(task.expected)));
+    assert.ok(!serialized.includes(JSON.stringify(task.actual)));
+  }
+  for (const projection of projections as StagedMemoryPublicResultV1[]) {
+    assert.equal(projection.schemaVersion, 1);
+    assert.equal(projection.benchmark, "staged-memory-synthetic-v1");
+    assert.match(projection.integrity.resultSha256, /^[0-9a-f]{64}$/);
+    assert.match(projection.fixtureHash, /^[0-9a-f]{64}$/);
+    assert.deepEqual(projection.seeds, result.meta.seeds);
+  }
+});
+
+test("controller modes beyond off are explicit refusals, not silent fallbacks", async () => {
+  await assert.rejects(
+    () => runStagedMemoryBenchmark(runOptions({ benchmarkOptions: { controllerMode: "shadow" } })),
+    /#2348/
+  );
+  await assert.rejects(
+    () => runStagedMemoryBenchmark(runOptions({ benchmarkOptions: { controllerMode: "active" } })),
+    /#2348/
+  );
+  await assert.rejects(
+    () => runStagedMemoryBenchmark(runOptions({ benchmarkOptions: { controllerMode: "sometimes" } })),
+    /controllerMode must be/
+  );
+});
+
+test("full mode without --dataset-dir is rejected", async () => {
+  await assert.rejects(() => runStagedMemoryBenchmark(runOptions({ mode: "full" })), /--dataset-dir/);
+});
+
+test("a full-mode run over a generated dataset-dir matches the quick run's staged metrics", async () => {
+  const out = await mkdtemp(path.join(tmpdir(), "staged-memory-dataset-"));
+  await generateStagedMemoryFixture({
+    driftDir: canonicalDriftDir,
+    seed: 11,
+    outDir: out,
+    casesPerUser: 6,
+    distractorCount: 3,
+  });
+  const full = await runStagedMemoryBenchmark(runOptions({ mode: "full", datasetDir: out }));
+  const stagedOptions = full.config.benchmarkOptions as Record<string, unknown>;
+  const armMeans = stagedOptions.armMeans as Record<string, Record<string, number | "NA">>;
+  assert.equal(armMeans["staged-memory"].construction_recall, 1);
+  assert.equal(armMeans["staged-memory"].scope_violation, 0);
+  assert.equal(full.meta.datasetHash, stagedOptions.fixtureHash);
+  assert.equal((stagedOptions.seeds as number[])[0], 11);
+  await rm(out, { recursive: true, force: true });
+});

--- a/packages/bench/src/benchmarks/remnic/staged-memory/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/runner.ts
@@ -131,34 +131,34 @@ export function estimateTokens(text: string): number {
  * ------------------------------------------------------------------------- */
 
 const CLAUSE_PATTERNS: readonly { attribute: string; pattern: RegExp }[] = [
-  { attribute: "employer", pattern: /^(.+?) works at (.+?)\.?$/ },
-  { attribute: "project", pattern: /^(.+?) is leading (.+?)\.?$/ },
-  { attribute: "hobby", pattern: /^(.+?) has gotten into (.+?)\.?$/ },
+  { attribute: "employer", pattern: /^(.{1,256}?) works at (.{1,256}?)\.?$/ },
+  { attribute: "project", pattern: /^(.{1,256}?) is leading (.{1,256}?)\.?$/ },
+  { attribute: "hobby", pattern: /^(.{1,256}?) has gotten into (.{1,256}?)\.?$/ },
   {
     attribute: "favorite-tool",
-    pattern: /^(.+?) relies on the (.+?) for daily planning\.?$/,
+    pattern: /^(.{1,256}?) relies on the (.{1,256}?) for daily planning\.?$/,
   },
-  { attribute: "pet", pattern: /^(.+?) has (.+?)\.?$/ },
-  { attribute: "role", pattern: /^(.+?) is an? (.+?)\.?$/ },
-  { attribute: "city", pattern: /^(.+?) lives in (.+?)\.?$/ },
+  { attribute: "pet", pattern: /^(.{1,256}?) has (.{1,256}?)\.?$/ },
+  { attribute: "role", pattern: /^(.{1,256}?) is an? (.{1,256}?)\.?$/ },
+  { attribute: "city", pattern: /^(.{1,256}?) lives in (.{1,256}?)\.?$/ },
 ];
 
 const QUESTION_PATTERNS: readonly { attribute: string; pattern: RegExp }[] = [
-  { attribute: "employer", pattern: /^Where does (.+?) work these days\?$/ },
-  { attribute: "role", pattern: /^What does (.+?) do for a living now\?$/ },
-  { attribute: "city", pattern: /^Which city is (.+?) living in currently\?$/ },
-  { attribute: "hobby", pattern: /^What pastime is (.+?) into at the moment\?$/ },
+  { attribute: "employer", pattern: /^Where does (.{1,256}?) work these days\?$/ },
+  { attribute: "role", pattern: /^What does (.{1,256}?) do for a living now\?$/ },
+  { attribute: "city", pattern: /^Which city is (.{1,256}?) living in currently\?$/ },
+  { attribute: "hobby", pattern: /^What pastime is (.{1,256}?) into at the moment\?$/ },
   {
     attribute: "pet",
-    pattern: /^What animal companion does (.+?) keep right now\?$/,
+    pattern: /^What animal companion does (.{1,256}?) keep right now\?$/,
   },
   {
     attribute: "favorite-tool",
-    pattern: /^Which planning app does (.+?) rely on at the moment\?$/,
+    pattern: /^Which planning app does (.{1,256}?) rely on at the moment\?$/,
   },
   {
     attribute: "project",
-    pattern: /^Which initiative is (.+?) leading right now\?$/,
+    pattern: /^Which initiative is (.{1,256}?) leading right now\?$/,
   },
 ];
 

--- a/packages/bench/src/benchmarks/remnic/staged-memory/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/runner.ts
@@ -1,0 +1,1024 @@
+/**
+ * Deterministic staged-memory benchmark runner (issue #2346,
+ * `staged-memory-synthetic-v1`).
+ *
+ * Proves the staged invariants offline on synthetic drift-gen material
+ * only: an early fact survives a context reset, distractors leave no
+ * residue after `resetContext`, a newer fact replaces an older fact, and
+ * user scope stays closed. The system under test is the hermetic
+ * deterministic engine below (same pattern as retention-aged-dataset): no
+ * orchestrator, no QMD, no network, no wall-clock inputs. Tokens are
+ * estimated (`ceil(chars / 4)`): cost diagnostics, never provider claims.
+ *
+ * Arms — identical fixture, seeds, task order, and token budgets:
+ *   empty            task query only; calibration floor.
+ *   persist-only     Stage 1 + Stage 3, no distractors; safety/cost pair.
+ *   static-context   distractors ride into Stage 3 (no reset); rejection pair.
+ *   staged-memory    the full three-stage path; gates apply to this arm.
+ *   oracle-retrieval fixture-selected gold evidence only; scorer
+ *                   calibration — never a system quality claim.
+ *
+ * Paired statistics report observational differences only; no
+ * counterfactual lift is claimed. Controller arms (baseline/shadow/active,
+ * issue #2348) are not implemented: the coordinator does not exist yet and
+ * #2348 depends on this issue. Requesting shadow/active fails loudly rather
+ * than silently degrading to baseline.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { aggregateTaskScores, exactMatch, f1Score } from "../../../scorer.js";
+import { createSeededRandom } from "../../../seeded-random.js";
+import { bootstrapMeanConfidenceInterval, pairedDeltaConfidenceInterval } from "../../../stats/bootstrap.js";
+import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../../types.js";
+import { buildStagedMemoryFixture, canonicalDriftDir, loadStagedMemoryFixture } from "./fixture.js";
+import {
+  type NaMetricEntry,
+  STAGED_MEMORY_PERMUTATION_SAMPLES,
+  STAGED_MEMORY_STATISTICS_SEED,
+  holmAdjust,
+  pairedPermutationTest,
+} from "./metrics.js";
+import {
+  STAGED_MEMORY_ARMS,
+  STAGED_MEMORY_BENCHMARK_ID,
+  STAGED_MEMORY_GENERATOR_VERSION,
+  STAGED_MEMORY_NAMESPACES,
+  STAGED_MEMORY_TRUSTED_PRINCIPAL,
+  type StagedMemoryArm,
+  type StagedMemoryCaseV1,
+  type StagedMemoryControllerMode,
+  type StagedMemoryFixtureManifestV1,
+  type StagedMemoryGoldFactV1,
+  type StagedMemoryPublicResultV1,
+} from "./schema.js";
+
+export const stagedMemorySyntheticV1Definition: BenchmarkDefinition = {
+  id: STAGED_MEMORY_BENCHMARK_ID,
+  title: "Staged Memory (Synthetic)",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: STAGED_MEMORY_BENCHMARK_ID,
+    version: STAGED_MEMORY_GENERATOR_VERSION,
+    description:
+      "Deterministic three-stage synthetic benchmark for persistence, context pressure, distractor rejection, supersession, and scope safety on drift-gen material (issue #2346).",
+    category: "retrieval",
+    citation: "Remnic synthetic benchmark for issue #2346; staged protocol after AgeMem v3",
+  },
+};
+
+/** Pinned context budget (chars) for every recall in every arm. */
+export const STAGED_MEMORY_CONTEXT_BUDGET_CHARS = 2000;
+/** Cost gate: staged input tokens per success may exceed persist-only by 10%. */
+const STAGED_COST_TOLERANCE = 0.1;
+
+interface Gate {
+  metric: string;
+  /** Staged-arm mean key (metrics record keys, not gate names). */
+  meanKey: string;
+  op: ">=" | "<=";
+  threshold: number;
+}
+
+const GATES: readonly Gate[] = Object.freeze([
+  { metric: "construction_recall", meanKey: "construction_recall", op: ">=", threshold: 0.9 },
+  { metric: "supersession_accuracy", meanKey: "supersession_accuracy", op: ">=", threshold: 0.95 },
+  { metric: "retrieval_recall_at_5", meanKey: "retrieval_recall_at_5", op: ">=", threshold: 0.9 },
+  { metric: "task_success", meanKey: "task_success", op: ">=", threshold: 0.85 },
+  { metric: "distractor_rejection", meanKey: "distractor_rejection", op: ">=", threshold: 0.95 },
+  { metric: "stale_answer_rate", meanKey: "stale_answer", op: "<=", threshold: 0.05 },
+  { metric: "context_reset_leakage_rate", meanKey: "context_reset_leakage", op: "<=", threshold: 0 },
+  { metric: "scope_violation_rate", meanKey: "scope_violation", op: "<=", threshold: 0 },
+]);
+
+const PRIMARY_PERMUTATION_PAIRS: readonly {
+  key: string;
+  candidateArm: StagedMemoryArm;
+  baselineArm: StagedMemoryArm;
+  metric: string;
+}[] = Object.freeze([
+  {
+    key: "distractor_rejection:staged-vs-static",
+    candidateArm: "staged-memory",
+    baselineArm: "static-context",
+    metric: "distractor_rejection",
+  },
+  {
+    key: "task_success:staged-vs-static",
+    candidateArm: "staged-memory",
+    baselineArm: "static-context",
+    metric: "task_success",
+  },
+  {
+    key: "input_tokens:staged-vs-persist",
+    candidateArm: "staged-memory",
+    baselineArm: "persist-only",
+    metric: "input_tokens",
+  },
+]);
+
+/** Deterministic token estimate: cost diagnostics only, never billed tokens. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/* ---------------------------------------------------------------------------
+ * Public-template inversion (drift-gen renders statements and questions
+ * through fixed ATTRIBUTE_SPECS templates; inverting those templates is
+ * public knowledge and carries no answer key).
+ * ------------------------------------------------------------------------- */
+
+const CLAUSE_PATTERNS: readonly { attribute: string; pattern: RegExp }[] = [
+  { attribute: "employer", pattern: /^(.+?) works at (.+?)\.?$/ },
+  { attribute: "project", pattern: /^(.+?) is leading (.+?)\.?$/ },
+  { attribute: "hobby", pattern: /^(.+?) has gotten into (.+?)\.?$/ },
+  {
+    attribute: "favorite-tool",
+    pattern: /^(.+?) relies on the (.+?) for daily planning\.?$/,
+  },
+  { attribute: "pet", pattern: /^(.+?) has (.+?)\.?$/ },
+  { attribute: "role", pattern: /^(.+?) is an? (.+?)\.?$/ },
+  { attribute: "city", pattern: /^(.+?) lives in (.+?)\.?$/ },
+];
+
+const QUESTION_PATTERNS: readonly { attribute: string; pattern: RegExp }[] = [
+  { attribute: "employer", pattern: /^Where does (.+?) work these days\?$/ },
+  { attribute: "role", pattern: /^What does (.+?) do for a living now\?$/ },
+  { attribute: "city", pattern: /^Which city is (.+?) living in currently\?$/ },
+  { attribute: "hobby", pattern: /^What pastime is (.+?) into at the moment\?$/ },
+  {
+    attribute: "pet",
+    pattern: /^What animal companion does (.+?) keep right now\?$/,
+  },
+  {
+    attribute: "favorite-tool",
+    pattern: /^Which planning app does (.+?) rely on at the moment\?$/,
+  },
+  {
+    attribute: "project",
+    pattern: /^Which initiative is (.+?) leading right now\?$/,
+  },
+];
+
+interface ParsedStatement {
+  subject: string;
+  attribute: string;
+  value: string;
+}
+
+function parseStatement(text: string): ParsedStatement | undefined {
+  for (const { attribute, pattern } of CLAUSE_PATTERNS) {
+    const match = pattern.exec(text);
+    if (match) {
+      return {
+        subject: match[1] as string,
+        attribute,
+        value: match[2] as string,
+      };
+    }
+  }
+  return undefined;
+}
+
+export function parseStagedQuestion(question: string): { subject: string; attribute: string } | undefined {
+  for (const { attribute, pattern } of QUESTION_PATTERNS) {
+    const match = pattern.exec(question);
+    if (match) {
+      return { subject: match[1] as string, attribute };
+    }
+  }
+  return undefined;
+}
+
+/** Strip a trailing plural "s" so "works" matches "work" (ranking only). */
+function stem(token: string): string {
+  return token.length > 3 && token.endsWith("s") ? token.slice(0, -1) : token;
+}
+
+function tokenize(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length > 0) tokens.add(stem(raw));
+  }
+  return tokens;
+}
+
+function overlapSize(left: ReadonlySet<string>, right: ReadonlySet<string>): number {
+  let size = 0;
+  for (const token of left) {
+    if (right.has(token)) size += 1;
+  }
+  return size;
+}
+
+/**
+ * Deterministic responder: inverts the public templates on the recalled text
+ * only. It never sees expected answers, gold rows, or the fixture. Absent or
+ * polluted evidence yields "unknown".
+ */
+export function respondStagedMemory(question: string, recalledText: string): string {
+  const parsed = parseStagedQuestion(question);
+  if (!parsed) return "unknown";
+  for (const line of recalledText.split("\n")) {
+    const statement = parseStatement(line.replace(/^-\s*/, ""));
+    if (statement && statement.subject === parsed.subject && statement.attribute === parsed.attribute) {
+      return statement.value;
+    }
+  }
+  return "unknown";
+}
+
+/* ---------------------------------------------------------------------------
+ * Deterministic scoped staged-memory engine (the system under test).
+ *
+ * Every method takes { trustedPrincipal, namespace }; missing, changed, or
+ * unallowlisted scope values throw. `appendContext` writes one session's
+ * active context only — never persistent tuples. `resetContext` clears that
+ * session's appended messages and never deletes tuples. `correct` scores
+ * with the caller-pinned epoch, never the system clock.
+ * ------------------------------------------------------------------------- */
+
+interface StagedScope {
+  trustedPrincipal: string;
+  namespace: string;
+}
+
+interface StagedTuple {
+  statement: string;
+  subject: string;
+  attribute: string;
+  value: string;
+  epoch: number;
+  current: boolean;
+}
+
+export interface StagedOperationWitness {
+  op: string;
+  ok: boolean;
+  count: number;
+  status: "recorded" | "unavailable";
+}
+
+export interface StagedRecallResult {
+  text: string;
+  requestedChars: number;
+  returnedChars: number;
+  truncated: boolean;
+}
+
+export class DeterministicStagedMemory {
+  private readonly tuplesByScope = new Map<string, StagedTuple[]>();
+  private readonly contextBySession = new Map<string, string[]>();
+  readonly witnesses: StagedOperationWitness[] = [];
+  readonly counts = {
+    store: 0,
+    appendContext: 0,
+    reset: 0,
+    resetContext: 0,
+    correct: 0,
+    recall: 0,
+    drain: 0,
+  };
+
+  constructor(private readonly allowedNamespaces: readonly string[]) {}
+
+  private requireScope(scope: StagedScope): string {
+    if (
+      !scope ||
+      scope.trustedPrincipal !== STAGED_MEMORY_TRUSTED_PRINCIPAL ||
+      !this.allowedNamespaces.includes(scope.namespace)
+    ) {
+      throw new Error("staged engine rejected scope: principal or namespace not allowlisted");
+    }
+    return `${scope.trustedPrincipal}|${scope.namespace}`;
+  }
+
+  /** Wipe one scope's persistent tuples and every session context. */
+  async reset(scope: StagedScope): Promise<void> {
+    const key = this.requireScope(scope);
+    this.tuplesByScope.delete(key);
+    for (const sessionKey of [...this.contextBySession.keys()]) {
+      if (sessionKey.startsWith(`${key}|`)) this.contextBySession.delete(sessionKey);
+    }
+    this.counts.reset += 1;
+    this.witnesses.push({ op: "reset", ok: true, count: 1, status: "recorded" });
+  }
+
+  /**
+   * Stage 1 ingestion: template-parseable statements in `messages` become
+   * persistent tuples under the scope's namespace. The engine never sees
+   * gold rows or IDs; construction is measured by parsing alone.
+   */
+  async store(scope: StagedScope, sessionId: string, messages: readonly string[], epoch: number): Promise<void> {
+    const key = this.requireScope(scope);
+    const tuples = this.tuplesByScope.get(key) ?? [];
+    let stored = 0;
+    for (const message of messages) {
+      const parsed = parseStatement(message);
+      if (!parsed) continue;
+      tuples.push({ ...parsed, statement: message, epoch, current: true });
+      stored += 1;
+    }
+    this.tuplesByScope.set(key, tuples);
+    this.counts.store += 1;
+    this.witnesses.push({
+      op: "store",
+      ok: true,
+      count: stored,
+      status: "recorded",
+    });
+    void sessionId;
+  }
+
+  async drain(): Promise<void> {
+    this.counts.drain += 1;
+    this.witnesses.push({ op: "drain", ok: true, count: 1, status: "recorded" });
+  }
+
+  /**
+   * Fixture-authorized supersession scored with the pinned transition epoch
+   * — never the system clock. Marks every strictly older tuple for the
+   * subject+attribute non-current; unrelated facts stay unchanged.
+   */
+  async correct(scope: StagedScope, transition: { subject: string; attribute: string; epoch: number }): Promise<void> {
+    const key = this.requireScope(scope);
+    let affected = 0;
+    for (const tuple of this.tuplesByScope.get(key) ?? []) {
+      if (
+        tuple.subject === transition.subject &&
+        tuple.attribute === transition.attribute &&
+        tuple.epoch < transition.epoch
+      ) {
+        tuple.current = false;
+        affected += 1;
+      }
+    }
+    this.counts.correct += 1;
+    this.witnesses.push({
+      op: "correct",
+      ok: true,
+      count: affected,
+      status: "recorded",
+    });
+  }
+
+  /** Stage 2: active-context writes for one session; tuples are untouched. */
+  async appendContext(scope: StagedScope, sessionId: string, messages: readonly string[]): Promise<void> {
+    const key = this.requireScope(scope);
+    const sessionKey = `${key}|${sessionId}`;
+    const lines = this.contextBySession.get(sessionKey) ?? [];
+    lines.push(...messages);
+    this.contextBySession.set(sessionKey, lines);
+    this.counts.appendContext += 1;
+    this.witnesses.push({
+      op: "appendContext",
+      ok: true,
+      count: messages.length,
+      status: "recorded",
+    });
+  }
+
+  /** Boundary reset: clears one session's appended messages, keeps tuples. */
+  async resetContext(scope: StagedScope, sessionId: string): Promise<void> {
+    const key = this.requireScope(scope);
+    this.contextBySession.set(`${key}|${sessionId}`, []);
+    this.counts.resetContext += 1;
+    this.witnesses.push({
+      op: "resetContext",
+      ok: true,
+      count: 1,
+      status: "recorded",
+    });
+  }
+
+  currentTuples(scope: StagedScope): StagedTuple[] {
+    return (this.tuplesByScope.get(this.requireScope(scope)) ?? []).filter((tuple) => tuple.current);
+  }
+
+  contextSnapshot(scope: StagedScope, sessionId: string): readonly string[] {
+    const key = this.requireScope(scope);
+    return [...(this.contextBySession.get(`${key}|${sessionId}`) ?? [])];
+  }
+
+  /**
+   * Namespace-filtered deterministic recall: current tuples plus the asked
+   * session's active-context lines, ranked by stemmed token overlap with the
+   * query. Ties break fresher-epoch-first, then statement order (total
+   * order, byte-stable across runs).
+   */
+  recall(
+    scope: StagedScope,
+    sessionId: string,
+    query: string,
+    budgetChars = STAGED_MEMORY_CONTEXT_BUDGET_CHARS
+  ): StagedRecallResult & { rankedStatements: string[] } {
+    this.requireScope(scope);
+    this.counts.recall += 1;
+    const queryTokens = tokenize(query);
+    const candidates: { line: string; epoch: number; order: number }[] = [];
+    let order = 0;
+    for (const tuple of this.currentTuples(scope)) {
+      candidates.push({ line: tuple.statement, epoch: tuple.epoch, order: order++ });
+    }
+    for (const line of this.contextSnapshot(scope, sessionId)) {
+      candidates.push({ line, epoch: -1, order: order++ });
+    }
+    const scored = candidates
+      .map((candidate) => ({
+        ...candidate,
+        score: overlapSize(tokenize(candidate.line), queryTokens),
+      }))
+      .sort((left, right) => right.score - left.score || right.epoch - left.epoch || left.order - right.order);
+    const lines: string[] = [];
+    let used = 0;
+    let truncated = false;
+    for (const candidate of scored) {
+      const rendered = `- ${candidate.line}`;
+      if (used + rendered.length + 1 > budgetChars) {
+        truncated = true;
+        break;
+      }
+      lines.push(rendered);
+      used += rendered.length + 1;
+    }
+    const text = lines.join("\n");
+    this.witnesses.push({
+      op: "recall",
+      ok: true,
+      count: lines.length,
+      status: "recorded",
+    });
+    return {
+      text,
+      requestedChars: budgetChars,
+      returnedChars: text.length,
+      truncated,
+      rankedStatements: scored.map((candidate) => candidate.line),
+    };
+  }
+
+  async statsAreZero(scope: StagedScope): Promise<boolean> {
+    const key = this.requireScope(scope);
+    const hasContext = [...this.contextBySession.keys()].some((sessionKey) => sessionKey.startsWith(`${key}|`));
+    return (this.tuplesByScope.get(key) ?? []).length === 0 && !hasContext;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Case execution.
+ * ------------------------------------------------------------------------- */
+
+interface CaseRun {
+  task: TaskResult;
+  metrics: Record<string, number | "NA">;
+}
+
+function goldIndex(fixtureCase: StagedMemoryCaseV1): Map<string, StagedMemoryGoldFactV1> {
+  return new Map(fixtureCase.exposure.goldFacts.map((gold) => [gold.factId, gold]));
+}
+
+async function runStagedCase(arm: StagedMemoryArm, fixtureCase: StagedMemoryCaseV1): Promise<CaseRun> {
+  const scope: StagedScope = {
+    trustedPrincipal: fixtureCase.scope.principal,
+    namespace: fixtureCase.namespace,
+  };
+  const gold = goldIndex(fixtureCase);
+  const engine = new DeterministicStagedMemory(STAGED_MEMORY_NAMESPACES);
+  const started = performance.now();
+  const metrics: Record<string, number | "NA"> = {};
+  const details: Record<string, unknown> = { arm };
+
+  // Invariant 1-3: fresh store, reset, assert zero stats.
+  await engine.reset(scope);
+  if (!(await engine.statsAreZero(scope))) {
+    throw new Error(`case ${fixtureCase.caseId}: store not empty after reset`);
+  }
+
+  const runsStage1 = arm !== "empty" && arm !== "oracle-retrieval";
+  if (runsStage1) {
+    // Invariants 4-6: exposure ingestion in manifest order (epoch groups,
+    // ascending), one drain after the stores complete.
+    const epochs = [...new Set(fixtureCase.exposure.goldFacts.map((row) => row.introducedEpoch))].sort(
+      (left, right) => left - right
+    );
+    for (const epoch of epochs) {
+      const messages = fixtureCase.exposure.goldFacts
+        .filter((row) => row.introducedEpoch === epoch)
+        .map((row) => row.statement);
+      await engine.store(scope, `${fixtureCase.exposure.sessionId}-e${epoch}`, messages, epoch);
+    }
+    await engine.drain();
+
+    // Construction recall: required current facts retrievable after Stage 1.
+    const currentPairs = new Set(engine.currentTuples(scope).map((tuple) => `${tuple.subject}|${tuple.attribute}`));
+    let requiredHit = 0;
+    for (const factId of fixtureCase.task.requiredFactIds) {
+      const row = gold.get(factId);
+      if (row && currentPairs.has(`${row.subject}|${row.attribute}`)) requiredHit += 1;
+    }
+    metrics.construction_recall = requiredHit / fixtureCase.task.requiredFactIds.length;
+
+    // Invariants 47-49: transitions through the authorized adapter, scored
+    // with the pinned epoch — never correction-planner wall-clock time.
+    let validTransitions = 0;
+    for (const transition of fixtureCase.transitions) {
+      const oldRow = gold.get(transition.oldFactId);
+      const newRow = gold.get(transition.newFactId);
+      if (!oldRow || !newRow) {
+        throw new Error(`case ${fixtureCase.caseId}: transition references unknown gold rows`);
+      }
+      await engine.correct(scope, {
+        subject: oldRow.subject,
+        attribute: oldRow.attribute,
+        epoch: transition.epoch,
+      });
+      const values = engine
+        .currentTuples(scope)
+        .filter((tuple) => tuple.subject === oldRow.subject && tuple.attribute === oldRow.attribute)
+        .map((tuple) => tuple.value);
+      if (values.includes(newRow.value) && !values.includes(oldRow.value)) {
+        validTransitions += 1;
+      }
+    }
+    metrics.supersession_accuracy =
+      fixtureCase.transitions.length === 0 ? "NA" : validTransitions / fixtureCase.transitions.length;
+
+    // Retrieval diagnostics: rank of the required statement among current
+    // tuples, before any distractor context exists.
+    const requiredRow = gold.get(fixtureCase.task.requiredFactIds[0] as string);
+    if (requiredRow) {
+      const ranked = engine.recall(scope, fixtureCase.exposure.sessionId, fixtureCase.task.question).rankedStatements;
+      const rank = ranked.indexOf(requiredRow.statement);
+      metrics.retrieval_recall_at_1 = rank === 0 ? 1 : 0;
+      metrics.retrieval_recall_at_5 = rank >= 0 && rank < 5 ? 1 : 0;
+      metrics.retrieval_mrr = rank >= 0 ? 1 / (rank + 1) : 0;
+    }
+  } else {
+    metrics.construction_recall = "NA";
+    metrics.supersession_accuracy = "NA";
+    metrics.retrieval_recall_at_1 = "NA";
+    metrics.retrieval_recall_at_5 = "NA";
+    metrics.retrieval_mrr = "NA";
+  }
+
+  // Invariants 43-46: both namespaces share one engine; a cross-namespace
+  // recall must return nothing from this case's namespace.
+  const otherNamespace = STAGED_MEMORY_NAMESPACES.find((namespace) => namespace !== fixtureCase.namespace) as string;
+  const crossRecall = engine.recall(
+    { trustedPrincipal: scope.trustedPrincipal, namespace: otherNamespace },
+    fixtureCase.exposure.sessionId,
+    fixtureCase.task.question
+  );
+  metrics.scope_violation = crossRecall.text.length > 0 ? 1 : 0;
+
+  const appliesDistractors = arm === "static-context" || arm === "staged-memory";
+  const stage2Session = fixtureCase.distractors[0]?.sessionId ?? `${fixtureCase.exposure.sessionId}-stage2`;
+  const recallSession = appliesDistractors ? stage2Session : fixtureCase.exposure.sessionId;
+
+  if (appliesDistractors) {
+    // Invariant 9-13 + 21-22: reset -> append at the Stage 1/2 boundary,
+    // same principal and namespace on every call, Stage 1 facts stay put.
+    await engine.resetContext(scope, stage2Session);
+    const survivedAfterBoundary = requiredStatementsIn(engine, scope, fixtureCase, gold);
+    metrics.persistent_survival = survivedAfterBoundary ? 1 : 0;
+
+    // Stage 2: exactly the registered distractors, never answer text.
+    await engine.appendContext(
+      scope,
+      stage2Session,
+      fixtureCase.distractors.map((distractor) => distractor.text)
+    );
+    details.distractorPresenceDuringStage2 = fixtureCase.distractors.filter((distractor) =>
+      engine.contextSnapshot(scope, stage2Session).includes(distractor.text)
+    ).length;
+
+    if (arm === "staged-memory") {
+      // Invariants 37-38: resetContext before the task query.
+      await engine.resetContext(scope, stage2Session);
+    }
+  } else if (arm === "persist-only") {
+    metrics.persistent_survival = requiredStatementsIn(engine, scope, fixtureCase, gold) ? 1 : 0;
+  } else {
+    metrics.persistent_survival = "NA";
+  }
+
+  // Stage 3: one recall + deterministic responder. The oracle arm recalls
+  // only fixture-selected gold statements (scorer calibration, not a
+  // quality claim).
+  const stage3 = engine.recall(scope, recallSession, fixtureCase.task.question);
+  const recallText =
+    arm === "oracle-retrieval"
+      ? fixtureCase.task.requiredFactIds
+          .map((factId) => gold.get(factId)?.statement ?? "")
+          .filter((statement) => statement.length > 0)
+          .map((statement) => `- ${statement}`)
+          .join("\n")
+      : stage3.text;
+  metrics.context_budget_utilization = recallText.length / STAGED_MEMORY_CONTEXT_BUDGET_CHARS;
+  metrics.context_truncated = arm === "oracle-retrieval" ? 0 : stage3.truncated ? 1 : 0;
+
+  if (appliesDistractors) {
+    const residue = countPresent(recallText, fixtureCase);
+    metrics.distractor_rejection = residue === 0 ? 1 : 0;
+    metrics.context_reset_leakage = arm === "staged-memory" ? (residue > 0 ? 1 : 0) : "NA";
+    if (arm === "staged-memory") {
+      // Invariant 64: required facts still present after both resets.
+      const requiredRow = gold.get(fixtureCase.task.requiredFactIds[0] as string);
+      const survived = requiredRow ? recallText.includes(requiredRow.statement) : false;
+      metrics.persistent_survival = metrics.persistent_survival === 1 && survived ? 1 : 0;
+    }
+  } else {
+    metrics.distractor_rejection = "NA";
+    metrics.context_reset_leakage = "NA";
+  }
+
+  const answer = respondStagedMemory(fixtureCase.task.question, recallText);
+  metrics.task_success = exactMatch(answer, fixtureCase.task.expectedAnswer) ? 1 : 0;
+  metrics.task_f1 = f1Score(answer, fixtureCase.task.expectedAnswer);
+  const supersededValues = fixtureCase.task.forbiddenFactIds
+    .map((factId) => gold.get(factId)?.value ?? "")
+    .filter((value) => value.length > 0);
+  metrics.stale_answer = fixtureCase.transitions.length > 0 && supersededValues.includes(answer) ? 1 : 0;
+  metrics.input_tokens = estimateTokens(`${fixtureCase.task.question}\n${recallText}`);
+  metrics.output_tokens = estimateTokens(answer);
+
+  details.operationCounts = { ...engine.counts };
+  details.distractorCounts = fixtureCase.distractors.length;
+  details.witnessStatuses = [...new Set(engine.witnesses.map((w) => w.status))];
+  if (engine.witnesses.some((witness) => witness.status === "unavailable")) {
+    throw new Error(`case ${fixtureCase.caseId}: a staged witness is unavailable`);
+  }
+
+  const task: TaskResult = {
+    taskId: `${fixtureCase.caseId}::${arm}`,
+    question: fixtureCase.task.question,
+    expected: fixtureCase.task.expectedAnswer,
+    actual: answer,
+    scores: numericScores(metrics),
+    latencyMs: Math.round(performance.now() - started),
+    tokens: {
+      input: metrics.input_tokens as number,
+      output: metrics.output_tokens as number,
+    },
+    details,
+  };
+  return { task, metrics };
+}
+
+function requiredStatementsIn(
+  engine: DeterministicStagedMemory,
+  scope: StagedScope,
+  fixtureCase: StagedMemoryCaseV1,
+  gold: Map<string, StagedMemoryGoldFactV1>
+): boolean {
+  const currentPairs = new Set(engine.currentTuples(scope).map((tuple) => `${tuple.subject}|${tuple.attribute}`));
+  return fixtureCase.task.requiredFactIds.every((factId) => {
+    const row = gold.get(factId);
+    return row !== undefined && currentPairs.has(`${row.subject}|${row.attribute}`);
+  });
+}
+
+function countPresent(text: string, fixtureCase: StagedMemoryCaseV1): number {
+  return fixtureCase.distractors.filter((distractor) => text.includes(distractor.text)).length;
+}
+
+function numericScores(metrics: Record<string, number | "NA">): Record<string, number> {
+  const scores: Record<string, number> = {};
+  for (const [key, value] of Object.entries(metrics)) {
+    if (typeof value === "number" && Number.isFinite(value)) scores[key] = value;
+  }
+  return scores;
+}
+
+/* ---------------------------------------------------------------------------
+ * Run assembly: arms, aggregates, NA accounting, paired statistics, gates.
+ * ------------------------------------------------------------------------- */
+
+interface ArmSummary {
+  arm: StagedMemoryArm;
+  means: Record<string, number | "NA">;
+  naMetrics: Record<string, NaMetricEntry>;
+}
+
+function summarizeArm(arm: StagedMemoryArm, runs: readonly CaseRun[]): ArmSummary {
+  const means: Record<string, number | "NA"> = {};
+  const naMetrics: Record<string, NaMetricEntry> = {};
+  const metricNames = new Set(runs.flatMap((run) => Object.keys(run.metrics)));
+  for (const metric of metricNames) {
+    const values = runs.map((run) => run.metrics[metric]).filter((value): value is number => typeof value === "number");
+    if (values.length === 0) {
+      means[metric] = "NA";
+      naMetrics[metric] = {
+        denominator: 0,
+        reason: `no ${arm} case produced a denominator for ${metric}`,
+      };
+      continue;
+    }
+    means[metric] = values.reduce((sum, value) => sum + value, 0) / values.length;
+    const naCount = runs.length - values.length;
+    if (naCount > 0) {
+      naMetrics[metric] = {
+        denominator: values.length,
+        reason: `${naCount} of ${runs.length} ${arm} cases are NA for ${metric}`,
+      };
+    }
+  }
+  return { arm, means, naMetrics };
+}
+
+function tokensPerSuccess(summary: ArmSummary): number | "NA" {
+  const { task_success: success, input_tokens: inputTokens } = summary.means;
+  if (success === "NA" || inputTokens === "NA" || success === 0) return "NA";
+  return inputTokens / success;
+}
+
+function normalizeControllerMode(value: unknown): StagedMemoryControllerMode {
+  if (value === undefined || value === null) return "off";
+  if (value === "off" || value === "shadow" || value === "active") return value;
+  throw new Error('controllerMode must be "off", "shadow", or "active"; rejecting invalid input');
+}
+
+export async function runStagedMemoryBenchmark(options: ResolvedRunBenchmarkOptions): Promise<BenchmarkResult> {
+  const benchmarkOptions = (options.benchmarkOptions ?? {}) as Record<string, unknown>;
+  const requestedMode = normalizeControllerMode(benchmarkOptions.controllerMode);
+  if (requestedMode !== "off") {
+    throw new Error(
+      `staged-memory-synthetic-v1 does not implement controller mode "${requestedMode}" yet: the coordinator lands with issue #2348, which depends on this benchmark`
+    );
+  }
+
+  let manifest: StagedMemoryFixtureManifestV1;
+  let fixtureHash: string;
+  let cases: StagedMemoryCaseV1[];
+  if (options.datasetDir) {
+    // Full protocol: only a validated, hash-verified fixture on disk.
+    const loaded = await loadStagedMemoryFixture(options.datasetDir);
+    manifest = loaded.manifest;
+    fixtureHash = loaded.fixtureHash;
+    cases = loaded.cases;
+  } else {
+    if (options.mode === "full") {
+      throw new Error("staged-memory-synthetic-v1 full mode requires --dataset-dir; generate a fixture first");
+    }
+    // Quick mode: the committed synthetic smoke corpus only — never a real
+    // dataset and never a caller-owned store.
+    const built = await buildStagedMemoryFixture({
+      driftDir: canonicalDriftDir(),
+      seed: typeof options.seed === "number" ? options.seed : 11,
+      casesPerUser: options.limit && options.limit > 0 ? options.limit : 6,
+      distractorCount: 3,
+    });
+    manifest = built.manifest;
+    cases = built.cases;
+    fixtureHash = createHash("sha256")
+      .update(cases.map((row) => JSON.stringify(row)).join("\n"))
+      .digest("hex");
+  }
+  if (options.limit && options.limit > 0) {
+    cases = cases.slice(0, options.limit);
+  }
+
+  const runsByArm = new Map<StagedMemoryArm, CaseRun[]>();
+  for (const arm of STAGED_MEMORY_ARMS) runsByArm.set(arm, []);
+  const tasks: TaskResult[] = [];
+  const totalTasks = cases.length * STAGED_MEMORY_ARMS.length;
+  for (const fixtureCase of cases) {
+    for (const arm of STAGED_MEMORY_ARMS) {
+      const run = await runStagedCase(arm, fixtureCase);
+      (runsByArm.get(arm) as CaseRun[]).push(run);
+      tasks.push(run.task);
+      options.onTaskComplete?.(run.task, tasks.length, totalTasks);
+    }
+  }
+
+  const summaries: Record<string, ArmSummary> = {};
+  const naMetrics: Record<string, NaMetricEntry> = {};
+  for (const arm of STAGED_MEMORY_ARMS) {
+    const summary = summarizeArm(arm, runsByArm.get(arm) ?? []);
+    summaries[arm] = summary;
+    for (const [metric, entry] of Object.entries(summary.naMetrics)) {
+      naMetrics[`${arm}:${metric}`] = entry;
+    }
+  }
+  const staged = summaries["staged-memory"] as ArmSummary;
+
+  // Paired permutation + bootstrap, paired by case ID. NA pairs are excluded
+  // pairwise; p-values are descriptive evidence, never significance claims.
+  const pairedPermutation: Record<
+    string,
+    { pValue: number; samples: number } | "NA"
+  > = {};
+  const bootstrapIntervals: Record<
+    string,
+    { lower: number; upper: number; level: number }
+  > = {};
+  let pairedSeedCounter = 0;
+  for (const pairing of PRIMARY_PERMUTATION_PAIRS) {
+    const candidateRuns = runsByArm.get(pairing.candidateArm) ?? [];
+    const baselineRuns = runsByArm.get(pairing.baselineArm) ?? [];
+    const baselineByCase = new Map(baselineRuns.map((run) => [caseIdOf(run), run.metrics[pairing.metric]]));
+    const differences: number[] = [];
+    for (const candidate of candidateRuns) {
+      const candidateValue = candidate.metrics[pairing.metric];
+      const baselineValue = baselineByCase.get(caseIdOf(candidate));
+      if (typeof candidateValue === "number" && typeof baselineValue === "number") {
+        differences.push(candidateValue - baselineValue);
+      }
+    }
+    if (differences.length === 0) {
+      pairedPermutation[pairing.key] = "NA";
+      continue;
+    }
+    pairedPermutation[pairing.key] = pairedPermutationTest(differences, {
+      samples: STAGED_MEMORY_PERMUTATION_SAMPLES,
+      seed: STAGED_MEMORY_STATISTICS_SEED,
+    });
+    bootstrapIntervals[pairing.key] = pairedDeltaConfidenceInterval(
+      differences,
+      differences.map(() => 0),
+      {
+        random: createSeededRandom(
+          (STAGED_MEMORY_STATISTICS_SEED + pairedSeedCounter++) >>> 0,
+        ),
+      },
+    );
+  }
+
+  const holmInput = new Map<string, number | "NA">();
+  for (const [key, value] of Object.entries(pairedPermutation)) {
+    holmInput.set(key, value === "NA" ? "NA" : value.pValue);
+  }
+  const primaryKeys = PRIMARY_PERMUTATION_PAIRS.map((pairing) => pairing.key);
+  const holm = holmAdjust(holmInput, primaryKeys);
+
+  // Deterministic gates on the staged arm plus the staged-vs-persist-only
+  // cost gate. A failed gate fails the run loudly; nothing is hidden.
+  const gateResults: Record<string, boolean> = {};
+  for (const gate of GATES) {
+    const value = staged.means[gate.meanKey];
+    gateResults[gate.metric] =
+      value === "NA" ? false : gate.op === ">=" ? value >= gate.threshold : value <= gate.threshold;
+  }
+  const stagedCost = tokensPerSuccess(staged);
+  const persistCost = tokensPerSuccess(summaries["persist-only"] as ArmSummary);
+  const costGate =
+    stagedCost === "NA" || persistCost === "NA"
+      ? true // NA cost is reported in naMetrics; it never silently blocks.
+      : stagedCost <= persistCost * (1 + STAGED_COST_TOLERANCE);
+  gateResults.staged_input_tokens_per_success_within_10pct_of_persist_only = costGate;
+  const failedGates = Object.entries(gateResults)
+    .filter(([, pass]) => !pass)
+    .map(([metric]) => metric);
+
+  const stagedOptions: Record<string, unknown> = {
+    schemaVersion: 1,
+    benchmark: STAGED_MEMORY_BENCHMARK_ID,
+    fixtureHash,
+    arms: [...STAGED_MEMORY_ARMS],
+    seeds: manifest.seeds,
+    statisticsSeed: STAGED_MEMORY_STATISTICS_SEED,
+    permutationSamples: STAGED_MEMORY_PERMUTATION_SAMPLES,
+    contextBudgetChars: STAGED_MEMORY_CONTEXT_BUDGET_CHARS,
+    controllerMode: "off",
+    requestedControllerMode: requestedMode,
+    shadowForced: false,
+    primaryPermutationMetrics: primaryKeys,
+    pairedPermutation,
+    bootstrapIntervals,
+    holmCorrection: holm,
+    naMetrics,
+    armMeans: Object.fromEntries(Object.entries(summaries).map(([arm, summary]) => [arm, summary.means])),
+    gates: gateResults,
+    note: "observational paired differences only; no counterfactual lift claim; oracle arm is scorer calibration",
+  };
+
+  const confidenceIntervals: Record<string, { lower: number; upper: number; level: number }> = {};
+  let ciSeedCounter = 0;
+  for (const [metric, value] of Object.entries(staged.means)) {
+    if (value === "NA") continue;
+    const values = (runsByArm.get("staged-memory") ?? [])
+      .map((run) => run.metrics[metric])
+      .filter((candidate): candidate is number => typeof candidate === "number");
+    if (values.length > 0) {
+      // Seeded per metric so replayed runs reproduce identical intervals
+      // (Math.random would break the determinism gate).
+      confidenceIntervals[`staged-memory:${metric}`] = bootstrapMeanConfidenceInterval(values, {
+        random: createSeededRandom((STAGED_MEMORY_STATISTICS_SEED + ciSeedCounter++) >>> 0),
+      });
+    }
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const result: BenchmarkResult = {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: manifest.seeds,
+      datasetHash: fixtureHash,
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "synthetic",
+      remnicConfig: options.remnicConfig ?? {},
+      benchmarkOptions: stagedOptions,
+    },
+    cost: {
+      totalTokens: tasks.reduce((sum, task) => sum + task.tokens.input + task.tokens.output, 0),
+      inputTokens: tasks.reduce((sum, task) => sum + task.tokens.input, 0),
+      outputTokens: tasks.reduce((sum, task) => sum + task.tokens.output, 0),
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+      categoryAggregates: Object.fromEntries(
+        STAGED_MEMORY_ARMS.map((arm) => {
+          const armTasks = (runsByArm.get(arm) ?? []).map((run) => run.task.scores);
+          return [arm, aggregateTaskScores(armTasks)];
+        })
+      ),
+      statistics: {
+        confidenceIntervals,
+        bootstrapSamples: 10_000,
+        effectSizes: {},
+      },
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+
+  if (failedGates.length > 0) {
+    throw new Error(`staged-memory-synthetic-v1 gates failed: ${failedGates.join(", ")}`, {
+      cause: result,
+    });
+  }
+  return result;
+}
+
+function caseIdOf(run: CaseRun): string {
+  return run.task.taskId.split("::")[0] as string;
+}
+
+/**
+ * Sanitized public projection per arm. IDs, counts, hashes, metrics, seeds,
+ * and statuses only — question, expected, actual, recalled, gold, and
+ * distractor text never cross this boundary.
+ */
+export function toStagedMemoryPublicResults(result: BenchmarkResult): StagedMemoryPublicResultV1[] {
+  const stagedOptions = (result.config.benchmarkOptions ?? {}) as Record<string, unknown>;
+  const armMeans = (stagedOptions.armMeans ?? {}) as Record<string, Record<string, number | "NA">>;
+  const naMetrics = (stagedOptions.naMetrics ?? {}) as Record<string, NaMetricEntry>;
+  const paired = (stagedOptions.pairedPermutation ?? {}) as StagedMemoryPublicResultV1["pairedPermutation"];
+  const holm = (stagedOptions.holmCorrection ?? {}) as StagedMemoryPublicResultV1["holmCorrection"];
+  const stagedMeans = armMeans["staged-memory"] ?? {};
+  const receiptMetrics: Record<string, number | "NA"> = {
+    persistent_survival_rate: stagedMeans.persistent_survival ?? "NA",
+    scope_violation_rate: stagedMeans.scope_violation ?? "NA",
+    context_reset_leakage_rate: stagedMeans.context_reset_leakage ?? "NA",
+  };
+  return Object.keys(armMeans).map((arm) => {
+    const projection: Omit<StagedMemoryPublicResultV1, "integrity"> = {
+      schemaVersion: 1,
+      benchmark: STAGED_MEMORY_BENCHMARK_ID,
+      runId: result.meta.id,
+      fixtureHash: String(stagedOptions.fixtureHash ?? ""),
+      arm,
+      controllerMode: "off",
+      requestedControllerMode: (stagedOptions.requestedControllerMode ?? "off") as StagedMemoryControllerMode,
+      coordinatorVersion: "none",
+      promotionReportHash: "none",
+      shadowForced: false,
+      receiptMetrics,
+      executorCounts: {},
+      seeds: result.meta.seeds,
+      metrics: armMeans[arm] ?? {},
+      naMetrics,
+      pairedPermutation: paired,
+      holmCorrection: holm,
+    };
+    const resultSha256 = createHash("sha256").update(JSON.stringify(projection)).digest("hex");
+    return {
+      ...projection,
+      integrity: {
+        manifestSha256: String(stagedOptions.fixtureHash ?? ""),
+        resultSha256,
+      },
+    };
+  });
+}

--- a/packages/bench/src/benchmarks/remnic/staged-memory/schema.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/schema.ts
@@ -201,10 +201,12 @@ export function assertSafeSourceManifestName(value: string): void {
   if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value)) {
     throw new Error("source.manifestName must be repo-relative, not absolute");
   }
-  if (value.split(/[/\\]/).includes("..")) {
+  const segments = value.split(/[/\\]/);
+  if (segments.includes("..")) {
     throw new Error("source.manifestName must not contain '..' segments");
   }
-  if (/(?:^|[/\\])(?:home|Users)[/\\][^/\\]+/.test(value)) {
+  const homeIdx = segments.findIndex((s) => s === "home" || s === "Users");
+  if (homeIdx >= 0 && homeIdx + 1 < segments.length && segments[homeIdx + 1] !== "") {
     throw new Error("source.manifestName must not be a home-directory path");
   }
 }

--- a/packages/bench/src/benchmarks/remnic/staged-memory/schema.ts
+++ b/packages/bench/src/benchmarks/remnic/staged-memory/schema.ts
@@ -1,0 +1,210 @@
+/**
+ * Strict versioned schemas for the staged-memory synthetic benchmark
+ * (issue #2346).
+ *
+ * Every fixture file is validated against these zod `.strict()` schemas:
+ * unknown fields are rejected, never silently defaulted. Public artifacts
+ * carry only the `StagedMemoryPublicResultV1` projection — no question,
+ * answer, recalled, gold, distractor, path, or host text leaves a run.
+ */
+
+import { z } from "zod";
+
+export const STAGED_MEMORY_BENCHMARK_ID = "staged-memory-synthetic-v1";
+export const STAGED_MEMORY_FIXTURE_NAME = "staged-memory-synthetic";
+export const STAGED_MEMORY_SCHEMA_VERSION = 1;
+export const STAGED_MEMORY_GENERATOR_VERSION = "1.0.0";
+/** Fixed sentinel (dataset convention 4: no wall-clock timestamps in files). */
+export const STAGED_MEMORY_CREATED_AT = "1970-01-01T00:00:00.000Z";
+
+/**
+ * Synthetic namespace allowlist. At least two distinct values; every case
+ * binds to exactly one, and namespace filters stay enabled for every scoped
+ * call. Both namespaces share one store during a run.
+ */
+export const STAGED_MEMORY_NAMESPACES = Object.freeze(["bench-staged-alpha", "bench-staged-beta"] as const);
+
+export const STAGED_MEMORY_TRUSTED_PRINCIPAL = "bench-staged-principal";
+
+/** Diagnostic baseline arms. Controller arms arrive with the #2348 coordinator. */
+export const STAGED_MEMORY_ARMS = Object.freeze([
+  "empty",
+  "persist-only",
+  "static-context",
+  "staged-memory",
+  "oracle-retrieval",
+] as const);
+
+export type StagedMemoryArm = (typeof STAGED_MEMORY_ARMS)[number];
+
+export type StagedMemoryControllerMode = "off" | "shadow" | "active";
+
+const hex64 = z.string().regex(/^[0-9a-f]{64}$/, "expected a sha256 hex digest");
+const nonEmpty = z.string().min(1);
+const positiveEpoch = z.number().int().positive();
+
+export const StagedMemoryFixtureManifestV1Schema = z
+  .object({
+    schemaVersion: z.literal(1),
+    name: z.literal("staged-memory-synthetic"),
+    version: nonEmpty,
+    generatorVersion: nonEmpty,
+    seeds: z.array(z.number().int().nonnegative()).min(1),
+    source: z
+      .object({
+        kind: z.literal("drift-gen"),
+        manifestName: nonEmpty,
+        manifestSha256: hex64,
+      })
+      .strict(),
+    counts: z
+      .object({
+        users: z.number().int().nonnegative(),
+        cases: z.number().int().nonnegative(),
+        distractors: z.number().int().nonnegative(),
+      })
+      .strict(),
+    files: z.record(hex64),
+    createdAt: z.literal("1970-01-01T00:00:00.000Z"),
+    licenses: z.array(z.object({ source: nonEmpty, license: nonEmpty }).strict()).min(1),
+    namespaces: z.array(nonEmpty).min(2),
+  })
+  .strict();
+
+export type StagedMemoryFixtureManifestV1 = z.infer<typeof StagedMemoryFixtureManifestV1Schema>;
+
+export const StagedMemoryDistractorV1Schema = z
+  .object({
+    id: nonEmpty,
+    sessionId: nonEmpty,
+    text: nonEmpty,
+    forbiddenFactIds: z.array(nonEmpty).min(1),
+    templateId: nonEmpty,
+  })
+  .strict();
+
+/**
+ * Drift-gen gold row projected into the fixture by stable fact ID: every
+ * fact introduced inside the exposure window, active or superseded. These
+ * stay runner-side; the memory engine and responder only ever see rendered
+ * statement text.
+ */
+export const StagedMemoryGoldFactV1Schema = z
+  .object({
+    factId: nonEmpty,
+    subject: nonEmpty,
+    attribute: nonEmpty,
+    value: nonEmpty,
+    statement: nonEmpty,
+    introducedEpoch: positiveEpoch,
+  })
+  .strict();
+
+export type StagedMemoryGoldFactV1 = z.infer<typeof StagedMemoryGoldFactV1Schema>;
+
+export const StagedMemoryCaseV1Schema = z
+  .object({
+    schemaVersion: z.literal(1),
+    caseId: nonEmpty,
+    userId: nonEmpty,
+    namespace: nonEmpty,
+    seed: z.number().int().nonnegative(),
+    exposure: z
+      .object({
+        sessionId: nonEmpty,
+        sourceSessionRefs: z.array(nonEmpty).min(1),
+        /** Current (non-superseded) fact IDs at the exposure epoch. */
+        salientFactIds: z.array(nonEmpty).min(1),
+        goldFacts: z.array(StagedMemoryGoldFactV1Schema).min(1),
+        /** Statements of `goldFacts`, in the same order. */
+        goldMemories: z.array(nonEmpty).min(1),
+        exposureEpoch: positiveEpoch,
+        /** Pinned effective timestamp for transition scoring; never wall clock. */
+        effectiveTimestamp: nonEmpty,
+      })
+      .strict(),
+    transitions: z.array(
+      z
+        .object({
+          oldFactId: nonEmpty,
+          newFactId: nonEmpty,
+          epoch: positiveEpoch,
+          kind: z.enum(["drifting", "contradicted"]),
+        })
+        .strict()
+    ),
+    distractors: z.array(StagedMemoryDistractorV1Schema),
+    task: z
+      .object({
+        question: nonEmpty,
+        expectedAnswer: nonEmpty,
+        requiredFactIds: z.array(nonEmpty).min(1),
+        forbiddenFactIds: z.array(nonEmpty),
+        answerFormat: z.literal("exact"),
+      })
+      .strict(),
+    scope: z
+      .object({
+        principal: nonEmpty,
+        allowedUserId: nonEmpty,
+        allowedNamespace: nonEmpty,
+      })
+      .strict(),
+  })
+  .strict();
+
+export type StagedMemoryCaseV1 = z.infer<typeof StagedMemoryCaseV1Schema>;
+export type StagedMemoryDistractorV1 = z.infer<typeof StagedMemoryDistractorV1Schema>;
+
+/**
+ * Public export projection. IDs, counts, hashes, metrics, arms, seeds, and
+ * statuses only — `toStagedMemoryPublicResults()` is the only sanctioned
+ * serializer for public artifacts.
+ */
+export interface StagedMemoryPublicResultV1 {
+  schemaVersion: 1;
+  benchmark: typeof STAGED_MEMORY_BENCHMARK_ID;
+  runId: string;
+  fixtureHash: string;
+  arm: string;
+  controllerMode: StagedMemoryControllerMode;
+  requestedControllerMode: StagedMemoryControllerMode;
+  coordinatorVersion: string;
+  promotionReportHash: string;
+  shadowForced: boolean;
+  receiptMetrics: Record<string, number | "NA">;
+  executorCounts: Record<string, number>;
+  seeds: number[];
+  metrics: Record<string, number | "NA">;
+  naMetrics: Record<string, { denominator: number; reason: string }>;
+  pairedPermutation: Record<string, { pValue: number; samples: number } | "NA">;
+  holmCorrection: {
+    adjustedPValues: Record<string, number | "NA">;
+    primaryMetrics: string[];
+  };
+  integrity: {
+    manifestSha256: string;
+    resultSha256: string;
+  };
+}
+
+/**
+ * Source manifest names must be repo-relative logical names. Absolute paths,
+ * `..` segments, and home-directory shapes are rejected before any manifest
+ * or result serialization (issue #2346, public-repo privacy rules). The
+ * offending value is never echoed: it may contain an operator path.
+ */
+export function assertSafeSourceManifestName(value: string): void {
+  if (value.length === 0) {
+    throw new Error("source.manifestName must not be empty");
+  }
+  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value)) {
+    throw new Error("source.manifestName must be repo-relative, not absolute");
+  }
+  if (value.split(/[/\\]/).includes("..")) {
+    throw new Error("source.manifestName must not contain '..' segments");
+  }
+  if (/(?:^|[/\\])(?:home|Users)[/\\][^/\\]+/.test(value)) {
+    throw new Error("source.manifestName must not be a home-directory path");
+  }
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -143,6 +143,10 @@ import {
   boundedMemoryContractsDefinition,
   runBoundedMemoryContractsBenchmark,
 } from "./benchmarks/remnic/bounded-memory-contracts/runner.js";
+import {
+  stagedMemorySyntheticV1Definition,
+  runStagedMemoryBenchmark,
+} from "./benchmarks/remnic/staged-memory/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -288,6 +292,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...boundedMemoryContractsDefinition,
     run: runBoundedMemoryContractsBenchmark,
+  },
+  {
+    ...stagedMemorySyntheticV1Definition,
+    run: runStagedMemoryBenchmark,
   },
 ];
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -47,6 +47,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "retention-aged-dataset",
       "memcorrect-v1",
       "bounded-memory-contracts",
+      "staged-memory-synthetic-v1",
     ],
   );
   assert.deepEqual(
@@ -87,11 +88,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset,memcorrect-v1,bounded-memory-contracts",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset,memcorrect-v1,bounded-memory-contracts,staged-memory-synthetic-v1",
   );
   // The synthetic ingestion adapter wires all built-in ingestion benchmarks.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, true);


### PR DESCRIPTION
Fixes #2346.

## Change

Deterministic staged-memory benchmark under packages/bench.

## Regression

fixture.test.ts and runner.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic staged-memory benchmark covering persistence, context, staged-memory, and oracle-retrieval scenarios.
  * Added fixture generation, validation, loading, and command-line workflows with integrity and safety checks.
  * Added reproducible statistical metrics, ratio handling, significance adjustments, and bootstrap intervals.
  * Added sanitized public results with hashes, metrics, statuses, and integrity information.
  * Registered the benchmark in the benchmark suite.

* **Tests**
  * Added comprehensive coverage for fixture integrity, isolation, reproducibility, scope enforcement, metrics, and execution gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->