### PR TITLE
feat(x): connector for X posts and bookmarks

### DIFF
--- a/.changeset/2009-x-connector.md
+++ b/.changeset/2009-x-connector.md
@@ -1,0 +1,5 @@
+---
+"@remnic/connector-x": minor
+---
+
+X (Twitter) connector for Remnic (#2009): new à-la-carte `@remnic/connector-x` package ingests the user's bookmarks and own posts through pluggable sources — a local corpus directory and a `bird`-style CLI (zero credits), and the official X MCP at `api.x.com/mcp` (budget-capped with clean `credits depleted` skips). Includes a Streamable-HTTP MCP client (session handling, SSE + JSON bodies), single-owner OAuth2 token refresh (file-locked rotation chain), post-id + content-fingerprint dedupe with provenance, `suggest`/`store` trust gating via a pluggable `XMemorySink`, and a `remnic-x status|sync` CLI. Strict `xConnector` config parsing rejects invalid values.

--- a/packages/connector-x/README.md
+++ b/packages/connector-x/README.md
@@ -1,0 +1,172 @@
+# @remnic/connector-x
+
+X (Twitter) connector for [Remnic](https://github.com/joshuaswarren/remnic) —
+remember the user's own X posts and bookmarks (issue #2009).
+
+Bookmarks are deliberate curation; posts are deliberate expression. Both are
+high-trust memory sources. This connector ingests them through **pluggable
+sources** and maps them to Remnic memories with dedupe, provenance, and
+trust gating.
+
+```
+npm install @remnic/connector-x        # à-la-carte; @remnic/core works alone without it
+```
+
+## Cost reality — read this first
+
+The official X MCP (`https://api.x.com/mcp`) is a transport over the same
+**metered X API**: every read consumes the same quota and pay-per-use credits
+as a raw v2 call. A `tools/call get_users_bookmarks` against an exhausted
+account returns `{"detail":"credits depleted","status":402}` (session
+`initialize`/`tools/list` stay free).
+
+The connector is budget-aware by design:
+
+- `maxPagesPerSync` (default 2) caps paid pages per cycle.
+- `maxCostUsdPerMonth` (default $1.00) is a hard ceiling; when projected
+  spend would cross it, the source **skips the cycle cleanly** (`skipped:
+  monthly-cost-cap`) instead of erroring.
+- `costPerReadUsd` (default $0.01 — ~1 credit/read pay-per-use reference
+  rate) converts reads to dollars; set it to your account's real rate.
+- Stop-on-known-ids: paging stops as soon as a page contains only posts
+  already ingested, so slow-changing bookmarks cost one page per sync.
+- Bookmarks change slowly — keep `syncSchedule` at `3x-daily` or slower.
+
+Because reads cost money, the source layer is pluggable so the same
+normalized records can come from zero-credit inputs, cheapest first:
+
+| kind       | credits | what it reads |
+|---|---|---|
+| `corpusDir` | 0 | `*.json` files in a local corpus directory (e.g. one exported by another pipeline) |
+| `cli`       | 0 | a cookie-GraphQL CLI such as `bird` (`bird bookmarks --json`) |
+| `mcp`       | paid | the official X MCP — canonical shape |
+
+## Config
+
+The `xConnector` block (issue #2009). Put it in a JSON file and point the
+CLI at it, or pass the parsed object to `parseXConnectorConfig` from a host:
+
+```jsonc
+{
+  "xConnector": {
+    "enabled": true,
+    "userId": "123456789",            // numeric X user id; enables own-post ingestion
+    "sources": [
+      { "id": "local-corpus", "kind": "corpusDir", "path": "~/corpus/bookmarks" },
+      { "id": "bird", "kind": "cli", "bin": "bird" },
+      {
+        "id": "x-mcp", "kind": "mcp", "url": "https://api.x.com/mcp",
+        "auth": { "tokenFile": "~/.openclaw/secrets/x-tokens.json" },
+        "bookmarksTool": "get_users_bookmarks",   // defaults shown; override if X renames
+        "timelineTool": "get_users_tweets",
+        "maxResults": 20,
+        "budget": { "maxPagesPerSync": 2, "maxCostUsdPerMonth": 1.0, "costPerReadUsd": 0.01 }
+      }
+    ],
+    "sourcePriority": ["local-corpus", "bird", "x-mcp"],  // cheapest first
+    "syncSchedule": "3x-daily",
+    "memoryMode": "suggest",          // "suggest" → review queue, "store" → direct write
+    "stateDir": "~/.remnic/x-connector"
+  }
+}
+```
+
+Invalid values are rejected, never silently reinterpreted: unknown kinds,
+duplicate source ids, priorities naming unknown sources, non-numeric
+`userId`, and bad enum values all throw `XConfigError`.
+
+## Auth setup (MCP source)
+
+Bookmarks need a **user-context OAuth2 token** — app-only bearers have no
+user context. There is no OAuth discovery or dynamic registration on
+`api.x.com/mcp`; you need a pre-registered confidential client:
+
+1. Create an OAuth2 client in the X developer portal.
+2. Run the authorization-code flow once (with offline access) and write the
+   token file:
+   ```json
+   { "access_token": "...", "refresh_token": "...", "expires_at": 1750000000000 }
+   ```
+   `expires_at` is epoch milliseconds. Unknown extra fields are preserved.
+3. Give the connector the client credentials (env is easiest):
+   `REMNIC_X_CLIENT_ID`, `REMNIC_X_CLIENT_SECRET`.
+
+### Single-owner refresh chain (important)
+
+X **rotates the refresh token on every refresh**. Two independent
+refreshers fork the chain and kill one of them — you get HTTP 401 on the
+next refresh and must re-authorize. `XTokenStore` is built to be the single
+owner: refreshes only run while holding `<tokenFile>.lock`; a concurrent
+refresher waits, then adopts the rotated pair from the file. Do not run
+another tool that refreshes the same grant.
+
+The token file is written 0600, atomically. A 400/401/403 on refresh raises
+`XRefreshChainBrokenError` with recovery instructions.
+
+## Ingestion → memory mapping
+
+Every source emits the same normalized record
+(`postId`, `kind: bookmark|own_post`, `author`, `createdAt`, `text`, `urls`,
+`mediaCount`, optional `enrichment`), deduped by `postId` + content
+fingerprint — re-fetching a bookmark daily never churns the memory store,
+and an edited post re-ingests exactly once.
+
+| record | tags | category | confidence |
+|---|---|---|---|
+| bookmark | `x/bookmark` | `reference` (has URL) or `interest` | 0.7 |
+| own post | `x/post` | `expression` | 0.9 |
+
+Author usernames become `person-<handle>` entity refs, feeding the entity
+graph. `memoryMode` gates trust: `suggest` (default) routes through
+`XMemorySink.submitSuggestion` (review queue); `store` routes through
+`storeMemory`. Records carry provenance (`sourceId`, `syncRunId`,
+`fetchedAt`) for attribution.
+
+## CLI
+
+```
+remnic-x status [--config path] [--json]   # offline: sources, availability, spend vs cap
+remnic-x sync   [--config path] [--json]   # one cycle; skips are expected, not errors
+```
+
+Default config path: `$REMNIC_X_CONFIG` or `~/.config/remnic/x-connector.json`.
+Exit code 0 for skips (credits depleted, caps), 1 for sink failures, 2 for
+bad invocation or config.
+
+## Host API
+
+```ts
+import { parseXConnectorConfig, runXSync, getXStatus } from "@remnic/connector-x";
+
+const config = parseXConnectorConfig(rawBlock);
+const report = await runXSync(config, {
+  sink: {
+    submitSuggestion: (s) => myReviewQueue.push(s),
+    storeMemory: async (s) => { await memoryStore.write(toMemory(s)); },
+  },
+});
+const status = await getXStatus(config); // offline, zero credits
+```
+
+The default on-disk sink (`createFileSink`) writes `suggest`-mode files to
+`<stateDir>/suggestions/` and `store`-mode files to `<stateDir>/records/`;
+every ingested record is also materialized under `<stateDir>/records/`.
+
+## Non-goals
+
+- No posting, liking, or bookmark writes (X blocks autonomous posting via
+  MCP; writes are priced per action).
+- No full-archive backfill through the metered MCP — backfill from a local
+  corpus.
+- No scraping: zero-credit sources are pluggable inputs provided by the
+  deployment.
+
+## Development
+
+```
+npm run test          # node:test via tsx, no network
+npm run check-types
+npm run build         # tsup → dist/
+```
+
+Tests run fully offline against scripted HTTP fakes and temp directories.

--- a/packages/connector-x/package.json
+++ b/packages/connector-x/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts src/cli.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/mcp-client.test.ts src/token-store.test.ts src/normalize.test.ts src/sources.test.ts src/sync.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/connector-x/package.json
+++ b/packages/connector-x/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@remnic/connector-x",
+  "version": "9.65.7",
+  "description": "X (Twitter) connector for Remnic — remember the user's posts and bookmarks via the official X MCP, a local corpus, or a CLI",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "remnic-x": "./dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts src/cli.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/config.test.ts src/mcp-client.test.ts src/token-store.test.ts src/normalize.test.ts src/sources.test.ts src/sync.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.65.7"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-x"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "x",
+    "twitter",
+    "bookmarks",
+    "mcp",
+    "connector"
+  ]
+}

--- a/packages/connector-x/src/cli.ts
+++ b/packages/connector-x/src/cli.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * `remnic-x` — standalone CLI for the X connector.
+ *
+ *   remnic-x status [--config <path>] [--json]
+ *   remnic-x sync   [--config <path>] [--json]
+ *
+ * The config file is JSON: either the `xConnector` block itself or a
+ * document with an `xConnector` key. Default path: $REMNIC_X_CONFIG or
+ * ~/.config/remnic/x-connector.json.
+ */
+
+import { readFile } from "node:fs/promises";
+import { exit } from "node:process";
+
+import { expandTildePath } from "@remnic/core";
+
+import { type XConnectorConfig, parseXConnectorConfig } from "./config.js";
+import { createFileSink } from "./file-sink.js";
+import { getXStatus, runXSync } from "./sync.js";
+import type { XStatusReport, XSyncReport } from "./types.js";
+
+const USAGE = [
+  "usage: remnic-x <status|sync> [--config <path>] [--json]",
+  "",
+  "  status   offline snapshot: sources, availability, spend vs cap",
+  "  sync     run one sync cycle per configured source priority",
+  "  --config path to the xConnector JSON (default: $REMNIC_X_CONFIG",
+  "           or ~/.config/remnic/x-connector.json)",
+  "  --json   machine-readable output",
+].join("\n");
+
+interface CliArgs {
+  command: "status" | "sync";
+  configPath: string;
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs | null {
+  let command: "status" | "sync" | null = null;
+  let configPath: string | null = null;
+  let json = false;
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "status" || arg === "sync") {
+      if (command !== null) return null;
+      command = arg;
+    } else if (arg === "--config") {
+      const value = argv[index + 1];
+      if (typeof value !== "string" || value.length === 0) return null;
+      configPath = value;
+      index += 1;
+    } else if (arg === "--json") {
+      json = true;
+    } else {
+      return null;
+    }
+  }
+  if (command === null) return null;
+  return {
+    command,
+    configPath: configPath ?? process.env.REMNIC_X_CONFIG ?? "~/.config/remnic/x-connector.json",
+    json,
+  };
+}
+
+async function loadConfig(configPath: string): Promise<XConnectorConfig> {
+  const resolved = expandTildePath(configPath);
+  let raw: string;
+  try {
+    raw = await readFile(resolved, "utf8");
+  } catch {
+    throw new Error(`config file not found: ${resolved} (pass --config or set REMNIC_X_CONFIG)`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`config file ${resolved} is not valid JSON (${err instanceof Error ? err.name : "parse error"})`);
+  }
+  const block =
+    typeof parsed === "object" && parsed !== null && "xConnector" in parsed && typeof parsed.xConnector === "object"
+      ? parsed.xConnector
+      : parsed;
+  return parseXConnectorConfig(block);
+}
+
+function printHuman(text: string): void {
+  process.stdout.write(`${text}\n`);
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args === null) {
+    process.stderr.write(`${USAGE}\n`);
+    return 2;
+  }
+  let config: XConnectorConfig;
+  try {
+    config = await loadConfig(args.configPath);
+  } catch (err) {
+    process.stderr.write(`remnic-x: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+  if (!config.enabled) {
+    printHuman(args.json ? JSON.stringify({ enabled: false }) : "xConnector is disabled.");
+    return 0;
+  }
+  if (args.command === "status") {
+    const status = await getXStatus(config);
+    printHuman(args.json ? JSON.stringify(status, null, 2) : renderStatus(status));
+    return 0;
+  }
+  const report = await runXSync(config, {
+    sink: createFileSink({ stateDir: config.stateDir, mode: config.memoryMode }),
+  });
+  printHuman(args.json ? JSON.stringify(report, null, 2) : renderReport(report));
+  // Skips are expected degradation (credits, caps), not failures.
+  return report.sinkFailures > 0 ? 1 : 0;
+}
+
+function renderStatus(status: XStatusReport): string {
+  const lines = [
+    `xConnector ${status.enabled ? "enabled" : "disabled"} · memoryMode=${status.memoryMode} · schedule=${status.syncSchedule}`,
+    `seen records: ${status.seenCount} · spend ${status.monthKey}: $${status.monthSpendUsd.toFixed(2)} of $${status.monthlyCostCapUsd.toFixed(2)} cap`,
+    `last sync: ${status.lastSyncAt ?? "never"}`,
+    "sources (priority order):",
+  ];
+  for (const source of status.sources) {
+    const flag = source.available ? "ok  " : "MISS";
+    lines.push(
+      `  ${source.priority}. [${flag}] ${source.sourceId} (${source.kind}) last=${source.lastSyncAt ?? "never"} new=${source.lastRecordsNew}${source.availabilityDetail !== undefined ? ` — ${source.availabilityDetail}` : ""}`
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderReport(report: XSyncReport): string {
+  const lines = [
+    `sync ${report.runId} · mode=${report.memoryMode} · suggested=${report.suggestionsSubmitted} stored=${report.memoriesStored} failures=${report.sinkFailures} · month spend $${report.monthSpendUsd.toFixed(2)}`,
+  ];
+  for (const source of report.sources) {
+    const note =
+      source.error !== undefined
+        ? ` error=${source.error}`
+        : source.skipped !== undefined
+          ? ` skipped=${source.skipped.reason}${source.skipped.detail !== undefined ? ` (${source.skipped.detail})` : ""}`
+          : "";
+    lines.push(
+      `  ${source.sourceId} (${source.kind}): new=${source.recordsNew} known=${source.recordsKnown} reads=${source.reads} pages=${source.pages}${note}`
+    );
+  }
+  return lines.join("\n");
+}
+
+main().then((code) => exit(code));

--- a/packages/connector-x/src/config.test.ts
+++ b/packages/connector-x/src/config.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  XConfigError,
+  coerceXBool,
+  monthlyCostCapUsd,
+  parseXConnectorConfig,
+  resolveMcpClientCredentials,
+} from "./config.js";
+
+test("parses a full block and applies defaults", () => {
+  const config = parseXConnectorConfig({
+    userId: "123456",
+    sources: [
+      {
+        id: "x-mcp",
+        kind: "mcp",
+        auth: { tokenFile: "~/secrets/x-tokens.json" },
+        budget: { maxPagesPerSync: 3, maxCostUsdPerMonth: 2.0 },
+      },
+      { id: "local", kind: "corpusDir", path: "~/corpus" },
+    ],
+    sourcePriority: ["local", "x-mcp"],
+  });
+  assert.equal(config.enabled, true);
+  assert.equal(config.memoryMode, "suggest");
+  assert.equal(config.syncSchedule, "3x-daily");
+  assert.equal(config.sources.length, 2);
+  const mcp = config.sources[0];
+  assert.ok(mcp.kind === "mcp");
+  assert.equal(mcp.url, "https://api.x.com/mcp");
+  assert.equal(mcp.bookmarksTool, "get_users_bookmarks");
+  assert.equal(mcp.budget.maxPagesPerSync, 3);
+  assert.equal(mcp.budget.costPerReadUsd, 0.01);
+  assert.equal(config.stateDir, "~/.remnic/x-connector");
+});
+
+test("coerces boolean-like strings and rejects garbage", () => {
+  assert.equal(coerceXBool("false", "f"), false);
+  assert.equal(coerceXBool("0", "f"), false);
+  assert.equal(coerceXBool("yes", "f"), true);
+  assert.throws(() => coerceXBool("maybe", "f"), XConfigError);
+});
+
+test("enabled=false string survives the boundary", () => {
+  const config = parseXConnectorConfig({ enabled: "false", sources: [{ id: "a", kind: "corpusDir", path: "/tmp/x" }] });
+  assert.equal(config.enabled, false);
+});
+
+test("rejects unknown source kinds", () => {
+  assert.throws(() => parseXConnectorConfig({ sources: [{ id: "s", kind: "scrape" }] }), /kind must be one of/);
+});
+
+test("rejects duplicate source ids", () => {
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        sources: [
+          { id: "dup", kind: "corpusDir", path: "/tmp/a" },
+          { id: "dup", kind: "cli" },
+        ],
+      }),
+    /duplicate source id/
+  );
+});
+
+test("rejects priorities naming unknown sources", () => {
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        sources: [{ id: "a", kind: "corpusDir", path: "/tmp/a" }],
+        sourcePriority: ["ghost"],
+      }),
+    /unknown source id/
+  );
+});
+
+test("rejects non-numeric userId and bad enum values", () => {
+  assert.throws(() => parseXConnectorConfig({ userId: "jane", sources: [] }), /numeric/);
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        memoryMode: "auto",
+        sources: [{ id: "a", kind: "corpusDir", path: "/tmp/a" }],
+      }),
+    /memoryMode/
+  );
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        syncSchedule: "5x-daily",
+        sources: [{ id: "a", kind: "corpusDir", path: "/tmp/a" }],
+      }),
+    /syncSchedule/
+  );
+});
+
+test("rejects invalid budget numbers instead of clamping", () => {
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        sources: [{ id: "m", kind: "mcp", budget: { maxPagesPerSync: 0 } }],
+      }),
+    /maxPagesPerSync/
+  );
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        sources: [{ id: "m", kind: "mcp", budget: { maxCostUsdPerMonth: -1 } }],
+      }),
+    /maxCostUsdPerMonth/
+  );
+  assert.throws(
+    () =>
+      parseXConnectorConfig({
+        sources: [{ id: "m", kind: "mcp", budget: { maxPagesPerSync: 2.5 } }],
+      }),
+    /maxPagesPerSync/
+  );
+});
+
+test("rejects an empty sources array", () => {
+  assert.throws(() => parseXConnectorConfig({ sources: [] }), /non-empty array/);
+});
+
+test("monthlyCostCapUsd is the max across mcp sources only", () => {
+  const config = parseXConnectorConfig({
+    sources: [
+      { id: "m1", kind: "mcp", budget: { maxCostUsdPerMonth: 0.5 } },
+      { id: "m2", kind: "mcp", budget: { maxCostUsdPerMonth: 1.5 } },
+      { id: "c", kind: "corpusDir", path: "/tmp/c" },
+    ],
+  });
+  assert.equal(monthlyCostCapUsd(config), 1.5);
+});
+
+test("resolveMcpClientCredentials prefers REMNIC_* env names", () => {
+  const mcp = parseXConnectorConfig({
+    sources: [{ id: "m", kind: "mcp" }],
+  }).sources[0];
+  assert.ok(mcp.kind === "mcp");
+  const creds = resolveMcpClientCredentials(mcp, {
+    REMNIC_X_CLIENT_ID: "primary",
+    X_CLIENT_ID: "secondary",
+    REMNIC_X_CLIENT_SECRET: "secret",
+  });
+  assert.equal(creds.clientId, "primary");
+  assert.equal(creds.clientSecret, "secret");
+  assert.equal(creds.tokenFile, "~/.openclaw/secrets/x-tokens.json");
+});

--- a/packages/connector-x/src/config.ts
+++ b/packages/connector-x/src/config.ts
@@ -1,0 +1,276 @@
+/**
+ * Strict parser for the `xConnector` config block (issue #2009).
+ *
+ * Invalid values are rejected, never silently reinterpreted: unknown
+ * source kinds, duplicate source ids, priorities naming unknown sources,
+ * non-finite numbers, and unrecognized enum values all throw.
+ */
+
+import type { XMemoryMode, XSourceKind } from "./types.js";
+
+export const X_SOURCE_KINDS: readonly XSourceKind[] = ["mcp", "corpusDir", "cli"];
+export const X_MEMORY_MODES: readonly XMemoryMode[] = ["suggest", "store"];
+export const X_SYNC_SCHEDULES: readonly string[] = ["hourly", "4x-daily", "3x-daily", "2x-daily", "daily", "weekly"];
+
+export const X_DEFAULT_MCP_URL = "https://api.x.com/mcp";
+export const X_DEFAULT_TOKEN_FILE = "~/.openclaw/secrets/x-tokens.json";
+export const X_DEFAULT_STATE_DIR = "~/.remnic/x-connector";
+/** Pay-per-use reference rate: ~1 credit per read at ~$0.01/credit. */
+export const X_DEFAULT_COST_PER_READ_USD = 0.01;
+
+export interface XBudgetConfig {
+  maxPagesPerSync: number;
+  maxCostUsdPerMonth: number;
+  costPerReadUsd: number;
+}
+
+interface XBudgetInput {
+  maxPagesPerSync?: unknown;
+  maxCostUsdPerMonth?: unknown;
+  costPerReadUsd?: unknown;
+}
+
+export interface XMcpSourceConfig {
+  id: string;
+  kind: "mcp";
+  url: string;
+  tokenFile: string;
+  bookmarksTool: string;
+  timelineTool: string;
+  maxResults: number;
+  budget: XBudgetConfig;
+}
+
+export interface XCorpusSourceConfig {
+  id: string;
+  kind: "corpusDir";
+  path: string;
+}
+
+export interface XCliSourceConfig {
+  id: string;
+  kind: "cli";
+  bin: string;
+  bookmarksArgs: string[];
+  /** When unset, this source contributes bookmarks only. */
+  postsArgs?: string[];
+}
+
+export type XSourceConfig = XMcpSourceConfig | XCorpusSourceConfig | XCliSourceConfig;
+
+export interface XConnectorConfig {
+  enabled: boolean;
+  userId?: string;
+  sources: XSourceConfig[];
+  sourcePriority: string[];
+  syncSchedule: string;
+  memoryMode: XMemoryMode;
+  stateDir: string;
+}
+
+export class XConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "XConfigError";
+  }
+}
+
+/** Coerces boolean-like strings at the config boundary; anything else is invalid. */
+export function coerceXBool(value: unknown, field: string): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+  }
+  throw new XConfigError(`${field} must be a boolean (got ${JSON.stringify(value)})`);
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new XConfigError(`${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return requiredString(value, field);
+}
+
+function positiveInt(value: unknown, field: string, fallback: number): number {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new XConfigError(`${field} must be an integer >= 1 (got ${JSON.stringify(value)})`);
+  }
+  return value;
+}
+
+function nonNegativeNumber(value: unknown, field: string, fallback: number): number {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new XConfigError(`${field} must be a finite number >= 0 (got ${JSON.stringify(value)})`);
+  }
+  return value;
+}
+
+function parseBudget(raw: unknown, sourceId: string): XBudgetConfig {
+  const input: XBudgetInput =
+    raw === undefined || raw === null ? {} : objectOrThrow(raw, `sources[${sourceId}].budget`);
+  return {
+    maxPagesPerSync: positiveInt(input.maxPagesPerSync, `sources[${sourceId}].budget.maxPagesPerSync`, 2),
+    maxCostUsdPerMonth: nonNegativeNumber(
+      input.maxCostUsdPerMonth,
+      `sources[${sourceId}].budget.maxCostUsdPerMonth`,
+      1.0
+    ),
+    costPerReadUsd: nonNegativeNumber(
+      input.costPerReadUsd,
+      `sources[${sourceId}].budget.costPerReadUsd`,
+      X_DEFAULT_COST_PER_READ_USD
+    ),
+  };
+}
+
+function objectOrThrow(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new XConfigError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseMcpSource(raw: Record<string, unknown>): XMcpSourceConfig {
+  const id = requiredString(raw.id, "source.id");
+  const auth = objectOrThrow(raw.auth ?? {}, `sources[${id}].auth`);
+  return {
+    id,
+    kind: "mcp",
+    url: optionalString(raw.url, `sources[${id}].url`) ?? X_DEFAULT_MCP_URL,
+    tokenFile: optionalString(auth.tokenFile ?? raw.tokenFile, `sources[${id}].auth.tokenFile`) ?? X_DEFAULT_TOKEN_FILE,
+    bookmarksTool: optionalString(raw.bookmarksTool, `sources[${id}].bookmarksTool`) ?? "get_users_bookmarks",
+    timelineTool: optionalString(raw.timelineTool, `sources[${id}].timelineTool`) ?? "get_users_tweets",
+    maxResults: positiveInt(raw.maxResults, `sources[${id}].maxResults`, 20),
+    budget: parseBudget(raw.budget, id),
+  };
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new XConfigError(`${field} must be an array of strings`);
+  }
+  return value.map((entry, index) => requiredString(entry, `${field}[${index}]`));
+}
+
+function parseCorpusSource(raw: Record<string, unknown>): XCorpusSourceConfig {
+  const id = requiredString(raw.id, "source.id");
+  return {
+    id,
+    kind: "corpusDir",
+    path: requiredString(raw.path, `sources[${id}].path`),
+  };
+}
+
+function parseCliSource(raw: Record<string, unknown>): XCliSourceConfig {
+  const id = requiredString(raw.id, "source.id");
+  const bookmarksArgs = stringArray(raw.bookmarksArgs, `sources[${id}].bookmarksArgs`);
+  return {
+    id,
+    kind: "cli",
+    bin: optionalString(raw.bin, `sources[${id}].bin`) ?? "bird",
+    bookmarksArgs: bookmarksArgs.length > 0 ? bookmarksArgs : ["bookmarks", "--json"],
+    postsArgs: (() => {
+      const postsArgs = stringArray(raw.postsArgs, `sources[${id}].postsArgs`);
+      return postsArgs.length > 0 ? postsArgs : undefined;
+    })(),
+  };
+}
+
+export function parseXConnectorConfig(raw: unknown): XConnectorConfig {
+  const input = objectOrThrow(raw, "xConnector");
+
+  const enabled = coerceXBool(input.enabled ?? true, "xConnector.enabled");
+
+  const userId = optionalString(input.userId, "xConnector.userId");
+  if (userId !== undefined && !/^\d+$/.test(userId)) {
+    throw new XConfigError("xConnector.userId must be the numeric X user id");
+  }
+
+  const sourcesRaw = input.sources;
+  if (!Array.isArray(sourcesRaw) || sourcesRaw.length === 0) {
+    throw new XConfigError("xConnector.sources must be a non-empty array");
+  }
+  const sources: XSourceConfig[] = [];
+  const seenIds = new Set<string>();
+  for (let index = 0; index < sourcesRaw.length; index++) {
+    const entry = objectOrThrow(sourcesRaw[index], `sources[${index}]`);
+    const kind = requiredString(entry.kind, `sources[${index}].kind`);
+    if (!(X_SOURCE_KINDS as readonly string[]).includes(kind)) {
+      throw new XConfigError(
+        `sources[${index}].kind must be one of ${X_SOURCE_KINDS.join(", ")} (got ${JSON.stringify(kind)})`
+      );
+    }
+    const source =
+      kind === "mcp" ? parseMcpSource(entry) : kind === "corpusDir" ? parseCorpusSource(entry) : parseCliSource(entry);
+    if (seenIds.has(source.id)) {
+      throw new XConfigError(`duplicate source id ${JSON.stringify(source.id)} in xConnector.sources`);
+    }
+    seenIds.add(source.id);
+    sources.push(source);
+  }
+
+  const sourcePriority = stringArray(input.sourcePriority, "xConnector.sourcePriority");
+  for (const id of sourcePriority) {
+    if (!seenIds.has(id)) {
+      throw new XConfigError(`xConnector.sourcePriority references unknown source id ${JSON.stringify(id)}`);
+    }
+  }
+  const orderedPriority = sourcePriority.length > 0 ? sourcePriority : sources.map((source) => source.id);
+
+  const memoryModeRaw = optionalString(input.memoryMode, "xConnector.memoryMode") ?? "suggest";
+  if (!(X_MEMORY_MODES as readonly string[]).includes(memoryModeRaw)) {
+    throw new XConfigError(
+      `xConnector.memoryMode must be one of ${X_MEMORY_MODES.join(", ")} (got ${JSON.stringify(memoryModeRaw)})`
+    );
+  }
+
+  const syncSchedule = optionalString(input.syncSchedule, "xConnector.syncSchedule") ?? "3x-daily";
+  if (!X_SYNC_SCHEDULES.includes(syncSchedule)) {
+    throw new XConfigError(
+      `xConnector.syncSchedule must be one of ${X_SYNC_SCHEDULES.join(", ")} (got ${JSON.stringify(syncSchedule)})`
+    );
+  }
+
+  return {
+    enabled,
+    userId,
+    sources,
+    sourcePriority: orderedPriority,
+    syncSchedule,
+    memoryMode: memoryModeRaw as XMemoryMode,
+    stateDir: optionalString(input.stateDir, "xConnector.stateDir") ?? X_DEFAULT_STATE_DIR,
+  };
+}
+
+/** OAuth2 client credentials for the MCP source, with env fallbacks. */
+export function resolveMcpClientCredentials(
+  source: XMcpSourceConfig,
+  env: NodeJS.ProcessEnv = process.env
+): { clientId?: string; clientSecret?: string; tokenFile: string } {
+  const clientId = env.REMNIC_X_CLIENT_ID ?? env.X_CLIENT_ID;
+  const clientSecret = env.REMNIC_X_CLIENT_SECRET ?? env.X_CLIENT_SECRET;
+  return {
+    clientId: typeof clientId === "string" && clientId.trim().length > 0 ? clientId.trim() : undefined,
+    clientSecret: typeof clientSecret === "string" && clientSecret.trim().length > 0 ? clientSecret.trim() : undefined,
+    tokenFile: source.tokenFile,
+  };
+}
+
+/** The effective monthly cost cap across all paid sources (max of per-source caps). */
+export function monthlyCostCapUsd(config: XConnectorConfig): number {
+  let cap = 0;
+  for (const source of config.sources) {
+    if (source.kind === "mcp") cap = Math.max(cap, source.budget.maxCostUsdPerMonth);
+  }
+  return cap;
+}

--- a/packages/connector-x/src/file-sink.ts
+++ b/packages/connector-x/src/file-sink.ts
@@ -1,0 +1,35 @@
+/**
+ * Default on-disk memory sink: `suggest` mode writes review-queue
+ * files under `<stateDir>/suggestions/`, `store` mode writes directly
+ * under `<stateDir>/records/`. Hosts with a live Remnic daemon pass
+ * their own XMemorySink instead.
+ */
+
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { expandTildePath } from "@remnic/core";
+
+import type { XMemorySink, XMemorySuggestion } from "./types.js";
+
+export interface FileSinkOptions {
+  stateDir: string;
+  mode: "suggest" | "store";
+}
+
+/** On-disk sink honoring the memoryMode trust gate by directory. */
+export function createFileSink(options: FileSinkOptions): XMemorySink {
+  const root = path.join(expandTildePath(options.stateDir), options.mode === "store" ? "records" : "suggestions");
+  const write = async (suggestion: XMemorySuggestion): Promise<void> => {
+    await mkdir(root, { recursive: true });
+    const safeName = suggestion.record.postId.replace(/[^0-9A-Za-z._-]/g, "_");
+    const target = path.join(root, `${safeName}.json`);
+    const tmp = `${target}.tmp`;
+    await writeFile(tmp, `${JSON.stringify(suggestion, null, 2)}\n`, { mode: 0o600 });
+    await rename(tmp, target);
+  };
+  return {
+    submitSuggestion: write,
+    storeMemory: write,
+  };
+}

--- a/packages/connector-x/src/guards.ts
+++ b/packages/connector-x/src/guards.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical unknown-payload guard for @remnic/connector-x.
+ *
+ * Fields stay `unknown` after narrowing; every field read is checked at
+ * its use site with `typeof` / `in` / `Array.isArray`.
+ */
+
+export function isXObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/connector-x/src/index.ts
+++ b/packages/connector-x/src/index.ts
@@ -1,0 +1,98 @@
+/**
+ * @remnic/connector-x — X (Twitter) connector for Remnic (issue #2009).
+ *
+ * À-la-carte optional companion of @remnic/core: installing core alone
+ * never pulls this in. Hosts import this module to run syncs and read
+ * status; the `remnic-x` bin offers the same operations standalone.
+ *
+ * Sources (pluggable, cheapest-first recommended):
+ *  - `corpusDir` — local bookmark/post JSON corpus (zero credits)
+ *  - `cli`       — cookie-GraphQL CLI such as `bird` (zero credits)
+ *  - `mcp`       — official X MCP at https://api.x.com/mcp (billed
+ *                  against X API credits; budget-capped, clean-skip on
+ *                  "credits depleted")
+ */
+
+export {
+  XConfigError,
+  X_DEFAULT_COST_PER_READ_USD,
+  X_DEFAULT_MCP_URL,
+  X_DEFAULT_STATE_DIR,
+  X_DEFAULT_TOKEN_FILE,
+  X_MEMORY_MODES,
+  X_SOURCE_KINDS,
+  X_SYNC_SCHEDULES,
+  coerceXBool,
+  monthlyCostCapUsd,
+  parseXConnectorConfig,
+  resolveMcpClientCredentials,
+} from "./config.js";
+export type {
+  XBudgetConfig,
+  XCliSourceConfig,
+  XConnectorConfig,
+  XCorpusSourceConfig,
+  XMcpSourceConfig,
+  XSourceConfig,
+} from "./config.js";
+
+export { isXObject } from "./guards.js";
+
+export {
+  XCreditsDepletedError,
+  X_MCP_DEFAULT_URL,
+  X_MCP_PROTOCOL_VERSION,
+  XMcpClient,
+  XMcpError,
+  looksLikeCreditsDepleted,
+  parseSseData,
+  toolResultTexts,
+} from "./mcp-client.js";
+export type { XMcpClientOptions, XMcpToolCallResult } from "./mcp-client.js";
+
+export {
+  recordFingerprint,
+  normalizeCorpusEntry,
+  normalizeMcpPayload,
+  stableStringify,
+  suggestionForRecord,
+} from "./normalize.js";
+
+export {
+  XBudgetTracker,
+  createXSource,
+  unlimitedBudget,
+} from "./sources.js";
+export type { XExecFn, XSourceDeps } from "./sources.js";
+
+export { getXStatus, runXSync } from "./sync.js";
+export type { XSyncDeps } from "./sync.js";
+
+export {
+  XRefreshChainBrokenError,
+  XTokenError,
+  XTokenStore,
+  X_TOKEN_REFRESH_URL,
+} from "./token-store.js";
+export type { XTokenPair, XTokenStoreOptions } from "./token-store.js";
+
+export type {
+  XAuthor,
+  XBudgetRuntime,
+  XMemoryMode,
+  XMemorySink,
+  XMemorySuggestion,
+  XPostRecord,
+  XProvenance,
+  XRecordKind,
+  XSource,
+  XSourceFetchContext,
+  XSourceFetchOutcome,
+  XSourceKind,
+  XSourceStatus,
+  XSourceSyncSummary,
+  XStatusReport,
+  XSyncReport,
+} from "./types.js";
+
+export { createFileSink } from "./file-sink.js";

--- a/packages/connector-x/src/mcp-client.test.ts
+++ b/packages/connector-x/src/mcp-client.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { XCreditsDepletedError, XMcpClient, XMcpError, parseSseData } from "./mcp-client.js";
+
+interface FetchCall {
+  method: string;
+  body: string;
+  headers: Record<string, string>;
+}
+
+type ToolStep =
+  | { kind: "status"; status: number }
+  | { kind: "tool"; text: string; isError?: boolean; sse?: boolean }
+  | { kind: "rpcError"; message: string; code?: number };
+
+interface Script {
+  sessionHeader: string;
+  toolScript: ToolStep[];
+  calls: FetchCall[];
+  sleeps: number[];
+}
+
+/**
+ * Request-driven fake X MCP server: initialize and notifications always
+ * succeed, tools/call pops the next scripted step and echoes the
+ * request id — immune to the client's internal id allocation.
+ */
+function makeClient(toolScript: ToolStep[], sessionHeader = "sess-42"): { client: XMcpClient; script: Script } {
+  const script: Script = { sessionHeader, toolScript, calls: [], sleeps: [] };
+  const client = new XMcpClient({
+    tokenProvider: async () => "user-token-not-real",
+    fetchImpl: (async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const headers = Object.fromEntries(Object.entries((init?.headers ?? {}) as Record<string, string>));
+      const message = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as {
+        id?: number;
+        method?: string;
+      };
+      script.calls.push({
+        method: message.method ?? "?",
+        body: typeof init?.body === "string" ? init.body : "",
+        headers,
+      });
+      if (message.method === "initialize") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "xmcp" } },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json", "Mcp-Session-Id": script.sessionHeader } }
+        );
+      }
+      if (message.method === "notifications/initialized") {
+        return new Response("", { status: 202 });
+      }
+      const step = script.toolScript.shift();
+      if (step === undefined) throw new Error("unexpected extra tools/call");
+      if (step.kind === "status") {
+        return new Response(JSON.stringify({ detail: "status" }), {
+          status: step.status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (step.kind === "rpcError") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: message.id, error: { code: -32000, message: step.message } }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      const envelope = {
+        jsonrpc: "2.0",
+        id: message.id,
+        result: { isError: step.isError === true, content: [{ type: "text", text: step.text }] },
+      };
+      return step.sse === true
+        ? new Response(`event: message\ndata: ${JSON.stringify(envelope)}\n\n`, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          })
+        : new Response(JSON.stringify(envelope), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+    }) as typeof fetch,
+    sleep: async (ms: number) => {
+      script.sleeps.push(ms);
+    },
+  });
+  return { client, script };
+}
+
+test("initialize → notification → tools/call carries session id and bearer", async () => {
+  const { client, script } = makeClient([{ kind: "tool", text: '{"data":[]}' }]);
+  const result = await client.callTool("get_users_bookmarks", { max_results: 5 });
+  assert.equal(result.isError, false);
+  assert.deepEqual(
+    script.calls.map((call) => call.method),
+    ["initialize", "notifications/initialized", "tools/call"]
+  );
+  const toolCall = script.calls[2];
+  assert.equal(toolCall.headers["Mcp-Session-Id"], "sess-42");
+  assert.equal(toolCall.headers.Authorization, "Bearer user-token-not-real");
+  assert.equal(JSON.parse(script.calls[0].body).params.protocolVersion, "2025-06-18");
+  assert.deepEqual(JSON.parse(toolCall.body).params, { name: "get_users_bookmarks", arguments: { max_results: 5 } });
+});
+
+test("parses SSE (text/event-stream) responses", async () => {
+  const { client } = makeClient([{ kind: "tool", text: '{"data":[{"id":"1"}]}', sse: true }]);
+  const result = await client.callTool("get_users_bookmarks", {});
+  assert.deepEqual(result.texts, ['{"data":[{"id":"1"}]}']);
+});
+
+test("parseSseData decodes data lines and skips keep-alives", () => {
+  const values = parseSseData(': ping\ndata: {"a":1}\n\ndata: not-json\n');
+  assert.deepEqual(values, [{ a: 1 }]);
+});
+
+test("HTTP 402 maps to XCreditsDepletedError", async () => {
+  const { client } = makeClient([{ kind: "status", status: 402 }]);
+  await assert.rejects(client.callTool("t", {}), XCreditsDepletedError);
+});
+
+test("402-in-tool-result (isError payload) maps to XCreditsDepletedError", async () => {
+  const { client } = makeClient([{ kind: "tool", text: '{"detail":"credits depleted","status":402}', isError: true }]);
+  await assert.rejects(client.callTool("get_users_bookmarks", {}), XCreditsDepletedError);
+});
+
+test("JSON-RPC error surfaces as XMcpError with detail", async () => {
+  const { client } = makeClient([{ kind: "rpcError", message: "bad args" }]);
+  await assert.rejects(client.callTool("t", {}), (err: unknown) => {
+    assert.ok(err instanceof XMcpError);
+    assert.match(err.message, /bad args/);
+    return true;
+  });
+});
+
+test("401 surfaces the refresh-chain hint", async () => {
+  const { client } = makeClient([{ kind: "status", status: 401 }]);
+  await assert.rejects(client.callTool("t", {}), /refresh chain is broken/);
+});
+
+test("session 404 re-initializes once and retries the call", async () => {
+  const { client, script } = makeClient([
+    { kind: "status", status: 404 },
+    { kind: "tool", text: '{"data":[]}' },
+  ]);
+  const result = await client.callTool("t", {});
+  assert.equal(result.isError, false);
+  assert.deepEqual(
+    script.calls.map((call) => call.method),
+    [
+      "initialize",
+      "notifications/initialized",
+      "tools/call", // 404 → session dropped
+      "initialize",
+      "notifications/initialized",
+      "tools/call",
+    ]
+  );
+});
+
+test("429 retries with backoff then succeeds", async () => {
+  const { client, script } = makeClient([
+    { kind: "status", status: 429 },
+    { kind: "tool", text: '{"data":[]}' },
+  ]);
+  const result = await client.callTool("t", {});
+  assert.equal(result.isError, false);
+  assert.deepEqual(script.sleeps, [500]);
+});
+
+test("requires a tokenProvider", () => {
+  assert.throws(
+    () => new XMcpClient({ tokenProvider: undefined as unknown as () => Promise<string> }),
+    /tokenProvider/
+  );
+});

--- a/packages/connector-x/src/mcp-client.ts
+++ b/packages/connector-x/src/mcp-client.ts
@@ -1,0 +1,353 @@
+/**
+ * Official X MCP client (Streamable HTTP, protocol 2025-06-18).
+ *
+ * Contract per https://docs.x.com (MCP, launched 2026-06-30): JSON-RPC
+ * over HTTP POST; `initialize` hands back an `Mcp-Session-Id` response
+ * header; response bodies may be plain JSON or SSE (`text/event-stream`,
+ * `data:` lines). Reads bill against X API credits — `credits depleted`
+ * (HTTP 402 or a 402-in-tool-result payload) maps to
+ * XCreditsDepletedError so callers can skip the cycle cleanly instead
+ * of erroring. Session `initialize`/`tools/list` are free.
+ *
+ * The API token is never logged and never included in thrown error
+ * messages.
+ */
+
+import { setTimeout as sleepMs } from "node:timers/promises";
+
+import { isXObject } from "./guards.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 2;
+const MAX_RETRY_DELAY_MS = 8_000;
+export const X_MCP_PROTOCOL_VERSION = "2025-06-18";
+export const X_MCP_DEFAULT_URL = "https://api.x.com/mcp";
+
+export class XMcpError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = "XMcpError";
+  }
+}
+
+/** Clean-skip signal: the account's X API credits are exhausted. */
+export class XCreditsDepletedError extends Error {
+  constructor() {
+    super("X API credits depleted — skipping this sync cycle");
+    this.name = "XCreditsDepletedError";
+  }
+}
+
+export interface XMcpToolCallResult {
+  isError: boolean;
+  /** text blocks of result.content, in order. */
+  texts: string[];
+  raw: unknown;
+}
+
+export interface XMcpClientOptions {
+  url?: string;
+  /** Lazily supplies a valid bearer token (user-context OAuth2). */
+  tokenProvider: () => Promise<string>;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  protocolVersion?: string;
+  clientName?: string;
+  clientVersion?: string;
+}
+
+interface JsonRpcMessage {
+  jsonrpc: "2.0";
+  id?: number;
+  method: string;
+  params?: unknown;
+}
+
+interface RpcResponse {
+  result: unknown;
+  headers: Headers | null;
+}
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) end--;
+  return value.slice(0, end);
+}
+
+/** Parses an SSE body into decoded `data:` JSON values, in order. */
+export function parseSseData(body: string): unknown[] {
+  const values: unknown[] = [];
+  for (const line of body.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice("data:".length).trim();
+    if (payload.length === 0) continue;
+    try {
+      values.push(JSON.parse(payload));
+    } catch {
+      // Ignore keep-alives and non-JSON comments.
+    }
+  }
+  return values;
+}
+
+function describeNetworkError(err: unknown): string {
+  if (!(err instanceof Error)) return "unexpected non-Error failure";
+  if ("code" in err && typeof err.code === "string" && err.code.length > 0) {
+    return `${err.name} (${err.code})`;
+  }
+  return err.name;
+}
+
+/** True when a tool-result body signals exhausted credits (docs + observed shape). */
+export function looksLikeCreditsDepleted(text: string): boolean {
+  return text.includes("credits depleted") || text.includes('"status":402');
+}
+
+/** Extracts text blocks from an MCP tool-result content array. */
+export function toolResultTexts(payload: Record<string, unknown>): string[] {
+  const content = Array.isArray(payload.content) ? payload.content : [];
+  const texts: string[] = [];
+  for (const block of content) {
+    if (isXObject(block) && block.type === "text" && typeof block.text === "string") {
+      texts.push(block.text);
+    }
+  }
+  return texts;
+}
+
+export class XMcpClient {
+  private readonly url: string;
+  private readonly tokenProvider: () => Promise<string>;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly protocolVersion: string;
+  private readonly clientName: string;
+  private readonly clientVersion: string;
+  private sessionId: string | null = null;
+  private nextMessageId = 1;
+
+  constructor(options: XMcpClientOptions) {
+    if (typeof options.tokenProvider !== "function") {
+      throw new XMcpError("XMcpClient requires a tokenProvider function");
+    }
+    this.url = stripTrailingSlashes(options.url ?? X_MCP_DEFAULT_URL);
+    this.tokenProvider = options.tokenProvider;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.sleep = options.sleep ?? sleepMs;
+    this.protocolVersion = options.protocolVersion ?? X_MCP_PROTOCOL_VERSION;
+    this.clientName = options.clientName ?? "remnic-connector-x";
+    this.clientVersion = options.clientVersion ?? "1.0.0";
+  }
+
+  /**
+   * Calls an MCP tool. Re-initializes once when the server rejects the
+   * session id (e.g. expired session), then retries the call.
+   */
+  async callTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<XMcpToolCallResult> {
+    return this.withSessionRetry(async () => {
+      const { result } = await this.rpcMessage(
+        {
+          jsonrpc: "2.0",
+          id: this.allocateId(),
+          method: "tools/call",
+          params: { name, arguments: args },
+        },
+        signal,
+        true
+      );
+      if (!isXObject(result)) {
+        throw new XMcpError(`tool ${name} returned a non-object result`);
+      }
+      const texts = toolResultTexts(result);
+      const isError = result.isError === true;
+      if (isError && looksLikeCreditsDepleted(texts.join("\n"))) {
+        throw new XCreditsDepletedError();
+      }
+      return { isError, texts, raw: result };
+    });
+  }
+
+  /** Best-effort session shutdown (MCP `DELETE`). */
+  async close(): Promise<void> {
+    if (this.sessionId === null) return;
+    const sessionId = this.sessionId;
+    this.sessionId = null;
+    try {
+      await this.fetchImpl(this.url, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${await this.tokenProvider()}`,
+          "Mcp-Session-Id": sessionId,
+        },
+      });
+    } catch {
+      // Shutdown is advisory.
+    }
+  }
+
+  private async withSessionRetry<T>(operation: () => Promise<T>): Promise<T> {
+    await this.ensureSession();
+    try {
+      return await operation();
+    } catch (err) {
+      if (err instanceof XMcpError && err.status === 404) {
+        // Session expired server-side: drop it and retry once on a fresh session.
+        this.sessionId = null;
+        await this.ensureSession();
+        return operation();
+      }
+      throw err;
+    }
+  }
+
+  private async ensureSession(signal?: AbortSignal): Promise<void> {
+    if (this.sessionId !== null) return;
+    const initialized = await this.rpcMessage(
+      {
+        jsonrpc: "2.0",
+        id: this.allocateId(),
+        method: "initialize",
+        params: {
+          protocolVersion: this.protocolVersion,
+          capabilities: {},
+          clientInfo: { name: this.clientName, version: this.clientVersion },
+        },
+      },
+      signal,
+      true
+    );
+    const sessionId = initialized.headers?.get("mcp-session-id");
+    if (typeof sessionId === "string" && sessionId.length > 0) {
+      this.sessionId = sessionId;
+    }
+    // Initialized notification: no id, no response body expected.
+    await this.rpcMessage({ jsonrpc: "2.0", method: "notifications/initialized" }, signal, false);
+  }
+
+  private allocateId(): number {
+    const id = this.nextMessageId;
+    this.nextMessageId += 1;
+    return id;
+  }
+
+  private async rpcMessage(
+    message: JsonRpcMessage,
+    signal: AbortSignal | undefined,
+    expectBody: boolean
+  ): Promise<RpcResponse> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      signal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${await this.tokenProvider()}`,
+      };
+      if (this.sessionId !== null) headers["Mcp-Session-Id"] = this.sessionId;
+
+      let response: Response;
+      try {
+        response = await this.fetchImpl(this.url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(message),
+          signal: combined,
+        });
+      } catch (err) {
+        if (signal?.aborted) throw err;
+        lastError = err;
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw new XMcpError(`X MCP request failed after ${MAX_RETRIES + 1} attempts: ${describeNetworkError(err)}`);
+      }
+
+      if (response.status === 402) throw new XCreditsDepletedError();
+      if (response.status === 401) {
+        throw new XMcpError(
+          "X MCP rejected the bearer token (401) — the OAuth2 token or refresh chain is broken; re-authorize",
+          401
+        );
+      }
+      if (response.status === 404 && this.sessionId !== null) {
+        throw new XMcpError("X MCP session expired", 404);
+      }
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new XMcpError(`X MCP responded ${response.status}`, response.status);
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(retryDelayMs(response, attempt));
+          continue;
+        }
+        throw lastError;
+      }
+      if (!response.ok) {
+        throw new XMcpError(`X MCP responded ${response.status}`, response.status);
+      }
+      if (!expectBody || response.status === 202) {
+        return { result: null, headers: response.headers };
+      }
+      const body = await response.text();
+      return {
+        result: this.decodeBody(body, response.headers, message.id),
+        headers: response.headers,
+      };
+    }
+    throw lastError instanceof Error ? lastError : new XMcpError("X MCP request failed");
+  }
+
+  private decodeBody(body: string, headers: Headers, messageId: number | undefined): unknown {
+    const contentType = headers.get("content-type") ?? "";
+    let messages: unknown[];
+    if (contentType.includes("text/event-stream")) {
+      messages = parseSseData(body);
+    } else {
+      try {
+        messages = [JSON.parse(body)];
+      } catch {
+        throw new XMcpError("X MCP returned a non-JSON body");
+      }
+    }
+    const match = messages.find((entry) => isXObject(entry) && entry.id === messageId && entry.error === undefined);
+    if (match === undefined) {
+      const errorEntry = messages.find(
+        (entry) => isXObject(entry) && entry.id === messageId && entry.error !== undefined
+      );
+      if (errorEntry !== undefined && isXObject(errorEntry)) {
+        const rpcError = errorEntry.error;
+        const detail =
+          isXObject(rpcError) && typeof rpcError.message === "string"
+            ? `${String(rpcError.code)}: ${rpcError.message}`
+            : "unknown JSON-RPC error";
+        if (looksLikeCreditsDepleted(detail)) throw new XCreditsDepletedError();
+        throw new XMcpError(`X MCP tool call failed: ${detail}`);
+      }
+      throw new XMcpError("X MCP response carried no message for this request id");
+    }
+    if (isXObject(match) && "result" in match) return match.result;
+    return match;
+  }
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_RETRY_DELAY_MS, 500 * 2 ** attempt);
+}
+
+function retryDelayMs(response: Response, attempt: number): number {
+  const headerValue = response.headers.get("retry-after");
+  if (headerValue !== null) {
+    const parsed = Number(headerValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.min(MAX_RETRY_DELAY_MS, Math.ceil(parsed * 1_000));
+    }
+  }
+  return backoffMs(attempt);
+}

--- a/packages/connector-x/src/normalize.test.ts
+++ b/packages/connector-x/src/normalize.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  normalizeCorpusEntry,
+  normalizeMcpPayload,
+  recordFingerprint,
+  stableStringify,
+  suggestionForRecord,
+} from "./normalize.js";
+
+const V2_PAGE = {
+  data: [
+    {
+      id: "1800",
+      text: "Great post on agent memory https://example.com/x",
+      author_id: "7",
+      created_at: "2026-07-01T12:00:00.000Z",
+      entities: { urls: [{ url: "https://t.co/abc", expanded_url: "https://example.com/x" }] },
+      attachments: { media_keys: ["3_1", "3_2"] },
+    },
+  ],
+  includes: { users: [{ id: "7", username: "karpathy", name: "Andrej" }] },
+  meta: { next_token: "p2" },
+};
+
+test("normalizes a v2 MCP payload with includes-based author resolution", () => {
+  const records = normalizeMcpPayload(V2_PAGE, "bookmark");
+  assert.equal(records.length, 1);
+  const record = records[0];
+  assert.equal(record.postId, "1800");
+  assert.equal(record.kind, "bookmark");
+  assert.equal(record.author?.username, "karpathy");
+  assert.equal(record.author?.id, "7");
+  assert.deepEqual(record.urls, ["https://example.com/x"]);
+  assert.equal(record.mediaCount, 2);
+  assert.equal(record.createdAt, "2026-07-01T12:00:00.000Z");
+});
+
+test("trims the trailing t.co share link from text", () => {
+  const records = normalizeMcpPayload(
+    {
+      data: [
+        {
+          id: "1801",
+          text: "Read this https://t.co/abc",
+          entities: { urls: [{ url: "https://t.co/abc", expanded_url: "https://example.com/a" }] },
+        },
+      ],
+    },
+    "bookmark"
+  );
+  assert.equal(records[0].text, "Read this");
+  assert.deepEqual(records[0].urls, ["https://example.com/a"]);
+});
+
+test("drops rows without an id or any content", () => {
+  const records = normalizeMcpPayload({ data: [{ text: "no id" }, { id: "9" }, null] }, "bookmark");
+  assert.equal(records.length, 0);
+});
+
+test("normalizes corpus entries across field aliases and kind labels", () => {
+  const record = normalizeCorpusEntry(
+    {
+      tweet_id: "42",
+      kind: "own_post",
+      username: "jane",
+      full_text: "Shipping the connector",
+      url: "https://x.com/jane/status/42",
+      bookmarked_at: "2026-07-02T00:00:00Z",
+      enrichment: { title: "launch note" },
+    },
+    "bookmark"
+  );
+  assert.ok(record !== null);
+  assert.equal(record.kind, "own_post");
+  assert.equal(record.author?.username, "jane");
+  assert.equal(record.text, "Shipping the connector");
+  assert.deepEqual(record.urls, ["https://x.com/jane/status/42"]);
+  assert.equal(record.bookmarkedAt, "2026-07-02T00:00:00Z");
+  assert.equal(record.enrichment?.title, "launch note");
+});
+
+test("fingerprint is stable across key order and ignores provenance", () => {
+  const a = normalizeCorpusEntry({ id: "5", text: "same", urls: "https://a.io" }, "bookmark");
+  const b = normalizeCorpusEntry({ urls: "https://a.io", text: "same", id: "5" }, "bookmark");
+  assert.ok(a !== null && b !== null);
+  a.provenance = { sourceId: "one", sourceKind: "corpusDir", syncRunId: "r1", fetchedAt: "now" };
+  b.provenance = { sourceId: "two", sourceKind: "cli", syncRunId: "r2", fetchedAt: "later" };
+  assert.equal(recordFingerprint(a), recordFingerprint(b));
+  assert.notEqual(stableStringify({ b: 1, a: 2 }), JSON.stringify({ b: 1, a: 2 }));
+  assert.equal(stableStringify({ b: 1, a: 2 }), stableStringify({ a: 2, b: 1 }));
+});
+
+test("changed content changes the fingerprint (re-bookmark without churn)", () => {
+  const base = normalizeCorpusEntry({ id: "5", text: "v1" }, "bookmark");
+  const edited = normalizeCorpusEntry({ id: "5", text: "v2" }, "bookmark");
+  assert.ok(base !== null && edited !== null);
+  assert.notEqual(recordFingerprint(base), recordFingerprint(edited));
+});
+
+test("bookmark suggestion maps to x/bookmark reference with entity link", () => {
+  const record = normalizeMcpPayload(V2_PAGE, "bookmark")[0];
+  const suggestion = suggestionForRecord(record);
+  assert.deepEqual(suggestion.tags, ["x/bookmark"]);
+  assert.equal(suggestion.category, "reference");
+  assert.equal(suggestion.entityRef, "person-karpathy");
+  assert.equal(suggestion.confidence, 0.7);
+  assert.equal(suggestion.postUrl, "https://x.com/karpathy/status/1800");
+  assert.match(suggestion.content, /Bookmarked on X from @karpathy/);
+  assert.match(suggestion.content, /https:\/\/example\.com\/x/);
+});
+
+test("own-post suggestion maps to x/post expression with higher confidence", () => {
+  const record = normalizeCorpusEntry(
+    { id: "9", kind: "post", username: "me", text: "I think connectors should compose" },
+    "bookmark"
+  );
+  assert.ok(record !== null);
+  const suggestion = suggestionForRecord(record);
+  assert.deepEqual(suggestion.tags, ["x/post"]);
+  assert.equal(suggestion.category, "expression");
+  assert.equal(suggestion.confidence, 0.9);
+  assert.equal(suggestion.postUrl, "https://x.com/me/status/9");
+});
+
+test("url-less bookmark classifies as interest and falls back to /i/status url", () => {
+  const record = normalizeCorpusEntry({ id: "10", text: "just an idea" }, "bookmark");
+  assert.ok(record !== null);
+  const suggestion = suggestionForRecord(record);
+  assert.equal(suggestion.category, "interest");
+  assert.equal(suggestion.postUrl, "https://x.com/i/status/10");
+});

--- a/packages/connector-x/src/normalize.ts
+++ b/packages/connector-x/src/normalize.ts
@@ -1,0 +1,249 @@
+/**
+ * Payload normalization for all three X sources plus the shared
+ * dedupe fingerprint and the record → memory mapping.
+ *
+ * All parsers are shape-tolerant: X MCP payloads follow the v2 API
+ * expansions shape (`data[]` + `includes.users`), local corpora and
+ * CLI tools use a variety of field aliases. Every field read is
+ * checked; unrecognized shapes yield empty results, never crashes.
+ */
+
+import { createHash } from "node:crypto";
+
+import { isXObject } from "./guards.js";
+import type { XMemorySuggestion, XPostRecord, XRecordKind } from "./types.js";
+
+/** Sorts keys recursively so key order never changes the fingerprint. */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, entry) => {
+    if (isXObject(entry)) {
+      return Object.fromEntries(
+        Object.keys(entry)
+          .sort()
+          .map((key) => [key, entry[key]])
+      );
+    }
+    return entry;
+  });
+}
+
+/** Identity fingerprint: same post + same content = same memory, regardless of source key order. */
+export function recordFingerprint(record: XPostRecord): string {
+  return createHash("sha256")
+    .update(
+      stableStringify({
+        postId: record.postId,
+        kind: record.kind,
+        text: record.text,
+        urls: [...record.urls].sort(),
+        authorUsername: record.author?.username ?? null,
+      })
+    )
+    .digest("hex");
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (!Array.isArray(value)) return [];
+  const urls: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.trim().length > 0) urls.push(entry.trim());
+    else if (isXObject(entry)) {
+      const expanded = firstString(entry.expanded_url, entry.url, entry.href);
+      if (expanded !== undefined) urls.push(expanded);
+    }
+  }
+  return urls;
+}
+
+function kindFrom(value: unknown, fallback: XRecordKind): XRecordKind {
+  const raw = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (raw === "bookmark" || raw === "bookmarks") return "bookmark";
+  if (raw === "own_post" || raw === "post" || raw === "tweet" || raw === "own-post") {
+    return "own_post";
+  }
+  return fallback;
+}
+
+/**
+ * Normalizes an MCP tool-result payload (v2 expansions shape) into
+ * records. Accepts `{data: [...]}` with `includes.users`, a bare
+ * array, or `{bookmarks: [...]}`.
+ */
+export function normalizeMcpPayload(payload: unknown, kind: XRecordKind, ownUsername?: string): XPostRecord[] {
+  const container = isXObject(payload) ? payload : {};
+  const includesUsers = isXObject(container.includes)
+    ? Array.isArray(container.includes.users)
+      ? container.includes.users
+      : []
+    : [];
+  const rows = Array.isArray(container.data)
+    ? container.data
+    : Array.isArray(payload)
+      ? payload
+      : isXObject(container.bookmarks) && Array.isArray(container.bookmarks.data)
+        ? container.bookmarks.data
+        : Array.isArray(container.bookmarks)
+          ? container.bookmarks
+          : [];
+  const records: XPostRecord[] = [];
+  for (const row of rows) {
+    const record = normalizeEntry(row, kind, includesUsers, ownUsername);
+    if (record !== null) records.push(record);
+  }
+  return records;
+}
+
+/** Normalizes one corpus/CLI entry (tolerant field aliases). */
+export function normalizeCorpusEntry(
+  entry: unknown,
+  fallbackKind: XRecordKind,
+  ownUsername?: string
+): XPostRecord | null {
+  return normalizeEntry(entry, fallbackKind, [], ownUsername);
+}
+
+function normalizeEntry(
+  entry: unknown,
+  fallbackKind: XRecordKind,
+  includesUsers: unknown[],
+  ownUsername?: string
+): XPostRecord | null {
+  if (!isXObject(entry)) return null;
+  const postId = firstString(entry.post_id, entry.id, entry.tweet_id, entry.postId);
+  const text = firstString(entry.text, entry.full_text, entry.content, entry.note) ?? "";
+  if (postId === undefined || (text.length === 0 && !hasUrls(entry))) return null;
+
+  const kind = kindFrom(entry.kind ?? entry.type, fallbackKind);
+  const authorRaw = isXObject(entry.author) ? entry.author : entry;
+  const authorId = firstString(entry.author_id, entry.authorId, authorRaw.id);
+  const authorUsername =
+    firstString(authorRaw.username, authorRaw.handle, authorRaw.screen_name) ??
+    lookupIncludedUsername(includesUsers, authorId) ??
+    ownUsername;
+  const authorName = firstString(authorRaw.name, authorRaw.display_name);
+  const author =
+    authorUsername !== undefined || authorId !== undefined || authorName !== undefined
+      ? {
+          ...(authorId !== undefined ? { id: authorId } : {}),
+          ...(authorUsername !== undefined ? { username: authorUsername } : {}),
+          ...(authorName !== undefined ? { name: authorName } : {}),
+        }
+      : undefined;
+
+  const urls = collectUrls(entry);
+  const createdAt = firstString(entry.created_at, entry.createdAt, entry.created_at_iso);
+  const bookmarkedAt = firstString(entry.bookmarked_at, entry.bookmarkedAt, entry.saved_at);
+  const mediaCount = countMedia(entry);
+  const enrichment = isXObject(entry.enrichment) ? entry.enrichment : undefined;
+
+  return {
+    postId,
+    kind,
+    ...(author !== undefined ? { author } : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    ...(bookmarkedAt !== undefined ? { bookmarkedAt } : {}),
+    text: trimTcoSuffix(text, entry),
+    urls,
+    mediaCount,
+    ...(enrichment !== undefined ? { enrichment } : {}),
+  };
+}
+
+function hasUrls(entry: Record<string, unknown>): boolean {
+  return collectUrls(entry).length > 0;
+}
+
+function collectUrls(entry: Record<string, unknown>): string[] {
+  const urls = [...asStringArray(entry.urls), ...asStringArray(entry.url), ...asStringArray(entry.links)];
+  if (isXObject(entry.entities) && Array.isArray(entry.entities.urls)) {
+    urls.push(...asStringArray(entry.entities.urls));
+  }
+  return [...new Set(urls)];
+}
+
+function countMedia(entry: Record<string, unknown>): number {
+  if (isXObject(entry.attachments) && Array.isArray(entry.attachments.media_keys)) {
+    return entry.attachments.media_keys.length;
+  }
+  if (Array.isArray(entry.media)) return entry.media.length;
+  if (isXObject(entry.media) && Array.isArray(entry.media.media_keys)) {
+    return entry.media.media_keys.length;
+  }
+  return 0;
+}
+
+function lookupIncludedUsername(includesUsers: unknown[], authorId: string | undefined): string | undefined {
+  if (authorId === undefined) return undefined;
+  for (const user of includesUsers) {
+    if (isXObject(user) && user.id === authorId) {
+      return firstString(user.username, user.screen_name);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * X appends the share URL (a t.co short link) to tweet text; when the
+ * text ends with exactly that short link, drop it — the expanded URL
+ * is already in `urls`.
+ */
+function trimTcoSuffix(text: string, entry: Record<string, unknown>): string {
+  const entities = isXObject(entry.entities) && Array.isArray(entry.entities.urls) ? entry.entities.urls : [];
+  for (const raw of entities) {
+    if (!isXObject(raw) || typeof raw.url !== "string") continue;
+    if (raw.url.includes("://t.co/") && text.endsWith(raw.url)) {
+      return text.slice(0, text.length - raw.url.length).trimEnd();
+    }
+  }
+  return text;
+}
+
+function postUrl(record: XPostRecord): string {
+  const username = record.author?.username;
+  return username !== undefined
+    ? `https://x.com/${username}/status/${record.postId}`
+    : `https://x.com/i/status/${record.postId}`;
+}
+
+const QUOTE = '"';
+
+/**
+ * Record → memory mapping (issue #2009 §2):
+ * - bookmarks → tag `x/bookmark`, category `reference` (carries a URL) or `interest`
+ * - own posts → tag `x/post`, category `expression`, higher confidence
+ */
+export function suggestionForRecord(record: XPostRecord): XMemorySuggestion {
+  const quoted = `${QUOTE}${record.text.slice(0, 280)}${record.text.length > 280 ? "…" : ""}${QUOTE}`;
+  const from = record.author?.username !== undefined ? ` from @${record.author.username}` : "";
+  const firstUrl = record.urls[0];
+  const title = enrichmentTitle(record);
+  const isOwnPost = record.kind === "own_post";
+  const content = isOwnPost
+    ? `Posted on X: ${quoted}${firstUrl !== undefined ? ` ${firstUrl}` : ""}${title !== undefined ? ` (${title})` : ""}`
+    : `Bookmarked on X${from}: ${quoted}${firstUrl !== undefined ? ` ${firstUrl}` : ""}${
+        title !== undefined ? ` (${title})` : ""
+      }`;
+  return {
+    record,
+    tags: [isOwnPost ? "x/post" : "x/bookmark"],
+    category: isOwnPost ? "expression" : firstUrl !== undefined ? "reference" : "interest",
+    ...(record.author?.username !== undefined ? { entityRef: `person-${record.author.username.toLowerCase()}` } : {}),
+    confidence: isOwnPost ? 0.9 : 0.7,
+    postUrl: postUrl(record),
+    content,
+  };
+}
+
+function enrichmentTitle(record: XPostRecord): string | undefined {
+  if (record.enrichment === undefined) return undefined;
+  const title = isXObject(record.enrichment) ? record.enrichment.title : undefined;
+  return typeof title === "string" && title.trim().length > 0 ? title.trim() : undefined;
+}

--- a/packages/connector-x/src/sources.test.ts
+++ b/packages/connector-x/src/sources.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { parseXConnectorConfig } from "./config.js";
+import { XBudgetTracker, createXSource, unlimitedBudget } from "./sources.js";
+import type { XExecFn } from "./sources.js";
+
+function mcpConfig(overrides: Record<string, unknown> = {}) {
+  return parseXConnectorConfig({
+    userId: "123",
+    sources: [{ id: "x-mcp", kind: "mcp", ...overrides }],
+  }).sources[0];
+}
+
+function tokenFileFor(dir: string): string {
+  return path.join(dir, "tokens.json");
+}
+
+async function seedTokens(dir: string): Promise<string> {
+  const file = tokenFileFor(dir);
+  await writeFile(
+    file,
+    JSON.stringify({ access_token: "tok", refresh_token: "r", expires_at: Date.now() + 3_600_000 })
+  );
+  return file;
+}
+
+function mcpResponses(pages: unknown[]): Response[] {
+  const out: Response[] = [
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Mcp-Session-Id": "s1" },
+    }),
+    new Response("", { status: 202 }),
+  ];
+  let id = 2;
+  for (const page of pages) {
+    out.push(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text: JSON.stringify(page) }] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    id += 1;
+  }
+  return out;
+}
+
+const ENV = { REMNIC_X_CLIENT_ID: "cid", REMNIC_X_CLIENT_SECRET: "csecret" };
+
+function page(ids: string[], nextToken?: string): unknown {
+  return {
+    data: ids.map((id) => ({ id, text: `post ${id}`, author_id: "7" })),
+    includes: { users: [{ id: "7", username: "author" }] },
+    ...(nextToken !== undefined ? { meta: { next_token: nextToken } } : {}),
+  };
+}
+
+test("mcp source paginates and stops on a page of known ids", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-src-"));
+  const tokenFile = await seedTokens(dir);
+  const responses = mcpResponses([page(["1", "2"], "p2"), page(["3"]), page(["9"])]);
+  let call = 0;
+  const source = createXSource(mcpConfig({ auth: { tokenFile } }), {
+    env: ENV,
+    userId: "123",
+    fetchImpl: (async () => {
+      call += 1;
+      const next = responses.shift();
+      assert.ok(next !== undefined);
+      return next;
+    }) as typeof fetch,
+  });
+  const budget = new XBudgetTracker({ maxPagesPerSync: 5, maxCostUsdPerMonth: 10, costPerReadUsd: 0.01 }, 0);
+  // Bookmarks page 2 contains only known ids → pagination stops after it,
+  // then one own-posts timeline page runs.
+  const outcome = await source.fetch({ knownIds: new Set(["3"]), budget });
+  assert.equal(outcome.records.length, 4);
+  assert.equal(outcome.reads, 3);
+  assert.equal(call, 5);
+  assert.equal(outcome.skipped, undefined);
+  assert.ok(outcome.records.some((record) => record.kind === "own_post" && record.postId === "9"));
+});
+
+test("mcp source enforces the page cap as a clean skip", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-src-"));
+  const tokenFile = await seedTokens(dir);
+  const responses = mcpResponses([page(["1"], "p2"), page(["2"], "p3"), page(["3"])]);
+  const source = createXSource(mcpConfig({ auth: { tokenFile } }), {
+    env: ENV,
+    fetchImpl: (async () => {
+      const next = responses.shift();
+      assert.ok(next !== undefined);
+      return next;
+    }) as typeof fetch,
+  });
+  const budget = new XBudgetTracker({ maxPagesPerSync: 2, maxCostUsdPerMonth: 10, costPerReadUsd: 0.01 }, 0);
+  const outcome = await source.fetch({ knownIds: new Set(), budget });
+  assert.equal(outcome.records.length, 2);
+  assert.equal(outcome.reads, 2);
+  assert.equal(outcome.skipped?.reason, "page-cap");
+});
+
+test("mcp source skips cleanly when the monthly cost cap is reached", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-src-"));
+  const tokenFile = await seedTokens(dir);
+  let fetches = 0;
+  const source = createXSource(mcpConfig({ auth: { tokenFile } }), {
+    env: ENV,
+    fetchImpl: (async () => {
+      fetches += 1;
+      return mcpResponses([page(["1"])])[2];
+    }) as typeof fetch,
+  });
+  const budget = new XBudgetTracker(
+    { maxPagesPerSync: 2, maxCostUsdPerMonth: 0.01, costPerReadUsd: 0.01 },
+    0.01 // already at cap this month
+  );
+  const outcome = await source.fetch({ knownIds: new Set(), budget });
+  assert.equal(outcome.records.length, 0);
+  assert.equal(outcome.skipped?.reason, "monthly-cost-cap");
+  assert.equal(fetches, 0); // initialize+notification never happened: gate ran first
+});
+
+test("mcp source maps credits-depleted to a clean skip", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-src-"));
+  const tokenFile = await seedTokens(dir);
+  const responses = [
+    ...mcpResponses([]).slice(0, 2),
+    new Response(JSON.stringify({ detail: "credits depleted", status: 402 }), { status: 402 }),
+  ];
+  const source = createXSource(mcpConfig({ auth: { tokenFile } }), {
+    env: ENV,
+    fetchImpl: (async () => {
+      const next = responses.shift();
+      assert.ok(next !== undefined);
+      return next;
+    }) as typeof fetch,
+  });
+  const outcome = await source.fetch({ knownIds: new Set(), budget: unlimitedBudget });
+  assert.equal(outcome.skipped?.reason, "credits-depleted");
+});
+
+test("mcp source without credentials degrades, not crashes", async () => {
+  const source = createXSource(mcpConfig(), { env: {} });
+  const outcome = await source.fetch({ knownIds: new Set(), budget: unlimitedBudget });
+  assert.equal(outcome.skipped?.reason, "auth-not-configured");
+});
+
+test("corpus source reads sorted json files and skips bad ones and escaping symlinks", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-x-corpus-"));
+  const outside = await mkdtemp(path.join(tmpdir(), "remnic-x-outside-"));
+  await writeFile(path.join(root, "b.json"), JSON.stringify({ id: "2", text: "second" }));
+  await writeFile(path.join(root, "a.json"), JSON.stringify([{ id: "1", text: "first" }]));
+  await writeFile(path.join(root, "bad.json"), "{not json");
+  await symlink(path.join(outside, "x.json"), path.join(root, "escape.json"));
+  await writeFile(path.join(outside, "x.json"), JSON.stringify({ id: "99", text: "outside" }));
+  const config = parseXConnectorConfig({
+    sources: [{ id: "c", kind: "corpusDir", path: root }],
+  }).sources[0];
+  const source = createXSource(config);
+  const outcome = await source.fetch({ knownIds: new Set(), budget: unlimitedBudget });
+  assert.equal(outcome.records.length, 2);
+  assert.ok(outcome.records.every((record) => record.postId !== "99"));
+  assert.equal(outcome.reads, 0);
+});
+
+test("corpus source reports a missing directory as a clean skip", async () => {
+  const config = parseXConnectorConfig({
+    sources: [{ id: "c", kind: "corpusDir", path: "/nonexistent/remnic-x-test" }],
+  }).sources[0];
+  const outcome = await createXSource(config).fetch({
+    knownIds: new Set(),
+    budget: unlimitedBudget,
+  });
+  assert.equal(outcome.skipped?.reason, "corpus-dir-missing");
+});
+
+test("cli source parses bird-style json output for bookmarks and posts", async () => {
+  const config = parseXConnectorConfig({
+    sources: [{ id: "b", kind: "cli", bin: "bird", postsArgs: ["timeline", "--json"] }],
+  }).sources[0];
+  const exec: XExecFn = async (_bin, args) => {
+    if (args.includes("bookmarks")) {
+      return { stdout: JSON.stringify([{ id: "7", text: "saved", username: "k" }]), stderr: "" };
+    }
+    return { stdout: JSON.stringify({ data: [{ id: "8", text: "mine", kind: "post" }] }), stderr: "" };
+  };
+  const outcome = await createXSource(config, { execImpl: exec }).fetch({
+    knownIds: new Set(),
+    budget: unlimitedBudget,
+  });
+  assert.equal(outcome.records.length, 2);
+  assert.deepEqual(outcome.records.map((record) => `${record.kind}:${record.postId}`).sort(), [
+    "bookmark:7",
+    "own_post:8",
+  ]);
+});
+
+test("cli source degrades when the binary is missing or output is not json", async () => {
+  const config = parseXConnectorConfig({
+    sources: [{ id: "b", kind: "cli" }],
+  }).sources[0];
+  const missing: XExecFn = async () => {
+    const err = new Error("spawn bird ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  };
+  const outcome = await createXSource(config, { execImpl: missing }).fetch({
+    knownIds: new Set(),
+    budget: unlimitedBudget,
+  });
+  assert.equal(outcome.skipped?.reason, "cli-not-installed");
+
+  const garbage: XExecFn = async () => ({ stdout: "not json", stderr: "" });
+  const outcome2 = await createXSource(config, { execImpl: garbage }).fetch({
+    knownIds: new Set(),
+    budget: unlimitedBudget,
+  });
+  assert.equal(outcome2.skipped?.reason, "cli-output-unparseable");
+});

--- a/packages/connector-x/src/sources.ts
+++ b/packages/connector-x/src/sources.ts
@@ -1,0 +1,363 @@
+/**
+ * Pluggable X sources (issue #2009): official X MCP (paid, budget-
+ * capped), a local corpus directory (zero credits), and a cookie-CLI
+ * such as `bird` (zero credits). All three emit the same normalized
+ * XPostRecord currency and degrade with a `skipped` reason instead of
+ * throwing, except auth/config breakage which surfaces to the sync
+ * report's `error` field.
+ */
+
+import { execFile } from "node:child_process";
+import { lstat, readFile, readdir, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { expandTildePath } from "@remnic/core";
+
+import {
+  type XBudgetConfig,
+  type XCliSourceConfig,
+  type XCorpusSourceConfig,
+  type XMcpSourceConfig,
+  resolveMcpClientCredentials,
+} from "./config.js";
+import { isXObject } from "./guards.js";
+import { XCreditsDepletedError, XMcpClient, XMcpError } from "./mcp-client.js";
+import { normalizeCorpusEntry, normalizeMcpPayload } from "./normalize.js";
+import { XTokenStore } from "./token-store.js";
+import type {
+  XBudgetRuntime,
+  XPostRecord,
+  XRecordKind,
+  XSource,
+  XSourceFetchContext,
+  XSourceFetchOutcome,
+} from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+export type XExecFn = (bin: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+
+export interface XSourceDeps {
+  /** Owning X user id — gates the own-posts timeline reads for MCP sources. */
+  userId?: string;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+  execImpl?: XExecFn;
+}
+
+/** Budget enforcement for paid (MCP) sources. */
+export class XBudgetTracker implements XBudgetRuntime {
+  pagesUsed = 0;
+  reads = 0;
+  readonly maxPages: number;
+
+  constructor(
+    private readonly budget: XBudgetConfig,
+    private readonly monthSpendUsd: number
+  ) {
+    this.maxPages = budget.maxPagesPerSync;
+  }
+
+  canRead(): { ok: true } | { ok: false; reason: string; detail?: string } {
+    if (this.pagesUsed >= this.budget.maxPagesPerSync) {
+      return { ok: false, reason: "page-cap", detail: `${this.budget.maxPagesPerSync} pages/sync` };
+    }
+    const projected = this.monthSpendUsd + (this.reads + 1) * this.budget.costPerReadUsd;
+    if (projected > this.budget.maxCostUsdPerMonth + 1e-9) {
+      return {
+        ok: false,
+        reason: "monthly-cost-cap",
+        detail: `$${projected.toFixed(2)} projected vs $${this.budget.maxCostUsdPerMonth.toFixed(2)} cap`,
+      };
+    }
+    return { ok: true };
+  }
+
+  noteRead(): void {
+    this.reads += 1;
+  }
+}
+
+/** Zero-credit sources never consume budget. */
+export const unlimitedBudget: XBudgetRuntime = {
+  pagesUsed: 0,
+  maxPages: Number.POSITIVE_INFINITY,
+  canRead: () => ({ ok: true }),
+  noteRead: () => {},
+};
+
+/** Builds the source adapter for a parsed source config entry. */
+export function createXSource(
+  config: XMcpSourceConfig | XCorpusSourceConfig | XCliSourceConfig,
+  deps: XSourceDeps = {}
+): XSource {
+  if (config.kind === "mcp") return createMcpSource(config, deps);
+  if (config.kind === "corpusDir") return createCorpusSource(config);
+  return createCliSource(config, deps);
+}
+
+// ── MCP source ──────────────────────────────────────────────────────────────
+
+function createMcpSource(config: XMcpSourceConfig, deps: XSourceDeps): XSource {
+  const credentials = resolveMcpClientCredentials(config, deps.env ?? process.env);
+  let client: XMcpClient | null = null;
+  const getClient = (): XMcpClient => {
+    if (client === null) {
+      if (credentials.clientId === undefined || credentials.clientSecret === undefined) {
+        throw new XMcpError(
+          `source ${config.id}: OAuth2 client credentials missing — set auth on the source or REMNIC_X_CLIENT_ID/REMNIC_X_CLIENT_SECRET`
+        );
+      }
+      const store = new XTokenStore({
+        tokenFile: expandTildePath(credentials.tokenFile),
+        clientId: credentials.clientId,
+        clientSecret: credentials.clientSecret,
+        ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+        ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+        ...(deps.now !== undefined ? { now: deps.now } : {}),
+      });
+      client = new XMcpClient({
+        url: config.url,
+        tokenProvider: () => store.getAccessToken(),
+        ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+        ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+      });
+    }
+    return client;
+  };
+
+  return {
+    id: config.id,
+    kind: "mcp",
+    async fetch(ctx: XSourceFetchContext): Promise<XSourceFetchOutcome> {
+      const records: XPostRecord[] = [];
+      let reads = 0;
+      let pages = 0;
+      let skipped: XSourceFetchOutcome["skipped"];
+      try {
+        getClient();
+      } catch (err) {
+        return {
+          records,
+          reads,
+          pages,
+          skipped: {
+            reason: "auth-not-configured",
+            ...(err instanceof Error ? { detail: err.message } : {}),
+          },
+        };
+      }
+
+      const runKind = async (kind: XRecordKind, toolName: string, args: Record<string, unknown>) => {
+        let nextToken: string | undefined;
+        for (;;) {
+          const gate = ctx.budget.canRead();
+          if (!gate.ok) {
+            skipped ??= {
+              reason: gate.reason,
+              ...(gate.detail !== undefined ? { detail: gate.detail } : {}),
+            };
+            return;
+          }
+          const page = await getClient().callTool(toolName, {
+            ...args,
+            ...(nextToken !== undefined ? { pagination_token: nextToken } : {}),
+          });
+          ctx.budget.noteRead();
+          reads += 1;
+          pages += 1;
+          ctx.budget.pagesUsed = pages;
+          const payload = parseToolJson(page.texts);
+          if (payload === null) {
+            skipped ??= { reason: "unexpected-payload", detail: `tool ${toolName}` };
+            return;
+          }
+          const pageRecords = normalizeMcpPayload(payload, kind);
+          records.push(...pageRecords);
+          nextToken = nextPageToken(payload);
+          if (nextToken === undefined || pageRecords.length === 0) return;
+          // Stop-on-known: a page of entirely known posts means everything
+          // deeper is older state we already ingested.
+          if (pageRecords.every((record) => ctx.knownIds.has(record.postId))) return;
+        }
+      };
+
+      try {
+        await runKind("bookmark", config.bookmarksTool, { max_results: config.maxResults });
+        if (deps.userId !== undefined) {
+          await runKind("own_post", config.timelineTool, {
+            id: deps.userId,
+            max_results: config.maxResults,
+          });
+        }
+      } catch (err) {
+        if (err instanceof XCreditsDepletedError) {
+          return { records, reads, pages, skipped: { reason: "credits-depleted" } };
+        }
+        throw err;
+      }
+      return { records, reads, pages, ...(skipped !== undefined ? { skipped } : {}) };
+    },
+  };
+}
+
+function parseToolJson(texts: string[]): unknown {
+  const candidates = [texts.join("\n"), ...texts];
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+function nextPageToken(payload: unknown): string | undefined {
+  if (!isXObject(payload)) return undefined;
+  if (isXObject(payload.meta)) {
+    for (const key of ["next_token", "next_cursor", "nextToken"] as const) {
+      const value = payload.meta[key];
+      if (typeof value === "string" && value.length > 0) return value;
+    }
+  }
+  for (const key of ["next_token", "next_cursor", "nextToken"] as const) {
+    const value = payload[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+// ── Corpus directory source ─────────────────────────────────────────────────
+
+function createCorpusSource(config: XCorpusSourceConfig): XSource {
+  return {
+    id: config.id,
+    kind: "corpusDir",
+    async fetch(): Promise<XSourceFetchOutcome> {
+      const root = expandTildePath(config.path);
+      let entries: string[];
+      try {
+        const rootStat = await stat(root);
+        if (!rootStat.isDirectory()) {
+          return { records: [], reads: 0, pages: 0, skipped: { reason: "corpus-dir-missing" } };
+        }
+        entries = (await readdir(root)).sort();
+      } catch {
+        return { records: [], reads: 0, pages: 0, skipped: { reason: "corpus-dir-missing" } };
+      }
+      const records: XPostRecord[] = [];
+      let parseFailures = 0;
+      let skippedFiles = 0;
+      const rootReal = await realpath(root);
+      for (const name of entries) {
+        if (!name.endsWith(".json")) continue;
+        const filePath = path.join(root, name);
+        try {
+          const info = await lstat(filePath);
+          if (info.isSymbolicLink()) {
+            // Containment: a symlink may not point outside the corpus root.
+            const target = await realpath(filePath);
+            if (!(target === rootReal || target.startsWith(`${rootReal}${path.sep}`))) {
+              skippedFiles += 1;
+              continue;
+            }
+          } else if (!info.isFile()) {
+            continue;
+          }
+          const parsed: unknown = JSON.parse(await readFile(filePath, "utf8"));
+          for (const entry of asEntryList(parsed)) {
+            const record = normalizeCorpusEntry(entry, "bookmark");
+            if (record !== null) records.push(record);
+          }
+        } catch {
+          parseFailures += 1;
+        }
+      }
+      const degraded =
+        records.length === 0 && (parseFailures > 0 || skippedFiles > 0)
+          ? {
+              skipped: {
+                reason: "corpus-empty",
+                detail: `${parseFailures} unparseable, ${skippedFiles} out-of-root files skipped`,
+              },
+            }
+          : {};
+      return { records, reads: 0, pages: 1, ...degraded };
+    },
+  };
+}
+
+function asEntryList(parsed: unknown): unknown[] {
+  if (Array.isArray(parsed)) return parsed;
+  if (isXObject(parsed) && Array.isArray(parsed.data)) return parsed.data;
+  return [parsed];
+}
+
+// ── CLI source ──────────────────────────────────────────────────────────────
+
+function createCliSource(config: XCliSourceConfig, deps: XSourceDeps): XSource {
+  const exec = deps.execImpl ?? defaultExec;
+  return {
+    id: config.id,
+    kind: "cli",
+    async fetch(): Promise<XSourceFetchOutcome> {
+      const records: XPostRecord[] = [];
+      const commands: Array<{ args: string[]; kind: XRecordKind }> = [
+        { args: config.bookmarksArgs, kind: "bookmark" },
+        ...(config.postsArgs !== undefined ? [{ args: config.postsArgs, kind: "own_post" as const }] : []),
+      ];
+      let skipped: XSourceFetchOutcome["skipped"];
+      for (const command of commands) {
+        let stdout: string;
+        try {
+          ({ stdout } = await exec(config.bin, command.args));
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          skipped = {
+            reason: code === "ENOENT" ? "cli-not-installed" : "cli-failed",
+            detail: code === "ENOENT" ? config.bin : exitDetail(err),
+          };
+          continue;
+        }
+        const parsed = parseStdout(stdout);
+        if (parsed === null) {
+          skipped = {
+            reason: "cli-output-unparseable",
+            detail: `${config.bin} ${command.args.join(" ")}`,
+          };
+          continue;
+        }
+        for (const entry of asEntryList(parsed)) {
+          const record = normalizeCorpusEntry(entry, command.kind);
+          if (record !== null) records.push(record);
+        }
+      }
+      return { records, reads: 0, pages: commands.length, ...(skipped !== undefined ? { skipped } : {}) };
+    },
+  };
+}
+
+function exitDetail(err: unknown): string {
+  if (isXObject(err) && typeof err.code === "number") return `exit ${err.code}`;
+  return "non-zero exit";
+}
+
+function parseStdout(stdout: string): unknown {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function defaultExec(bin: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await execFileAsync(bin, args, {
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return { stdout, stderr };
+}

--- a/packages/connector-x/src/sync.test.ts
+++ b/packages/connector-x/src/sync.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { type XConnectorConfig, parseXConnectorConfig } from "./config.js";
+import { createFileSink } from "./file-sink.js";
+import { getXStatus, runXSync } from "./sync.js";
+import type { XMemorySink, XMemorySuggestion } from "./types.js";
+
+function recordingSink(fail = false): XMemorySink & {
+  suggestions: XMemorySuggestion[];
+  stored: XMemorySuggestion[];
+} {
+  const sink = {
+    suggestions: [] as XMemorySuggestion[],
+    stored: [] as XMemorySuggestion[],
+  };
+  return {
+    ...sink,
+    async submitSuggestion(suggestion) {
+      if (fail) throw new Error("queue down");
+      sink.suggestions.push(suggestion);
+    },
+    async storeMemory(suggestion) {
+      if (fail) throw new Error("store down");
+      sink.stored.push(suggestion);
+    },
+  };
+}
+
+async function corpusWith(entries: Record<string, unknown>): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-sync-"));
+  for (const [name, payload] of Object.entries(entries)) {
+    await writeFile(path.join(dir, name), JSON.stringify(payload));
+  }
+  return dir;
+}
+
+function configFor(overrides: Record<string, unknown>): XConnectorConfig {
+  return parseXConnectorConfig(overrides);
+}
+
+test("first sync ingests, dedupes on the second, and updates on content change", async () => {
+  const corpus = await corpusWith({
+    "a.json": { id: "1", text: "first bookmark", username: "k" },
+    "b.json": { id: "2", text: "second bookmark" },
+  });
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const config = configFor({
+    stateDir,
+    sources: [{ id: "local", kind: "corpusDir", path: corpus }],
+  });
+  const sink = recordingSink();
+
+  const first = await runXSync(config, { sink });
+  assert.equal(first.sources[0].recordsNew, 2);
+  assert.equal(first.suggestionsSubmitted, 2);
+  assert.equal(first.sources[0].skipped, undefined);
+  assert.deepEqual(sink.suggestions.map((entry) => entry.record.postId).sort(), ["1", "2"]);
+  assert.ok(sink.suggestions.every((entry) => entry.tags.includes("x/bookmark")));
+
+  // Record files materialized with provenance stamped.
+  const recordFiles = (await readdir(path.join(stateDir, "records"))).sort();
+  assert.deepEqual(recordFiles, ["1.json", "2.json"]);
+  const persisted = JSON.parse(await readFile(path.join(stateDir, "records", "1.json"), "utf8")) as {
+    provenance: { sourceId: string; syncRunId: string };
+  };
+  assert.equal(persisted.provenance.sourceId, "local");
+  assert.equal(persisted.provenance.syncRunId, first.runId);
+
+  // Second sync over the same corpus: everything known, nothing new emitted.
+  const second = await runXSync(config, { sink });
+  assert.equal(second.sources[0].recordsNew, 0);
+  assert.equal(second.sources[0].recordsKnown, 2);
+  assert.equal(second.suggestionsSubmitted, 0);
+
+  // Same post id, edited content → re-ingested once, firstSeenAt preserved.
+  await writeFile(
+    path.join(corpus, "a.json"),
+    JSON.stringify({ id: "1", text: "first bookmark EDITED", username: "k" })
+  );
+  const third = await runXSync(config, { sink });
+  assert.equal(third.sources[0].recordsNew, 1);
+  assert.equal(third.sources[0].recordsKnown, 1);
+  const edited = JSON.parse(await readFile(path.join(stateDir, "records", "1.json"), "utf8")) as { text: string };
+  assert.equal(edited.text, "first bookmark EDITED");
+});
+
+test("source priority order is honored (cheapest first)", async () => {
+  const corpus = await corpusWith({ "a.json": { id: "1", text: "from corpus" } });
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const config = configFor({
+    stateDir,
+    sourcePriority: ["cheap", "dear"],
+    sources: [
+      { id: "dear", kind: "cli" },
+      { id: "cheap", kind: "corpusDir", path: corpus },
+    ],
+  });
+  const order: string[] = [];
+  const exec = async (bin: string) => {
+    order.push(bin);
+    return { stdout: JSON.stringify([{ id: "9", text: "from cli", kind: "own_post" }]), stderr: "" };
+  };
+  const report = await runXSync(config, { sink: recordingSink(), execImpl: exec });
+  assert.deepEqual(
+    report.sources.map((entry) => entry.sourceId),
+    ["cheap", "dear"]
+  );
+  assert.deepEqual(order, ["bird"]);
+  const kinds = report.sources.flatMap((entry) => entry.recordsNew);
+  assert.deepEqual(kinds, [1, 1]);
+});
+
+test("memoryMode=store routes through storeMemory", async () => {
+  const corpus = await corpusWith({ "a.json": { id: "5", text: "mine", kind: "post" } });
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const config = configFor({
+    stateDir,
+    memoryMode: "store",
+    sources: [{ id: "local", kind: "corpusDir", path: corpus }],
+  });
+  const sink = recordingSink();
+  const report = await runXSync(config, { sink });
+  assert.equal(report.memoryMode, "store");
+  assert.equal(report.memoriesStored, 1);
+  assert.equal(report.suggestionsSubmitted, 0);
+  assert.equal(sink.stored[0].tags[0], "x/post");
+});
+
+test("sink failures are counted, never crash the sync", async () => {
+  const corpus = await corpusWith({
+    "a.json": { id: "1", text: "x" },
+    "b.json": { id: "2", text: "y" },
+  });
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const config = configFor({
+    stateDir,
+    sources: [{ id: "local", kind: "corpusDir", path: corpus }],
+  });
+  const report = await runXSync(config, { sink: recordingSink(true) });
+  assert.equal(report.sinkFailures, 2);
+  assert.equal(report.sources[0].recordsNew, 2);
+});
+
+test("mcp spend accrues in the monthly ledger and status reports it against the cap", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-mcp-"));
+  const tokenFile = path.join(dir, "tokens.json");
+  await writeFile(
+    tokenFile,
+    JSON.stringify({ access_token: "tok", refresh_token: "r", expires_at: Date.now() + 3_600_000 })
+  );
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const config = configFor({
+    stateDir,
+    sources: [
+      {
+        id: "x-mcp",
+        kind: "mcp",
+        auth: { tokenFile },
+        budget: { maxPagesPerSync: 1, maxCostUsdPerMonth: 5, costPerReadUsd: 0.01 },
+      },
+    ],
+  });
+  const responses = [
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", "Mcp-Session-Id": "s" },
+    }),
+    new Response("", { status: 202 }),
+    new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ data: [{ id: "77", text: "paid read" }] }),
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    ),
+  ];
+  const report = await runXSync(config, {
+    sink: recordingSink(),
+    env: { REMNIC_X_CLIENT_ID: "cid", REMNIC_X_CLIENT_SECRET: "sec" },
+    fetchImpl: (async () => {
+      const next = responses.shift();
+      assert.ok(next !== undefined);
+      return next;
+    }) as typeof fetch,
+  });
+  assert.equal(report.sources[0].reads, 1);
+  assert.equal(report.monthSpendUsd, 0.01);
+
+  const status = await getXStatus(config, {
+    env: { REMNIC_X_CLIENT_ID: "cid", REMNIC_X_CLIENT_SECRET: "sec" },
+  });
+  assert.equal(status.monthSpendUsd, 0.01);
+  assert.equal(status.monthlyCostCapUsd, 5);
+  assert.equal(status.seenCount, 1);
+  assert.equal(status.lastSyncAt !== null, true);
+  assert.equal(status.sources[0].sourceId, "x-mcp");
+  assert.equal(status.sources[0].available, true);
+  assert.equal(status.sources[0].lastRecordsNew, 1);
+});
+
+test("status flags a missing corpus dir and missing credentials offline", async () => {
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const config = configFor({
+    stateDir,
+    sources: [
+      { id: "c", kind: "corpusDir", path: "/nonexistent/remnic-x-corpus" },
+      { id: "m", kind: "mcp" },
+    ],
+  });
+  const status = await getXStatus(config, { env: {} });
+  const corpus = status.sources.find((entry) => entry.sourceId === "c");
+  const mcp = status.sources.find((entry) => entry.sourceId === "m");
+  assert.ok(corpus !== undefined && mcp !== undefined);
+  assert.equal(corpus.available, false);
+  assert.match(corpus.availabilityDetail ?? "", /not found/);
+  assert.equal(mcp.available, false);
+  assert.equal(status.lastSyncAt, null);
+});
+
+test("file sink honors the trust gate by directory", async () => {
+  const stateDir = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const corpus = await corpusWith({ "a.json": { id: "1", text: "z" } });
+  const suggestConfig = configFor({
+    stateDir,
+    sources: [{ id: "local", kind: "corpusDir", path: corpus }],
+  });
+  await runXSync(suggestConfig, { sink: createFileSink({ stateDir, mode: "suggest" }) });
+  const suggestFiles = await readdir(path.join(stateDir, "suggestions"));
+  assert.deepEqual(suggestFiles, ["1.json"]);
+
+  const storeState = await mkdtemp(path.join(tmpdir(), "remnic-x-state-"));
+  const storeConfig = configFor({
+    stateDir: storeState,
+    sources: [{ id: "local", kind: "corpusDir", path: corpus }],
+  });
+  await runXSync(storeConfig, {
+    sink: createFileSink({ stateDir: storeState, mode: "store" }),
+  });
+  const storeFiles = await readdir(path.join(storeState, "records"));
+  assert.deepEqual(storeFiles, ["1.json"]);
+});

--- a/packages/connector-x/src/sync.ts
+++ b/packages/connector-x/src/sync.ts
@@ -1,0 +1,364 @@
+/**
+ * Sync orchestration (issue #2009): run sources in configured priority
+ * order (cheapest first is the recommended arrangement), dedupe by
+ * post_id + content fingerprint, stamp provenance, and route the mapped
+ * memory through the trust gate (`suggest` → review queue, `store` →
+ * direct write). Persisted state lives in `<stateDir>/state.json`
+ * (dedupe map, per-source last sync + new counts, monthly cost ledger);
+ * every ingested record is materialized under `<stateDir>/records/`.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { expandTildePath } from "@remnic/core";
+
+import {
+  monthlyCostCapUsd,
+  resolveMcpClientCredentials,
+  type XConnectorConfig,
+  type XSourceConfig,
+} from "./config.js";
+import { isXObject } from "./guards.js";
+import { recordFingerprint, suggestionForRecord } from "./normalize.js";
+import { createXSource, unlimitedBudget, XBudgetTracker, type XSourceDeps } from "./sources.js";
+import type {
+  XMemorySink,
+  XPostRecord,
+  XSourceFetchOutcome,
+  XSourceStatus,
+  XSourceSyncSummary,
+  XStatusReport,
+  XSyncReport,
+} from "./types.js";
+
+const SEEN_CAP = 20_000;
+
+interface SeenEntry {
+  fingerprint: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  kind: string;
+}
+
+interface XSyncState {
+  version: 1;
+  seen: Record<string, SeenEntry>;
+  lastSyncAt: Record<string, string>;
+  /** new records recorded by the latest sync, per source id */
+  lastNewCount: Record<string, number>;
+  /** usd spent per "YYYY-MM", paid sources only */
+  costLedger: Record<string, number>;
+}
+
+export interface XSyncDeps extends XSourceDeps {
+  sink: XMemorySink;
+}
+
+function freshState(): XSyncState {
+  return { version: 1, seen: {}, lastSyncAt: {}, lastNewCount: {}, costLedger: {} };
+}
+
+function monthKeyOf(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 7);
+}
+
+function resolveStateDir(config: XConnectorConfig): string {
+  return expandTildePath(config.stateDir);
+}
+
+function stringRecord(raw: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
+async function loadState(stateDir: string): Promise<{ state: XSyncState; warning?: string }> {
+  const statePath = path.join(stateDir, "state.json");
+  let raw: string;
+  try {
+    raw = await readFile(statePath, "utf8");
+  } catch {
+    return { state: freshState() };
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isXObject(parsed) || !isXObject(parsed.seen)) throw new Error("bad shape");
+    const costLedger: Record<string, number> = {};
+    if (isXObject(parsed.costLedger)) {
+      for (const [key, value] of Object.entries(parsed.costLedger)) {
+        if (typeof value === "number" && Number.isFinite(value)) costLedger[key] = value;
+      }
+    }
+    const seen: Record<string, SeenEntry> = {};
+    for (const [postId, entry] of Object.entries(parsed.seen)) {
+      if (isXObject(entry) && typeof entry.fingerprint === "string") {
+        seen[postId] = {
+          fingerprint: entry.fingerprint,
+          firstSeenAt: typeof entry.firstSeenAt === "string" ? entry.firstSeenAt : "",
+          lastSeenAt: typeof entry.lastSeenAt === "string" ? entry.lastSeenAt : "",
+          kind: typeof entry.kind === "string" ? entry.kind : "",
+        };
+      }
+    }
+    const lastNewCountRaw = isXObject(parsed.lastNewCount) ? parsed.lastNewCount : {};
+    const lastNewCount: Record<string, number> = {};
+    for (const [key, value] of Object.entries(lastNewCountRaw)) {
+      if (typeof value === "number" && Number.isFinite(value)) lastNewCount[key] = value;
+    }
+    return {
+      state: {
+        version: 1,
+        seen,
+        lastSyncAt: stringRecord(isXObject(parsed.lastSyncAt) ? parsed.lastSyncAt : {}),
+        lastNewCount,
+        costLedger,
+      },
+    };
+  } catch {
+    // A corrupt state file only costs dedupe history (re-fetch, re-dedupe):
+    // quarantine it and start fresh rather than failing the sync.
+    const quarantine = `${statePath}.corrupt`;
+    try {
+      await rename(statePath, quarantine);
+    } catch {
+      // Leave it; the save below overwrites.
+    }
+    return {
+      state: freshState(),
+      warning: `state.json was unreadable and has been quarantined at ${quarantine}`,
+    };
+  }
+}
+
+async function saveState(stateDir: string, state: XSyncState): Promise<void> {
+  const entries = Object.entries(state.seen);
+  if (entries.length > SEEN_CAP) {
+    // ponytail: FIFO prune by firstSeenAt; switch to an LRU store if a
+    // single principal ever exceeds 20k live records.
+    entries.sort((a, b) => compareIso(a[1].firstSeenAt, b[1].firstSeenAt, a[0], b[0]));
+    for (const [postId] of entries.slice(0, entries.length - SEEN_CAP)) {
+      delete state.seen[postId];
+    }
+  }
+  const statePath = path.join(stateDir, "state.json");
+  const tmpPath = `${statePath}.${process.pid}.tmp`;
+  await writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  await rename(tmpPath, statePath);
+}
+
+function compareIso(a: string, b: string, idA: string, idB: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  // Total comparator: fall back to id so equal keys keep a stable order.
+  return idA < idB ? -1 : idA > idB ? 1 : 0;
+}
+
+function orderedSources(config: XConnectorConfig): XSourceConfig[] {
+  const byId = new Map(config.sources.map((source) => [source.id, source]));
+  const ordered: XSourceConfig[] = [];
+  for (const id of config.sourcePriority) {
+    const source = byId.get(id);
+    if (source !== undefined) ordered.push(source);
+  }
+  for (const source of config.sources) {
+    if (!config.sourcePriority.includes(source.id)) ordered.push(source);
+  }
+  return ordered;
+}
+
+async function writeRecordFile(stateDir: string, record: XPostRecord): Promise<void> {
+  const recordsDir = path.join(stateDir, "records");
+  await mkdir(recordsDir, { recursive: true });
+  const safeName = record.postId.replace(/[^0-9A-Za-z._-]/g, "_");
+  const recordPath = path.join(recordsDir, `${safeName}.json`);
+  const tmpPath = `${recordPath}.tmp`;
+  await writeFile(tmpPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  await rename(tmpPath, recordPath);
+}
+
+/** Runs one sync cycle. Source-level degradation lands in the report, never a throw. */
+export async function runXSync(config: XConnectorConfig, deps: XSyncDeps): Promise<XSyncReport> {
+  const stateDir = resolveStateDir(config);
+  await mkdir(path.join(stateDir, "records"), { recursive: true });
+  const { state, warning } = await loadState(stateDir);
+  if (warning !== undefined) {
+    process.stderr.write(`[remnic-x] warning: ${warning}\n`);
+  }
+  const now = deps.now ?? (() => Date.now());
+  const startedMs = now();
+  const runId = randomUUID();
+  const monthKey = monthKeyOf(startedMs);
+  const knownIds = new Set(Object.keys(state.seen));
+
+  const summaries: XSourceSyncSummary[] = [];
+  let suggestionsSubmitted = 0;
+  let memoriesStored = 0;
+  let sinkFailures = 0;
+
+  for (const sourceConfig of orderedSources(config)) {
+    const summary: XSourceSyncSummary = {
+      sourceId: sourceConfig.id,
+      kind: sourceConfig.kind,
+      recordsNew: 0,
+      recordsKnown: 0,
+      reads: 0,
+      pages: 0,
+    };
+    const source = createXSource(sourceConfig, { ...deps, userId: config.userId });
+    const budget =
+      sourceConfig.kind === "mcp"
+        ? new XBudgetTracker(sourceConfig.budget, state.costLedger[monthKey] ?? 0)
+        : unlimitedBudget;
+    let outcome: XSourceFetchOutcome;
+    try {
+      outcome = await source.fetch({ knownIds, budget });
+    } catch (err) {
+      summary.error = err instanceof Error ? err.message : String(err);
+      summaries.push(summary);
+      continue;
+    }
+    summary.reads = outcome.reads;
+    summary.pages = outcome.pages;
+    summary.skipped = outcome.skipped;
+
+    for (const raw of outcome.records) {
+      const record: XPostRecord = {
+        ...raw,
+        provenance: {
+          sourceId: sourceConfig.id,
+          sourceKind: sourceConfig.kind,
+          syncRunId: runId,
+          fetchedAt: new Date(startedMs).toISOString(),
+        },
+      };
+      const fingerprint = recordFingerprint(record);
+      const seenEntry = state.seen[record.postId];
+      if (seenEntry !== undefined && seenEntry.fingerprint === fingerprint) {
+        seenEntry.lastSeenAt = new Date(startedMs).toISOString();
+        summary.recordsKnown += 1;
+        continue;
+      }
+      knownIds.add(record.postId);
+      state.seen[record.postId] = {
+        fingerprint,
+        firstSeenAt:
+          seenEntry !== undefined && seenEntry.firstSeenAt.length > 0
+            ? seenEntry.firstSeenAt
+            : new Date(startedMs).toISOString(),
+        lastSeenAt: new Date(startedMs).toISOString(),
+        kind: record.kind,
+      };
+      summary.recordsNew += 1;
+      try {
+        await writeRecordFile(stateDir, record);
+      } catch (err) {
+        sinkFailures += 1;
+        summary.error = `record write failed: ${err instanceof Error ? err.name : "write error"}`;
+        continue;
+      }
+      try {
+        const suggestion = suggestionForRecord(record);
+        if (config.memoryMode === "store") {
+          await deps.sink.storeMemory(suggestion);
+          memoriesStored += 1;
+        } else {
+          await deps.sink.submitSuggestion(suggestion);
+          suggestionsSubmitted += 1;
+        }
+      } catch {
+        sinkFailures += 1;
+      }
+    }
+
+    if (sourceConfig.kind === "mcp" && outcome.reads > 0) {
+      state.costLedger[monthKey] =
+        (state.costLedger[monthKey] ?? 0) + outcome.reads * sourceConfig.budget.costPerReadUsd;
+    }
+    state.lastSyncAt[sourceConfig.id] = new Date(startedMs).toISOString();
+    state.lastNewCount[sourceConfig.id] = summary.recordsNew;
+    summaries.push(summary);
+  }
+
+  const finishedMs = now();
+  await saveState(stateDir, state);
+
+  return {
+    runId,
+    startedAt: new Date(startedMs).toISOString(),
+    finishedAt: new Date(finishedMs).toISOString(),
+    memoryMode: config.memoryMode,
+    sources: summaries,
+    suggestionsSubmitted,
+    memoriesStored,
+    sinkFailures,
+    monthKey,
+    monthSpendUsd: state.costLedger[monthKey] ?? 0,
+  };
+}
+
+/**
+ * Offline status snapshot: config sources, availability, spend vs cap.
+ * No network calls, no credit use.
+ */
+export async function getXStatus(
+  config: XConnectorConfig,
+  deps: Pick<XSyncDeps, "execImpl" | "env"> = {}
+): Promise<XStatusReport> {
+  const stateDir = resolveStateDir(config);
+  const { state } = await loadState(stateDir);
+  const monthKey = monthKeyOf(Date.now());
+  const sources: XSourceStatus[] = [];
+  for (let index = 0; index < config.sourcePriority.length; index++) {
+    const id = config.sourcePriority[index];
+    const sourceConfig = config.sources.find((entry) => entry.id === id);
+    if (sourceConfig === undefined) continue;
+    sources.push({
+      sourceId: id,
+      kind: sourceConfig.kind,
+      priority: index,
+      lastSyncAt: state.lastSyncAt[id] ?? null,
+      lastRecordsNew: state.lastNewCount[id] ?? 0,
+      ...(await probeAvailability(sourceConfig, deps)),
+    });
+  }
+  const lastSyncValues = Object.values(state.lastSyncAt).sort();
+  return {
+    enabled: config.enabled,
+    memoryMode: config.memoryMode,
+    syncSchedule: config.syncSchedule,
+    sources,
+    seenCount: Object.keys(state.seen).length,
+    monthKey,
+    monthSpendUsd: state.costLedger[monthKey] ?? 0,
+    monthlyCostCapUsd: monthlyCostCapUsd(config),
+    lastSyncAt: lastSyncValues.length > 0 ? lastSyncValues[lastSyncValues.length - 1] : null,
+  };
+}
+
+async function probeAvailability(
+  sourceConfig: XSourceConfig,
+  deps: Pick<XSyncDeps, "execImpl" | "env">
+): Promise<{ available: boolean; availabilityDetail?: string }> {
+  if (sourceConfig.kind === "corpusDir") {
+    const dir = expandTildePath(sourceConfig.path);
+    try {
+      const info = await stat(dir);
+      return info.isDirectory()
+        ? { available: true }
+        : { available: false, availabilityDetail: `${sourceConfig.path} is not a directory` };
+    } catch {
+      return { available: false, availabilityDetail: `${sourceConfig.path} not found` };
+    }
+  }
+  if (sourceConfig.kind === "cli") {
+    return { available: true, availabilityDetail: `assumed present (${sourceConfig.bin})` };
+  }
+  const credentials = resolveMcpClientCredentials(sourceConfig, deps.env ?? process.env);
+  return credentials.clientId !== undefined && credentials.clientSecret !== undefined
+    ? { available: true }
+    : { available: false, availabilityDetail: "OAuth2 client credentials missing" };
+}

--- a/packages/connector-x/src/token-store.test.ts
+++ b/packages/connector-x/src/token-store.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { XRefreshChainBrokenError, XTokenStore } from "./token-store.js";
+
+const FAR_FUTURE = Date.now() + 3_600_000;
+
+async function newTokenFile(extras: Record<string, unknown> = {}): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-tokens-"));
+  const file = path.join(dir, "x-tokens.json");
+  await writeFile(
+    file,
+    JSON.stringify({
+      access_token: "old-access",
+      refresh_token: "old-refresh",
+      expires_at: FAR_FUTURE,
+      ...extras,
+    }),
+    { mode: 0o600 }
+  );
+  return file;
+}
+
+function makeStore(file: string, overrides: Partial<ConstructorParameters<typeof XTokenStore>[0]> = {}) {
+  const calls: Array<{ url: string; auth: string; body: string }> = [];
+  const store = new XTokenStore({
+    tokenFile: file,
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    fetchImpl: (async () => {
+      calls.push({ url: "stub", auth: "stub", body: "stub" });
+      return new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 7200,
+          token_type: "bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof fetch,
+    now: () => Date.now(),
+    sleep: async () => {},
+    lockWaitMs: 5_000,
+    ...overrides,
+  });
+  return { store, calls };
+}
+
+test("valid cached token is returned without any network call", async () => {
+  const file = await newTokenFile();
+  const { store, calls } = makeStore(file);
+  assert.equal(await store.getAccessToken(), "old-access");
+  assert.equal(calls.length, 0);
+});
+
+test("expired token refreshes under the lock and rotates the file", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-rot-"));
+  const file = path.join(dir, "x-tokens.json");
+  await writeFile(
+    file,
+    JSON.stringify({
+      access_token: "old-access",
+      refresh_token: "old-refresh",
+      expires_at: Date.now() - 1_000,
+      note_from_other_tool: "keep me",
+    })
+  );
+  const seen: Array<{ url: string; headers: Record<string, string>; body: string }> = [];
+  const store = new XTokenStore({
+    tokenFile: file,
+    clientId: "cid",
+    clientSecret: "csecret",
+    fetchImpl: (async (_input: unknown, init?: { headers?: Record<string, string>; body?: string }) => {
+      seen.push({
+        url: "https://api.x.com/2/oauth2/token",
+        headers: init?.headers ?? {},
+        body: init?.body ?? "",
+      });
+      return new Response(
+        JSON.stringify({ access_token: "rotated", refresh_token: "rotated-refresh", expires_in: 7200 }),
+        { status: 200 }
+      );
+    }) as typeof fetch,
+    now: () => Date.now(),
+    sleep: async () => {},
+  });
+  assert.equal(await store.getAccessToken(), "rotated");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].headers.Authorization, `Basic ${Buffer.from("cid:csecret").toString("base64")}`);
+  assert.match(seen[0].body, /grant_type=refresh_token/);
+  assert.match(seen[0].body, /refresh_token=old-refresh/);
+  const persisted = JSON.parse(await readFile(file, "utf8")) as Record<string, unknown>;
+  assert.equal(persisted.access_token, "rotated");
+  assert.equal(persisted.refresh_token, "rotated-refresh");
+  assert.equal(persisted.note_from_other_tool, "keep me");
+  // Lock released after refresh.
+  await assert.rejects(readFile(`${file}.lock`));
+});
+
+test("concurrent owner: waits and adopts the rotated pair instead of double-refreshing", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-lock-"));
+  const file = path.join(dir, "x-tokens.json");
+  await writeFile(
+    file,
+    JSON.stringify({ access_token: "expired", refresh_token: "chain", expires_at: Date.now() - 1 })
+  );
+  // Simulate the other owner's lock: fresh mtime, removed after a few polls.
+  const lockPath = `${file}.lock`;
+  await writeFile(lockPath, "other-pid\n");
+  let polls = 0;
+  let clock = Date.now();
+  const store = new XTokenStore({
+    tokenFile: file,
+    clientId: "cid",
+    clientSecret: "csecret",
+    fetchImpl: (async () => {
+      throw new Error("must not refresh: another owner holds the chain");
+    }) as typeof fetch,
+    now: () => clock,
+    sleep: async () => {
+      polls += 1;
+      clock += 300;
+      if (polls === 3) {
+        const { rm } = await import("node:fs/promises");
+        await rm(lockPath);
+        await writeFile(
+          file,
+          JSON.stringify({
+            access_token: "adopted",
+            refresh_token: "adopted-refresh",
+            expires_at: clock + 600_000,
+          })
+        );
+      }
+    },
+    lockWaitMs: 60_000,
+  });
+  assert.equal(await store.getAccessToken(), "adopted");
+});
+
+test("refresh 401 means the chain forked", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-broken-"));
+  const file = path.join(dir, "x-tokens.json");
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, JSON.stringify({ access_token: "x", refresh_token: "forked", expires_at: Date.now() - 1 }));
+  const store = new XTokenStore({
+    tokenFile: file,
+    clientId: "cid",
+    clientSecret: "csecret",
+    fetchImpl: (async () => new Response("unauthorized", { status: 401 })) as typeof fetch,
+    now: () => Date.now(),
+    sleep: async () => {},
+  });
+  await assert.rejects(store.refresh(), XRefreshChainBrokenError);
+});
+
+test("a stale lock is stolen and the refresh proceeds", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-x-stale-"));
+  const file = path.join(dir, "x-tokens.json");
+  await writeFile(file, JSON.stringify({ access_token: "x", refresh_token: "r", expires_at: Date.now() - 1 }));
+  const lockPath = `${file}.lock`;
+  await writeFile(lockPath, "dead-pid\n");
+  // Age the lock past the stale threshold.
+  const stale = new Date(Date.now() - 120_000);
+  await utimes(lockPath, stale, stale);
+  const { store } = makeStore(file);
+  const pair = await store.refresh();
+  assert.equal(pair.accessToken, "new-access");
+  await assert.rejects(readFile(lockPath));
+});
+
+test("missing client credentials fail fast with setup guidance", () => {
+  assert.throws(
+    () =>
+      new XTokenStore({
+        tokenFile: "/tmp/whatever.json",
+        clientId: "",
+        clientSecret: "csecret",
+      }),
+    /clientId/
+  );
+});

--- a/packages/connector-x/src/token-store.ts
+++ b/packages/connector-x/src/token-store.ts
@@ -1,0 +1,342 @@
+/**
+ * OAuth2 user-token store with single-owner refresh for the X MCP
+ * source.
+ *
+ * X rotates the refresh token on EVERY refresh. Two independent
+ * refreshers fork the chain and kill one of them (observed failure:
+ * HTTP 401 on refresh after two tools both rotated the same grant).
+ * This store is therefore the single owner of the refresh chain: the
+ * refresh runs only while holding `${tokenFile}.lock`; a concurrent
+ * refresher waits, then adopts the rotated pair from the file — it
+ * never refreshes in parallel.
+ *
+ * Token files are written 0600, atomic (tmp + rename), and unknown
+ * top-level fields are preserved on rotation.
+ */
+
+import { open, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as sleepMs } from "node:timers/promises";
+
+import { isXObject } from "./guards.js";
+
+export const X_TOKEN_REFRESH_URL = "https://api.x.com/2/oauth2/token";
+const EXPIRY_MARGIN_MS = 60_000;
+const DEFAULT_LOCK_STALE_MS = 60_000;
+const DEFAULT_LOCK_WAIT_MS = 15_000;
+const LOCK_POLL_MS = 200;
+
+export class XTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "XTokenError";
+  }
+}
+
+/** The refresh chain forked or was revoked — re-authorization is required. */
+export class XRefreshChainBrokenError extends XTokenError {
+  constructor(detail: string) {
+    super(
+      `X OAuth2 refresh failed (${detail}). The refresh chain was rotated by another refresher or the grant was revoked. Ensure only one refresher owns the chain, then re-authorize to write a fresh token file.`
+    );
+    this.name = "XRefreshChainBrokenError";
+  }
+}
+
+export interface XTokenPair {
+  accessToken: string;
+  refreshToken: string;
+  /** Epoch ms when the access token expires. */
+  expiresAt: number;
+}
+
+export interface XTokenStoreOptions {
+  tokenFile: string;
+  clientId: string;
+  clientSecret: string;
+  /** OAuth2 token endpoint. */
+  refreshUrl?: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  lockStaleMs?: number;
+  lockWaitMs?: number;
+}
+
+interface LockHandle {
+  release(): Promise<void>;
+}
+
+class LockUnavailableError extends Error {}
+
+export class XTokenStore {
+  private readonly tokenFile: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly refreshUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly lockStaleMs: number;
+  private readonly lockWaitMs: number;
+  private cached: XTokenPair | null = null;
+
+  constructor(options: XTokenStoreOptions) {
+    if (typeof options.tokenFile !== "string" || options.tokenFile.length === 0) {
+      throw new XTokenError("XTokenStore requires tokenFile");
+    }
+    for (const [field, value] of [
+      ["clientId", options.clientId],
+      ["clientSecret", options.clientSecret],
+    ] as const) {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        throw new XTokenError(
+          `XTokenStore requires ${field} (pre-registered confidential client; set xConnector source auth or the REMNIC_X_CLIENT_ID/REMNIC_X_CLIENT_SECRET env vars)`
+        );
+      }
+    }
+    this.tokenFile = options.tokenFile;
+    this.clientId = options.clientId.trim();
+    this.clientSecret = options.clientSecret.trim();
+    this.refreshUrl = options.refreshUrl ?? X_TOKEN_REFRESH_URL;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.now = options.now ?? (() => Date.now());
+    this.lockStaleMs = options.lockStaleMs ?? DEFAULT_LOCK_STALE_MS;
+    this.lockWaitMs = options.lockWaitMs ?? DEFAULT_LOCK_WAIT_MS;
+    this.sleep = options.sleep ?? sleepMs;
+  }
+
+  /** Returns a valid access token, refreshing under the lock when expired. */
+  async getAccessToken(): Promise<string> {
+    return (await this.getValidPair()).accessToken;
+  }
+
+  private async getValidPair(): Promise<XTokenPair> {
+    const current = this.cached ?? (await this.readTokenFile());
+    if (current !== null && current.expiresAt - EXPIRY_MARGIN_MS > this.now()) {
+      this.cached = current;
+      return current;
+    }
+    const refreshed = await this.refreshWithLock();
+    this.cached = refreshed;
+    return refreshed;
+  }
+
+  /**
+   * Refreshes the token pair under the file lock. When another owner
+   * holds the lock, waits for it, then adopts the pair it wrote.
+   */
+  async refresh(): Promise<XTokenPair> {
+    const pair = await this.refreshWithLock();
+    this.cached = pair;
+    return pair;
+  }
+
+  private async refreshWithLock(): Promise<XTokenPair> {
+    let lock: LockHandle | null = null;
+    try {
+      lock = await this.acquireLock();
+    } catch (err) {
+      if (err instanceof LockUnavailableError) {
+        return this.waitForOtherOwner();
+      }
+      throw err;
+    }
+    try {
+      // Re-read under the lock: another owner may have rotated while we waited.
+      const underLock = await this.readTokenFile();
+      if (underLock !== null && underLock.expiresAt - EXPIRY_MARGIN_MS > this.now()) {
+        return underLock;
+      }
+      const refreshToken =
+        underLock?.refreshToken ??
+        (() => {
+          throw new XTokenError(
+            `X token file ${this.tokenFile} is missing or carries no refresh_token — run the OAuth2 user-code flow once to seed it`
+          );
+        })();
+      const rotated = await this.requestRefresh(refreshToken);
+      await this.writeTokenFile(rotated);
+      return rotated;
+    } finally {
+      await lock.release();
+    }
+  }
+
+  private async waitForOtherOwner(): Promise<XTokenPair> {
+    const deadline = this.now() + this.lockWaitMs;
+    while (this.now() < deadline) {
+      await this.sleep(LOCK_POLL_MS);
+      const pair = await this.readTokenFile();
+      if (pair !== null && pair.expiresAt - EXPIRY_MARGIN_MS > this.now()) {
+        return pair;
+      }
+    }
+    throw new XTokenError(
+      `another refresher has held ${this.tokenFile}.lock for over ` +
+        `${Math.round(this.lockWaitMs / 1000)}s — investigate the competing owner`
+    );
+  }
+
+  private async acquireLock(): Promise<LockHandle> {
+    const lockPath = `${this.tokenFile}.lock`;
+    const deadline = this.now() + this.lockWaitMs;
+    for (;;) {
+      try {
+        const handle = await open(lockPath, "wx");
+        await handle.write(`${process.pid}\n`);
+        await handle.close();
+        return {
+          release: async () => {
+            try {
+              await unlink(lockPath);
+            } catch {
+              // Already gone — nothing to release.
+            }
+          },
+        };
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "EEXIST") throw err;
+        if (await this.stealStaleLock(lockPath)) continue;
+        if (this.now() >= deadline) throw new LockUnavailableError("lock wait timeout");
+        await this.sleep(LOCK_POLL_MS);
+      }
+    }
+  }
+
+  /** Steals the lock when its mtime is older than lockStaleMs. */
+  private async stealStaleLock(lockPath: string): Promise<boolean> {
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await stat(lockPath)).mtimeMs;
+    } catch {
+      // Lock vanished between open(EEXIST) and stat — retry create.
+      return true;
+    }
+    if (this.now() - mtimeMs < this.lockStaleMs) return false;
+    try {
+      await unlink(lockPath);
+    } catch {
+      // Another stealer won the race — the next create attempt decides.
+    }
+    return true;
+  }
+
+  private async requestRefresh(refreshToken: string): Promise<XTokenPair> {
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: this.clientId,
+    }).toString();
+    let response: Response;
+    try {
+      response = await this.fetchImpl(this.refreshUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic ${Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64")}`,
+        },
+        body,
+      });
+    } catch (err) {
+      throw new XTokenError(`X OAuth2 refresh request failed: ${err instanceof Error ? err.name : "network error"}`);
+    }
+    if (response.status === 400 || response.status === 401 || response.status === 403) {
+      throw new XRefreshChainBrokenError(`HTTP ${response.status}`);
+    }
+    if (!response.ok) {
+      throw new XTokenError(`X OAuth2 refresh responded HTTP ${response.status}`);
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new XTokenError("X OAuth2 refresh returned a non-JSON body");
+    }
+    if (!isTokenResponse(payload)) {
+      throw new XTokenError("X OAuth2 refresh returned an unexpected payload shape");
+    }
+    return {
+      accessToken: payload.access_token,
+      // X rotates refresh tokens; keep the old one when the response omits it.
+      refreshToken: typeof payload.refresh_token === "string" ? payload.refresh_token : refreshToken,
+      expiresAt: this.now() + payload.expires_in * 1_000,
+    };
+  }
+
+  private async readTokenFile(): Promise<XTokenPair | null> {
+    let raw: string;
+    try {
+      raw = await readFile(this.tokenFile, "utf8");
+    } catch {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new XTokenError(`X token file ${this.tokenFile} is not valid JSON`);
+    }
+    if (!isXObject(parsed)) return null;
+    const accessToken = firstString(parsed.access_token, parsed.accessToken);
+    if (accessToken === undefined) {
+      throw new XTokenError(`X token file ${this.tokenFile} carries no access token`);
+    }
+    const refreshToken = firstString(parsed.refresh_token, parsed.refreshToken) ?? "";
+    const expiresAtRaw = parsed.expires_at ?? parsed.expiresAt;
+    const expiresAt =
+      typeof expiresAtRaw === "number" && Number.isFinite(expiresAtRaw)
+        ? expiresAtRaw
+        : // Files without expiry force one refresh on first use.
+          0;
+    return { accessToken, refreshToken, expiresAt };
+  }
+
+  /** Atomic 0600 write; preserves unknown top-level fields from the prior file. */
+  private async writeTokenFile(pair: XTokenPair): Promise<void> {
+    let previous: Record<string, unknown> = {};
+    try {
+      const priorRaw: unknown = JSON.parse(await readFile(this.tokenFile, "utf8"));
+      if (isXObject(priorRaw)) previous = priorRaw;
+    } catch {
+      previous = {};
+    }
+    const next: Record<string, unknown> = {
+      ...previous,
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      expires_at: pair.expiresAt,
+    };
+    const dir = path.dirname(this.tokenFile);
+    const tmpPath = path.join(dir, `.${path.basename(this.tokenFile)}.${process.pid}.${Date.now()}.tmp`);
+    await writeFile(tmpPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    try {
+      await rename(tmpPath, this.tokenFile);
+    } catch (err) {
+      try {
+        await unlink(tmpPath);
+      } catch {
+        // Best-effort cleanup.
+      }
+      throw new XTokenError(
+        `failed to persist rotated X tokens to ${this.tokenFile}: ${err instanceof Error ? err.name : "write error"}`
+      );
+    }
+  }
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
+function isTokenResponse(value: unknown): value is {
+  access_token: string;
+  refresh_token?: unknown;
+  expires_in: number;
+} {
+  return isXObject(value) && typeof value.access_token === "string";
+}

--- a/packages/connector-x/src/types.ts
+++ b/packages/connector-x/src/types.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared types for @remnic/connector-x.
+ */
+
+export type XRecordKind = "bookmark" | "own_post";
+
+/** Trust gate for extracted memories. "suggest" routes through a review queue; "store" writes directly. */
+export type XMemoryMode = "suggest" | "store";
+
+export type XSourceKind = "mcp" | "corpusDir" | "cli";
+
+export interface XAuthor {
+  id?: string;
+  username?: string;
+  name?: string;
+}
+
+export interface XProvenance {
+  sourceId: string;
+  sourceKind: XSourceKind;
+  syncRunId: string;
+  fetchedAt: string;
+}
+
+/** Normalized record, the common currency every source emits. */
+export interface XPostRecord {
+  postId: string;
+  kind: XRecordKind;
+  author?: XAuthor;
+  /** Post creation time (ISO 8601) when the source carries it. */
+  createdAt?: string;
+  /** When the bookmark act happened (ISO 8601), when known. */
+  bookmarkedAt?: string;
+  text: string;
+  urls: string[];
+  mediaCount: number;
+  /** Zero-credit enrichment (e.g. resolved URL titles from a local corpus). */
+  enrichment?: Record<string, unknown>;
+  provenance?: XProvenance;
+}
+
+/** The memory a record maps to, before trust gating. */
+export interface XMemorySuggestion {
+  record: XPostRecord;
+  tags: string[];
+  category: string;
+  entityRef?: string;
+  confidence: number;
+  postUrl: string;
+  /** Composed memory sentence. */
+  content: string;
+}
+
+/**
+ * Host-provided memory sink. `submitSuggestion` feeds the review queue;
+ * `storeMemory` writes directly. The connector picks per `memoryMode`.
+ */
+export interface XMemorySink {
+  submitSuggestion(suggestion: XMemorySuggestion): Promise<void>;
+  storeMemory(suggestion: XMemorySuggestion): Promise<void>;
+}
+
+export interface XSourceFetchOutcome {
+  records: XPostRecord[];
+  /** Billable reads consumed (MCP only; 0 for zero-credit sources). */
+  reads: number;
+  pages: number;
+  /** Present when the source degraded instead of erroring. */
+  skipped?: { reason: string; detail?: string };
+}
+
+export interface XSource {
+  id: string;
+  kind: XSourceKind;
+  fetch(ctx: XSourceFetchContext): Promise<XSourceFetchOutcome>;
+}
+
+export interface XSourceFetchContext {
+  knownIds: ReadonlySet<string>;
+  budget: XBudgetRuntime;
+  signal?: AbortSignal;
+}
+
+/** Budget enforcement shared by the sync loop and the MCP source. */
+export interface XBudgetRuntime {
+  canRead(): { ok: true } | { ok: false; reason: string; detail?: string };
+  noteRead(): void;
+  /** Pages consumed this sync by the current source. */
+  pagesUsed: number;
+  maxPages: number;
+}
+
+export interface XSourceSyncSummary {
+  sourceId: string;
+  kind: XSourceKind;
+  recordsNew: number;
+  recordsKnown: number;
+  reads: number;
+  pages: number;
+  skipped?: { reason: string; detail?: string };
+  error?: string;
+}
+
+export interface XSyncReport {
+  runId: string;
+  startedAt: string;
+  finishedAt: string;
+  memoryMode: XMemoryMode;
+  sources: XSourceSyncSummary[];
+  suggestionsSubmitted: number;
+  memoriesStored: number;
+  sinkFailures: number;
+  monthKey: string;
+  monthSpendUsd: number;
+}
+
+export interface XSourceStatus {
+  sourceId: string;
+  kind: XSourceKind;
+  priority: number;
+  lastSyncAt: string | null;
+  lastRecordsNew: number;
+  available: boolean;
+  availabilityDetail?: string;
+}
+
+export interface XStatusReport {
+  enabled: boolean;
+  memoryMode: XMemoryMode;
+  syncSchedule: string;
+  sources: XSourceStatus[];
+  seenCount: number;
+  monthKey: string;
+  monthSpendUsd: number;
+  monthlyCostCapUsd: number;
+  lastSyncAt: string | null;
+}

--- a/packages/connector-x/tsconfig.json
+++ b/packages/connector-x/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connector-x:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/export-weclone:
     devDependencies:
       '@remnic/core':

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -30,6 +30,7 @@ const expectedPublishDirs = [
   "packages/connector-granola",
   "packages/connector-droid",
   "packages/connector-reitti",
+  "packages/connector-x",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
Fixes #2009.

## Change

À-la-carte `@remnic/connector-x`. Bookmarks and own posts via official X MCP, local corpus, or CLI.

## Regression

`packages/connector-x/src/*.test.ts` (52 tests).