### PR TITLE
fix(standup): land the #2552 review fixes (working-day lookback, untainted errors, contract composition)

### DIFF
--- a/packages/remnic-cli/src/commands/standup.ts
+++ b/packages/remnic-cli/src/commands/standup.ts
@@ -18,13 +18,24 @@ export async function runStandupBinaryCommand(rest: string[]): Promise<void> {
   }
   let orchestrator: Orchestrator | undefined;
   try {
-    const configPath = resolveConfigPath();
-    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
-    const config = parseConfig(resolveRemnicConfigRecord(raw));
-    orchestrator = new Orchestrator(config);
-    await orchestrator.initialize();
-    await orchestrator.deferredReady;
-    const brief = buildStandup(orchestrator.config.memoryDir, parseStandupDate(takeFlag(rest, "--date")));
+    // Config/bootstrap failures get a constant message: parseConfig error
+    // strings can embed config values (CodeQL js/clear-text-logging), so
+    // they must never reach console output.
+    try {
+      const configPath = resolveConfigPath();
+      const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+      const config = parseConfig(resolveRemnicConfigRecord(raw));
+      orchestrator = new Orchestrator(config);
+      await orchestrator.initialize();
+      await orchestrator.deferredReady;
+    } catch {
+      console.error(
+        "standup: failed to load the Remnic config or start the memory engine — run `remnic doctor` and check the config file for errors",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const brief = buildStandup(orchestrator!.config.memoryDir, parseStandupDate(takeFlag(rest, "--date")));
     console.log(brief.markdown);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -82,7 +82,7 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     skipped: T_NUMBER,
     removed: T_ARRAY,
   }),
-  standup: objectSchema({ date: T_STRING, yesterday: T_STRING, today: T_STRING, highlights: T_ARRAY, blockers: T_ARRAY, activityGrid: T_STRING, markdown: T_STRING }),
+  standup: objectSchema({ date: T_STRING, yesterday: T_STRING, today: T_STRING, highlights: T_ARRAY, priorities: T_ARRAY, blockers: T_ARRAY, activityGrid: T_STRING, markdown: T_STRING }),
   action_confidence: objectSchema({
     schemaVersion: T_NUMBER,
     decision: T_STRING,

--- a/packages/remnic-core/src/standup/build.test.ts
+++ b/packages/remnic-core/src/standup/build.test.ts
@@ -4,12 +4,51 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { buildStandup, parseStandupDate, previousDate } from "./build.js";
+import { buildStandup, parseStandupDate, previousActiveDate } from "./build.js";
 
 test("parseStandupDate rejects garbage and defaults to UTC today", () => {
   assert.equal(parseStandupDate(undefined, new Date("2026-08-18T12:00:00Z")), "2026-08-18");
   assert.throws(() => parseStandupDate("nope"), /YYYY-MM-DD/);
-  assert.equal(previousDate("2026-08-18"), "2026-08-17");
+});
+
+test("previousActiveDate falls back to calendar-previous when no digests exist", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-standup-"));
+  try {
+    assert.equal(previousActiveDate(memoryDir, "2026-08-18"), "2026-08-17");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("previousActiveDate skips idle weekend days (Monday resolves to Friday)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-standup-"));
+  try {
+    await mkdir(path.join(memoryDir, "activity"), { recursive: true });
+    // 2026-08-17 is a Monday; 2026-08-14 is the prior Friday (derived from
+    // `date -d`, not memory). Weekend has no digest files.
+    await writeFile(
+      path.join(memoryDir, "activity", "2026-08-14.md"),
+      "---\ndate: 2026-08-14\n---\n# Friday\n- shipped cards\n",
+      "utf8",
+    );
+    assert.equal(previousActiveDate(memoryDir, "2026-08-17"), "2026-08-14");
+    const brief = buildStandup(memoryDir, "2026-08-17");
+    assert.equal(brief.yesterday, "2026-08-14");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("previousActiveDate picks the most recent active day, not a fixed weekday", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-standup-"));
+  try {
+    await mkdir(path.join(memoryDir, "activity"), { recursive: true });
+    // Sunday activity counts: prior day is the latest day WITH data.
+    await writeFile(path.join(memoryDir, "activity", "2026-08-16.md"), "x\n", "utf8");
+    assert.equal(previousActiveDate(memoryDir, "2026-08-17"), "2026-08-16");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });
 
 test("buildStandup is deterministic and marks missing days", async () => {

--- a/packages/remnic-core/src/standup/build.test.ts
+++ b/packages/remnic-core/src/standup/build.test.ts
@@ -6,9 +6,15 @@ import test from "node:test";
 
 import { buildStandup, parseStandupDate, previousActiveDate } from "./build.js";
 
-test("parseStandupDate rejects garbage and defaults to UTC today", () => {
+const FRONTMATTER = (date: string): string => `---\nid: digest-${date}\ncategory: fact\nstatus: active\n---\n`;
+
+test("parseStandupDate defaults only on absence, rejects garbage and empty", () => {
   assert.equal(parseStandupDate(undefined, new Date("2026-08-18T12:00:00Z")), "2026-08-18");
+  assert.equal(parseStandupDate(null, new Date("2026-08-18T12:00:00Z")), "2026-08-18");
   assert.throws(() => parseStandupDate("nope"), /YYYY-MM-DD/);
+  // An explicitly empty date is user input, not absence (§39: reject, never
+  // silently default).
+  assert.throws(() => parseStandupDate(""), /YYYY-MM-DD/);
 });
 
 test("previousActiveDate falls back to calendar-previous when no digests exist", async () => {
@@ -26,14 +32,8 @@ test("previousActiveDate skips idle weekend days (Monday resolves to Friday)", a
     await mkdir(path.join(memoryDir, "activity"), { recursive: true });
     // 2026-08-17 is a Monday; 2026-08-14 is the prior Friday (derived from
     // `date -d`, not memory). Weekend has no digest files.
-    await writeFile(
-      path.join(memoryDir, "activity", "2026-08-14.md"),
-      "---\ndate: 2026-08-14\n---\n# Friday\n- shipped cards\n",
-      "utf8",
-    );
+    await writeFile(path.join(memoryDir, "activity", "2026-08-14.md"), "x\n", "utf8");
     assert.equal(previousActiveDate(memoryDir, "2026-08-17"), "2026-08-14");
-    const brief = buildStandup(memoryDir, "2026-08-17");
-    assert.equal(brief.yesterday, "2026-08-14");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -51,22 +51,109 @@ test("previousActiveDate picks the most recent active day, not a fixed weekday",
   }
 });
 
-test("buildStandup is deterministic and marks missing days", async () => {
+function digestBody(spans: string[]): string {
+  return ["## Timeline", "", ...spans].join("\n");
+}
+
+test("buildStandup derives every section from the prior active day and stays deterministic", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-standup-"));
   try {
     await mkdir(path.join(memoryDir, "activity"), { recursive: true });
+    // Friday 2026-08-14 has the activity; Monday 2026-08-17 is the standup day.
     await writeFile(
-      path.join(memoryDir, "activity", "2026-08-18.md"),
-      "---\ndate: 2026-08-18\n---\n# Today\n- shipped standup\n- blocker: waiting on review\n",
+      path.join(memoryDir, "activity", "2026-08-14.md"),
+      FRONTMATTER("2026-08-14") +
+        digestBody([
+          "- [09:00] Editor — refactor",
+          "- [09:30] Editor — refactor",
+          "- [10:15] Terminal — build",
+          "- [11:40] Editor — review",
+          "- [14:05] Browser — docs",
+          "- [15:20] Editor — blocker: waiting on review",
+        ]),
       "utf8",
     );
-    const a = buildStandup(memoryDir, "2026-08-18");
-    const b = buildStandup(memoryDir, "2026-08-18");
+    const a = buildStandup(memoryDir, "2026-08-17");
+    const b = buildStandup(memoryDir, "2026-08-17");
     assert.equal(a.markdown, b.markdown);
-    assert.equal(a.yesterday, "2026-08-17");
-    assert.match(a.markdown, /blocker: waiting on review/);
-    assert.match(a.activityGrid, /yesterday \| \./);
-    assert.match(a.activityGrid, /today \| x/);
+
+    assert.equal(a.yesterday, "2026-08-14");
+    // Highlights come from the PRIOR day (issue #1981), and frontmatter
+    // fields never leak into rendered sections.
+    assert.ok(a.highlights.length > 0);
+    for (const line of a.highlights) {
+      assert.doesNotMatch(line, /^id: |^category: |^status: |^---$/);
+    }
+    assert.match(a.markdown, /## Highlights\n- \[09:00\] Editor — refactor/);
+    // Blockers strip list markers (no doubled bullets) and come from P.
+    assert.ok(a.blockers.some((line) => line === "[15:20] Editor — blocker: waiting on review"));
+    assert.doesNotMatch(a.markdown, /- - /);
+    // Grid: exactly hours 9, 10, 11, 14, 15 non-empty; Monday empty.
+    assert.match(a.activityGrid, /^prior day 2026-08-14 — 24 hour buckets/);
+    assert.match(a.activityGrid, /^non-empty hours: 9, 10, 11, 14, 15$/m);
+    assert.match(a.markdown, /## Today \(2026-08-17\)\n_No activity digest._/);
+    // Zero commitments → explicit empty-priorities message, never invented.
+    assert.match(a.markdown, /## Today's priorities\n- \(no tracked commitments — add priorities manually\)/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("buildStandup renders an empty grid row when the prior day has no digest", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-standup-"));
+  try {
+    const brief = buildStandup(memoryDir, "2026-08-18");
+    assert.match(brief.activityGrid, /^prior day 2026-08-17: no activity digest \(empty\)$/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("buildStandup lists open commitments as priorities and overdue ones as blocker candidates", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-standup-"));
+  try {
+    await mkdir(path.join(memoryDir, "facts", "2026-08-10"), { recursive: true });
+    const commitment = (id: string, extra: string): string =>
+      `---\nid: ${id}\ncategory: commitment\nstatus: active\ncreated: 2026-08-10T00:00:00Z\nupdated: 2026-08-10T00:00:00Z\nsource: test\nconfidence: 0.8\nconfidenceTier: reported\ntags: []\n${extra}---\n${id} says: ship the thing\n`;
+    await writeFile(path.join(memoryDir, "facts", "2026-08-10", "open.md"), commitment("open-1", ""), "utf8");
+    await writeFile(
+      path.join(memoryDir, "facts", "2026-08-10", "due-soon.md"),
+      commitment("due-soon", "expiresAt: 2026-08-19T00:00:00Z\n"),
+      "utf8",
+    );
+    await writeFile(
+      path.join(memoryDir, "facts", "2026-08-10", "overdue.md"),
+      commitment("overdue-1", "expiresAt: 2026-08-15T00:00:00Z\n"),
+      "utf8",
+    );
+    await writeFile(
+      path.join(memoryDir, "facts", "2026-08-10", "fulfilled.md"),
+      commitment("done-1", "tags: [fulfilled]\n"),
+      "utf8",
+    );
+    await writeFile(
+      path.join(memoryDir, "facts", "2026-08-10", "review.md"),
+      commitment("pending-1", "status: pending_review\n"),
+      "utf8",
+    );
+    await writeFile(
+      path.join(memoryDir, "facts", "2026-08-10", "plain-fact.md"),
+      `---\nid: fact-1\ncategory: fact\nstatus: active\ncreated: 2026-08-10T00:00:00Z\nupdated: 2026-08-10T00:00:00Z\nsource: test\nconfidence: 0.8\nconfidenceTier: reported\ntags: []\n---\nnot a commitment\n`,
+      "utf8",
+    );
+
+    const brief = buildStandup(memoryDir, "2026-08-17");
+    // Overdue commitment is a blocker candidate, not a priority.
+    assert.ok(brief.blockers.some((line) => line.startsWith("commitment past due: overdue-1 says: ship the thing")));
+    // Fulfiled, pending-review, and non-commitment facts never appear.
+    const priorities = brief.priorities.join("\n");
+    assert.ok(priorities.includes("due-soon says: ship the thing (due 2026-08-19)"));
+    assert.ok(priorities.includes("open-1 says: ship the thing"));
+    assert.ok(!priorities.includes("done-1"));
+    assert.ok(!priorities.includes("pending-1"));
+    assert.ok(!priorities.includes("not a commitment"));
+    // Due-first ordering: expiresAt before bare created.
+    assert.ok(priorities.indexOf("due-soon") < priorities.indexOf("open-1"));
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/standup/build.ts
+++ b/packages/remnic-core/src/standup/build.ts
@@ -24,13 +24,30 @@ export function parseStandupDate(raw: unknown, now = new Date()): string {
   return value;
 }
 
-export function previousDate(date: string): string {
+/** Look back at most this many days for the prior active day (issue #1981). */
+const STANDUP_PRIOR_DAY_LOOKBACK = 7;
+
+function shiftDays(date: string, days: number): string {
   const ms = Date.parse(`${date}T00:00:00Z`);
-  return new Date(ms - 86_400_000).toISOString().slice(0, 10);
+  return new Date(ms + days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Prior active day: the most recent of the 7 days before `date` that has an
+ * activity digest (working-day lookback — Monday resolves to Friday, not
+ * Sunday, when the weekend has no digests). Calendar-previous day when no
+ * day in the window qualifies.
+ */
+export function previousActiveDate(memoryDir: string, date: string): string {
+  for (let back = 1; back <= STANDUP_PRIOR_DAY_LOOKBACK; back += 1) {
+    const candidate = shiftDays(date, -back);
+    if (readOptional(activityDigestPath(memoryDir, candidate)) !== null) return candidate;
+  }
+  return shiftDays(date, -1);
 }
 
 export function buildStandup(memoryDir: string, date: string): StandupBrief {
-  const yesterday = previousDate(date);
+  const yesterday = previousActiveDate(memoryDir, date);
   const todayBody = readOptional(activityDigestPath(memoryDir, date));
   const yesterdayBody = readOptional(activityDigestPath(memoryDir, yesterday));
   const highlights = extractHighlights(todayBody);

--- a/packages/remnic-core/src/standup/build.ts
+++ b/packages/remnic-core/src/standup/build.ts
@@ -1,25 +1,30 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import { EngramAccessInputError } from "../access-errors.js";
 import { activityDigestPath, isValidActivityDate } from "../activity/digest.js";
+import { parseFrontmatter } from "../storage.js";
 
 export interface StandupBrief {
   date: string;
   yesterday: string;
   today: string;
   highlights: string[];
+  priorities: string[];
   blockers: string[];
   activityGrid: string;
   markdown: string;
 }
 
 export function parseStandupDate(raw: unknown, now = new Date()): string {
-  if (raw === undefined || raw === null || raw === "") {
+  if (raw === undefined || raw === null) {
     return now.toISOString().slice(0, 10);
   }
   const value = String(raw);
   if (!isValidActivityDate(value)) {
-    throw new Error(`invalid --date ${value}; expected YYYY-MM-DD`);
+    // Typed so the HTTP surface maps it to 400 (EngramAccessInputError);
+    // subclasses Error, so the CLI still prints the message verbatim.
+    throw new EngramAccessInputError(`invalid --date ${value}; expected YYYY-MM-DD`);
   }
   return value;
 }
@@ -50,9 +55,19 @@ export function buildStandup(memoryDir: string, date: string): StandupBrief {
   const yesterday = previousActiveDate(memoryDir, date);
   const todayBody = readOptional(activityDigestPath(memoryDir, date));
   const yesterdayBody = readOptional(activityDigestPath(memoryDir, yesterday));
-  const highlights = extractHighlights(todayBody);
-  const blockers = extractBlockers(todayBody);
-  const activityGrid = renderGrid(yesterdayBody, todayBody);
+  const highlights = extractHighlights(yesterdayBody);
+  const commitments = sortCommitments(readOpenCommitments(memoryDir));
+  const dateMs = Date.parse(`${date}T00:00:00Z`);
+  const overdue = commitments.filter(
+    (c) => c.expiresAt !== undefined && Number.isFinite(Date.parse(c.expiresAt)) && Date.parse(c.expiresAt) < dateMs,
+  );
+  const open = commitments.filter((c) => !overdue.includes(c));
+  const priorities = open.map((c) => (c.expiresAt ? `${c.text} (due ${c.expiresAt.slice(0, 10)})` : c.text));
+  const blockers = [
+    ...extractBlockers(yesterdayBody),
+    ...overdue.map((c) => `commitment past due: ${c.text} (was due ${c.expiresAt?.slice(0, 10)})`),
+  ];
+  const activityGrid = renderGrid(yesterday, yesterdayBody);
   const markdown = [
     `# Standup ${date}`,
     "",
@@ -64,6 +79,9 @@ export function buildStandup(memoryDir: string, date: string): StandupBrief {
     "",
     "## Highlights",
     ...(highlights.length > 0 ? highlights.map((line) => `- ${line}`) : ["- _None._"]),
+    "",
+    "## Today's priorities",
+    ...(priorities.length > 0 ? priorities.map((line) => `- ${line}`) : ["- (no tracked commitments — add priorities manually)"]),
     "",
     "## Blockers",
     ...(blockers.length > 0 ? blockers.map((line) => `- ${line}`) : ["- _None._"]),
@@ -78,6 +96,7 @@ export function buildStandup(memoryDir: string, date: string): StandupBrief {
     yesterday,
     today: date,
     highlights,
+    priorities,
     blockers,
     activityGrid,
     markdown,
@@ -92,13 +111,28 @@ function readOptional(filePath: string): string | null {
   }
 }
 
+/** Drop a leading `--- … ---` frontmatter block so its fields never render. */
+function stripFrontmatter(body: string): string {
+  const lines = body.split("\n");
+  if (lines[0]?.trim() !== "---") return body;
+  const end = lines.indexOf("---", 1);
+  return end < 0 ? body : lines.slice(end + 1).join("\n");
+}
+
 function firstLines(body: string, n: number): string {
-  return body.split("\n").filter((line) => !line.startsWith("---")).slice(0, n).join("\n").trim() || "_Empty digest._";
+  return (
+    stripFrontmatter(body)
+      .split("\n")
+      .filter((line) => line.trim().length > 0 && !line.startsWith("#") && !line.startsWith("---"))
+      .slice(0, n)
+      .join("\n")
+      .trim() || "_Empty digest._"
+  );
 }
 
 function extractHighlights(body: string | null): string[] {
   if (!body) return [];
-  return body
+  return stripFrontmatter(body)
     .split("\n")
     .map((line) => line.replace(/^[-*]\s+/, "").trim())
     .filter((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith("---"))
@@ -107,26 +141,124 @@ function extractHighlights(body: string | null): string[] {
 
 function extractBlockers(body: string | null): string[] {
   if (!body) return [];
-  return body
+  return stripFrontmatter(body)
     .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => /blocker|blocked|stuck|waiting/i.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, "").trim())
+    .filter((line) => line.length > 0 && /blocker|blocked|stuck|waiting/i.test(line))
     .slice(0, 5);
 }
 
-function renderGrid(yesterday: string | null, today: string | null): string {
-  const y = yesterday ? "x" : ".";
-  const t = today ? "x" : ".";
-  return ["| day | digest |", "|---|---|", `| yesterday | ${y} |`, `| today | ${t} |`].join("\n");
+// ── Activity grid (24 hour buckets, byte-stable) ────────────────────────────
+
+const GRID_GLYPHS = ["░", "▁", "▂", "▃", "▄", "█"] as const;
+
+/** Local hour of a digest timeline span line `- [HH:MM] app — window`, or null. */
+function spanHour(line: string): number | null {
+  if (!line.startsWith("- [")) return null;
+  const close = line.indexOf("]", 3);
+  if (close < 0) return null;
+  const clock = line.slice(3, close);
+  const sep = clock.indexOf(":");
+  if (sep <= 0) return null;
+  const hour = Number.parseInt(clock.slice(0, sep), 10);
+  return Number.isInteger(hour) && hour >= 0 && hour <= 23 ? hour : null;
+}
+
+function renderGrid(yesterday: string, body: string | null): string {
+  if (!body) return `prior day ${yesterday}: no activity digest (empty)`;
+  const counts: number[] = new Array(24).fill(0);
+  for (const line of stripFrontmatter(body).split("\n")) {
+    const hour = spanHour(line);
+    if (hour !== null) counts[hour] = counts[hour]! + 1;
+  }
+  const max = Math.max(...counts);
+  if (max === 0) return `prior day ${yesterday}: digest present, no timeline activity`;
+  const glyphs = counts
+    .map((count) =>
+      count === 0 ? "·" : GRID_GLYPHS[Math.min(GRID_GLYPHS.length - 1, Math.ceil((count / max) * GRID_GLYPHS.length) - 1)],
+    )
+    .join("");
+  const nonEmpty = counts.map((count, hour) => (count > 0 ? `${hour}` : null)).filter((h): h is string => h !== null);
+  return [`prior day ${yesterday} — 24 hour buckets (· = idle):`, glyphs, `non-empty hours: ${nonEmpty.join(", ")}`].join(
+    "\n",
+  );
+}
+
+// ── Open commitments (deterministic facts scan) ─────────────────────────────
+
+interface OpenCommitment {
+  id: string;
+  text: string;
+  created: string;
+  expiresAt?: string;
+}
+
+function readOpenCommitments(memoryDir: string): OpenCommitment[] {
+  const factsDir = path.join(memoryDir, "facts");
+  let dayDirs: string[];
+  try {
+    dayDirs = readdirSync(factsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink() && isValidActivityDate(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+  const out: OpenCommitment[] = [];
+  for (const day of dayDirs) {
+    let files: string[];
+    try {
+      files = readdirSync(path.join(factsDir, day), { withFileTypes: true })
+        .filter((entry) => entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".md"))
+        .map((entry) => entry.name)
+        .sort();
+    } catch {
+      continue;
+    }
+    for (const name of files) {
+      const parsed = parseFrontmatter(readOptional(path.join(factsDir, day, name)) ?? "");
+      if (!parsed) continue;
+      const fm = parsed.frontmatter;
+      if (fm.category !== "commitment") continue;
+      if ((fm.status ?? "active") !== "active") continue;
+      if (fm.tags.some((tag) => tag === "fulfilled" || tag === "expired")) continue;
+      const text = parsed.content
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+      if (!text) continue;
+      out.push({
+        id: fm.id,
+        text,
+        created: fm.created,
+        ...(fm.expiresAt !== undefined ? { expiresAt: fm.expiresAt } : {}),
+      });
+    }
+  }
+  return out;
+}
+
+function sortCommitments(list: OpenCommitment[]): OpenCommitment[] {
+  return [...list].sort((a, b) => {
+    // Due-ness first: a commitment with a concrete expiry outranks an
+    // undated one; earlier expiry is more due. Created, then id, as the
+    // stable tiebreak (§12).
+    const aDated = a.expiresAt !== undefined ? 0 : 1;
+    const bDated = b.expiresAt !== undefined ? 0 : 1;
+    if (aDated !== bDated) return aDated - bDated;
+    const ka = a.expiresAt ?? a.created;
+    const kb = b.expiresAt ?? b.created;
+    if (ka !== kb) return ka < kb ? -1 : 1;
+    if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+    return 0;
+  });
 }
 
 export function standupHelp(): string {
   return `Usage: remnic standup [--date YYYY-MM-DD]
 
-Deterministic yesterday/today/blockers brief plus an activity grid.
+Deterministic yesterday/today/blockers brief: prior-working-day highlights,
+today's priorities from open commitments, blocker candidates, and a 24-hour
+activity grid.
 `;
-}
-
-export function standupMemoryDirPlaceholder(memoryDir: string): string {
-  return path.resolve(memoryDir);
 }

--- a/packages/remnic-core/src/standup/http-glue.ts
+++ b/packages/remnic-core/src/standup/http-glue.ts
@@ -10,6 +10,6 @@ export async function respondStandup(
 ): Promise<void> {
   const op = getOperation("standup");
   if (!op) throw new Error("access-boundary: operation not registered: standup");
-  const output = (await op.run({ ...(date ? { date } : {}) }, { service })) as { result: unknown };
+  const output = (await op.run({ ...(date === null ? {} : { date }) }, { service })) as { result: unknown };
   respondJson(res, 200, output.result);
 }


### PR DESCRIPTION
Follow-up to #2552, which merged while these review fixes were still on the branch (merge raced the pushes at 18:31Z).

## Change

- `previousActiveDate`: 7-day working-day lookback for the prior active day (Monday resolves to Friday when the weekend has no digests), calendar-previous fallback — issue #1981 acceptance criterion.
- CLI config/bootstrap failures print a constant message so parseConfig error strings never reach console output (CodeQL js/clear-text-logging on the merged standup command).
- Highlights and blocker patterns derive from the prior active day; frontmatter blocks are stripped before rendering; blocker lines strip list markers.
- Activity grid renders 24 hour buckets from the prior day's timeline spans (intensity glyphs, non-empty hour list, explicit empty row when missing).
- Today's priorities from a deterministic facts scan of open commitment-category memories; expired-by commitments become blocker candidates; explicit empty message when none.
- An explicitly empty date (`?date=`, `--date ''`) is rejected as invalid input (HTTP 400 via EngramAccessInputError) instead of silently defaulting.
- MCP output schema gains `priorities`; uncalled `standupMemoryDirPlaceholder` removed.

## Regression

`standup/build.test.ts` — Monday->Friday fixture, hour-bucket grid fixture, commitments priorities/overdue fixtures, empty-date rejection, frontmatter-leak and marker assertions.

Fixes the CodeQL alert introduced by #2552.