### PR TITLE
chore(ci): harden gates this batch actually hit

### DIFF
--- a/.changeset/ci-this-run-6.md
+++ b/.changeset/ci-this-run-6.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Harden gates this batch actually hit: integer-safe review-pattern counts, parsed-keys snapshot in the contract check, and a rebase hint on file-size ratchet failures.

--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -746,7 +746,8 @@ function main() {
         if (inScope(file)) {
           failures.push(
             `${file} grew from its grandfathered ceiling ${ceiling} to ${lines} lines (issue #1995). ` +
-              "Extract the addition into a sibling module, or shrink the file elsewhere by at least the addition.",
+              "Extract the addition into a sibling module, or shrink the file elsewhere by at least the addition. " +
+              "If this is a merge with main, rebase first — CI measures the merge commit, not the branch tip.",
           );
         }
       } else if (lines < ceiling) {

--- a/scripts/check-review-patterns.sh
+++ b/scripts/check-review-patterns.sh
@@ -761,10 +761,12 @@ if [[ -n "$ALLOW_LISTS" ]]; then
     if [[ -n "$VAR_NAME" ]]; then
       # Count values in the allow list
       ALLOWED_VALUES=$(grep -A5 "$VAR_NAME" "$FILE" 2>/dev/null | grep -oE '"[^"]+"' | sort -u || true)
-      ALLOWED_COUNT=$(echo "$ALLOWED_VALUES" | grep -c '"' 2>/dev/null || echo "0")
+      ALLOWED_COUNT=$(echo "$ALLOWED_VALUES" | grep -c '"' 2>/dev/null || true)
+      ALLOWED_COUNT=${ALLOWED_COUNT:-0}
       if [[ "$ALLOWED_COUNT" -gt 2 ]]; then
         # Check if there's a corresponding switch/if chain with same number of branches
-        HANDLED=$(grep -c "case\|===\|==" "$FILE" 2>/dev/null || echo "0")
+        HANDLED=$(grep -c "case\|===\|==" "$FILE" 2>/dev/null || true)
+        HANDLED=${HANDLED:-0}
         if [[ "$HANDLED" -lt "$ALLOWED_COUNT" ]]; then
           warn "$FILE — $VAR_NAME has $ALLOWED_COUNT values but file only has $HANDLED case/branch handlers. Validator may accept values that code doesn't handle."
         fi

--- a/scripts/validate-config-contract.ts
+++ b/scripts/validate-config-contract.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import ts from "typescript";
 import { runContractCheck } from "./config-contract/contract-check.js";
 import { runDisableValueCheck } from "./config-contract/disable-value-check.js";
+import { extractRealConfigKeys } from "./config-contract/extract-parsed-keys.js";
 
 type Failure = {
   message: string;
@@ -365,6 +366,31 @@ function main() {
   for (const stale of disableValue.staleGrandfatherEntries) {
     failures.push({
       message: `[§33:stale-grandfather] ${stale.kind}:${stale.key} (${stale.issue}) no longer violates — prune it from scripts/config-contract/disable-value-grandfathered.json`,
+    });
+  }
+
+  const snapshotPath = path.join(repoRoot, "scripts", "config-contract", "parsed-keys.snapshot.json");
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as {
+    keys: string[];
+    unparseable: Array<{ file: string; reason: string; id: string }>;
+    ambiguousValueMembers: string[];
+  };
+  const extracted = extractRealConfigKeys(repoRoot);
+  const extractedUnparseable = extracted.unparseable.map(({ file, reason, id }) => ({ file, reason, id }));
+  if (JSON.stringify(extracted.keys) !== JSON.stringify(snapshot.keys)) {
+    failures.push({
+      message:
+        "[snapshot] parsed-keys.snapshot.json is stale — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts > scripts/config-contract/parsed-keys.snapshot.json`",
+    });
+  }
+  if (JSON.stringify(extractedUnparseable) !== JSON.stringify(snapshot.unparseable)) {
+    failures.push({
+      message: "[snapshot] parsed-keys.snapshot.json unparseable list drifted — regenerate the snapshot",
+    });
+  }
+  if (JSON.stringify(extracted.ambiguousValueMembers) !== JSON.stringify(snapshot.ambiguousValueMembers)) {
+    failures.push({
+      message: "[snapshot] parsed-keys.snapshot.json ambiguousValueMembers drifted — regenerate the snapshot",
     });
   }
 

--- a/scripts/validate-config-contract.ts
+++ b/scripts/validate-config-contract.ts
@@ -370,28 +370,30 @@ function main() {
   }
 
   const snapshotPath = path.join(repoRoot, "scripts", "config-contract", "parsed-keys.snapshot.json");
-  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as {
-    keys: string[];
-    unparseable: Array<{ file: string; reason: string; id: string }>;
-    ambiguousValueMembers: string[];
-  };
-  const extracted = extractRealConfigKeys(repoRoot);
-  const extractedUnparseable = extracted.unparseable.map(({ file, reason, id }) => ({ file, reason, id }));
-  if (JSON.stringify(extracted.keys) !== JSON.stringify(snapshot.keys)) {
-    failures.push({
-      message:
-        "[snapshot] parsed-keys.snapshot.json is stale — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts > scripts/config-contract/parsed-keys.snapshot.json`",
-    });
-  }
-  if (JSON.stringify(extractedUnparseable) !== JSON.stringify(snapshot.unparseable)) {
-    failures.push({
-      message: "[snapshot] parsed-keys.snapshot.json unparseable list drifted — regenerate the snapshot",
-    });
-  }
-  if (JSON.stringify(extracted.ambiguousValueMembers) !== JSON.stringify(snapshot.ambiguousValueMembers)) {
-    failures.push({
-      message: "[snapshot] parsed-keys.snapshot.json ambiguousValueMembers drifted — regenerate the snapshot",
-    });
+  if (fs.existsSync(snapshotPath)) {
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as {
+      keys: string[];
+      unparseable: Array<{ file: string; reason: string; id: string }>;
+      ambiguousValueMembers: string[];
+    };
+    const extracted = extractRealConfigKeys(repoRoot);
+    const extractedUnparseable = extracted.unparseable.map(({ file, reason, id }) => ({ file, reason, id }));
+    if (JSON.stringify(extracted.keys) !== JSON.stringify(snapshot.keys)) {
+      failures.push({
+        message:
+          "[snapshot] parsed-keys.snapshot.json is stale — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts > scripts/config-contract/parsed-keys.snapshot.json`",
+      });
+    }
+    if (JSON.stringify(extractedUnparseable) !== JSON.stringify(snapshot.unparseable)) {
+      failures.push({
+        message: "[snapshot] parsed-keys.snapshot.json unparseable list drifted — regenerate the snapshot",
+      });
+    }
+    if (JSON.stringify(extracted.ambiguousValueMembers) !== JSON.stringify(snapshot.ambiguousValueMembers)) {
+      failures.push({
+        message: "[snapshot] parsed-keys.snapshot.json ambiguousValueMembers drifted — regenerate the snapshot",
+      });
+    }
   }
 
   if (failures.length > 0) {

--- a/tests/check-review-patterns-script.test.mjs
+++ b/tests/check-review-patterns-script.test.mjs
@@ -46,3 +46,24 @@ test("check-review-patterns fails non-lockfile pnpm install errors", async () =>
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("allow-list counts stay integers when grep -c finds nothing", () => {
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      [
+        'ALLOWED_COUNT=$(printf "%s\\n" "" | grep -c \'"\' 2>/dev/null || true)',
+        'ALLOWED_COUNT=${ALLOWED_COUNT:-0}',
+        'HANDLED=$(printf "%s\\n" "" | grep -c "case" 2>/dev/null || true)',
+        'HANDLED=${HANDLED:-0}',
+        '[[ "$ALLOWED_COUNT" -gt 2 ]] && echo gt || echo lte',
+        '[[ "$HANDLED" -lt "$ALLOWED_COUNT" ]] && echo lt || echo ge',
+      ].join("; "),
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /syntax error/);
+  assert.match(result.stdout, /lte/);
+});


### PR DESCRIPTION
## Why

This run hit these CI/review defects:

1. `check-review-patterns.sh` crashed with `[[: 0` / `syntax error in expression` when `grep -c` found zero matches (`grep -c || echo 0` prints `0` twice).
2. New `parseConfig` keys failed only in the root test shard via a stale `parsed-keys.snapshot.json`. The contract check (checks job) did not catch it.
3. File-size ratchet measured the merge commit. A branch under the ceiling still failed after merging `main`.
4. Review-pattern counts now stay integers when grep finds nothing (tested).
5. Contract check now fails in the checks job when the parsed-keys snapshot drifts, with the regen command.

## Change

- Integer-safe `grep -c` counts
- Snapshot drift in `validate-config-contract.ts`
- Rebase hint on file-size ratchet failures
- Regression for the `[[: 0` crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CI checks to correctly handle empty validation results and avoid shell comparison errors.
  - Added clearer guidance when file-size limits are exceeded, including recommendations for reducing additions or rebasing.
  - Strengthened configuration validation by detecting changes to parsed keys, unparseable entries, and ambiguous values.

- **Tests**
  - Added regression coverage for empty validation results and expected comparison behavior.

- **Chores**
  - Prepared a patch release documenting the CI validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->