### PR TITLE
chore(ci): encode five gates this batch actually hit

### DIFF
--- a/.changeset/ci-this-run-7.md
+++ b/.changeset/ci-this-run-7.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: count only Fixes/Closes/Resolves in scope-budget, check package typecheck scripts before tsc, and squash-merge via REST when GraphQL is rate-limited.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Package typecheck scripts
+        run: node scripts/check-package-typecheck-scripts.mjs
+
+
       - name: Typecheck
         run: pnpm run check-types
 

--- a/scripts/check-package-typecheck-scripts.mjs
+++ b/scripts/check-package-typecheck-scripts.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Fail when a packages/* tsconfig package is missing check-types,
+ * or missing precheck-types while it depends on @remnic/core.
+ * Hit this run: connector-x failed tests (root) 10 minutes in.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export function missingTypecheckScripts(packagesDir = join(repoRoot, "packages")) {
+  const names = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(packagesDir, name, "tsconfig.json")))
+    .sort();
+
+  const missingCheckTypes = [];
+  const missingPrecheck = [];
+  for (const name of names) {
+    const pkg = JSON.parse(readFileSync(join(packagesDir, name, "package.json"), "utf8"));
+    if (!pkg.scripts?.["check-types"]) missingCheckTypes.push(name);
+    const usesCore = Boolean(
+      pkg.dependencies?.["@remnic/core"] ||
+        pkg.devDependencies?.["@remnic/core"] ||
+        pkg.peerDependencies?.["@remnic/core"],
+    );
+    if (usesCore && pkg.name !== "@remnic/plugin-openclaw" && !pkg.scripts?.["precheck-types"]) {
+      missingPrecheck.push(name);
+    }
+  }
+  return { missingCheckTypes, missingPrecheck };
+}
+
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const { missingCheckTypes, missingPrecheck } = missingTypecheckScripts();
+  if (missingCheckTypes.length > 0 || missingPrecheck.length > 0) {
+    if (missingCheckTypes.length > 0) {
+      console.error(`packages missing scripts.check-types: ${missingCheckTypes.join(", ")}`);
+    }
+    if (missingPrecheck.length > 0) {
+      console.error(
+        `packages that depend on @remnic/core need scripts.precheck-types (copy packages/connector-limitless): ${missingPrecheck.join(", ")}`,
+      );
+    }
+    process.exit(1);
+  }
+}

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -301,6 +301,9 @@ run node scripts/check-ratchets.mjs
 run node scripts/check-package-test-files.mjs
 run node scripts/check-hook-runner-sync.mjs
 run node scripts/check-hook-grep-targets.mjs
+
+run node scripts/check-package-typecheck-scripts.mjs
+
 run node scripts/check-last-recall-json-load.mjs
 
 run node scripts/check-docs-parity.mjs

--- a/scripts/pr-scope-budget.mjs
+++ b/scripts/pr-scope-budget.mjs
@@ -126,8 +126,13 @@ export function extractIssueRefs(text) {
     .replace(/<!--[\s\S]*?-->/g, " ")
     .replace(/```[\s\S]*?```/g, " ")
     .replace(/`[^`]*`/g, " ");
-  for (const match of prose.matchAll(/(?<![0-9A-Za-z_#])#(\d+)(?![0-9A-Za-z_])/g)) {
+  for (const match of prose.matchAll(
+    /\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+#(\d+)((?:\s*(?:,|and)\s*#\d+)*)/gi,
+  )) {
     issues.add(Number(match[1]));
+    for (const extra of match[2].matchAll(/#(\d+)/g)) {
+      issues.add(Number(extra[1]));
+    }
   }
   return issues;
 }

--- a/scripts/squash-merge-pr.mjs
+++ b/scripts/squash-merge-pr.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Squash-merge via REST. Use when GraphQL merge is rate-limited (this run).
+ * usage: node scripts/squash-merge-pr.mjs <n>
+ */
+import { spawnSync } from "node:child_process";
+
+const pr = process.argv[2];
+if (!/^\d+$/.test(pr ?? "")) {
+  console.error("usage: node scripts/squash-merge-pr.mjs <pr-number>");
+  process.exit(2);
+}
+
+const result = spawnSync(
+  "gh",
+  [
+    "api",
+    "-X",
+    "PUT",
+    `repos/{owner}/{repo}/pulls/${pr}/merge`,
+    "-f",
+    "merge_method=squash",
+  ],
+  { stdio: "inherit" },
+);
+process.exit(result.status === null ? 1 : result.status);

--- a/tests/pr-scope-budget.test.mjs
+++ b/tests/pr-scope-budget.test.mjs
@@ -173,19 +173,31 @@ test("renames out of core paths still count against the budget (round 3)", () =>
 // --- Subsystem-group / multi-issue detection (issue #2067) ---
 
 test("issue references are extracted, deduped, boundary-checked, and code-stripped", () => {
-  const issues = extractIssueRefs("Closes #12, part of #34 and see #12 again (no digits: #).");
+  const issues = extractIssueRefs("Closes #12, Fixes #12 again, and Resolves #99.");
   assert.deepEqual(
     [...issues].sort((a, b) => a - b),
-    [12, 34]
+    [12, 99]
   );
   assert.equal(extractIssueRefs("").size, 0);
   assert.equal(extractIssueRefs(undefined).size, 0);
-  // Non-issue hashes must not count: hex color / commit-ish in code spans are
-  // stripped, and alphanumeric neighbours break the reference boundary.
   const filtered = extractIssueRefs(
-    "real #42, hidden <!-- see #77 -->, color `#123456`, block ```\n#999\n```, run#7 x#8y ##9"
+    "Fixes #42, hidden <!-- Closes #77 -->, color `#123456`, block ```\nFixes #999\n```, run#7 x#8y ##9"
   );
   assert.deepEqual([...filtered], [42]);
+});
+
+test("extractIssueRefs ignores see/part-of/pull URLs (this-run #2550)", () => {
+  const issues = extractIssueRefs(
+    "Fixes #2387.\nSupport-passport recovery from https://github.com/joshuaswarren/remnic/pull/2360. See #12, part of #34."
+  );
+  assert.deepEqual([...issues], [2387]);
+});
+
+test("extractIssueRefs accepts GitHub Fixes #1 and #2 lists", () => {
+  assert.deepEqual(
+    [...extractIssueRefs("Fixes #111 and #222, also Closes #333, #444")].sort((a, b) => a - b),
+    [111, 222, 333, 444],
+  );
 });
 
 test("classifySubsystem picks the longest matching prefix", () => {
@@ -232,7 +244,7 @@ test(">=3 related groups + >=2 issues warns without failing (shared package ance
     thresholds: THRESHOLDS,
     ignorePatterns: NO_IGNORES,
     subsystemGroups: GROUPS,
-    prText: "Part of #111 and #222",
+    prText: "Fixes #111. Fixes #222",
   });
   assert.equal(result.verdict, "warn");
   assert.match(result.detail, /span 3 subsystem groups/);
@@ -246,7 +258,7 @@ test("unrelated groups (no package ancestor) + >=2 issues fails; exempt bypasses
     thresholds: THRESHOLDS,
     ignorePatterns: NO_IGNORES,
     subsystemGroups: GROUPS,
-    prText: "Fixes #111, also #222",
+    prText: "Fixes #111. Fixes #222",
   };
   const fail = evaluateScopeBudget({ ...base, labels: [] });
   assert.equal(fail.verdict, "fail");

--- a/tests/root-typecheck-coverage.test.ts
+++ b/tests/root-typecheck-coverage.test.ts
@@ -44,7 +44,11 @@ test("root typecheck covers package tsconfigs", () => {
     })
     .sort();
 
-  assert.deepEqual(packagesMissingCheckTypes, []);
+  assert.deepEqual(
+    packagesMissingCheckTypes,
+    [],
+    packagesMissingCheckTypes.length ? `add scripts.check-types to: ${packagesMissingCheckTypes.join(", ")}` : "",
+  );
 
   const packagesMissingCorePrecheck = packageNamesWithTsconfig
     .filter((name) => {
@@ -61,5 +65,11 @@ test("root typecheck covers package tsconfigs", () => {
     })
     .sort();
 
-  assert.deepEqual(packagesMissingCorePrecheck, []);
+  assert.deepEqual(
+    packagesMissingCorePrecheck,
+    [],
+    packagesMissingCorePrecheck.length
+      ? `add scripts.precheck-types (copy packages/connector-limitless) to: ${packagesMissingCorePrecheck.join(", ")}`
+      : "",
+  );
 });

--- a/tests/squash-merge-pr.test.mjs
+++ b/tests/squash-merge-pr.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = join(dirname(dirname(fileURLToPath(import.meta.url))), "scripts/squash-merge-pr.mjs");
+
+test("squash-merge-pr rejects a missing PR number", () => {
+  const result = spawnSync(process.execPath, [script], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /usage:/);
+});


### PR DESCRIPTION
## Why

This batch hit five process defects. Encode them so the next batch fails faster.

1. Scope-budget counted any `#N` and `/pull/N`. A follow-up PR that mentioned an earlier PR failed the split rule. Count only `Fixes` / `Closes` / `Resolves` (including `Fixes #1 and #2`).
2. A new connector package without `precheck-types` failed `tests (root)` after ten minutes. The same check now runs in the `checks` job and in preflight.
3. Missing-script asserts now name the package and the copy-from example.
4. GraphQL merge hit a rate limit. `scripts/squash-merge-pr.mjs` squash-merges via REST.
5. `Fixes #1 and #2` is GitHub close grammar and now counts both issues.

## Regression

`tests/pr-scope-budget.test.mjs`, `tests/squash-merge-pr.test.mjs`, `tests/root-typecheck-coverage.test.ts`.