### PR TITLE
feat(import): add à-la-carte OKF bundle importer

### DIFF
--- a/.changeset/1947-import-okf.md
+++ b/.changeset/1947-import-okf.md
@@ -1,0 +1,6 @@
+---
+"@remnic/cli": minor
+"@remnic/import-okf": minor
+---
+
+Add à-la-carte `@remnic/import-okf` and `remnic import okf <dir>`.

--- a/packages/import-okf/package.json
+++ b/packages/import-okf/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@remnic/import-okf",
+  "version": "9.65.8",
+  "description": "Import an OKF v0.1 knowledge bundle into Remnic memories",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/adapter.test.ts src/parser.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.65.8"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-okf"
+  },
+  "keywords": ["remnic", "memory", "okf", "import"]
+}

--- a/packages/import-okf/src/adapter.test.ts
+++ b/packages/import-okf/src/adapter.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import type { ImportTurn, ImporterWriteTarget } from "@remnic/core";
+import { runImporter } from "@remnic/core";
+
+import { adapter, okfAdapter } from "./adapter.js";
+
+function makeTarget(): { target: ImporterWriteTarget; received: ImportTurn[][] } {
+  const received: ImportTurn[][] = [];
+  return {
+    target: {
+      async ingestBulkImportBatch(turns) {
+        received.push(turns.map((t) => ({ ...t })));
+      },
+      bulkImportWriteNamespace() {
+        return "default";
+      },
+    },
+    received,
+  };
+}
+
+describe("okf adapter", () => {
+  it("exports a canonical adapter", () => {
+    assert.equal(adapter.name, "okf");
+    assert.equal(okfAdapter, adapter);
+  });
+
+  it("imports a directory bundle", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "okf-adapter-"));
+    writeFileSync(path.join(root, "a.md"), "---\ntype: Preference\n---\nDark mode.\n");
+    const { target, received } = makeTarget();
+    const result = await runImporter(adapter, root, target);
+    assert.equal(result.memoriesPlanned, 1);
+    assert.equal(result.memoriesWritten, 1);
+    assert.equal(received.flat()[0]?.participantName, "okf");
+  });
+
+  it("dry-run writes nothing", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "okf-dry-"));
+    writeFileSync(path.join(root, "a.md"), "---\ntype: Moment\n---\nShipped.\n");
+    const { target, received } = makeTarget();
+    const result = await runImporter(adapter, root, target, { dryRun: true });
+    assert.equal(result.dryRun, true);
+    assert.equal(result.memoriesWritten, 0);
+    assert.equal(received.length, 0);
+  });
+});

--- a/packages/import-okf/src/adapter.ts
+++ b/packages/import-okf/src/adapter.ts
@@ -1,0 +1,43 @@
+import type {
+  ImportedMemory,
+  ImporterAdapter,
+  ImporterParseOptions,
+  ImporterWriteResult,
+  ImporterWriteTarget,
+} from "@remnic/core";
+import { defaultWriteMemoriesToOrchestrator } from "@remnic/core";
+
+import { parseOkfBundle, type ParsedOkfBundle } from "./parser.js";
+
+export const OKF_SOURCE_LABEL = "okf";
+
+export const adapter: ImporterAdapter<ParsedOkfBundle> = {
+  name: "okf",
+  sourceLabel: OKF_SOURCE_LABEL,
+
+  parse(input: unknown, options?: ImporterParseOptions): ParsedOkfBundle {
+    return parseOkfBundle(typeof input === "string" ? input : options?.filePath);
+  },
+
+  transform(parsed: ParsedOkfBundle): ImportedMemory[] {
+    return parsed.documents
+      .filter((doc) => doc.content.length > 0)
+      .map((doc) => ({
+        content: doc.content,
+        sourceLabel: OKF_SOURCE_LABEL,
+        importedFromPath: `${parsed.root}/${doc.relPath}`,
+        metadata: { category: doc.category, relPath: doc.relPath },
+        ...(doc.sourceId ? { sourceId: doc.sourceId } : {}),
+        ...(doc.sourceTimestamp ? { sourceTimestamp: doc.sourceTimestamp } : {}),
+      }));
+  },
+
+  async writeTo(
+    target: ImporterWriteTarget,
+    memories: ImportedMemory[],
+  ): Promise<ImporterWriteResult> {
+    return defaultWriteMemoriesToOrchestrator(target, memories);
+  },
+};
+
+export const okfAdapter = adapter;

--- a/packages/import-okf/src/index.ts
+++ b/packages/import-okf/src/index.ts
@@ -1,0 +1,2 @@
+export { adapter, okfAdapter, OKF_SOURCE_LABEL } from "./adapter.js";
+export { parseOkfBundle, type ParsedOkfBundle, type ParsedOkfDocument } from "./parser.js";

--- a/packages/import-okf/src/parser.test.ts
+++ b/packages/import-okf/src/parser.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { parseOkfBundle } from "./parser.js";
+
+function fixture(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "okf-import-"));
+  writeFileSync(
+    path.join(root, "note.md"),
+    `---\nid: fact-1\ntype: Memory Fact\ntimestamp: 2026-01-02T00:00:00.000Z\n---\nPostgres is the store.\n`,
+  );
+  writeFileSync(path.join(root, "index.md"), "---\ntype: Index\n---\nskip\n");
+  mkdirSync(path.join(root, "nested"));
+  writeFileSync(
+    path.join(root, "nested", "decision.md"),
+    `---\ntype: Decision\n---\nUse QMD.\n`,
+  );
+  return root;
+}
+
+test("parseOkfBundle reads markdown docs and skips reserved names", () => {
+  const parsed = parseOkfBundle(fixture());
+  assert.equal(parsed.documents.length, 2);
+  assert.equal(parsed.documents[0]?.category, "decision");
+  assert.equal(parsed.documents[1]?.sourceId, "fact-1");
+  assert.equal(parsed.documents[1]?.content, "Postgres is the store.");
+});
+
+test("parseOkfBundle rejects archives and missing paths", () => {
+  assert.throws(() => parseOkfBundle("bundle.zip"), /unpack first/);
+  assert.throws(() => parseOkfBundle("bundle.tar.gz"), /unpack first/);
+  assert.throws(() => parseOkfBundle(""), /directory path/);
+});

--- a/packages/import-okf/src/parser.ts
+++ b/packages/import-okf/src/parser.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const RESERVED = new Set(["index.md", "log.md"]);
+
+const CATEGORY_BY_TYPE: Record<string, string> = {
+  "Memory Fact": "fact",
+  Decision: "decision",
+  Preference: "preference",
+  Commitment: "commitment",
+  Relationship: "relationship",
+  Principle: "principle",
+  Moment: "moment",
+  Skill: "skill",
+  Correction: "correction",
+  Rule: "rule",
+};
+
+export interface ParsedOkfDocument {
+  relPath: string;
+  category: string;
+  content: string;
+  sourceId?: string;
+  sourceTimestamp?: string;
+}
+
+export interface ParsedOkfBundle {
+  root: string;
+  documents: ParsedOkfDocument[];
+}
+
+export function parseOkfBundle(input: unknown): ParsedOkfBundle {
+  if (typeof input !== "string" || input.trim() === "") {
+    throw new Error("OKF import requires a directory path");
+  }
+  const root = path.resolve(input.trim());
+  if (/\.(zip|tgz|tar\.gz)$/i.test(root)) {
+    throw new Error(`unpack first: archive imports are not supported (${root})`);
+  }
+  let stat;
+  try {
+    stat = statSync(root);
+  } catch {
+    throw new Error(`OKF bundle not found: ${root}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`OKF import requires a directory, got a file: ${root}`);
+  }
+  const documents: ParsedOkfDocument[] = [];
+  walk(root, root, documents);
+  documents.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  return { root, documents };
+}
+
+function walk(root: string, dir: string, out: ParsedOkfDocument[]): void {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(root, full, out);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    if (RESERVED.has(entry.name)) continue;
+    out.push(parseDocument(root, full));
+  }
+}
+
+function parseDocument(root: string, filePath: string): ParsedOkfDocument {
+  const raw = readFileSync(filePath, "utf8");
+  const { fields, body } = splitFrontmatter(raw);
+  const type = fields.type ?? "";
+  return {
+    relPath: path.relative(root, filePath).split(path.sep).join("/"),
+    category: CATEGORY_BY_TYPE[type] ?? "fact",
+    content: body.trim(),
+    ...(fields.id ? { sourceId: fields.id } : {}),
+    ...(fields.timestamp ?? fields.updated ?? fields.created
+      ? { sourceTimestamp: fields.timestamp ?? fields.updated ?? fields.created }
+      : {}),
+  };
+}
+
+function splitFrontmatter(text: string): { fields: Record<string, string>; body: string } {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
+    return { fields: {}, body: text };
+  }
+  const end = text.indexOf("\n---", 4);
+  if (end < 0) return { fields: {}, body: text };
+  const raw = text.slice(4, end);
+  const body = text.slice(end + 4).replace(/^\r?\n/, "");
+  const fields: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+    fields[match[1]] = match[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return { fields, body };
+}

--- a/packages/import-okf/tsconfig.json
+++ b/packages/import-okf/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -49,6 +49,7 @@
     "@remnic/import-lossless-claw": "^9.65.8",
     "@remnic/import-mem0": "^9.65.8",
     "@remnic/import-supermemory": "^9.65.8",
+    "@remnic/import-okf": "^9.65.8",
     "@remnic/connector-limitless": "^9.65.8",
     "@remnic/connector-bee": "^9.65.8",
     "@remnic/connector-omi": "^9.65.8",
@@ -83,6 +84,9 @@
       "optional": true
     },
     "@remnic/import-supermemory": {
+      "optional": true
+    },
+    "@remnic/import-okf": {
       "optional": true
     },
     "@remnic/connector-limitless": {

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -95,7 +95,7 @@ describe("parseImportArgs", () => {
   it("rejects an unknown adapter with the valid list", () => {
     assert.throws(
       () => parseImportArgs(["--adapter", "bogus"]),
-      /chatgpt, claude, gemini, mem0, supermemory/,
+      /chatgpt, claude, gemini, mem0, supermemory, okf/,
     );
   });
 
@@ -106,6 +106,7 @@ describe("parseImportArgs", () => {
       "gemini",
       "mem0",
       "supermemory",
+      "okf",
     ] as const) {
       const parsed = parseImportArgs(["--adapter", name]);
       assert.equal(parsed.adapter, name);
@@ -179,9 +180,15 @@ describe("parseImportArgs", () => {
 
   it("rejects stray positional arguments rather than silently dropping them", () => {
     assert.throws(
-      () => parseImportArgs(["--adapter", "chatgpt", "/tmp/export.json"]),
-      /positional argument '\/tmp\/export\.json'/,
+      () => parseImportArgs(["--adapter", "chatgpt", "/tmp/a.json", "/tmp/b.json"]),
+      /positional argument '\/tmp\/b\.json'/,
     );
+  });
+
+  it("accepts remnic import okf <dir>", () => {
+    const parsed = parseImportArgs(["okf", "/tmp/okf-bundle"]);
+    assert.equal(parsed.adapter, "okf");
+    assert.equal(parsed.file, "/tmp/okf-bundle");
   });
 
   // Cursor bugbot on PR #583: boolean flags must not be consumed before
@@ -360,7 +367,7 @@ describe("runImportCommand — slice 1 integration", () => {
             },
           },
         ),
-      /ZIP imports are not supported by --file yet/,
+      /unpack first/,
     );
   });
 });

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -92,16 +92,16 @@ export interface ImportDispatchIO {
   stderr: (line: string) => void;
 }
 
-export const IMPORT_USAGE = `remnic import — Bring memory from ChatGPT, Claude, Gemini, Mem0, or Supermemory (issue #568)
+export const IMPORT_USAGE = `remnic import — Bring memory from ChatGPT, Claude, Gemini, Mem0, Supermemory, or OKF
 
 Usage:
   remnic import --adapter <name> --file <path> [options]
+  remnic import okf <dir> [options]
 
 Required:
   --adapter <name>            One of: ${SUPPORTED_IMPORTERS.join(" | ")}
-  --file <path>               Path to a text/JSON source export. ZIP archives
-                              are not accepted by this single-file path yet. May be
-                              omitted for API-only adapters (mem0).
+  --file <path>               Path to a text/JSON source export, or an OKF directory.
+                              Archives must be unpacked first.
 
 Options:
   --dry-run                   Parse and transform only; do not write memories.
@@ -117,16 +117,10 @@ Bulk mode (slice 7):
                               mem0 exports inside <dir> and run each
                               matching adapter. Replaces --adapter/--file.
 
-Slice 1 ships infrastructure only. Adapter packages
-(@remnic/import-chatgpt, @remnic/import-claude, @remnic/import-gemini,
-@remnic/import-mem0, @remnic/import-supermemory) land in follow-up slices.
-Install whichever you need:
+Install the adapter you need:
 
   npm install -g @remnic/import-chatgpt
-  npm install -g @remnic/import-claude
-  npm install -g @remnic/import-gemini
-  npm install -g @remnic/import-mem0
-  npm install -g @remnic/import-supermemory
+  npm install -g @remnic/import-okf
 `;
 
 /**
@@ -140,7 +134,10 @@ Install whichever you need:
 export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
   const args = [...rest];
 
-  const adapter = takeValue(args, "--adapter");
+  let adapter = takeValue(args, "--adapter");
+  if (!adapter && args[0] && !args[0].startsWith("--") && isSupportedImporterName(args[0])) {
+    adapter = args.shift() as typeof adapter;
+  }
   if (!adapter) {
     throw new Error(
       `--adapter <name> is required. Valid values: ${SUPPORTED_IMPORTERS.join(", ")}`,
@@ -160,9 +157,8 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
   // first, `takeValue` sees the adjacent `--dry-run` token and correctly
   // rejects it as a missing value. Cursor bugbot flagged this on PR #583.
   const fileRaw = takeOptionalValue(args, "--file");
-  // Expand leading `~` so paths like `~/export.json` resolve. Node's fs
-  // does not expand the tilde — CLAUDE.md rule 17.
-  const file = fileRaw !== undefined ? expandTilde(fileRaw) : undefined;
+  let file = fileRaw !== undefined ? expandTilde(fileRaw) : undefined;
+
 
   const batchSizeRaw = takeOptionalValue(args, "--batch-size");
   let batchSize: number | undefined;
@@ -193,8 +189,11 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
   // booleans.
   const dryRun = consumeFlag(args, "--dry-run");
   const includeConversations = consumeFlag(args, "--include-conversations");
-
+  if (file === undefined && args[0] && !args[0].startsWith("--")) {
+    file = expandTilde(args.shift() as string);
+  }
   rejectLeftoverImportArgs(args, "remnic import");
+
 
   return {
     adapter,
@@ -230,21 +229,20 @@ export async function runImportCommand(
   args: ImportDispatchArgs,
   io: ImportDispatchIO,
 ): Promise<RunImporterResult> {
-  if (args.file && isZipFilePath(args.file)) {
+  if (args.file && (isZipFilePath(args.file) || /\.(tgz|tar\.gz)$/i.test(args.file))) {
     throw new Error(
-      `ZIP imports are not supported by --file yet: '${args.file}'. ` +
-        "Extract the archive first or use --all-from-bundle for supported bundle layouts.",
+      `unpack first: archive imports are not supported ('${args.file}'). Extract the archive, then pass the directory.`,
     );
   }
   const adapter = await io.loadAdapter(args.adapter);
 
-  // Shape inputs the adapter understands. Adapters that accept raw file
-  // bytes (e.g. a ZIP buffer) are free to re-read the path themselves via
-  // `parseOptions.filePath`; this slice-1 wiring passes the file contents as
-  // a string for text/JSON exports and the path as a fallback so adapters
-  // can choose.
   let input: unknown;
-  if (args.file) {
+  if (args.adapter === "okf") {
+    if (!args.file) {
+      throw new Error("OKF import requires a directory path (remnic import okf <dir>)");
+    }
+    input = args.file;
+  } else if (args.file) {
     try {
       input = await io.readFile(args.file);
     } catch (err) {
@@ -255,10 +253,9 @@ export async function runImportCommand(
       );
     }
   } else {
-    // No file → API-only adapter (mem0). Pass `undefined` through; adapters
-    // that require a file will surface their own error.
     input = undefined;
   }
+
 
   const parseOptions: ImporterParseOptions = {
     filePath: args.file,

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -23,6 +23,7 @@ describe("optional-importer loader", () => {
       "gemini",
       "mem0",
       "supermemory",
+      "okf",
     ]);
   });
 

--- a/packages/remnic-cli/src/optional-importer.ts
+++ b/packages/remnic-cli/src/optional-importer.ts
@@ -46,6 +46,7 @@ export const SUPPORTED_IMPORTERS = [
   "gemini",
   "mem0",
   "supermemory",
+  "okf",
 ] as const;
 export type SupportedImporterName = (typeof SUPPORTED_IMPORTERS)[number];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/import-okf:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/import-supermemory:
     devDependencies:
       '@remnic/core':

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -16,6 +16,7 @@ const expectedPublishDirs = [
   "packages/export-weclone",
   "packages/import-weclone",
   "packages/import-chatgpt",
+  "packages/import-okf",
   "packages/import-claude",
   "packages/import-gemini",
   "packages/import-mem0",


### PR DESCRIPTION
Fixes #1947.

## Change

`@remnic/import-okf` plus `remnic import okf <dir>`. Archives must be unpacked first. Optional peer, computed-specifier load.

## Regression

`packages/import-okf/src/*.test.ts`, `import-dispatch.test.ts`.