### PR TITLE
feat(capture): publish darwin native helpers from release CI

### DIFF
--- a/.changeset/2139-darwin-publish.md
+++ b/.changeset/2139-darwin-publish.md
@@ -1,0 +1,7 @@
+---
+"@remnic/capture-native-darwin-arm64": minor
+"@remnic/capture-native-darwin-x64": minor
+"@remnic/capture-screen": patch
+---
+
+Publish darwin native helper packages from macOS CI on release.

--- a/.github/workflows/capture-native-helper.yml
+++ b/.github/workflows/capture-native-helper.yml
@@ -17,6 +17,11 @@ on:
       - 'packages/capture-native-darwin-x64/**'
       - 'packages/capture-screen/**'
       - '.github/workflows/capture-native-helper.yml'
+  release:
+    # The GitHub release created at the end of release-and-publish.yml is the
+    # publish trigger: by then versions are bumped on the tagged commit, so
+    # the darwin platform packages publish at exactly the release version.
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -104,6 +109,73 @@ jobs:
           name: remnic-capture-helper-${{ matrix.arch }}
           path: ${{ matrix.platformPackage }}/bin/remnic-capture-helper
           if-no-files-found: error
+
+
+  publish:
+    if: github.event_name == 'release'
+    needs: swift
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            platformPackage: packages/capture-native-darwin-arm64
+          - arch: x64
+            platformPackage: packages/capture-native-darwin-x64
+    name: publish (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download helper binary
+        uses: actions/download-artifact@v4
+        with:
+          name: remnic-capture-helper-${{ matrix.arch }}
+          path: ${{ matrix.platformPackage }}/bin
+
+      - name: Mark helper executable
+        run: chmod +x "${{ matrix.platformPackage }}/bin/remnic-capture-helper"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish platform package
+        working-directory: ${{ matrix.platformPackage }}
+        run: |
+          set -euo pipefail
+          pkg_name="$(node -p "require('./package.json').name")"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if npm view "${pkg_name}@${pkg_version}" version >/dev/null 2>&1; then
+            echo "::notice::${pkg_name}@${pkg_version} already published; skipping."
+            exit 0
+          fi
+          publish_log="$(mktemp)"
+          if pnpm publish --access public --provenance --no-git-checks >"$publish_log" 2>&1; then
+            cat "$publish_log"
+            rm -f "$publish_log"
+            exit 0
+          fi
+          cat "$publish_log"
+          if grep -q "npm error code E404" "$publish_log"; then
+            echo "::error::Provision npm trusted publishing for ${pkg_name}, then rerun this workflow."
+            rm -f "$publish_log"
+            exit 1
+          fi
+          rm -f "$publish_log"
+          exit 1
 
   # The screen-activity daemon (@remnic/capture-screen) is TypeScript and is
   # proven on Linux like the rest of the workspace.

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -610,6 +610,11 @@ jobs:
               echo "::notice::Skipping private package: $pkg_dir"
               continue
             fi
+            if ! node -e "const os=require('./$pkg_json').os; if (!Array.isArray(os) || os.length===0) process.exit(0); process.exit(os.includes(process.platform)?0:1)"; then
+              echo "::notice::Skipping $pkg_dir (os-restricted; published by capture-native-helper.yml)"
+              continue
+            fi
+
             pkg_name="$(node -p "require('./$pkg_json').name")"
             pkg_version="$(node -p "require('./$pkg_json').version")"
             if npm view "${pkg_name}@${pkg_version}" version >/dev/null 2>&1; then

--- a/packages/capture-native-darwin-arm64/README.md
+++ b/packages/capture-native-darwin-arm64/README.md
@@ -4,11 +4,10 @@ macOS Apple Silicon (arm64) platform package for the unified Remnic native
 capture helper, `remnic-capture-helper`. One binary serves both the audio
 capture pipeline (#1897) and the screen-activity pipeline (#1899).
 
-> **Not yet published.** This package is currently `private` and not on npm.
-> Runtime distribution via npm is tracked in
-> https://github.com/joshuaswarren/remnic/issues/2139. Until then, build the
-> helper from source (`packages/capture-native-darwin-helper`) and point
-> `REMNIC_CAPTURE_HELPER_BIN` at the binary.
+Install with `npm install @remnic/capture-native-darwin-arm64`.
+The binary is staged by the `capture-native-helper` workflow on release.
+To build from source, use `packages/capture-native-darwin-helper` and set
+`REMNIC_CAPTURE_HELPER_BIN` to the binary.
 
 ## What this package provides
 

--- a/packages/capture-native-darwin-arm64/package.json
+++ b/packages/capture-native-darwin-arm64/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@remnic/capture-native-darwin-arm64",
-  "version": "9.14.0",
-  "private": true,
+  "version": "9.65.8",
   "description": "macOS Apple Silicon native capture helper for Remnic — audio, screen accessibility (AX), and window OCR",
   "type": "module",
   "os": ["darwin"],

--- a/packages/capture-native-darwin-x64/README.md
+++ b/packages/capture-native-darwin-x64/README.md
@@ -4,11 +4,10 @@ macOS Intel (x64) platform package for the unified Remnic native capture
 helper, `remnic-capture-helper`. One binary serves both the audio capture
 pipeline (#1897) and the screen-activity pipeline (#1899).
 
-> **Not yet published.** This package is currently `private` and not on npm.
-> Runtime distribution via npm is tracked in
-> https://github.com/joshuaswarren/remnic/issues/2139. Until then, build the
-> helper from source (`packages/capture-native-darwin-helper`) and point
-> `REMNIC_CAPTURE_HELPER_BIN` at the binary.
+Install with `npm install @remnic/capture-native-darwin-x64`.
+The binary is staged by the `capture-native-helper` workflow on release.
+To build from source, use `packages/capture-native-darwin-helper` and set
+`REMNIC_CAPTURE_HELPER_BIN` to the binary.
 
 ## What this package provides
 

--- a/packages/capture-native-darwin-x64/package.json
+++ b/packages/capture-native-darwin-x64/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@remnic/capture-native-darwin-x64",
-  "version": "9.14.0",
-  "private": true,
+  "version": "9.65.8",
   "description": "macOS Intel native capture helper for Remnic — audio, screen accessibility (AX), and window OCR",
   "type": "module",
   "os": ["darwin"],

--- a/packages/capture-screen/src/helper.test.ts
+++ b/packages/capture-screen/src/helper.test.ts
@@ -48,9 +48,8 @@ test("a missing helper package degrades honestly with an install hint (never MOD
   const res = await resolveHelperBinaryPath({});
   assert.equal(res.binaryPath, null);
   assert.ok(res.hint, "an unavailable helper must carry a hint");
-  assert.match(res.hint ?? "", /issues\/2139/);
+  assert.match(res.hint ?? "", /npm install @remnic\/capture-native-/);
   assert.match(res.hint ?? "", /REMNIC_CAPTURE_HELPER_BIN/);
-  assert.doesNotMatch(res.hint ?? "", /npm install/);
   assert.doesNotMatch(res.hint ?? "", /MODULE_NOT_FOUND/);
 });
 

--- a/packages/capture-screen/src/helper.ts
+++ b/packages/capture-screen/src/helper.ts
@@ -41,9 +41,9 @@ export function helperPackageName(platform: string = process.platform, arch: str
 
 function installHint(pkg: string): string {
   return (
-    `native capture helper (${pkg}) is not available on this install — it ships via a tracked follow-up ` +
-    `(https://github.com/joshuaswarren/remnic/issues/2139). To enable live screen capture now, build the Swift ` +
-    `helper from source (packages/capture-native-darwin-helper) and set REMNIC_CAPTURE_HELPER_BIN to the binary`
+    `native capture helper (${pkg}) is not available on this install. ` +
+    `Run \`npm install ${pkg}\` or build the Swift helper from source ` +
+    `(packages/capture-native-darwin-helper) and set REMNIC_CAPTURE_HELPER_BIN to the binary`
   );
 }
 

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -13,6 +13,8 @@ const expectedPublishDirs = [
   "packages/coding-graph",
   "packages/capture-audio",
   "packages/capture-screen",
+  "packages/capture-native-darwin-arm64",
+  "packages/capture-native-darwin-x64",
   "packages/export-weclone",
   "packages/import-weclone",
   "packages/import-chatgpt",
@@ -57,6 +59,15 @@ test("release workflow publish order matches the supported npm install surfaces"
   assert.match(workflow, /cp scripts\/publish-order\.mjs "\$\{RUNNER_TEMP\}\/publish-order\.mjs"/);
   assert.match(workflow, /node "\$\{RUNNER_TEMP\}\/publish-order\.mjs" --repo-root "\$PWD" --output/);
   assert.match(workflow, /mapfile -t PUBLISH_ORDER/);
+});
+
+test("capture-native-helper publishes darwin platform packages on release", async () => {
+  const helper = await readFile(".github/workflows/capture-native-helper.yml", "utf8");
+  const release = await readFile(".github/workflows/release-and-publish.yml", "utf8");
+  assert.match(helper, /if: github\.event_name == 'release'/);
+  assert.match(helper, /id-token: write/);
+  assert.match(helper, /pnpm publish --access public --provenance --no-git-checks/);
+  assert.match(release, /os-restricted; published by capture-native-helper\.yml/);
 });
 
 test("release workflow verifies the OpenClaw ClawHub packlist after build", async () => {


### PR DESCRIPTION
Fixes #2139.

## Change

OIDC publish of `@remnic/capture-native-darwin-arm64` and `-x64` from `capture-native-helper.yml` on GitHub release. Linux release-and-publish skips os-restricted packages. Helper-missing hint is `npm install`.

## Regression

`tests/release-workflow-public-packages.test.ts`, `packages/capture-screen/src/helper.test.ts`.