### PR TITLE
feat(okf): export a portable OKF v0.1 knowledge bundle

### DIFF
--- a/.changeset/1948-export-okf.md
+++ b/.changeset/1948-export-okf.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": minor
+"@remnic/cli": minor
+---
+
+Add `remnic export okf --out <dir>` to write a portable OKF v0.1 knowledge bundle.

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ See [docs/importers.md](docs/importers.md) for input formats, provenance metadat
 |---------|--------------|
 | `remnic okf lint` | Report files missing frontmatter or `type`; exit 1 when findings remain (`--json` for machine output) |
 | `remnic okf sweep` | Backfill missing `type` values from `category` without bumping `updated` (opt-in via `okf.sweepEnabled`) |
+| `remnic export okf --out <dir>` | Export a portable OKF v0.1 knowledge bundle (plaintext interchange; not a capsule) |
 
 Config gates, lint finding codes, and the full category-to-type mapping: [docs/okf.md](docs/okf.md).
 

--- a/docs/okf.md
+++ b/docs/okf.md
@@ -10,6 +10,17 @@ Spec (v0.1 revision): https://github.com/GoogleCloudPlatform/knowledge-catalog/b
 |---|---|
 | `remnic okf lint` | Report missing frontmatter or `type`. Encrypted files are skipped. Exit 1 when findings remain. `--json` prints the result object. |
 | `remnic okf sweep` | Add missing `type` values without bumping `updated`. Gated by `okf.sweepEnabled`. |
+| `remnic export okf --out <dir>` | Write a portable OKF v0.1 bundle (lossy interchange). Capsules stay the lossless Remnic transport. |
+
+## Capsule vs OKF export
+
+| | Capsule | OKF export |
+|---|---|---|
+| Command | `remnic capsule export` | `remnic export okf --out <dir>` |
+| Shape | `.capsule.json.gz[.enc]` | Directory of markdown + `index.md` |
+| Fidelity | Lossless Remnic transport | Lossy interchange / publication |
+| Default contents | Full store | Active memories only; no profile, wearables, or `state/` |
+
 
 Lint walks every `.md` file under the memory directory, skipping `state/`, `.git/`, and symlinks. Findings carry a stable code:
 

--- a/llms.txt
+++ b/llms.txt
@@ -106,8 +106,10 @@ Every memory file carries an inert `type` field alongside the canonical
 reports conformance findings (exit 1 when any remain; --json supported).
 `remnic okf sweep` backfills missing `type` values without bumping
 `updated` (opt-in via okf.sweepEnabled, default false; `type` emission
-itself is gated by okf.conformanceEnabled, default true). Full mapping
-and finding codes: docs/okf.md.
+itself is gated by okf.conformanceEnabled, default true).
+`remnic export okf --out <dir>` writes a portable plaintext OKF bundle
+(lossy interchange). Capsules remain the lossless Remnic transport.
+Full mapping and finding codes: docs/okf.md.
 
 SEARCH BACKENDS
 

--- a/packages/remnic-cli/src/commands/export-okf.ts
+++ b/packages/remnic-cli/src/commands/export-okf.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Orchestrator, parseConfig, resolveRemnicConfigRecord } from "@remnic/core";
+import { exportOkfBundle, parseIncludeStatus } from "@remnic/core/export-okf";
+import { resolveConfigPath } from "../index.js";
+
+function takeFlag(rest: string[], name: string): string | undefined {
+  const index = rest.indexOf(name);
+  if (index < 0) return undefined;
+  const value = rest[index + 1];
+  if (value === undefined || value.startsWith("-")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+export async function runExportOkfBinaryCommand(rest: string[]): Promise<void> {
+  if (rest[0] === "--help" || rest[0] === "-h" || rest.length === 0) {
+    console.log("Usage: remnic export okf --out <dir> [--force] [--include-profile] [--log]");
+    return;
+  }
+  if (rest[0] !== "okf") {
+    console.error("Usage: remnic export okf --out <dir>");
+    process.exitCode = 1;
+    return;
+  }
+  const args = rest.slice(1);
+  let orchestrator: Orchestrator | undefined;
+  try {
+    const out = takeFlag(args, "--out");
+    if (!out) throw new Error("Missing --out");
+    const namespace = takeFlag(args, "--namespace") ?? "";
+    const configPath = resolveConfigPath();
+    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+    const config = parseConfig(resolveRemnicConfigRecord(raw));
+    orchestrator = new Orchestrator(config);
+    await orchestrator.initialize();
+    await orchestrator.deferredReady;
+    const memoryDir = namespace
+      ? path.join(orchestrator.config.memoryDir, "namespaces", namespace)
+      : orchestrator.config.memoryDir;
+    const result = await exportOkfBundle({
+      memoryDir,
+      outDir: out,
+      includeStatus: parseIncludeStatus(takeFlag(args, "--include-status")),
+      includeCategories: takeFlag(args, "--include-categories")?.split(","),
+      excludeTags: takeFlag(args, "--exclude-tags")?.split(","),
+      includeProfile: args.includes("--include-profile"),
+      includeWearables: args.includes("--include-wearables"),
+      includeLog: args.includes("--log"),
+      force: args.includes("--force"),
+    });
+    if (result.plaintextWarning) console.log("PLAINTEXT EXPORT: the OKF bundle is unencrypted.");
+    console.log(`OKF export: ${result.exported} concepts, ${result.excluded} excluded`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  } finally {
+    orchestrator?.abortDeferredInit();
+    await orchestrator?.destroy();
+  }
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -170,6 +170,7 @@ import {
 import { PLUGIN_ID as REMNIC_OPENCLAW_PLUGIN_ID, resolveRemnicPluginEntry } from "@remnic/core/plugin-id.js";
 import { runMeetingsBinaryCommand } from "./commands/meetings.js"; import { runWearablesBinaryCommand } from "./commands/wearables.js"; import { runLocationBinaryCommand } from "./commands/location.js";
 import { runOkfBinaryCommand } from "./commands/okf.js";
+import { runExportOkfBinaryCommand } from "./commands/export-okf.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
 import { runDriftBinaryCommand } from "./commands/drift.js";
@@ -13085,6 +13086,9 @@ Other:
     case "okf":
       await runOkfBinaryCommand(rest);
       break;
+    case "export":
+      await runExportOkfBinaryCommand(rest);
+      break;
 
     case "external-wiki": {
       await runExternalWikiBinaryCommand(rest);
@@ -13341,6 +13345,8 @@ Usage:
   remnic okf <lint|sweep> [--json]
     OKF v0.1 conformance: lint reports missing frontmatter/type findings,
     sweep backfills missing type values (okf.sweepEnabled).
+  remnic export okf --out <dir>
+    Write a portable OKF v0.1 knowledge bundle (plaintext interchange).
   remnic external-wiki search <query...> [--wiki-id <id>] [--limit <1-20>] [--max-chars-per-hit <100-8000>] [--json]
   remnic doctor                Run diagnostics
   remnic config                Show current config

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -436,7 +436,7 @@ type CommandName =
   | "promotion-candidates"
   | "security"
   | "wearables"
-  | "meetings" | "okf" | "location"
+  | "meetings" | "okf" | "location" | "export"
   | "external-wiki"
   | "capsule"
   | "offline"

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2030,6 +2030,16 @@
       "remnic-source": "./src/token-estimate.ts",
       "import": "./dist/token-estimate.js"
     },
+    "./export-okf": {
+      "types": "./dist/transfer/export-okf.d.ts",
+      "remnic-source": "./src/transfer/export-okf.ts",
+      "import": "./dist/transfer/export-okf.js"
+    },
+    "./export-okf.js": {
+      "types": "./dist/transfer/export-okf.d.ts",
+      "remnic-source": "./src/transfer/export-okf.ts",
+      "import": "./dist/transfer/export-okf.js"
+    },
     "./active-context-transform": {
       "types": "./dist/active-context-transform.d.ts",
       "remnic-source": "./src/active-context-transform.ts",

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -15,7 +15,7 @@ import { utcDayRange } from "./transcript.js";
 import { padEndDisplay, truncateGraphemeSafe } from "./whitespace.js";
 import { runWearablesCliCommand } from "./wearables/cli.js";
 import { registerMeetingsCommands } from "./cli/meetings-commands.js";
-import { registerOkfCommands } from "./cli/okf-commands.js";
+import { registerExportOkfCommand, registerOkfCommands } from "./cli/okf-commands.js";
 import { registerSkillsCommands } from "./cli/skills-commands.js";
 import { registerResearchStatusCommands } from "./cli/research-status-commands.js";
 import { registerCreationLedgerCommands } from "./cli/creation-ledger-commands.js";
@@ -4367,7 +4367,7 @@ export function registerCli(
             return;
           }
           console.log("OK");
-        });
+        }); registerExportOkfCommand(exportCmd, orchestrator);
 
       const importCmd = cmd
         .command("import")

--- a/packages/remnic-core/src/cli/okf-commands.ts
+++ b/packages/remnic-core/src/cli/okf-commands.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import type { Orchestrator } from "../orchestrator.js";
 import type { CliCommand } from "../cli.js";
 import { runOkfCliCommand } from "../okf/cli.js";
+import { exportOkfBundle, parseIncludeStatus } from "../transfer/export-okf.js";
 
 export function registerOkfCommands(cmd: CliCommand, orchestrator: Orchestrator): void {
   const okfCmd = cmd.command("okf").description("OKF v0.1 conformance (lint, sweep)");
@@ -20,4 +22,46 @@ export function registerOkfCommands(cmd: CliCommand, orchestrator: Orchestrator)
     const options = (args[0] ?? {}) as Record<string, unknown>;
     await forward(["sweep", ...(options.json === true ? ["--json"] : [])]);
   });
+}
+
+export function registerExportOkfCommand(exportCmd: CliCommand, orchestrator: Orchestrator): void {
+  exportCmd
+    .command("okf")
+    .description("Export a portable OKF v0.1 knowledge bundle")
+    .requiredOption("--out <path>", "Output directory")
+    .option("--namespace <ns>", "Namespace to export")
+    .option("--include-status <status>", "Repeatable status allow-list (default: active)")
+    .option("--include-categories <categories>", "Comma-separated category allow-list")
+    .option("--exclude-tags <tags>", "Comma-separated tags to drop")
+    .option("--include-profile", "Include profile.md (default off)")
+    .option("--include-wearables", "Include wearable day transcripts (default off)")
+    .option("--log", "Write log.md from the lifecycle ledger")
+    .option("--force", "Replace a non-empty output directory")
+    .action(async (...args: unknown[]) => {
+      const options = (args[0] ?? {}) as Record<string, unknown>;
+      const out = options.out ? String(options.out) : "";
+      if (!out) throw new Error("Missing --out");
+      const includeStatus = parseIncludeStatus(options.includeStatus);
+      const namespace = options.namespace ? String(options.namespace) : "";
+      const memoryDir = namespace
+        ? path.join(orchestrator.config.memoryDir, "namespaces", namespace)
+        : orchestrator.config.memoryDir;
+      const result = await exportOkfBundle({
+        memoryDir,
+        outDir: out,
+        includeStatus,
+        includeCategories: options.includeCategories ? String(options.includeCategories).split(",") : undefined,
+        excludeTags: options.excludeTags ? String(options.excludeTags).split(",") : undefined,
+        includeProfile: options.includeProfile === true,
+        includeWearables: options.includeWearables === true,
+        includeLog: options.log === true,
+        force: options.force === true,
+      });
+      if (result.plaintextWarning) {
+        console.log("PLAINTEXT EXPORT: the OKF bundle is unencrypted.");
+      }
+      console.log(
+        `OKF export: ${result.exported} concepts, ${result.excluded} excluded`,
+      );
+    });
 }

--- a/packages/remnic-core/src/transfer/export-okf.test.ts
+++ b/packages/remnic-core/src/transfer/export-okf.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync, lstatSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { StorageManager } from "../storage.js";
+import {
+  DEFAULT_OKF_LOG_MAX_ENTRIES,
+  exportOkfBundle,
+  OKF_EXPORT_VERSION,
+  OKF_LOG_TRUNCATION_MARKER,
+  parseIncludeStatus,
+} from "./export-okf.js";
+
+async function seedStore(dir: string): Promise<{ factId: string; decisionId: string }> {
+  const storage = new StorageManager(dir);
+  await storage.ensureDirectories();
+  const decision = await storage.writeMemory("decision", "# Use SQLite\n\nWe use SQLite for the local store.", {
+    source: "test",
+    confidence: 0.9,
+  });
+  const fact = await storage.writeMemory(
+    "fact",
+    "# Rate limit\n\nAPI rate limit is 100/min.\n\n<oai-mem-citation>\n<citation_entries>\nfacts/note.md:1-2|note=[source]\n</citation_entries>\n</oai-mem-citation>\n",
+    {
+      source: "test",
+      confidence: 0.9,
+      tags: ["api"],
+      links: [{ targetId: decision.id, linkType: "supports", strength: 0.8 }],
+    },
+  );
+  const superseded = await storage.writeMemory("fact", "# Old limit\n\nAPI rate limit is 10/min.", { source: "test" });
+  await storage.writeMemoryFrontmatter((await storage.getMemoryById(superseded.id))!, { status: "superseded" });
+  const pending = await storage.writeMemory("correction", "# Pending\n\nNeeds review.", { source: "test" });
+  await storage.writeMemoryFrontmatter((await storage.getMemoryById(pending.id))!, { status: "pending_review" });
+  await writeFile(path.join(dir, "profile.md"), "# User\n\nPrefers short answers.\n", "utf8");
+  return { factId: fact.id, decisionId: decision.id };
+}
+test("parseIncludeStatus rejects unknown values", () => {
+  assert.deepEqual(parseIncludeStatus(undefined), ["active"]);
+  assert.throws(() => parseIncludeStatus("nope"), /allowed:/);
+});
+
+test("exportOkfBundle writes a deterministic active-only bundle", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outA = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-a-"));
+  const outB = path.join(os.tmpdir(), `remnic-okf-b-${Date.now()}`);
+  try {
+    await seedStore(memoryDir);
+    await rm(outA, { recursive: true, force: true });
+    const first = await exportOkfBundle({ memoryDir, outDir: outA });
+    assert.equal(first.exported, 2);
+    assert.ok(first.excluded >= 2);
+    const root = await readFile(path.join(outA, "index.md"), "utf8");
+    assert.match(root, new RegExp(`okf_version: "${OKF_EXPORT_VERSION}"`));
+    assert.doesNotMatch(root, /^type:/m);
+    assert.equal(existsSync(path.join(outA, "profile.md")), false);
+    const files = collectFiles(outA);
+    assert.ok(files.some((f) => f.includes("facts/")));
+    const factFile = files.find((f) => f.includes("facts/"))!;
+    const factBody = await readFile(path.join(outA, factFile), "utf8");
+    assert.match(factBody, /# Citations/);
+    assert.match(factBody, /# Related/);
+    assert.match(factBody, /type: Memory Fact/);
+    await exportOkfBundle({ memoryDir, outDir: outB });
+    assert.deepEqual(collectFiles(outA), collectFiles(outB));
+    for (const rel of collectFiles(outA)) {
+      assert.equal(await readFile(path.join(outA, rel), "utf8"), await readFile(path.join(outB, rel), "utf8"));
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outA, { recursive: true, force: true });
+    await rm(outB, { recursive: true, force: true });
+  }
+});
+
+test("profile stays off unless requested; non-empty out requires --force", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-out-"));
+  try {
+    await seedStore(memoryDir);
+    await rm(outDir, { recursive: true, force: true });
+    await exportOkfBundle({ memoryDir, outDir, includeProfile: true });
+    const profile = await readFile(path.join(outDir, "profile.md"), "utf8");
+    assert.match(profile, /type: Profile/);
+    await writeFile(path.join(outDir, "keep.txt"), "old", "utf8");
+    await assert.rejects(exportOkfBundle({ memoryDir, outDir }), /not empty/);
+    assert.equal(await readFile(path.join(outDir, "keep.txt"), "utf8"), "old");
+    await exportOkfBundle({ memoryDir, outDir, force: true });
+    assert.equal(existsSync(path.join(outDir, "keep.txt")), false);
+    assert.equal(existsSync(path.join(outDir, "index.md")), true);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("log.md is newest-first and marks truncation", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outDir = path.join(os.tmpdir(), `remnic-okf-log-${Date.now()}`);
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.ensureDirectories();
+    await storage.writeMemory("fact", "# One\n\nbody", { source: "test" });
+    await storage.appendMemoryLifecycleEvents([
+      {
+        eventId: "e2",
+        memoryId: "m1",
+        eventType: "created",
+        timestamp: "2026-08-02T00:00:00.000Z",
+        actor: "test",
+        ruleVersion: "1",
+      },
+      {
+        eventId: "e1",
+        memoryId: "m1",
+        eventType: "updated",
+        timestamp: "2026-08-01T00:00:00.000Z",
+        actor: "test",
+        ruleVersion: "1",
+      },
+    ]);
+    await exportOkfBundle({ memoryDir, outDir, includeLog: true, logMaxEntries: 1 });
+    const log = await readFile(path.join(outDir, "log.md"), "utf8");
+    assert.match(log, /## 20\d{2}-\d{2}-\d{2}/);
+    assert.match(log, new RegExp(OKF_LOG_TRUNCATION_MARKER));
+    assert.ok(DEFAULT_OKF_LOG_MAX_ENTRIES > 1);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("symlink out is rejected", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const real = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-real-"));
+  const link = `${real}-link`;
+  try {
+    await seedStore(memoryDir);
+    await symlink(real, link);
+    await assert.rejects(exportOkfBundle({ memoryDir, outDir: link }), /symlink/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(real, { recursive: true, force: true });
+    await rm(link, { force: true });
+  }
+});
+
+function collectFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const full = path.join(dir, name);
+      const stat = lstatSync(full);
+      if (stat.isSymbolicLink()) continue;
+      if (stat.isDirectory()) walk(full);
+      else out.push(path.relative(root, full).split(path.sep).join("/"));
+    }
+  };
+  walk(root);
+  return out.sort();
+}

--- a/packages/remnic-core/src/transfer/export-okf.ts
+++ b/packages/remnic-core/src/transfer/export-okf.ts
@@ -1,0 +1,372 @@
+import { lstatSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { parseOaiMemCitation } from "../citations.js";
+import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
+import { normalizeProjectionPreview } from "../memory-projection-format.js";
+import { lintOkfDir } from "../okf/lint.js";
+import { okfTypeForMemory, OKF_PROFILE_TYPE } from "../okf/type-mapping.js";
+import { StorageManager } from "../storage.js";
+import type { MemoryFile, MemoryLink, MemoryStatus } from "../types.js";
+
+export const OKF_EXPORT_VERSION = "0.1";
+export const OKF_LOG_TRUNCATION_MARKER = "<!-- okf-log-truncated -->";
+export const DEFAULT_OKF_LOG_MAX_ENTRIES = 500;
+
+const MEMORY_STATUSES: readonly MemoryStatus[] = [
+  "active",
+  "pending_review",
+  "rejected",
+  "quarantined",
+  "superseded",
+  "archived",
+  "forgotten",
+];
+
+export interface ExportOkfOptions {
+  memoryDir: string;
+  outDir: string;
+  includeStatus?: readonly string[];
+  includeCategories?: readonly string[];
+  excludeTags?: readonly string[];
+  includeProfile?: boolean;
+  includeWearables?: boolean;
+  includeLog?: boolean;
+  logMaxEntries?: number;
+  force?: boolean;
+}
+
+export interface ExportOkfResult {
+  exported: number;
+  excluded: number;
+  byCategory: Record<string, number>;
+  plaintextWarning: boolean;
+}
+
+export function parseIncludeStatus(raw: unknown): MemoryStatus[] {
+  const values = splitCsv(raw);
+  if (values.length === 0) return ["active"];
+  const allowed = new Set<string>(MEMORY_STATUSES);
+  for (const value of values) {
+    if (!allowed.has(value)) {
+      throw new Error(`invalid --include-status ${value}; allowed: ${MEMORY_STATUSES.join(", ")}`);
+    }
+  }
+  return values as MemoryStatus[];
+}
+
+export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkfResult> {
+  const outDir = path.resolve(opts.outDir);
+  rejectSymlinkPath(outDir);
+  const includeStatus = new Set(parseIncludeStatus(opts.includeStatus));
+  const includeCategories = opts.includeCategories?.length ? new Set(opts.includeCategories) : null;
+  const excludeTags = new Set(opts.excludeTags ?? []);
+  const storage = new StorageManager(opts.memoryDir);
+  const memories = await storage.readAllMemories();
+  const included: MemoryFile[] = [];
+  let excluded = 0;
+  for (const memory of memories) {
+    const rel = toRel(memory.path, opts.memoryDir);
+    if (!opts.includeWearables && rel.startsWith("wearables/")) {
+      excluded += 1;
+      continue;
+    }
+    const status = inferMemoryStatus(memory.frontmatter, memory.path);
+    if (!includeStatus.has(status)) {
+      excluded += 1;
+      continue;
+    }
+    if (includeCategories && !includeCategories.has(memory.frontmatter.category)) {
+      excluded += 1;
+      continue;
+    }
+    if ((memory.frontmatter.tags ?? []).some((tag) => excludeTags.has(tag))) {
+      excluded += 1;
+      continue;
+    }
+    included.push(memory);
+  }
+  included.sort((a, b) => toRel(a.path, opts.memoryDir).localeCompare(toRel(b.path, opts.memoryDir)));
+
+  const staging = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-export-"));
+  const byCategory: Record<string, number> = {};
+  const idToRel = new Map<string, string>();
+  for (const memory of included) {
+    const rel = toRel(memory.path, opts.memoryDir);
+    idToRel.set(memory.frontmatter.id, rel);
+  }
+  for (const memory of included) {
+    const rel = toRel(memory.path, opts.memoryDir);
+    const rendered = renderMemory(memory, rel, idToRel);
+    writeBundleFile(staging, rel, rendered);
+    const category = memory.frontmatter.category;
+    byCategory[category] = (byCategory[category] ?? 0) + 1;
+  }
+
+  if (opts.includeProfile) {
+    try {
+      const profile = await storage.readProfile();
+      if (profile) {
+        writeBundleFile(
+          staging,
+          "profile.md",
+          renderFrontmatter({
+            type: OKF_PROFILE_TYPE,
+            title: "User Profile",
+            timestamp: new Date(0).toISOString(),
+          }) + profile.replace(/^\uFEFF/, ""),
+        );
+      }
+    } catch {
+      // Profile is optional even when requested.
+    }
+  }
+
+  if (opts.includeLog) {
+    const events = await storage.readAllMemoryLifecycleEvents();
+    writeBundleFile(staging, "log.md", renderLog(events, idToRel, opts.logMaxEntries ?? DEFAULT_OKF_LOG_MAX_ENTRIES));
+  }
+
+  writeIndexes(staging, included, opts.memoryDir);
+  const lint = lintOkfDir(staging);
+  const blocking = lint.findings.filter((f) => f.code !== "skipped_encrypted" && f.code !== "reserved_basename");
+  if (blocking.length > 0) {
+    rmSync(staging, { recursive: true, force: true });
+    throw new Error(`OKF export failed lint: ${blocking.map((f) => `${f.file}: ${f.message}`).join("; ")}`);
+  }
+
+  publishBundle(staging, outDir, opts.force === true);
+  return {
+    exported: included.length,
+    excluded,
+    byCategory,
+    plaintextWarning: true,
+  };
+}
+
+function publishBundle(staging: string, outDir: string, force: boolean): void {
+  let exists = false;
+  try {
+    const stat = lstatSync(outDir);
+    if (stat.isSymbolicLink()) throw new Error(`--out must not be a symlink: ${outDir}`);
+    exists = true;
+    const entries = listNonDot(outDir);
+    if (entries.length > 0 && !force) {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(`--out ${outDir} is not empty; pass --force to replace it`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  mkdirSync(path.dirname(outDir), { recursive: true });
+  if (exists && force) {
+    const backup = `${outDir}.okf-prev`;
+    try {
+      renameSync(outDir, backup);
+    } catch {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(`cannot replace --out ${outDir}`);
+    }
+    try {
+      renameSync(staging, outDir);
+      rmSync(backup, { recursive: true, force: true });
+    } catch (err) {
+      try {
+        renameSync(backup, outDir);
+      } catch {
+        // Keep backup if restore fails.
+      }
+      throw err;
+    }
+    return;
+  }
+  renameSync(staging, outDir);
+}
+
+function renderMemory(memory: MemoryFile, rel: string, idToRel: Map<string, string>): string {
+  const fm = memory.frontmatter;
+  const title = firstHeading(memory.content) ?? `${humanize(fm.category)} ${fm.created.slice(0, 10)}`;
+  const type = fm.type ?? okfTypeForMemory(fm);
+  const fields: Record<string, unknown> = {
+    type,
+    title,
+    description: normalizeProjectionPreview(memory.content),
+    tags: fm.tags ?? [],
+    timestamp: fm.updated,
+    ...fm,
+  };
+  if (fm.artifactType) fields.resource = rel;
+  let body = memory.content.trim();
+  const citation = parseOaiMemCitation(body);
+  if (citation) {
+    const start = body.indexOf("<oai-mem-citation>");
+    const end = body.indexOf("</oai-mem-citation>");
+    if (start >= 0 && end > start) {
+      body = `${body.slice(0, start).trimEnd()}\n\n${body.slice(end + "</oai-mem-citation>".length).trimStart()}`.trim();
+    }
+    const lines = citation.entries.map((entry, index) => `${index + 1}. [${entry.path}](${entry.path})`);
+    body = `${body}\n\n# Citations\n\n${lines.join("\n")}\n`;
+  }
+  const links = fm.links ?? [];
+  if (links.length > 0) {
+    body += `\n# Related\n\n${links.map((link) => renderRelated(link, idToRel)).join("\n")}\n`;
+  }
+  return renderFrontmatter(fields) + body + (body.endsWith("\n") ? "" : "\n");
+}
+
+function renderRelated(link: MemoryLink, idToRel: Map<string, string>): string {
+  const target = idToRel.get(link.targetId) ?? link.targetId;
+  const href = target.startsWith("/") ? target : `/${target}`;
+  return `- ${link.linkType}: [${link.targetId}](${href})`;
+}
+
+function writeIndexes(root: string, memories: MemoryFile[], memoryDir: string): void {
+  const groups = new Map<string, MemoryFile[]>();
+  for (const memory of memories) {
+    const rel = toRel(memory.path, memoryDir);
+    const dir = path.posix.dirname(rel);
+    const key = dir === "." ? "" : dir.split("/")[0] ?? "";
+    const list = groups.get(key) ?? [];
+    list.push(memory);
+    groups.set(key, list);
+  }
+  const sections = [...groups.keys()].sort().map((key) => {
+    const heading = key === "" ? "Root" : humanize(key);
+    const lines = (groups.get(key) ?? [])
+      .sort((a, b) => toRel(a.path, memoryDir).localeCompare(toRel(b.path, memoryDir)))
+      .map((memory) => {
+        const rel = toRel(memory.path, memoryDir);
+        const title = firstHeading(memory.content) ?? memory.frontmatter.id;
+        const description = normalizeProjectionPreview(memory.content);
+        return `* [${title}](/${rel}) - ${description}`;
+      });
+    return `## ${heading}\n\n${lines.join("\n")}`;
+  });
+  writeBundleFile(root, "index.md", `---\nokf_version: "${OKF_EXPORT_VERSION}"\n---\n\n${sections.join("\n\n")}\n`);
+}
+
+function renderLog(
+  events: Array<{ timestamp?: string; type?: string; action?: string; memoryId?: string }>,
+  idToRel: Map<string, string>,
+  maxEntries: number,
+): string {
+  const sorted = [...events].sort((a, b) => String(b.timestamp ?? "").localeCompare(String(a.timestamp ?? "")));
+  const truncated = sorted.length > maxEntries;
+  const kept = sorted.slice(0, maxEntries);
+  const byDay = new Map<string, typeof kept>();
+  for (const event of kept) {
+    const day = String(event.timestamp ?? "").slice(0, 10) || "unknown";
+    const list = byDay.get(day) ?? [];
+    list.push(event);
+    byDay.set(day, list);
+  }
+  const days = [...byDay.keys()].sort((a, b) => b.localeCompare(a));
+  const parts = ["# Log", ""];
+  for (const day of days) {
+    parts.push(`## ${day}`, "");
+    for (const event of byDay.get(day) ?? []) {
+      const action = boldAction(event.type ?? event.action ?? "Update");
+      const id = event.memoryId;
+      const rel = id ? idToRel.get(id) : undefined;
+      const target = rel ? `[${id}](/${rel})` : id ?? "";
+      parts.push(`- **${action}** ${target}`.trimEnd());
+    }
+    parts.push("");
+  }
+  if (truncated) parts.push(OKF_LOG_TRUNCATION_MARKER, "");
+  return `${parts.join("\n")}\n`;
+}
+
+function boldAction(raw: string): string {
+  const lower = raw.toLowerCase();
+  if (lower.includes("create") || lower.includes("add")) return "Creation";
+  if (lower.includes("deprecat") || lower.includes("delete") || lower.includes("archiv")) return "Deprecation";
+  return "Update";
+}
+
+function renderFrontmatter(fields: Record<string, unknown>): string {
+  const keys = Object.keys(fields).sort((a, b) => {
+    const order = ["type", "title", "description", "tags", "timestamp"];
+    const ai = order.indexOf(a);
+    const bi = order.indexOf(b);
+    if (ai >= 0 || bi >= 0) return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+    return a.localeCompare(b);
+  });
+  const lines = keys.flatMap((key) => yamlLine(key, fields[key]));
+  return `---\n${lines.join("\n")}\n---\n\n`;
+}
+
+function yamlLine(key: string, value: unknown): string[] {
+  if (value === undefined) return [];
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${key}: []`];
+    if (value.every((item) => typeof item !== "object" || item === null)) {
+      return [`${key}:`, ...value.map((item) => `  - ${yamlScalar(item)}`)];
+    }
+    return [`${key}: ${JSON.stringify(value)}`];
+  }
+  if (typeof value === "object" && value !== null) return [`${key}: ${JSON.stringify(value)}`];
+  return [`${key}: ${yamlScalar(value)}`];
+}
+
+function yamlScalar(value: unknown): string {
+  if (typeof value === "string") {
+    if (value === "" || /[:#\n]/.test(value) || value !== value.trim()) return JSON.stringify(value);
+    return value;
+  }
+  return String(value);
+}
+
+function firstHeading(content: string): string | undefined {
+  for (const line of content.split("\n")) {
+    const match = /^#\s+(.+)$/.exec(line.trim());
+    if (match) return match[1]!.trim();
+  }
+  return undefined;
+}
+
+function humanize(value: string): string {
+  return value.replace(/[_-]/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function toRel(abs: string, root: string): string {
+  return path.relative(path.resolve(root), path.resolve(abs)).split(path.sep).join("/");
+}
+
+function writeBundleFile(root: string, rel: string, content: string): void {
+  const dest = path.join(root, ...rel.split("/"));
+  mkdirSync(path.dirname(dest), { recursive: true });
+  writeFileSync(dest, content, "utf8");
+}
+
+function splitCsv(raw: unknown): string[] {
+  if (raw === undefined || raw === null || raw === "") return [];
+  const parts = Array.isArray(raw) ? raw.map(String) : String(raw).split(",");
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+function rejectSymlinkPath(target: string): void {
+  let current = path.resolve(target);
+  while (true) {
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        throw new Error(`--out path component is a symlink: ${current}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+}
+
+function listNonDot(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter((name) => name !== "." && name !== "..");
+  } catch {
+    return [];
+  }
+}

--- a/packages/remnic-core/src/transfer/export-okf.ts
+++ b/packages/remnic-core/src/transfer/export-okf.ts
@@ -190,12 +190,12 @@ function renderMemory(memory: MemoryFile, rel: string, idToRel: Map<string, stri
   const title = firstHeading(memory.content) ?? `${humanize(fm.category)} ${fm.created.slice(0, 10)}`;
   const type = fm.type ?? okfTypeForMemory(fm);
   const fields: Record<string, unknown> = {
+    ...fm,
     type,
     title,
     description: normalizeProjectionPreview(memory.content),
     tags: fm.tags ?? [],
     timestamp: fm.updated,
-    ...fm,
   };
   if (fm.artifactType) fields.resource = rel;
   let body = memory.content.trim();


### PR DESCRIPTION
Fixes #1948.

## Change

`remnic export okf --out <dir>` writes a portable OKF v0.1 bundle. Active memories only by default. No profile, wearables, or state/. Capsules stay the lossless transport.

## Regression

`packages/remnic-core/src/transfer/export-okf.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `remnic export okf --out <dir>` to export portable OKF v0.1 knowledge bundles.
  * Supports status, category, tag, and wearable-content filters, profile and lifecycle log inclusion, and forced replacement of existing output.
  * Validates exports and reports included, excluded, and category totals, with plaintext-content warnings.

* **Documentation**
  * Added usage guidance and a comparison of OKF and Capsule export formats.
  * Expanded OKF conformance documentation, including type emission and mapping details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->