### PR TITLE
fix(okf): address export review findings (namespace traversal, publish safety, child indexes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The search index lives separately and is rebuildable from these files at any tim
 
 See [docs/importers.md](docs/importers.md) for input formats, provenance metadata, and the full privacy breakdown.
 
-**Open Knowledge Format (OKF).** The memory directory doubles as an OKF v0.1 knowledge bundle: every memory file ships an inert `type` field next to Remnic's canonical `category`, so OKF-aware consumers can read your store without a converter. `category` stays authoritative — `type` is interop metadata and never overrides it on parse. Two commands keep the bundle conformant:
+**Open Knowledge Format (OKF).** The memory directory doubles as an OKF v0.1 knowledge bundle: every memory file ships an inert `type` field next to Remnic's canonical `category`, so OKF-aware consumers can read your store without a converter. `category` stays authoritative — `type` is interop metadata and never overrides it on parse. Two commands keep the bundle conformant, and a third exports a portable copy for interchange:
 
 | Command | What it does |
 |---------|--------------|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,7 +22,7 @@ New to Remnic? Start with the [quickstart](guides/quickstart.md), then come back
 - Placeholders use `<angle-brackets>`. Optional arguments use `[square-brackets]`.
 - Run any command with `--help` for its full option list.
 
-Remnic ships 35 top-level command names (`benchmark` is a compatibility alias of `bench`), grouped below by what you reach for them.
+Remnic ships 36 top-level command names (`benchmark` is a compatibility alias of `bench`), grouped below by what you reach for them.
 
 ## Setup & health
 
@@ -120,6 +120,7 @@ remnic capsule lineage --fork-id <id> --root <memory-dir>
 | `remnic import --adapter <name> --file <path> [--dry-run] [--batch-size <n>]` | Import from a supported export file |
 | `remnic import-lossless-claw --src <path> [--dry-run] [--session-filter <id>]` | Migrate a lossless-claw LCM database into Remnic's LCM mode |
 | `remnic training:export --format <name> --output <path>` | Export memories as a fine-tuning dataset |
+| `remnic export okf --out <dir> [--namespace <ns>] [--include-status <list>] [--force]` | Export the memory store as a portable plaintext OKF v0.1 knowledge bundle (`--log` adds log.md; `--include-profile` opts in) |
 
 `remnic import --adapter` supports exactly these adapters: `chatgpt`, `claude`, `gemini`, `mem0`, and `supermemory`. WeClone is not an import adapter — it is hosted-only via `openclaw engram bulk-import --source weclone`. Lossless-claw has its own dedicated `remnic import-lossless-claw` command above.
 

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@ Published npm packages:
   @remnic/core             Memory engine: orchestrator, storage, extraction,
                            search, entity graph, trust zones, LCM.
                            Framework-agnostic; every adapter builds on it.
-  @remnic/cli              Standalone `remnic` CLI (35 top-level commands).
+  @remnic/cli              Standalone `remnic` CLI (36 top-level commands).
                            Ships `remnic` and legacy `engram` bins.
   @remnic/server           Standalone HTTP + MCP server. Multi-token auth,
                            daemon mode, OAuth facade. Ships `remnic-server`
@@ -181,13 +181,13 @@ MCP tools:
   inspection, observation, correction planning, peers, wearables, and
   maintenance. Every MCP tool ships an outputSchema.
 
-Standalone CLI (`remnic`, 35 top-level commands, plus a
+Standalone CLI (`remnic`, 36 top-level commands, plus a
 `benchmark` alias of `bench`):
   init, migrate, status, query, action-confidence, xray, doctor, config,
   daemon, token, tree, onboard, curate, review, sync, offline, oauth, dedup,
   connectors, space, bench (alias benchmark), briefing, versions, binary,
   taxonomy, enrich, procedural, openclaw, extensions, training:export, import,
-  import-lossless-claw, wearables, capsule.
+  import-lossless-claw, wearables, capsule, export.
   Full reference: docs/cli.md.
 
 OpenClaw-hosted surface (`openclaw engram <command>`):

--- a/packages/remnic-cli/src/commands/export-okf.ts
+++ b/packages/remnic-cli/src/commands/export-okf.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import path from "node:path";
 import { Orchestrator, parseConfig, resolveRemnicConfigRecord } from "@remnic/core";
 import { exportOkfBundle, parseIncludeStatus } from "@remnic/core/export-okf";
 import { resolveConfigPath } from "../index.js";
@@ -27,20 +26,29 @@ export async function runExportOkfBinaryCommand(rest: string[]): Promise<void> {
   const args = rest.slice(1);
   let orchestrator: Orchestrator | undefined;
   try {
+    // Config/bootstrap failures get a constant message: parseConfig error
+    // strings can embed config values (CodeQL js/clear-text-logging), so
+    // they must never reach console output.
+    try {
+      const configPath = resolveConfigPath();
+      const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+      const config = parseConfig(resolveRemnicConfigRecord(raw));
+      orchestrator = new Orchestrator(config);
+      await orchestrator.initialize();
+      await orchestrator.deferredReady;
+    } catch {
+      console.error(
+        "export okf: failed to load the Remnic config or start the memory engine — run `remnic doctor` and check the config file for errors",
+      );
+      process.exitCode = 1;
+      return;
+    }
     const out = takeFlag(args, "--out");
     if (!out) throw new Error("Missing --out");
-    const namespace = takeFlag(args, "--namespace") ?? "";
-    const configPath = resolveConfigPath();
-    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    const config = parseConfig(resolveRemnicConfigRecord(raw));
-    orchestrator = new Orchestrator(config);
-    await orchestrator.initialize();
-    await orchestrator.deferredReady;
-    const memoryDir = namespace
-      ? path.join(orchestrator.config.memoryDir, "namespaces", namespace)
-      : orchestrator.config.memoryDir;
+    const namespace = takeFlag(args, "--namespace");
     const result = await exportOkfBundle({
-      memoryDir,
+      memoryDir: orchestrator.config.memoryDir,
+      namespace: namespace || undefined,
       outDir: out,
       includeStatus: parseIncludeStatus(takeFlag(args, "--include-status")),
       includeCategories: takeFlag(args, "--include-categories")?.split(","),

--- a/packages/remnic-core/src/cli/okf-commands.ts
+++ b/packages/remnic-core/src/cli/okf-commands.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { Orchestrator } from "../orchestrator.js";
 import type { CliCommand } from "../cli.js";
 import { runOkfCliCommand } from "../okf/cli.js";
@@ -42,12 +41,10 @@ export function registerExportOkfCommand(exportCmd: CliCommand, orchestrator: Or
       const out = options.out ? String(options.out) : "";
       if (!out) throw new Error("Missing --out");
       const includeStatus = parseIncludeStatus(options.includeStatus);
-      const namespace = options.namespace ? String(options.namespace) : "";
-      const memoryDir = namespace
-        ? path.join(orchestrator.config.memoryDir, "namespaces", namespace)
-        : orchestrator.config.memoryDir;
+      const namespace = options.namespace ? String(options.namespace) : undefined;
       const result = await exportOkfBundle({
-        memoryDir,
+        memoryDir: orchestrator.config.memoryDir,
+        namespace,
         outDir: out,
         includeStatus,
         includeCategories: options.includeCategories ? String(options.includeCategories).split(",") : undefined,

--- a/packages/remnic-core/src/transfer/export-okf.test.ts
+++ b/packages/remnic-core/src/transfer/export-okf.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile, symlink } from "node:fs/promises";
 import { existsSync, lstatSync, readdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -63,7 +63,7 @@ test("exportOkfBundle writes a deterministic active-only bundle", async () => {
     const factBody = await readFile(path.join(outA, factFile), "utf8");
     assert.match(factBody, /# Citations/);
     assert.match(factBody, /# Related/);
-    assert.match(factBody, /type: Memory Fact/);
+    assert.match(factBody, /type: "Memory Fact"/);
     await exportOkfBundle({ memoryDir, outDir: outB });
     assert.deepEqual(collectFiles(outA), collectFiles(outB));
     for (const rel of collectFiles(outA)) {
@@ -84,7 +84,7 @@ test("profile stays off unless requested; non-empty out requires --force", async
     await rm(outDir, { recursive: true, force: true });
     await exportOkfBundle({ memoryDir, outDir, includeProfile: true });
     const profile = await readFile(path.join(outDir, "profile.md"), "utf8");
-    assert.match(profile, /type: Profile/);
+    assert.match(profile, /type: "Profile"/);
     await writeFile(path.join(outDir, "keep.txt"), "old", "utf8");
     await assert.rejects(exportOkfBundle({ memoryDir, outDir }), /not empty/);
     assert.equal(await readFile(path.join(outDir, "keep.txt"), "utf8"), "old");
@@ -125,6 +125,7 @@ test("log.md is newest-first and marks truncation", async () => {
     await exportOkfBundle({ memoryDir, outDir, includeLog: true, logMaxEntries: 1 });
     const log = await readFile(path.join(outDir, "log.md"), "utf8");
     assert.match(log, /## 20\d{2}-\d{2}-\d{2}/);
+    assert.match(log, /\*\*Creation\*\*/);
     assert.match(log, new RegExp(OKF_LOG_TRUNCATION_MARKER));
     assert.ok(DEFAULT_OKF_LOG_MAX_ENTRIES > 1);
   } finally {
@@ -145,6 +146,83 @@ test("symlink out is rejected", async () => {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(real, { recursive: true, force: true });
     await rm(link, { force: true });
+  }
+});
+
+test("existing empty out dir is replaced; a non-directory out is rejected", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outDir = path.join(os.tmpdir(), `remnic-okf-empty-${Date.now()}`);
+  const fileOut = path.join(os.tmpdir(), `remnic-okf-file-${Date.now()}`);
+  try {
+    await seedStore(memoryDir);
+    await mkdir(outDir);
+    await exportOkfBundle({ memoryDir, outDir });
+    assert.equal(existsSync(path.join(outDir, "index.md")), true);
+    await writeFile(fileOut, "x", "utf8");
+    await assert.rejects(exportOkfBundle({ memoryDir, outDir: fileOut }), /not a directory/);
+    assert.equal(await readFile(fileOut, "utf8"), "x");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outDir, { recursive: true, force: true });
+    await rm(fileOut, { force: true });
+  }
+});
+
+test("namespace traversal is rejected and the namespace subtree is exported", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outDir = path.join(os.tmpdir(), `remnic-okf-ns-${Date.now()}`);
+  try {
+    await seedStore(memoryDir);
+    await assert.rejects(
+      exportOkfBundle({ memoryDir, namespace: "../escape", outDir }),
+      /invalid namespace path/,
+    );
+    const teamDir = path.join(memoryDir, "namespaces", "team");
+    await mkdir(path.dirname(teamDir), { recursive: true });
+    await seedStore(teamDir);
+    const result = await exportOkfBundle({ memoryDir, namespace: "team", outDir });
+    assert.equal(result.exported, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("child directories carry index.md files without frontmatter", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outDir = path.join(os.tmpdir(), `remnic-okf-child-${Date.now()}`);
+  try {
+    await seedStore(memoryDir);
+    await exportOkfBundle({ memoryDir, outDir });
+    const files = collectFiles(outDir);
+    const decisionIndex = files.find((rel) => /^decisions\/[^/]+\/index\.md$/.test(rel));
+    assert.ok(decisionIndex, `missing decisions index.md in ${files.join(",")}`);
+    const factIndex = files.find((rel) => /^facts\/[^/]+\/index\.md$/.test(rel));
+    assert.ok(factIndex, `missing facts index.md in ${files.join(",")}`);
+    const child = await readFile(path.join(outDir, decisionIndex!), "utf8");
+    assert.doesNotMatch(child, /^---/);
+    assert.match(child, /^# 20\d{2}-\d{2}-\d{2}$/m);
+    assert.match(child, /\[Use SQLite\]\(\/decisions\//);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outDir, { recursive: true, force: true });
+  }
+});
+
+test("frontmatter quotes string scalars that look like other YAML types", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-src-"));
+  const outDir = path.join(os.tmpdir(), `remnic-okf-quote-${Date.now()}`);
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.ensureDirectories();
+    await storage.writeMemory("fact", "# true\n\nA title that would parse as a boolean.", { source: "test" });
+    await exportOkfBundle({ memoryDir, outDir });
+    const files = collectFiles(outDir).filter((rel) => rel.startsWith("facts/") && !rel.endsWith("index.md"));
+    const body = await readFile(path.join(outDir, files[0]!), "utf8");
+    assert.match(body, /^title: "true"$/m);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outDir, { recursive: true, force: true });
   }
 });
 

--- a/packages/remnic-core/src/transfer/export-okf.ts
+++ b/packages/remnic-core/src/transfer/export-okf.ts
@@ -1,11 +1,12 @@
 import { lstatSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import type { Stats } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 
 import { parseOaiMemCitation } from "../citations.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { normalizeProjectionPreview } from "../memory-projection-format.js";
+import { resolveNamespaceChildRoot } from "../namespaces/path.js";
 import { lintOkfDir } from "../okf/lint.js";
 import { okfTypeForMemory, OKF_PROFILE_TYPE } from "../okf/type-mapping.js";
 import { StorageManager } from "../storage.js";
@@ -27,6 +28,7 @@ const MEMORY_STATUSES: readonly MemoryStatus[] = [
 
 export interface ExportOkfOptions {
   memoryDir: string;
+  namespace?: string;
   outDir: string;
   includeStatus?: readonly string[];
   includeCategories?: readonly string[];
@@ -60,15 +62,19 @@ export function parseIncludeStatus(raw: unknown): MemoryStatus[] {
 export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkfResult> {
   const outDir = path.resolve(opts.outDir);
   rejectSymlinkPath(outDir);
+  const replaceExisting = inspectOutDir(outDir, opts.force === true);
+  const memoryDir = opts.namespace
+    ? resolveNamespaceChildRoot(opts.memoryDir, opts.namespace)
+    : opts.memoryDir;
   const includeStatus = new Set(parseIncludeStatus(opts.includeStatus));
   const includeCategories = opts.includeCategories?.length ? new Set(opts.includeCategories) : null;
   const excludeTags = new Set(opts.excludeTags ?? []);
-  const storage = new StorageManager(opts.memoryDir);
+  const storage = new StorageManager(memoryDir);
   const memories = await storage.readAllMemories();
   const included: MemoryFile[] = [];
   let excluded = 0;
   for (const memory of memories) {
-    const rel = toRel(memory.path, opts.memoryDir);
+    const rel = toRel(memory.path, memoryDir);
     if (!opts.includeWearables && rel.startsWith("wearables/")) {
       excluded += 1;
       continue;
@@ -88,17 +94,21 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
     }
     included.push(memory);
   }
-  included.sort((a, b) => toRel(a.path, opts.memoryDir).localeCompare(toRel(b.path, opts.memoryDir)));
+  included.sort((a, b) => toRel(a.path, memoryDir).localeCompare(toRel(b.path, memoryDir)));
 
-  const staging = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-export-"));
+  const outParent = path.dirname(outDir);
+  mkdirSync(outParent, { recursive: true });
+  // Stage as a hidden sibling of --out so the publish rename never crosses
+  // a filesystem boundary (EXDEV when /tmp and --out live on different mounts).
+  const staging = await mkdtemp(path.join(outParent, ".remnic-okf-export-"));
   const byCategory: Record<string, number> = {};
   const idToRel = new Map<string, string>();
   for (const memory of included) {
-    const rel = toRel(memory.path, opts.memoryDir);
+    const rel = toRel(memory.path, memoryDir);
     idToRel.set(memory.frontmatter.id, rel);
   }
   for (const memory of included) {
-    const rel = toRel(memory.path, opts.memoryDir);
+    const rel = toRel(memory.path, memoryDir);
     const rendered = renderMemory(memory, rel, idToRel);
     writeBundleFile(staging, rel, rendered);
     const category = memory.frontmatter.category;
@@ -129,7 +139,7 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
     writeBundleFile(staging, "log.md", renderLog(events, idToRel, opts.logMaxEntries ?? DEFAULT_OKF_LOG_MAX_ENTRIES));
   }
 
-  writeIndexes(staging, included, opts.memoryDir);
+  writeIndexes(staging, included, memoryDir);
   const lint = lintOkfDir(staging);
   const blocking = lint.findings.filter((f) => f.code !== "skipped_encrypted" && f.code !== "reserved_basename");
   if (blocking.length > 0) {
@@ -137,7 +147,7 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
     throw new Error(`OKF export failed lint: ${blocking.map((f) => `${f.file}: ${f.message}`).join("; ")}`);
   }
 
-  publishBundle(staging, outDir, opts.force === true);
+  publishBundle(staging, outDir, replaceExisting);
   return {
     exported: included.length,
     excluded,
@@ -146,43 +156,45 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
   };
 }
 
-function publishBundle(staging: string, outDir: string, force: boolean): void {
-  let exists = false;
+function inspectOutDir(outDir: string, force: boolean): boolean {
+  let stat: Stats;
   try {
-    const stat = lstatSync(outDir);
-    if (stat.isSymbolicLink()) throw new Error(`--out must not be a symlink: ${outDir}`);
-    exists = true;
-    const entries = listNonDot(outDir);
-    if (entries.length > 0 && !force) {
-      rmSync(staging, { recursive: true, force: true });
-      throw new Error(`--out ${outDir} is not empty; pass --force to replace it`);
-    }
+    stat = lstatSync(outDir);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
   }
-  mkdirSync(path.dirname(outDir), { recursive: true });
-  if (exists && force) {
-    const backup = `${outDir}.okf-prev`;
-    try {
-      renameSync(outDir, backup);
-    } catch {
-      rmSync(staging, { recursive: true, force: true });
-      throw new Error(`cannot replace --out ${outDir}`);
-    }
-    try {
-      renameSync(staging, outDir);
-      rmSync(backup, { recursive: true, force: true });
-    } catch (err) {
-      try {
-        renameSync(backup, outDir);
-      } catch {
-        // Keep backup if restore fails.
-      }
-      throw err;
-    }
+  if (stat.isSymbolicLink()) throw new Error(`--out must not be a symlink: ${outDir}`);
+  if (!stat.isDirectory()) throw new Error(`--out exists and is not a directory: ${outDir}`);
+  if (!force && listNonDot(outDir).length > 0) {
+    throw new Error(`--out ${outDir} is not empty; pass --force to replace it`);
+  }
+  return true;
+}
+
+function publishBundle(staging: string, outDir: string, exists: boolean): void {
+  if (!exists) {
+    renameSync(staging, outDir);
     return;
   }
-  renameSync(staging, outDir);
+  const backup = `${outDir}.okf-prev`;
+  try {
+    renameSync(outDir, backup);
+  } catch {
+    rmSync(staging, { recursive: true, force: true });
+    throw new Error(`cannot replace --out ${outDir}`);
+  }
+  try {
+    renameSync(staging, outDir);
+    rmSync(backup, { recursive: true, force: true });
+  } catch (err) {
+    try {
+      renameSync(backup, outDir);
+    } catch {
+      // Keep backup if restore fails.
+    }
+    throw err;
+  }
 }
 
 function renderMemory(memory: MemoryFile, rel: string, idToRel: Map<string, string>): string {
@@ -224,31 +236,46 @@ function renderRelated(link: MemoryLink, idToRel: Map<string, string>): string {
 
 function writeIndexes(root: string, memories: MemoryFile[], memoryDir: string): void {
   const groups = new Map<string, MemoryFile[]>();
+  const byDir = new Map<string, MemoryFile[]>();
   for (const memory of memories) {
     const rel = toRel(memory.path, memoryDir);
     const dir = path.posix.dirname(rel);
-    const key = dir === "." ? "" : dir.split("/")[0] ?? "";
-    const list = groups.get(key) ?? [];
+    const key = dir === "." ? "" : (dir.split("/")[0] ?? "");
+    const section = groups.get(key) ?? [];
+    section.push(memory);
+    groups.set(key, section);
+    if (dir === ".") continue;
+    const list = byDir.get(dir) ?? [];
     list.push(memory);
-    groups.set(key, list);
+    byDir.set(dir, list);
   }
+  const entry = (memory: MemoryFile): string => {
+    const rel = toRel(memory.path, memoryDir);
+    const title = firstHeading(memory.content) ?? memory.frontmatter.id;
+    const description = normalizeProjectionPreview(memory.content);
+    return `* [${title}](/${rel}) - ${description}`;
+  };
+  const byPath = (a: MemoryFile, b: MemoryFile): number =>
+    toRel(a.path, memoryDir).localeCompare(toRel(b.path, memoryDir));
   const sections = [...groups.keys()].sort().map((key) => {
     const heading = key === "" ? "Root" : humanize(key);
-    const lines = (groups.get(key) ?? [])
-      .sort((a, b) => toRel(a.path, memoryDir).localeCompare(toRel(b.path, memoryDir)))
-      .map((memory) => {
-        const rel = toRel(memory.path, memoryDir);
-        const title = firstHeading(memory.content) ?? memory.frontmatter.id;
-        const description = normalizeProjectionPreview(memory.content);
-        return `* [${title}](/${rel}) - ${description}`;
-      });
+    const lines = (groups.get(key) ?? []).sort(byPath).map(entry);
     return `## ${heading}\n\n${lines.join("\n")}`;
   });
   writeBundleFile(root, "index.md", `---\nokf_version: "${OKF_EXPORT_VERSION}"\n---\n\n${sections.join("\n\n")}\n`);
+  // OKF spec section 8: an index MAY appear in any directory. Give every
+  // directory that directly holds exported concepts a child index — one
+  // section, no frontmatter (only the bundle root may carry okf_version).
+  for (const dir of [...byDir.keys()].sort()) {
+    const lines = (byDir.get(dir) ?? []).sort(byPath).map(entry);
+    const name = dir.split("/").at(-1) ?? dir;
+    const heading = /^\d{4}-\d{2}-\d{2}$/.test(name) ? name : humanize(name);
+    writeBundleFile(root, `${dir}/index.md`, `# ${heading}\n\n${lines.join("\n")}\n`);
+  }
 }
 
 function renderLog(
-  events: Array<{ timestamp?: string; type?: string; action?: string; memoryId?: string }>,
+  events: Array<{ timestamp?: string; eventType?: string; type?: string; action?: string; memoryId?: string }>,
   idToRel: Map<string, string>,
   maxEntries: number,
 ): string {
@@ -267,7 +294,7 @@ function renderLog(
   for (const day of days) {
     parts.push(`## ${day}`, "");
     for (const event of byDay.get(day) ?? []) {
-      const action = boldAction(event.type ?? event.action ?? "Update");
+      const action = boldAction(event.eventType ?? event.type ?? event.action ?? "Update");
       const id = event.memoryId;
       const rel = id ? idToRel.get(id) : undefined;
       const target = rel ? `[${id}](/${rel})` : id ?? "";
@@ -312,17 +339,19 @@ function yamlLine(key: string, value: unknown): string[] {
 }
 
 function yamlScalar(value: unknown): string {
-  if (typeof value === "string") {
-    if (value === "" || /[:#\n]/.test(value) || value !== value.trim()) return JSON.stringify(value);
-    return value;
-  }
+  if (typeof value === "string") return JSON.stringify(value);
   return String(value);
 }
 
 function firstHeading(content: string): string | undefined {
   for (const line of content.split("\n")) {
-    const match = /^#\s+(.+)$/.exec(line.trim());
-    if (match) return match[1]!.trim();
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("#") || trimmed.startsWith("##")) continue;
+    const heading = trimmed.slice(1);
+    const separator = heading[0];
+    if (separator !== " " && separator !== "\t") continue;
+    const title = heading.trim();
+    if (title) return title;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

#2548 landed while its review round was still open. This PR batch-fixes the findings that shipped unfixed on main.

### Security
- `--namespace` on both `export okf` entry points now resolves through `resolveNamespaceChildRoot` (rejects `..`/absolute traversal) instead of a raw `path.join` on the CLI value.

### Publish safety
- Staging moved from the OS temp dir to a hidden sibling of `--out`, so the publish rename cannot fail with `EXDEV` when `--out` lives on another filesystem.
- An existing empty `--out` is replaced through the backup-and-swap path instead of a bare rename (EEXIST on some platforms); a non-directory `--out` is rejected up front, before any writes.

### Correctness
- Child `index.md` files are written in every directory that directly holds exported concepts (OKF spec section 8; no frontmatter outside the bundle root).
- `log.md` renders the stored lifecycle `eventType`, so created/deprecated events no longer render as Update.
- All YAML string scalars are quoted; titles like `true` or `*foo` no longer change type on round-trip.

### CodeQL
- Polynomial heading regex replaced with a string scan (clears the polynomial-ReDoS alert on uncontrolled data).
- The standalone CLI keeps config-load failures out of console output with the established constant-message pattern (`okf`/`wearables` commands), clearing the clear-text-logging alert.

### Docs
- `export` added to the standalone CLI inventory (35 → 36 top-level commands); README OKF lead-in now matches the three-row command table.

## Tests

Extended `export-okf.test.ts`: empty-dir replace, non-directory rejection, namespace traversal rejection plus namespace-subtree export, child index generation, quoted scalars, and lifecycle event rendering. `npm run preflight:quick` green.

Follow-up to #1948 / #2548.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `remnic export okf` command for exporting portable plaintext OKF v0.1 knowledge bundles.
  * Added support for exporting namespace-scoped knowledge and selected statuses.
  * Generated root and directory index files in exported bundles.

* **Bug Fixes**
  * Improved output validation, replacement of empty destinations, and safe export publishing.
  * Enhanced YAML and Markdown handling for reliable exported content.
  * Exported logs now include creation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->