### PR TITLE
fix(passport): harden replacement recovery from deferred review

### DIFF
--- a/.changeset/2387-support-passport-followup.md
+++ b/.changeset/2387-support-passport-followup.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Harden support-passport replacement recovery from deferred PR #2360 review findings.

--- a/packages/remnic-core/src/access-admin-ops-surface.ts
+++ b/packages/remnic-core/src/access-admin-ops-surface.ts
@@ -23,6 +23,7 @@ import { resolveScopeProfilePlan } from "./namespaces/scope-profiles.js";
 import type { Orchestrator } from "./orchestrator.js";
 import { formatProfileTraceAscii } from "./profiling.js";
 import { resolveScopePlan } from "./scopes/scope-plan.js";
+import { isSupportPassportPrivateMemory } from "./support-passport/card-projection.js";
 import {
   EngramAccessInputError,
   buildProjectedGovernanceProposedActions,
@@ -818,7 +819,11 @@ export class AccessAdminOpsSurface {
       readMemory: async (namespace, memoryId) => {
         const resolved = await this.deps.orchestrator.getStorage(namespace);
         const memory = await resolved.getMemoryById(memoryId);
-        if (!memory) return null;
+        // Owner-private support-passport records must not cross their
+        // storage boundary through a copy-based promotion; reported as not
+        // found so the route never confirms a private record's existence
+        // (#2387).
+        if (!memory || isSupportPassportPrivateMemory(memory)) return null;
         return {
           category: memory.frontmatter.category,
           content: memory.content,

--- a/packages/remnic-core/src/access-service-offline-file-content.test.ts
+++ b/packages/remnic-core/src/access-service-offline-file-content.test.ts
@@ -516,6 +516,69 @@ test("offline apply routes reject forged support-passport metadata and allow pub
   }
 });
 
+test("offline apply rejects JSON-escaped support-passport markers (#2387)", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-access-escaped-marker-"));
+  try {
+    const storage = new StorageManager(root);
+    await storage.ensureDirectories();
+    const { service } = createManifestService({ root, storage });
+    // The raw frontmatter text never contains the literal marker substring;
+    // only JSON.parse of the structured-attribute value reconstructs it.
+    const escaped = Buffer.from([
+      "---",
+      "id: escaped-marker",
+      "category: fact",
+      `structuredAttributes: {"support\\u002dpassport-owner":"${"a".repeat(64)}"}`,
+      "---",
+      "Ordinary-looking body",
+    ].join("\n"));
+
+    const chunkPath = "facts/2026-08-13/escaped-chunk.md";
+    await assert.rejects(
+      () => service.offlineSyncApplyFileContent({
+        sourceId: "peer",
+        path: chunkPath,
+        sha256: sha256(escaped),
+        bytes: escaped.length,
+        mtimeMs: 0,
+        offset: 0,
+        content: escaped,
+      }),
+      (error) => error instanceof EngramAccessInputError && /private support-passport record/.test(error.message),
+    );
+    await assert.rejects(() => readFile(path.join(root, chunkPath)));
+
+    const changesetPath = "facts/2026-08-13/escaped-changeset.md";
+    await assert.rejects(
+      () => service.offlineSyncApply({
+        returnCurrentFiles: false,
+        changeset: {
+          format: OFFLINE_SYNC_CHANGESET_FORMAT,
+          schemaVersion: 1,
+          createdAt: new Date().toISOString(),
+          sourceId: "peer",
+          includeTranscripts: true,
+          changes: [{
+            type: "upsert",
+            path: changesetPath,
+            file: {
+              path: changesetPath,
+              sha256: sha256(escaped),
+              bytes: escaped.length,
+              mtimeMs: 0,
+              contentBase64: escaped.toString("base64"),
+            },
+          }],
+        },
+      }),
+      (error) => error instanceof EngramAccessInputError && /private support-passport record/.test(error.message),
+    );
+    await assert.rejects(() => readFile(path.join(root, changesetPath)));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline apply-file-content reports invalid metadata as input errors", async () => {
   const service = createOfflineService();
   await assert.rejects(

--- a/packages/remnic-core/src/memory-projection-store.ts
+++ b/packages/remnic-core/src/memory-projection-store.ts
@@ -130,11 +130,13 @@ function migrateMemoryCurrentTable(db: BetterSqlite3Database): void {
   if (!columns.has("preview_text")) {
     db.exec(`ALTER TABLE memory_current ADD COLUMN preview_text TEXT NOT NULL DEFAULT ''`);
   }
+  if (!columns.has("private_record")) db.exec(`ALTER TABLE memory_current ADD COLUMN private_record INTEGER NOT NULL DEFAULT 0; UPDATE memory_current SET private_record = 1 WHERE tags_json LIKE '%support-passport-%'`);
 }
 
 function memoryCurrentRequiresMigration(db: BetterSqlite3Database): boolean {
   const columns = listTableColumns(db, "memory_current");
-  return columns.size > 0 && (!columns.has("tags_json") || !columns.has("preview_text"));
+  return columns.size > 0 &&
+    (!columns.has("tags_json") || !columns.has("preview_text") || !columns.has("private_record"));
 }
 
 function migrateProjectionSchemaIfNeeded(memoryDir: string): void {

--- a/packages/remnic-core/src/support-passport/card-projection.ts
+++ b/packages/remnic-core/src/support-passport/card-projection.ts
@@ -307,6 +307,7 @@ function parseSupportPassportCardMetadata(
 export function hasLiveSupportPassportCard(memory: Pick<MemoryFile, "frontmatter" | "content">): boolean {
   const metadata = parseSupportPassportCardMetadata(memory);
   if (metadata?.fields.status !== "active" && metadata?.fields.status !== "pending_review") return false;
+  if (metadata.sourceMemoryIds.length === 0) return false;
   return SupportPassportCardSchema.omit({ revision: true }).safeParse({
     ...metadata.fields,
     statement: stripAttributesSuffix(memory.content),

--- a/packages/remnic-core/src/support-passport/card-service-commit-forwarding.test.ts
+++ b/packages/remnic-core/src/support-passport/card-service-commit-forwarding.test.ts
@@ -56,6 +56,7 @@ test("rejected-draft recovery forwards the commit notification", async () => {
   assert.ok(replacement);
   const storage = {
     getMemoryById: async (id: string) => (id === "draft-one" ? replaced : null),
+    getMemoryByIdIncludingArchived: async (id: string) => (id === "draft-one" ? replaced : null),
   } as unknown as StorageManager;
   const service = new SupportPassportCardService({
     resolveOwner: async () => ({ principal: PRINCIPAL, namespace: NAMESPACE, storage }),

--- a/packages/remnic-core/src/support-passport/card-service.test.ts
+++ b/packages/remnic-core/src/support-passport/card-service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -1420,6 +1420,80 @@ test("retrying an interrupted pending-draft replacement reuses one approvable dr
       (await subject.service.listCards({ principal: "owner:alice" })).map((card) => [card.cardId, card.status]),
       [[approved.cardId, "active"]]
     );
+  } finally {
+    await subject.cleanup();
+  }
+});
+
+test("replacement recovery reads a cold-tier rejected predecessor (#2387)", async () => {
+  const subject = await makeSubject();
+  try {
+    const draft = await subject.service.createManualDraft({
+      principal: "owner:alice",
+      title: "Quiet place",
+      statement: "Offer me a quiet place.",
+      category: "environment",
+      reviewBy: OWNER_REVIEW_BY,
+    });
+    const originalWrite = subject.aliceStorage.writeMemoryFrontmatterIfUnchanged.bind(subject.aliceStorage);
+    let interrupted = false;
+    subject.aliceStorage.writeMemoryFrontmatterIfUnchanged = async (memory, patch, lifecycle) => {
+      if (!interrupted && lifecycle?.reasonCode === "draft-replacement-complete") {
+        interrupted = true;
+        throw new Error("simulated process exit before the prepared marker cleared");
+      }
+      return await originalWrite(memory, patch, lifecycle);
+    };
+
+    await assert.rejects(
+      subject.service.replaceCard({
+        principal: "owner:alice",
+        cardId: draft.cardId,
+        expectedRevision: draft.revision,
+        title: "Quiet place and time",
+        statement: "Offer me a quiet place and time.",
+        category: "environment",
+        reviewBy: OWNER_REVIEW_BY,
+      }),
+      /simulated process exit/
+    );
+    subject.aliceStorage.writeMemoryFrontmatterIfUnchanged = originalWrite;
+
+    // Interrupted state: the prior draft is durably rejected while the
+    // replacement still carries its prepared marker. Simulate tier
+    // migration demoting the rejected predecessor to the cold tier.
+    const beforeRecovery = await subject.aliceStorage.readAllMemories();
+    const replacement = beforeRecovery.find((memory) => memory.frontmatter.id !== draft.cardId);
+    assert.ok(replacement);
+    assert.equal(replacement.frontmatter.status, "pending_review");
+    assert.equal(
+      replacement.frontmatter.structuredAttributes?.["support-passport-draft-replacement-prepared"],
+      "true"
+    );
+    const rejectedDraft = beforeRecovery.find((memory) => memory.frontmatter.id === draft.cardId);
+    assert.ok(rejectedDraft);
+    assert.equal(rejectedDraft.frontmatter.status, "rejected");
+    const coldDir = path.join(subject.aliceStorage.dir, "cold", "preference");
+    await mkdir(coldDir, { recursive: true });
+    await rename(rejectedDraft.path, path.join(coldDir, path.basename(rejectedDraft.path)));
+    StorageManager.clearAllStaticCaches();
+    assert.equal(await subject.aliceStorage.getMemoryById(draft.cardId), null);
+    const replacementCard = projectSupportPassportCard(replacement);
+    assert.ok(replacementCard);
+    const approved = await subject.service.approveCard({
+      principal: "owner:alice",
+      cardId: replacement.frontmatter.id,
+      expectedRevision: replacementCard.card.revision,
+    });
+    assert.equal(approved.status, "active");
+
+    assert.deepEqual(
+      (await subject.service.listCards({ principal: "owner:alice" })).map((card) => [card.cardId, card.status]),
+      [[replacement.frontmatter.id, "active"]]
+    );
+
+    const coldPredecessor = await subject.aliceStorage.getMemoryByIdIncludingArchived(draft.cardId);
+    assert.equal(coldPredecessor?.frontmatter.status, "rejected");
   } finally {
     await subject.cleanup();
   }

--- a/packages/remnic-core/src/support-passport/card-service.ts
+++ b/packages/remnic-core/src/support-passport/card-service.ts
@@ -832,7 +832,7 @@ export class SupportPassportCardService {
     if (currentCard.card.status === "pending_review") {
       const priorId = currentMemory.frontmatter.supersedes;
       if (!priorId) return currentMemory;
-      const prior = await storage.getMemoryById(priorId);
+      const prior = await storage.getMemoryByIdIncludingArchived(priorId);
       if (
         prior &&
         ownsMemory(prior, namespace, principal) &&
@@ -973,7 +973,10 @@ export class SupportPassportCardService {
     onCommitted?: () => void
   ): Promise<void> {
     if (!replacement.replacesDraftId) return;
-    const replacedDraft = await storage.getMemoryById(replacement.replacesDraftId);
+    // Tier-independent: an interrupted edit's rejected predecessor can be
+    // demoted to the cold tier before recovery runs; a hot-only lookup would
+    // mistake it for deleted and orphan the valid replacement (#2387).
+    const replacedDraft = await storage.getMemoryByIdIncludingArchived(replacement.replacesDraftId);
     const projectedDraft = replacedDraft ? projectOwnedCard(replacedDraft, namespace, principal) : null;
     if (
       replacedDraft &&
@@ -999,7 +1002,7 @@ export class SupportPassportCardService {
         return;
       }
     }
-    const currentDraft = await storage.getMemoryById(replacement.replacesDraftId);
+    const currentDraft = await storage.getMemoryByIdIncludingArchived(replacement.replacesDraftId);
     if (
       currentDraft &&
       ownsMemory(currentDraft, namespace, principal) &&

--- a/packages/remnic-core/src/support-passport/card-state.ts
+++ b/packages/remnic-core/src/support-passport/card-state.ts
@@ -152,7 +152,11 @@ export function ownerListCards(storedCards: StoredSupportPassportCard[]): Stored
     if (activeReplacementPredecessors.has(item.card.cardId)) return false;
     if (replacedDraftIds.has(item.card.cardId)) return false;
     if (!item.replacesDraftId) return true;
+    // The replaced draft may be demoted to the cold tier or archived after
+    // its rejection; a hot-only projection then reports it missing. A
+    // missing predecessor must not hide the replacement — only a restored
+    // active predecessor does (#2387).
     const replacedStatus = byId.get(item.replacesDraftId)?.card.status;
-    return replacedStatus === "pending_review" || replacedStatus === "rejected";
+    return replacedStatus === undefined || replacedStatus === "pending_review" || replacedStatus === "rejected";
   });
 }

--- a/packages/remnic-core/src/support-passport/offline-sync-guard.ts
+++ b/packages/remnic-core/src/support-passport/offline-sync-guard.ts
@@ -9,9 +9,13 @@ import {
   type OfflineSyncApplyChangesetResult,
   type OfflineSyncApplyFileContentChunkResult,
 } from "../offline-sync.js";
+import { parseFrontmatter } from "../storage.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { MemoryFile } from "../types.js";
-import { createSupportPassportPrivateFileExclusion } from "./card-projection.js";
+import {
+  createSupportPassportPrivateFileExclusion,
+  isSupportPassportPrivateMemory,
+} from "./card-projection.js";
 
 const MAX_SUPPORT_PASSPORT_FRONTMATTER_BYTES = 1_048_576;
 const SUPPORT_PASSPORT_MARKER = "support-passport-";
@@ -62,6 +66,15 @@ function completeFrontmatter(raw: Buffer): string | null {
 
 function assertFrontmatterAllowed(frontmatter: string, relativePath: string): void {
   if (frontmatter.includes(SUPPORT_PASSPORT_MARKER)) {
+    throw new Error(`offline sync cannot modify private support-passport record: ${relativePath}`);
+  }
+  // Canonical classification (#2387): YAML/JSON escapes — e.g. a
+  // structured-attribute key written as `support\u002dpassport-owner` — hide
+  // the marker from the raw scan above, while the storage reader's
+  // JSON.parse reconstructs it after the write. Validate the parsed
+  // frontmatter with the same predicate the read path classifies by.
+  const parsed = parseFrontmatter(frontmatter);
+  if (parsed && isSupportPassportPrivateMemory({ frontmatter: parsed.frontmatter })) {
     throw new Error(`offline sync cannot modify private support-passport record: ${relativePath}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3557,18 +3557,22 @@ const pluginDefinition = {
                     namespaces: namespace ? [namespace] : undefined,
                     mode: resolvedMode,
                   }),
-                  filterPrivate: async (results) => {
-                    const visible = await orchestrator.filterPrivateSearchResults(
-                      results,
-                      namespace ? [namespace] : [],
-                    );
-                    return minScore === undefined
-                      ? visible
-                      : visible.filter((result) => result.score >= minScore);
-                  },
+                  filterPrivate: (results) => orchestrator.filterPrivateSearchResults(
+                    results,
+                    namespace ? [namespace] : [],
+                  ),
                   isExcluded: (resultPath) => isMemoryArtifactPath(resultPath),
                 });
-                return visibleResults
+                // minScore is a ranking preference, not a privacy/artifact
+                // exclusion: results arrive score-descending, so rows behind
+                // the returned page cannot clear a threshold the page failed.
+                // Filtering after the refill keeps a strict threshold from
+                // walking the backend candidate cap one page-doubling at a
+                // time (#2387).
+                const scoredResults = minScore === undefined
+                  ? visibleResults
+                  : visibleResults.filter((result) => result.score >= minScore);
+                return scoredResults
                   .map((result, index): RuntimeSearchResult => {
                   const candidate = result as unknown as {
                     path?: string;

--- a/src/memory-promote.ts
+++ b/src/memory-promote.ts
@@ -6,6 +6,7 @@ import {
   TAG_LIMITS,
 } from "@remnic/core/write-envelope";
 import { stripAttributesSuffix } from "@remnic/core/storage";
+import { isSupportPassportPrivateMemory } from "@remnic/core/support-passport";
 import { displayErrorDetail } from "@remnic/core/runtime/better-sqlite";
 import { isSafeRouteNamespace } from "@remnic/core/routing/engine";
 import { indexMemoryAsync, indexesExistAsync } from "./temporal-index.js";
@@ -75,7 +76,11 @@ export async function executeMemoryPromote(
 
   const src = await orchestrator.getStorage(srcNs);
   const mem = await src.getMemoryById(memoryId);
-  if (!mem) {
+  // Owner-private support-passport records must not cross their storage
+  // boundary through a copy-based promotion. Reported as not found so the
+  // tool never confirms a private record's existence to another principal
+  // (#2387).
+  if (!mem || isSupportPassportPrivateMemory(mem)) {
     return `Memory not found in ${srcNs}: ${memoryId}`;
   }
 

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -16,6 +16,7 @@ import { runMemoryGovernance } from "../src/maintenance/memory-governance.ts";
 import {
   getMemoryProjectionPath,
   initializeMemoryProjectionDb, markProjectedMemoryPathInvalid,
+  probeProjectionHealth,
   readProjectedEntityMentions,
   readProjectedLatestReviewQueue,
   readProjectedMemoryBrowse, updateProjectedMemoryPath,
@@ -467,6 +468,95 @@ test("projection reads lazily migrate legacy schema columns for existing project
     } finally {
       migrated.close();
     }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("privacy-filtered browse lazily migrates schema-v3 projections to private_record (#2387)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-v3-"));
+  try {
+    const projectionPath = getMemoryProjectionPath(memoryDir);
+    await mkdir(path.dirname(projectionPath), { recursive: true });
+    const db = new Database(projectionPath);
+    try {
+      db.exec(`
+        CREATE TABLE meta (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+
+        CREATE TABLE memory_current (
+          memory_id TEXT PRIMARY KEY,
+          category TEXT NOT NULL,
+          status TEXT NOT NULL,
+          path_rel TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          entity_ref TEXT,
+          source TEXT NOT NULL,
+          confidence REAL NOT NULL,
+          confidence_tier TEXT NOT NULL,
+          tags_json TEXT NOT NULL DEFAULT '[]',
+          preview_text TEXT NOT NULL DEFAULT ''
+        );
+      `);
+      const insert = db.prepare(`
+        INSERT INTO memory_current (
+          memory_id, category, status, path_rel, created_at, updated_at,
+          entity_ref, source, confidence, confidence_tier, tags_json, preview_text
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      insert.run(
+        "fact-public", "fact", "active", "facts/2026-03-08/public.md",
+        "2026-03-08T00:00:00.000Z", "2026-03-08T01:00:00.000Z",
+        null, "test", 0.8, "implied", "[]", "public preview",
+      );
+      insert.run(
+        "pref-passport", "preference", "active", "preferences/2026-03-08/passport.md",
+        "2026-03-08T00:00:00.000Z", "2026-03-08T01:00:00.000Z",
+        null, "test", 0.8, "implied",
+        JSON.stringify(["support-passport-card"]), "private preview",
+      );
+    } finally {
+      db.close();
+    }
+
+    // First privacy-filtered browse cannot serve from the v3 store...
+    assert.equal(
+      readProjectedMemoryBrowse(memoryDir, { limit: 20, offset: 0, excludePrivateRecords: true }),
+      null,
+    );
+    // ...but it migrates the store on the way out.
+    const migrated = new Database(projectionPath);
+    try {
+      const columns = migrated
+        .prepare(`PRAGMA table_info(memory_current)`)
+        .all() as Array<{ name: string }>;
+      assert.equal(columns.some((column) => column.name === "private_record"), true);
+      const privateFlag = (memoryId: string): unknown =>
+        migrated
+          .prepare(`SELECT private_record FROM memory_current WHERE memory_id = ?`)
+          .get(memoryId);
+      for (const [memoryId, expected] of [["pref-passport", 1], ["fact-public", 0]] as const) {
+        const row = privateFlag(memoryId);
+        assert.ok(row && typeof row === "object" && "private_record" in row);
+        assert.equal(Number(row.private_record), expected);
+      }
+    } finally {
+      migrated.close();
+    }
+
+    const browse = readProjectedMemoryBrowse(memoryDir, {
+      limit: 20,
+      offset: 0,
+      excludePrivateRecords: true,
+    });
+    assert.ok(browse);
+    assert.equal(browse?.total, 1);
+    assert.equal(browse?.memories[0]?.id, "fact-public");
+
+    assert.equal(probeProjectionHealth(memoryDir).state, "openable");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/tests/memory-promote.test.ts
+++ b/tests/memory-promote.test.ts
@@ -196,3 +196,45 @@ test("memory promotion preserves origin for long legacy IDs", async () => {
   assert.equal(promotedAttributes?.promotedFromMemoryId, memoryId);
   assert.equal(promotedAttributes?.promotedFromMemoryIdHash, memoryIdHash);
 });
+
+test("memory promotion refuses owner-private support passport records (#2387)", async () => {
+  for (const frontmatter of [
+    { category: "preference", confidence: 0.8, tags: ["support-passport-card"] },
+    {
+      category: "preference",
+      confidence: 0.8,
+      structuredAttributes: { "support-passport-owner": "a".repeat(64) },
+    },
+  ] as const) {
+    let writes = 0;
+    const sourceStorage = {
+      getMemoryById: async () => ({
+        content: "Private owner card statement",
+        frontmatter,
+      }),
+    };
+    const destinationStorage = {
+      writeSealedMemory: async () => {
+        writes += 1;
+        return { id: "leaked-1", tombstoneBlocked: false };
+      },
+    };
+    const orchestrator = {
+      config: {
+        defaultNamespace: "default",
+        sharedNamespace: "shared",
+        memoryDir: "/tmp/remnic-memory-promote-test",
+        queryAwareIndexingEnabled: false,
+      },
+      getStorage: async (namespace: string) =>
+        namespace === "default" ? sourceStorage : destinationStorage,
+    };
+
+    const result = await executeMemoryPromote(orchestrator as never, {
+      memoryId: "card-1",
+    });
+
+    assert.equal(result, "Memory not found in default: card-1");
+    assert.equal(writes, 0);
+  }
+});

--- a/tests/openclaw-adapter-scenarios.test.ts
+++ b/tests/openclaw-adapter-scenarios.test.ts
@@ -425,6 +425,55 @@ test("scenario: compatibility memory runtime excludes private support-passport r
   });
 });
 
+test("scenario: compatibility memory runtime applies minScore after private-refill (#2387)", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator }) => {
+    const runtime = capture.registrations("registerMemoryRuntime")[0]?.[0] as
+      | {
+          getMemorySearchManager(params: {
+            cfg: unknown;
+            agentId: string;
+          }): Promise<{
+            manager: {
+              search(
+                query: string,
+                options?: { maxResults?: number; minScore?: number },
+              ): Promise<Array<{ citation: string; score?: number }>>;
+            };
+          }>;
+        }
+      | undefined;
+    assert.equal(typeof runtime?.getMemorySearchManager, "function");
+
+    const rankedResults = Array.from({ length: 40 }, (_, index) => ({
+      id: `result-${index}`,
+      path: `preferences/result-${index}.md`,
+      snippet: `snippet ${index}`,
+      score: index === 0 ? 0.9 : 0.5,
+    }));
+    const requestedLimits: number[] = [];
+    orchestrator.searchAcrossNamespaces = async (params: Record<string, unknown>) => {
+      const limit = Number(params.maxResults);
+      requestedLimits.push(limit);
+      return rankedResults.slice(0, limit);
+    };
+    orchestrator.filterPrivateSearchResults = async (results: Array<{ path: string }>) => results;
+
+    const { manager } = await runtime!.getMemorySearchManager({ cfg: {}, agentId: "generalist" });
+
+    // A strict threshold the whole page fails must not walk the backend
+    // candidate cap: score filtering is not a privacy exclusion.
+    const none = await manager.search("support", { maxResults: 5, minScore: 0.95 });
+    assert.deepEqual(requestedLimits, [5]);
+    assert.deepEqual(none, []);
+
+    // Threshold survivors are kept with the same single backend page.
+    requestedLimits.length = 0;
+    const some = await manager.search("support", { maxResults: 2, minScore: 0.85 });
+    assert.deepEqual(requestedLimits, [2]);
+    assert.deepEqual(some.map((result) => result.citation), ["preferences/result-0.md"]);
+  });
+});
+
 test("scenario: prompt injection precomputes recall and serves the cached prompt-section builder", async () => {
   await withScenarioRegistration(async ({ capture, orchestrator }) => {
     let recallCount = 0;

--- a/tests/orchestrator-tier-migration.test.ts
+++ b/tests/orchestrator-tier-migration.test.ts
@@ -68,7 +68,7 @@ test("tier migration pins live passport cards but routes completed private recor
       "support-passport-title": "Quiet space",
       "support-passport-order": "0",
       "support-passport-review-by": "2026-09-01T12:00:00.000Z",
-      "support-passport-source-ids": "",
+      "support-passport-source-ids": "source-1",
     };
     const active = await storage.writeMemory("preference", "Offer a quiet place.", {
       source: "support-passport",

--- a/tests/tier-routing.test.ts
+++ b/tests/tier-routing.test.ts
@@ -153,6 +153,7 @@ test("decideTierTransition does not pin incomplete support passport metadata", (
   for (const requiredAttribute of [
     "support-passport-order",
     "support-passport-review-by",
+    "support-passport-source-ids",
   ] as const) {
     const incomplete: Record<string, string> = { ...attributes };
     delete incomplete[requiredAttribute];

--- a/tests/tier-routing.test.ts
+++ b/tests/tier-routing.test.ts
@@ -119,7 +119,7 @@ test("decideTierTransition keeps live support passport cards in the hot tier", (
         "support-passport-title": "Quiet space",
         "support-passport-order": "0",
         "support-passport-review-by": "2026-09-01T12:00:00.000Z",
-        "support-passport-source-ids": "",
+        "support-passport-source-ids": "source-1",
       },
       confidence: 0,
       confidenceTier: "speculative",


### PR DESCRIPTION
Fixes #2387.

## Change

Support-passport replacement recovery from deferred review findings. Projection-store stays at its grandfather ceiling.

## Regression

`support-passport/card-service.test.ts` (58 tests).