### PR TITLE
feat(okf): export codegraph, architecture card, and ADRs

### DIFF
--- a/.changeset/1950-okf-codegraph.md
+++ b/.changeset/1950-okf-codegraph.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": minor
+"@remnic/cli": minor
+---
+
+Add `remnic codegraph export-okf` to project architecture, ADRs, and modules as an OKF bundle.

--- a/packages/remnic-cli/src/commands/codegraph.ts
+++ b/packages/remnic-cli/src/commands/codegraph.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import { Orchestrator, parseConfig, resolveRemnicConfigRecord } from "@remnic/core";
+import {
+  exportCodegraphOkfBundle,
+  parseOkfCodegraphSymbolFilter,
+} from "@remnic/core/export-okf-codegraph";
+import { resolveConfigPath } from "../index.js";
+
+function takeFlag(rest: string[], name: string): string | undefined {
+  const index = rest.indexOf(name);
+  if (index < 0) return undefined;
+  const value = rest[index + 1];
+  if (value === undefined || value.startsWith("-")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+export async function runCodegraphBinaryCommand(rest: string[]): Promise<void> {
+  if (rest[0] === "--help" || rest[0] === "-h" || rest.length === 0) {
+    console.log(
+      "Usage: remnic codegraph export-okf --project <id> --out <dir> [--max-module-concepts <n>] [--symbols none|exported|all] [--force]",
+    );
+    return;
+  }
+  if (rest[0] !== "export-okf") {
+    console.error("Usage: remnic codegraph export-okf --project <id> --out <dir>");
+    process.exitCode = 1;
+    return;
+  }
+  const args = rest.slice(1);
+  let orchestrator: Orchestrator | undefined;
+  try {
+    const project = takeFlag(args, "--project");
+    const out = takeFlag(args, "--out");
+    if (!project) throw new Error("Missing --project");
+    if (!out) throw new Error("Missing --out");
+    const configPath = resolveConfigPath();
+    const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+    const config = parseConfig(resolveRemnicConfigRecord(raw));
+    orchestrator = new Orchestrator(config);
+    await orchestrator.initialize();
+    await orchestrator.deferredReady;
+    const maxRaw = takeFlag(args, "--max-module-concepts");
+    const result = await exportCodegraphOkfBundle({
+      config: orchestrator.config,
+      memoryDir: orchestrator.config.memoryDir,
+      projectId: project,
+      outDir: out,
+      force: args.includes("--force"),
+      includeAdrs: !args.includes("--no-include-adrs"),
+      symbols: parseOkfCodegraphSymbolFilter(takeFlag(args, "--symbols")),
+      ...(maxRaw !== undefined ? { maxModuleConcepts: Number(maxRaw) } : {}),
+    });
+    console.log(
+      `OKF codegraph export: ${result.moduleConcepts} modules, ${result.decisions} decisions` +
+        (result.truncated ? " (truncated)" : ""),
+    );
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  } finally {
+    orchestrator?.abortDeferredInit();
+    await orchestrator?.destroy();
+  }
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -171,6 +171,7 @@ import { PLUGIN_ID as REMNIC_OPENCLAW_PLUGIN_ID, resolveRemnicPluginEntry } from
 import { runMeetingsBinaryCommand } from "./commands/meetings.js"; import { runWearablesBinaryCommand } from "./commands/wearables.js"; import { runLocationBinaryCommand } from "./commands/location.js";
 import { runOkfBinaryCommand } from "./commands/okf.js";
 import { runExportOkfBinaryCommand } from "./commands/export-okf.js";
+import { runCodegraphBinaryCommand } from "./commands/codegraph.js";
 import { runStandupBinaryCommand } from "./commands/standup.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
@@ -437,7 +438,7 @@ type CommandName =
   | "promotion-candidates"
   | "security"
   | "wearables"
-  | "meetings" | "okf" | "location" | "export" | "standup"
+  | "meetings" | "okf" | "location" | "export" | "standup" | "codegraph"
   | "external-wiki"
   | "capsule"
   | "offline"
@@ -13092,6 +13093,9 @@ Other:
       break;
     case "standup":
       await runStandupBinaryCommand(rest);
+      break;
+    case "codegraph":
+      await runCodegraphBinaryCommand(rest);
       break;
 
     case "external-wiki": {

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2040,6 +2040,17 @@
       "remnic-source": "./src/transfer/export-okf.ts",
       "import": "./dist/transfer/export-okf.js"
     },
+    "./export-okf-codegraph": {
+      "types": "./dist/coding/export-okf-codegraph.d.ts",
+      "remnic-source": "./src/coding/export-okf-codegraph.ts",
+      "import": "./dist/coding/export-okf-codegraph.js"
+    },
+    "./export-okf-codegraph.js": {
+      "types": "./dist/coding/export-okf-codegraph.d.ts",
+      "remnic-source": "./src/coding/export-okf-codegraph.ts",
+      "import": "./dist/coding/export-okf-codegraph.js"
+    },
+
     "./standup": {
       "types": "./dist/standup/build.d.ts",
       "remnic-source": "./src/standup/build.ts",

--- a/packages/remnic-core/src/coding/export-okf-codegraph.test.ts
+++ b/packages/remnic-core/src/coding/export-okf-codegraph.test.ts
@@ -18,8 +18,8 @@ import test from "node:test";
 import type { PluginConfig } from "../types.js";
 import { StorageManager } from "../storage.js";
 import { serializeDecisionRecord, type DecisionRecord } from "./decision-records.js";
-import { tryLoadCodingGraphModule } from "./optional-coding-graph.js";
-import { resolveCodegraphDbPath } from "./codegraph-runtime.js";
+import { getCodegraphStore, resolveCodegraphDbPath } from "./codegraph-runtime.js";
+
 import {
   DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS,
   OKF_CODEGRAPH_TRUNCATION_MARKER,
@@ -47,8 +47,6 @@ interface Fixture {
 }
 
 async function seedGraphStore(memoryDir: string): Promise<string> {
-  const mod = await tryLoadCodingGraphModule();
-  assert.notEqual(mod, null, "@remnic/coding-graph must be installed for this test");
   const dbPath = resolveCodegraphDbPath({
     config: GATE_ON_CONFIG,
     memoryDir,
@@ -56,50 +54,52 @@ async function seedGraphStore(memoryDir: string): Promise<string> {
     projectId: PROJECT_ID,
   });
   mkdirSync(path.dirname(dbPath), { recursive: true });
-  const store = await mod!.GraphStore.open({ dbPath });
-  try {
-    const big = await store.upsertFileBatch?.([
-      {
-        path: "src/big.ts",
-        language: "typescript" as const,
-        contentHash: "h-big",
-        symbols: [
-          { kind: "function" as const, name: "alpha", qualifiedName: "big.alpha", span: { startByte: 0, endByte: 10 } },
-          { kind: "function" as const, name: "beta", qualifiedName: "big.beta", span: { startByte: 10, endByte: 20 } },
-          { kind: "type" as const, name: "internal", qualifiedName: "big.internal", span: { startByte: 20, endByte: 30 } },
-        ],
-        exports: [{ name: "alpha", span: { startByte: 0, endByte: 5 } }],
-        edges: [
-          {
-            srcQualifiedName: "big.alpha",
-            dstQualifiedName: "small.zulu",
-            type: "CALLS",
-            confidence: 0.95,
-            provenance: "heuristic",
-          },
-          {
-            srcQualifiedName: "big.beta",
-            dstQualifiedName: "small.zulu",
-            type: "IMPORTS",
-            confidence: 0.4,
-            provenance: "heuristic",
-          },
-        ],
-      },
-      {
-        path: "src/small.ts",
-        language: "typescript" as const,
-        contentHash: "h-small",
-        symbols: [
-          { kind: "function" as const, name: "zulu", qualifiedName: "small.zulu", span: { startByte: 0, endByte: 8 } },
-        ],
-        exports: [{ name: "zulu", span: { startByte: 0, endByte: 4 } }],
-      },
-    ]);
-    assert.equal(big?.ok, true, `upsertFileBatch failed: ${JSON.stringify(big)}`);
-  } finally {
-    await store.close();
-  }
+  const store = await getCodegraphStore({
+    config: GATE_ON_CONFIG,
+    memoryDir,
+    principal: "default",
+    projectId: PROJECT_ID,
+  });
+
+  const big = await store.upsertFileBatch?.([
+    {
+      path: "src/big.ts",
+      language: "typescript" as const,
+      contentHash: "h-big",
+      symbols: [
+        { kind: "function" as const, name: "alpha", qualifiedName: "big.alpha", span: { startByte: 0, endByte: 10 } },
+        { kind: "function" as const, name: "beta", qualifiedName: "big.beta", span: { startByte: 10, endByte: 20 } },
+        { kind: "type" as const, name: "internal", qualifiedName: "big.internal", span: { startByte: 20, endByte: 30 } },
+      ],
+      exports: [{ name: "alpha", span: { startByte: 0, endByte: 5 } }],
+      edges: [
+        {
+          srcQualifiedName: "big.alpha",
+          dstQualifiedName: "small.zulu",
+          type: "CALLS",
+          confidence: 0.95,
+          provenance: "heuristic",
+        },
+        {
+          srcQualifiedName: "big.beta",
+          dstQualifiedName: "small.zulu",
+          type: "IMPORTS",
+          confidence: 0.4,
+          provenance: "heuristic",
+        },
+      ],
+    },
+    {
+      path: "src/small.ts",
+      language: "typescript" as const,
+      contentHash: "h-small",
+      symbols: [
+        { kind: "function" as const, name: "zulu", qualifiedName: "small.zulu", span: { startByte: 0, endByte: 8 } },
+      ],
+      exports: [{ name: "zulu", span: { startByte: 0, endByte: 4 } }],
+    },
+  ]);
+  assert.equal(big?.ok, true, `upsertFileBatch failed: ${JSON.stringify(big)}`);
   return dbPath;
 }
 

--- a/packages/remnic-core/src/coding/export-okf-codegraph.test.ts
+++ b/packages/remnic-core/src/coding/export-okf-codegraph.test.ts
@@ -1,0 +1,363 @@
+// Focused regression for the codegraph OKF projection (issue #1950).
+//
+// Fixture: a two-file synthetic repo indexed into a real GraphStore via the
+// optional-engine loader (never a static optional-package import), plus a
+// supersede pair + one accepted ADR and an architecture-card memory in the
+// project's coding namespace. Covers the issue's acceptance set: bundle
+// shape + verbatim card, determinism, truncation with a legal broken link,
+// the --symbols ladder, gating refusals, and store-byte immutability.
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { PluginConfig } from "../types.js";
+import { StorageManager } from "../storage.js";
+import { serializeDecisionRecord, type DecisionRecord } from "./decision-records.js";
+import { tryLoadCodingGraphModule } from "./optional-coding-graph.js";
+import { resolveCodegraphDbPath } from "./codegraph-runtime.js";
+import {
+  DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS,
+  OKF_CODEGRAPH_TRUNCATION_MARKER,
+  exportCodegraphOkfBundle,
+  parseOkfCodegraphSymbolFilter,
+} from "./export-okf-codegraph.js";
+
+const PROJECT_ID = "p1";
+const CARD_MARKDOWN = "# Demo Repo\n\nLanguages: typescript\n\nModules: 2\n";
+
+const GATE_ON_CONFIG = {
+  codingKnowledge: {
+    enabled: true,
+    codegraphTools: true,
+    decisionRecords: true,
+    codegraphDbDir: "",
+  },
+} as unknown as PluginConfig;
+
+interface Fixture {
+  memoryDir: string;
+  repoDir: string;
+  dbPath: string;
+  sqliteBefore: string;
+}
+
+async function seedGraphStore(memoryDir: string): Promise<string> {
+  const mod = await tryLoadCodingGraphModule();
+  assert.notEqual(mod, null, "@remnic/coding-graph must be installed for this test");
+  const dbPath = resolveCodegraphDbPath({
+    config: GATE_ON_CONFIG,
+    memoryDir,
+    principal: "default",
+    projectId: PROJECT_ID,
+  });
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const store = await mod!.GraphStore.open({ dbPath });
+  try {
+    const big = await store.upsertFileBatch?.([
+      {
+        path: "src/big.ts",
+        language: "typescript" as const,
+        contentHash: "h-big",
+        symbols: [
+          { kind: "function" as const, name: "alpha", qualifiedName: "big.alpha", span: { startByte: 0, endByte: 10 } },
+          { kind: "function" as const, name: "beta", qualifiedName: "big.beta", span: { startByte: 10, endByte: 20 } },
+          { kind: "type" as const, name: "internal", qualifiedName: "big.internal", span: { startByte: 20, endByte: 30 } },
+        ],
+        exports: [{ name: "alpha", span: { startByte: 0, endByte: 5 } }],
+        edges: [
+          {
+            srcQualifiedName: "big.alpha",
+            dstQualifiedName: "small.zulu",
+            type: "CALLS",
+            confidence: 0.95,
+            provenance: "heuristic",
+          },
+          {
+            srcQualifiedName: "big.beta",
+            dstQualifiedName: "small.zulu",
+            type: "IMPORTS",
+            confidence: 0.4,
+            provenance: "heuristic",
+          },
+        ],
+      },
+      {
+        path: "src/small.ts",
+        language: "typescript" as const,
+        contentHash: "h-small",
+        symbols: [
+          { kind: "function" as const, name: "zulu", qualifiedName: "small.zulu", span: { startByte: 0, endByte: 8 } },
+        ],
+        exports: [{ name: "zulu", span: { startByte: 0, endByte: 4 } }],
+      },
+    ]);
+    assert.equal(big?.ok, true, `upsertFileBatch failed: ${JSON.stringify(big)}`);
+  } finally {
+    await store.close();
+  }
+  return dbPath;
+}
+
+async function writeAdr(
+  storage: StorageManager,
+  record: DecisionRecord,
+  options: { status?: "archived" } = {},
+): Promise<void> {
+  await storage.writeMemory("decision", serializeDecisionRecord(record), {
+    source: "coding-decision",
+    tags: ["decision-record"],
+    structuredAttributes: { decisionStatus: record.status },
+    ...(options.status ? { status: options.status } : {}),
+  });
+}
+
+async function seedNamespace(memoryDir: string): Promise<void> {
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-p1");
+  const storage = new StorageManager(namespaceDir);
+  await storage.ensureDirectories();
+  // Accepted ADR with an explicit id.
+  await writeAdr(storage, {
+    id: "ADR-0001",
+    title: "Use SQLite for the graph store",
+    status: "accepted",
+    context: "The graph needs a local queryable store.",
+    decision: "Store the code graph in per-project SQLite files.",
+    consequences: "Reads stay local; no server required.",
+    entityRefs: [],
+  });
+  // Supersede pair in the production shape: frontmatter id left EMPTY (the
+  // memory id is canonical) and the replacement carries `supersedes`.
+  await writeAdr(
+    storage,
+    {
+      id: "",
+      title: "Single-pass indexing",
+      status: "superseded",
+      context: "Initial indexing approach.",
+      decision: "Index everything in one pass.",
+      consequences: undefined,
+      entityRefs: [],
+    },
+    { status: "archived" },
+  );
+  await writeAdr(storage, {
+    id: "",
+    title: "Incremental indexing",
+    status: "accepted",
+    context: "Single-pass reindexes were too slow.",
+    decision: "Index only files whose content hash changed.",
+    consequences: undefined,
+    entityRefs: [],
+    supersedes: "ADR-0002",
+  });
+  // Architecture card memory (surface classification: fact + tag + cardKind).
+  await storage.writeMemory("fact", CARD_MARKDOWN, {
+    source: "coding-architecture",
+    tags: ["architecture-card"],
+    structuredAttributes: { cardKind: "architecture" },
+  });
+}
+
+async function makeFixture(): Promise<Fixture> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-cg-mem-"));
+  const repoDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-cg-repo-"));
+  const dbPath = await seedGraphStore(memoryDir);
+  await seedNamespace(memoryDir);
+  return {
+    memoryDir,
+    repoDir,
+    dbPath,
+    sqliteBefore: sha256File(dbPath),
+  };
+}
+
+function sha256File(file: string): string {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function collectFiles(root: string, prefix = ""): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...collectFiles(path.join(root, entry.name), rel));
+    else out.push(rel);
+  }
+  return out.sort();
+}
+
+async function exportBundle(fx: Fixture, outDir: string, overrides: Record<string, unknown> = {}) {
+  return exportCodegraphOkfBundle({
+    config: GATE_ON_CONFIG,
+    memoryDir: fx.memoryDir,
+    projectId: PROJECT_ID,
+    outDir,
+    cwd: fx.repoDir,
+    ...overrides,
+  } as Parameters<typeof exportCodegraphOkfBundle>[0]);
+}
+
+test("parseOkfCodegraphSymbolFilter defaults to exported and rejects unknowns", () => {
+  assert.equal(parseOkfCodegraphSymbolFilter(undefined), "exported");
+  assert.equal(parseOkfCodegraphSymbolFilter("ALL"), "all");
+  assert.equal(parseOkfCodegraphSymbolFilter("none"), "none");
+  assert.throws(() => parseOkfCodegraphSymbolFilter("some"), /allowed:/);
+  assert.equal(DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS, 500);
+});
+
+test("exportCodegraphOkfBundle writes the full bundle: card verbatim, ADRs, modules, edges", async () => {
+  const fx = await makeFixture();
+  const out = path.join(fx.memoryDir, "out-a");
+  try {
+    const result = await exportBundle(fx, out);
+    assert.equal(result.moduleConcepts, 2);
+    assert.equal(result.moduleFilesInGraph, 2);
+    assert.equal(result.truncated, false);
+    assert.equal(result.decisions, 3);
+    assert.equal(result.architectureCard, true);
+
+    // Root index carries the version stamp + counts.
+    const root = await readFile(path.join(out, "index.md"), "utf8");
+    assert.match(root, /okf_version: "0.1"/);
+    assert.match(root, /- code modules: 2 of 2 indexed files/);
+    assert.equal(root.includes(OKF_CODEGRAPH_TRUNCATION_MARKER), false);
+
+    // Architecture card: OKF type frontmatter + stored body verbatim
+    // (storage-layer attribute suffix stripped).
+    const arch = await readFile(path.join(out, "architecture.md"), "utf8");
+    assert.match(arch, /type: Architecture Card/);
+    assert.ok(arch.includes(CARD_MARKDOWN.trimEnd()), "card body must be verbatim");
+    assert.equal(arch.includes("[Attributes:"), false);
+
+    // Decisions: all three statuses exported with type + original keys.
+    const decisionFiles = collectFiles(path.join(out, "decisions")).sort();
+    assert.deepEqual(
+      decisionFiles.filter((f) => f !== "index.md"),
+      ["ADR-0001.md", "ADR-0002.md", "ADR-0003.md"],
+    );
+    const adr1 = await readFile(path.join(out, "decisions", "ADR-0001.md"), "utf8");
+    assert.match(adr1, /type: Decision Record/);
+    assert.match(adr1, /title: Use SQLite for the graph store/);
+    assert.match(adr1, /status: accepted/);
+    assert.match(adr1, /# Decision/);
+    const adr3 = await readFile(path.join(out, "decisions", "ADR-0003.md"), "utf8");
+    assert.match(adr3, /- supersedes: \[ADR-0002\]\(\/decisions\/ADR-0002\.md\)/);
+    const decisionsIndex = await readFile(path.join(out, "decisions", "index.md"), "utf8");
+    // ACTIVE statuses listed before superseded.
+    assert.ok(decisionsIndex.indexOf("## Accepted") < decisionsIndex.indexOf("## Superseded"));
+
+    // Modules: one concept per file; symbols table (exported default);
+    // edges under # Dependencies with kind prose + bundle-relative links.
+    const big = await readFile(path.join(out, "modules", "src", "big.ts.md"), "utf8");
+    assert.match(big, /type: Code Module/);
+    assert.match(big, /title: src\/big\.ts/);
+    assert.match(big, /description: 3 symbols, typescript/);
+    assert.match(big, /tags:\n  - typescript/);
+    assert.match(big, /# Symbols/);
+    assert.match(big, /\| alpha \| function \| 0-10 \|/);
+    assert.equal(big.includes("internal"), false, "unexported symbol hidden by default");
+    assert.match(big, /# Dependencies/);
+    assert.match(big, /- calls: \[zulu\(\) in src\/small\.ts\]\(\/modules\/src\/small\.ts\.md\) \(confidence: high\)/);
+    assert.match(big, /- imports: \[src\/small\.ts\]\(\/modules\/src\/small\.ts\.md\) \(confidence: low\)/);
+    const modulesIndex = await readFile(path.join(out, "modules", "index.md"), "utf8");
+    assert.match(modulesIndex, /## src/);
+
+    // Read-only guarantee: the store's bytes are unchanged.
+    assert.equal(sha256File(fx.dbPath), fx.sqliteBefore);
+  } finally {
+    await rm(fx.memoryDir, { recursive: true, force: true });
+    await rm(fx.repoDir, { recursive: true, force: true });
+  }
+});
+
+test("exportCodegraphOkfBundle is byte-stable for an unchanged graph", async () => {
+  const fx = await makeFixture();
+  const outA = path.join(fx.memoryDir, "det-a");
+  const outB = path.join(fx.memoryDir, "det-b");
+  try {
+    await exportBundle(fx, outA);
+    await exportBundle(fx, outB);
+    assert.deepEqual(collectFiles(outA), collectFiles(outB));
+    for (const rel of collectFiles(outA)) {
+      assert.equal(
+        await readFile(path.join(outA, rel), "utf8"),
+        await readFile(path.join(outB, rel), "utf8"),
+        `${rel} must be byte-identical across exports`,
+      );
+    }
+  } finally {
+    await rm(fx.memoryDir, { recursive: true, force: true });
+    await rm(fx.repoDir, { recursive: true, force: true });
+  }
+});
+
+test("truncation keeps the most-symbolic file, notices in the root index, keeps broken links", async () => {
+  const fx = await makeFixture();
+  const out = path.join(fx.memoryDir, "out-trunc");
+  try {
+    const result = await exportBundle(fx, out, { maxModuleConcepts: 1 });
+    assert.equal(result.moduleConcepts, 1);
+    assert.equal(result.moduleFilesInGraph, 2);
+    assert.equal(result.truncated, true);
+    assert.equal(existsSync(path.join(out, "modules", "src", "small.ts.md")), false);
+    const root = await readFile(path.join(out, "index.md"), "utf8");
+    assert.match(root, new RegExp(OKF_CODEGRAPH_TRUNCATION_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    // The edge to the truncated target survives as a legal broken link.
+    const big = await readFile(path.join(out, "modules", "src", "big.ts.md"), "utf8");
+    assert.match(big, /\(\/modules\/src\/small\.ts\.md\) \(confidence: high\) \(link target not exported\)/);
+    assert.equal(sha256File(fx.dbPath), fx.sqliteBefore);
+  } finally {
+    await rm(fx.memoryDir, { recursive: true, force: true });
+    await rm(fx.repoDir, { recursive: true, force: true });
+  }
+});
+
+test("--symbols none|all changes only the # Symbols tables", async () => {
+  const fx = await makeFixture();
+  const outNone = path.join(fx.memoryDir, "sym-none");
+  const outAll = path.join(fx.memoryDir, "sym-all");
+  try {
+    await exportBundle(fx, outNone, { symbols: "none" });
+    await exportBundle(fx, outAll, { symbols: "all" });
+    const noneBig = await readFile(path.join(outNone, "modules", "src", "big.ts.md"), "utf8");
+    const allBig = await readFile(path.join(outAll, "modules", "src", "big.ts.md"), "utf8");
+    assert.equal(noneBig.includes("# Symbols"), false);
+    assert.match(allBig, /\| internal \| type \| 20-30 \|/);
+    // Frontmatter and Dependencies are identical across the two filters.
+    assert.equal(noneBig.split("# Dependencies")[0].split("# Symbols")[0], allBig.split("# Symbols")[0]);
+    assert.equal(
+      `# Dependencies${noneBig.split("# Dependencies")[1]}`,
+      `# Dependencies${allBig.split("# Dependencies")[1]}`,
+    );
+  } finally {
+    await rm(fx.memoryDir, { recursive: true, force: true });
+    await rm(fx.repoDir, { recursive: true, force: true });
+  }
+});
+
+test("gating: disabled config and unknown project produce tagged actionable refusals", async () => {
+  const fx = await makeFixture();
+  const out = path.join(fx.memoryDir, "out-gate");
+  try {
+    await assert.rejects(
+      exportBundle(fx, out, { config: { codingKnowledge: { enabled: false } } as unknown as PluginConfig }),
+      (err: unknown) => err instanceof Error && "code" in err && (err as { code: string }).code === "disabled",
+    );
+    await assert.rejects(
+      exportBundle(fx, out, { projectId: "nope" }),
+      (err: unknown) =>
+        err instanceof Error &&
+        "code" in err &&
+        (err as { code: string }).code === "project_not_found" &&
+        /known projects: .*p1/.test(err.message),
+    );
+    assert.equal(existsSync(out), false, "no bundle on refusal");
+  } finally {
+    await rm(fx.memoryDir, { recursive: true, force: true });
+    await rm(fx.repoDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/coding/export-okf-codegraph.test.ts
+++ b/packages/remnic-core/src/coding/export-okf-codegraph.test.ts
@@ -19,6 +19,7 @@ import type { PluginConfig } from "../types.js";
 import { StorageManager } from "../storage.js";
 import { serializeDecisionRecord, type DecisionRecord } from "./decision-records.js";
 import { getCodegraphStore, resolveCodegraphDbPath } from "./codegraph-runtime.js";
+import { isCodingGraphInstalled } from "./optional-coding-graph.js";
 
 import {
   DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS,
@@ -176,6 +177,13 @@ async function makeFixture(): Promise<Fixture> {
   };
 }
 
+async function requireEngine(t: { skip: (reason: string) => void }): Promise<boolean> {
+  if (await isCodingGraphInstalled()) return true;
+  t.skip("@remnic/coding-graph is optional and not installed");
+  return false;
+}
+
+
 function sha256File(file: string): string {
   return createHash("sha256").update(readFileSync(file)).digest("hex");
 }
@@ -209,7 +217,8 @@ test("parseOkfCodegraphSymbolFilter defaults to exported and rejects unknowns", 
   assert.equal(DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS, 500);
 });
 
-test("exportCodegraphOkfBundle writes the full bundle: card verbatim, ADRs, modules, edges", async () => {
+test("exportCodegraphOkfBundle writes the full bundle: card verbatim, ADRs, modules, edges", async (t) => {
+  if (!(await requireEngine(t))) return;
   const fx = await makeFixture();
   const out = path.join(fx.memoryDir, "out-a");
   try {
@@ -274,7 +283,8 @@ test("exportCodegraphOkfBundle writes the full bundle: card verbatim, ADRs, modu
   }
 });
 
-test("exportCodegraphOkfBundle is byte-stable for an unchanged graph", async () => {
+test("exportCodegraphOkfBundle is byte-stable for an unchanged graph", async (t) => {
+  if (!(await requireEngine(t))) return;
   const fx = await makeFixture();
   const outA = path.join(fx.memoryDir, "det-a");
   const outB = path.join(fx.memoryDir, "det-b");
@@ -295,7 +305,8 @@ test("exportCodegraphOkfBundle is byte-stable for an unchanged graph", async () 
   }
 });
 
-test("truncation keeps the most-symbolic file, notices in the root index, keeps broken links", async () => {
+test("truncation keeps the most-symbolic file, notices in the root index, keeps broken links", async (t) => {
+  if (!(await requireEngine(t))) return;
   const fx = await makeFixture();
   const out = path.join(fx.memoryDir, "out-trunc");
   try {
@@ -316,7 +327,8 @@ test("truncation keeps the most-symbolic file, notices in the root index, keeps 
   }
 });
 
-test("--symbols none|all changes only the # Symbols tables", async () => {
+test("--symbols none|all changes only the # Symbols tables", async (t) => {
+  if (!(await requireEngine(t))) return;
   const fx = await makeFixture();
   const outNone = path.join(fx.memoryDir, "sym-none");
   const outAll = path.join(fx.memoryDir, "sym-all");
@@ -339,25 +351,31 @@ test("--symbols none|all changes only the # Symbols tables", async () => {
   }
 });
 
-test("gating: disabled config and unknown project produce tagged actionable refusals", async () => {
+test("gating: disabled config and unknown project produce tagged actionable refusals", async (t) => {
+  const out = path.join(os.tmpdir(), `okf-cg-gate-${process.pid}`);
+  await assert.rejects(
+    exportCodegraphOkfBundle({
+      config: { codingKnowledge: { enabled: false } } as unknown as PluginConfig,
+      memoryDir: os.tmpdir(),
+      projectId: PROJECT_ID,
+      outDir: out,
+    }),
+    (err: unknown) => err instanceof Error && "code" in err && (err as { code: string }).code === "disabled",
+  );
+  if (!(await requireEngine(t))) return;
   const fx = await makeFixture();
-  const out = path.join(fx.memoryDir, "out-gate");
   try {
     await assert.rejects(
-      exportBundle(fx, out, { config: { codingKnowledge: { enabled: false } } as unknown as PluginConfig }),
-      (err: unknown) => err instanceof Error && "code" in err && (err as { code: string }).code === "disabled",
-    );
-    await assert.rejects(
-      exportBundle(fx, out, { projectId: "nope" }),
+      exportBundle(fx, path.join(fx.memoryDir, "out-gate"), { projectId: "nope" }),
       (err: unknown) =>
         err instanceof Error &&
         "code" in err &&
         (err as { code: string }).code === "project_not_found" &&
         /known projects: .*p1/.test(err.message),
     );
-    assert.equal(existsSync(out), false, "no bundle on refusal");
   } finally {
     await rm(fx.memoryDir, { recursive: true, force: true });
     await rm(fx.repoDir, { recursive: true, force: true });
   }
 });
+

--- a/packages/remnic-core/src/coding/export-okf-codegraph.ts
+++ b/packages/remnic-core/src/coding/export-okf-codegraph.ts
@@ -1,0 +1,565 @@
+/**
+ * Codegraph OKF projection (issue #1950).
+ *
+ * Read-only projection of one project's code-graph SQLite store into an
+ * OKF v0.1 knowledge bundle: the stored architecture card, decision
+ * records, and one `Code Module` concept per indexed source file with its
+ * symbols and outgoing edges. The store is NEVER opened for write — the
+ * SQLite file is opened `readonly`, so an export cannot mutate indexing
+ * state and the file's bytes are stable across runs.
+ *
+ * Rendering discipline mirrors architecture-card.ts (rule 38): byte-stable
+ * output for an unchanged graph; every list is sorted with a total order.
+ * Shared bundle mechanics come from ../okf/render.ts (one source of truth
+ * with the memory exporter, issue #1948).
+ */
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { lintOkfDir } from "../okf/lint.js";
+import {
+  OKF_ARCHITECTURE_CARD_TYPE,
+  OKF_CODE_MODULE_TYPE,
+  OKF_DECISION_RECORD_TYPE,
+} from "../okf/type-mapping.js";
+import {
+  OKF_EXPORT_VERSION,
+  publishBundle,
+  renderFrontmatter,
+  rejectSymlinkPath,
+  writeBundleFile,
+} from "../okf/render.js";
+import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
+import { StorageManager, stripAttributesSuffix } from "../storage.js";
+import type { PluginConfig } from "../types.js";
+import { findArchitectureCardMemory, type ArchitectureSurfaceStorage } from "./architecture-surfaces.js";
+import {
+  CodegraphRuntimeError,
+  codegraphSurfaceVisible,
+  listCodegraphProjects,
+  resolveCodegraphDbPath,
+} from "./codegraph-runtime.js";
+import { defaultGitInvoker, normalizeOriginUrl } from "./git-context.js";
+import { projectNamespaceName } from "./coding-namespace.js";
+import {
+  ACTIVE_DECISION_STATUSES,
+  DECISION_STATUSES,
+  parseDecisionRecord,
+  type DecisionRecord,
+} from "./decision-records.js";
+import { buildCodingGraphInstallHint, isCodingGraphInstalled } from "./optional-coding-graph.js";
+
+/** Default cap on rendered module concepts (`--max-module-concepts`). */
+export const DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS = 500;
+
+/**
+ * Visible marker written into the root index when module concepts were
+ * truncated (mirrors `ARCHITECTURE_CARD_TRUNCATION_MARKER` — never
+ * silently incomplete).
+ */
+export const OKF_CODEGRAPH_TRUNCATION_MARKER = "<!-- okf-codegraph-truncated -->";
+
+export type OkfCodegraphSymbolFilter = "none" | "exported" | "all";
+
+const SYMBOL_FILTERS: readonly OkfCodegraphSymbolFilter[] = ["none", "exported", "all"];
+
+export function parseOkfCodegraphSymbolFilter(raw: unknown): OkfCodegraphSymbolFilter {
+  const value = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (value.length === 0) return "exported";
+  if ((SYMBOL_FILTERS as readonly string[]).includes(value)) return value as OkfCodegraphSymbolFilter;
+  throw new Error(`invalid --symbols ${String(raw)}; allowed: ${SYMBOL_FILTERS.join(", ")}`);
+}
+
+export interface ExportOkfCodegraphOptions {
+  readonly config: PluginConfig;
+  readonly memoryDir: string;
+  /** Store owner; defaults to `"default"` like the access-service principal key. */
+  readonly principal?: string;
+  readonly projectId: string;
+  readonly outDir: string;
+  /**
+   * Working directory used to resolve git context (repo root, origin URL).
+   * Defaults to `process.cwd()`.
+   */
+  readonly cwd?: string;
+  readonly maxModuleConcepts?: number;
+  readonly symbols?: OkfCodegraphSymbolFilter;
+  /** Default ON; pass `false` for `--no-include-adrs`. */
+  readonly includeAdrs?: boolean;
+  readonly force?: boolean;
+  /**
+   * Namespace holding the project's decision records + architecture card.
+   * Defaults to the project-scope coding namespace for the project id.
+   */
+  readonly namespace?: string;
+}
+
+export interface ExportOkfCodegraphResult {
+  readonly projectId: string;
+  readonly moduleConcepts: number;
+  readonly moduleFilesInGraph: number;
+  readonly truncated: boolean;
+  readonly decisions: number;
+  readonly architectureCard: boolean;
+}
+
+interface GraphFileRow {
+  readonly id: number;
+  readonly path: string;
+  readonly lang: string;
+}
+
+interface GraphNodeRow {
+  readonly name: string;
+  readonly label: string;
+  readonly file_id: number;
+  readonly span_start: number;
+  readonly span_end: number;
+  readonly is_exported: number;
+}
+
+interface GraphEdgeRow {
+  readonly type: string;
+  readonly confidence: number;
+  readonly src_file_id: number;
+  readonly dst_file_id: number;
+  readonly dst_name: string;
+  readonly dst_path: string;
+}
+
+export async function exportCodegraphOkfBundle(
+  opts: ExportOkfCodegraphOptions,
+): Promise<ExportOkfCodegraphResult> {
+  if (!codegraphSurfaceVisible(opts.config)) {
+    throw new CodegraphRuntimeError(
+      "disabled",
+      "codegraph tools are disabled (codingKnowledge.enabled or codingKnowledge.codegraphTools is false)",
+    );
+  }
+  if (!(await isCodingGraphInstalled())) {
+    throw new CodegraphRuntimeError("package_missing", buildCodingGraphInstallHint());
+  }
+  const principal = opts.principal?.trim() || "default";
+  const projectId = opts.projectId.trim();
+  if (projectId.length === 0) {
+    throw new CodegraphRuntimeError(
+      "project_required",
+      "codegraph export-okf requires --project (or a cwd inside the project's git repo)",
+    );
+  }
+  rejectSymlinkPath(path.resolve(opts.outDir));
+  // Explicit option validation (config-coercion footgun): honor the given
+  // value or fail loudly — never silently default a bad input. `0` is a
+  // legitimate "no module concepts" cap and is honored.
+  const maxModules = opts.maxModuleConcepts ?? DEFAULT_OKF_CODEGRAPH_MAX_MODULE_CONCEPTS;
+  if (!Number.isInteger(maxModules) || maxModules < 0) {
+    throw new Error(
+      `invalid --max-module-concepts ${String(opts.maxModuleConcepts)}; must be a non-negative integer`,
+    );
+  }
+  const dbPath = resolveCodegraphDbPath({ config: opts.config, memoryDir: opts.memoryDir, principal, projectId });
+  if (!existsSync(dbPath)) {
+    const known = listCodegraphProjects({
+      config: opts.config,
+      memoryDir: opts.memoryDir,
+      principal,
+      listDir: (dir) => {
+        try {
+          return readdirSync(dir);
+        } catch {
+          return [];
+        }
+      },
+    });
+    throw new CodegraphRuntimeError(
+      "project_not_found",
+      `no codegraph store for project '${projectId}' (principal '${principal}'); known projects: ${
+        known.length > 0 ? known.join(", ") : "(none)"
+      }`,
+    );
+  }
+
+  // Read the graph through a readonly handle — bytes on disk are never
+  // touched, and the store cache (write-mode handles) is bypassed entirely.
+  const graphIndexedAt = statSync(dbPath).mtime.toISOString();
+  const db = openBetterSqlite3(dbPath, { readonly: true, fileMustExist: true });
+  let files: GraphFileRow[];
+  let nodes: GraphNodeRow[];
+  let edges: GraphEdgeRow[];
+  try {
+    files = db.prepare("SELECT id, path, lang FROM files ORDER BY path ASC").all() as GraphFileRow[];
+    nodes = db
+      .prepare(
+        `SELECT n.name, n.label, n.file_id, n.span_start, n.span_end,
+                COALESCE(na.is_exported, 0) AS is_exported
+           FROM nodes n LEFT JOIN node_attributes na ON na.node_id = n.id`,
+      )
+      .all() as GraphNodeRow[];
+    edges = db
+      .prepare(
+        `SELECT e.type, e.confidence, s.file_id AS src_file_id, d.file_id AS dst_file_id,
+                d.name AS dst_name, df.path AS dst_path
+           FROM edges e
+           JOIN nodes s ON s.id = e.src
+           JOIN nodes d ON d.id = e.dst
+           JOIN files df ON d.file_id = df.id`,
+      )
+      .all() as GraphEdgeRow[];
+  } finally {
+    db.close();
+  }
+
+  // Trust boundary: file paths come from the indexed graph. Reject anything
+  // that is not a strict repo-relative POSIX path so a hostile row cannot
+  // escape the staging directory via writeBundleFile's path.join.
+  const safeFiles = files.filter(
+    (f) => f.path.length > 0 && !f.path.startsWith("/") && !f.path.split("/").includes(".."),
+  );
+  const fileIdToPath = new Map<number, string>(safeFiles.map((f) => [f.id, f.path]));
+  const nodesByFile = new Map<number, GraphNodeRow[]>();
+  for (const node of nodes) {
+    if (!fileIdToPath.has(node.file_id)) continue;
+    const list = nodesByFile.get(node.file_id) ?? [];
+    list.push(node);
+    nodesByFile.set(node.file_id, list);
+  }
+
+  // Deterministic truncation: most symbols first, path ascending as the
+  // tie-break (issue acceptance: cap of 1 keeps the highest-symbol file).
+  const ranked = [...safeFiles].sort((a, b) => {
+    const aCount = (nodesByFile.get(a.id) ?? []).length;
+    const bCount = (nodesByFile.get(b.id) ?? []).length;
+    if (aCount !== bCount) return bCount - aCount;
+    return a.path.localeCompare(b.path);
+  });
+  const keptFiles = ranked.slice(0, maxModules);
+  const keptPaths = new Set<string>(keptFiles.map((f) => f.path));
+  const truncated = safeFiles.length > keptFiles.length;
+
+  const symbolFilter = parseOkfCodegraphSymbolFilter(opts.symbols);
+  const git = await resolveGitHints(opts.cwd ?? process.cwd());
+  const staging = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-codegraph-"));
+let decisions = 0;
+let architectureCard = false;
+try {
+  const namespace = opts.namespace?.trim() || projectNamespaceName(projectId);
+    const namespaceDir = path.join(opts.memoryDir, "namespaces", namespace);
+    if (opts.includeAdrs !== false && existsSync(namespaceDir)) {
+      const storage = new StorageManager(namespaceDir);
+      const memories = await storage.readAllMemories();
+      // Architecture card — reuse the surface's classification (rule 53).
+      const card = await findArchitectureCardMemory(readOnlyCardStorage(storage, namespaceDir, namespace));
+      if (card) {
+        architectureCard = true;
+        writeBundleFile(
+          staging,
+          "architecture.md",
+          renderFrontmatter({
+            type: OKF_ARCHITECTURE_CARD_TYPE,
+            title: git.repoName,
+            ...(git.originUrl ? { resource: git.originUrl } : git.repoRoot ? { resource: git.repoRoot } : {}),
+            timestamp: card.frontmatter.updated ?? card.frontmatter.created,
+          }) +
+            stripAttributesSuffix(card.content.replace(/^\uFEFF/, "")).trimEnd() +
+            "\n",
+        );
+      }
+      const records: Array<{ record: DecisionRecord; timestamp: string }> = [];
+      for (const memory of memories) {
+        if (memory.frontmatter.category !== "decision") continue;
+        try {
+          const parsed = parseDecisionRecord(memory.content);
+          records.push({
+            // Production writes leave the ADR frontmatter id empty and use
+            // the memory id as the canonical identifier (decisionRecord
+            // surface path) — prefer the ADR id, fall back to the memory id.
+            record: parsed.id ? parsed : { ...parsed, id: memory.frontmatter.id },
+            timestamp: memory.frontmatter.updated ?? memory.frontmatter.created,
+          });
+        } catch {
+          // Unparseable decision bodies are skipped, mirroring the surface's
+          // safeParseDecisionRecord degradation.
+        }
+      }
+      records.sort((a, b) => a.record.title.localeCompare(b.record.title));
+      decisions = records.length;
+      for (const { record, timestamp } of records) {
+        writeBundleFile(staging, `decisions/${decisionFileStem(record)}.md`, renderDecision(record, timestamp));
+      }
+      if (records.length > 0 || architectureCard) {
+        writeBundleFile(staging, "decisions/index.md", renderDecisionsIndex(records));
+      }
+    }
+
+    for (const file of keptFiles) {
+      writeBundleFile(
+        staging,
+        `modules/${file.path}.md`,
+        renderModule(
+          file,
+          nodesByFile.get(file.id) ?? [],
+          edges,
+          fileIdToPath,
+          keptPaths,
+          symbolFilter,
+          git,
+          graphIndexedAt,
+        ),
+      );
+    }
+    if (keptFiles.length > 0) {
+      writeBundleFile(staging, "modules/index.md", renderModulesIndex(keptFiles));
+    }
+    writeBundleFile(
+      staging,
+      "index.md",
+      renderRootIndex(git.repoName, projectId, architectureCard, decisions, keptFiles, safeFiles, truncated),
+    );
+
+    // Self-validate with the #1946 conformance checker; non-conformant
+    // output fails the command. Reserved basenames (the bundle's own
+    // index.md files) are the documented exemption, as in the memory export.
+    const lint = lintOkfDir(staging);
+    const blocking = lint.findings.filter((f) => f.code !== "skipped_encrypted" && f.code !== "reserved_basename");
+    if (blocking.length > 0) {
+      throw new Error(`OKF codegraph export failed lint: ${blocking.map((f) => `${f.file}: ${f.message}`).join("; ")}`);
+    }
+    publishBundle(staging, path.resolve(opts.outDir), opts.force === true);
+  } catch (err) {
+    rmSync(staging, { recursive: true, force: true });
+    throw err;
+  }
+  return {
+    projectId,
+    moduleConcepts: keptFiles.length,
+    moduleFilesInGraph: safeFiles.length,
+    truncated,
+    decisions,
+    architectureCard,
+  };
+}
+
+/**
+ * Read-only adapter over the namespace StorageManager for
+ * {@link findArchitectureCardMemory} — write arms throw so a future edit
+ * cannot silently turn the exporter into a mutating surface.
+ */
+function readOnlyCardStorage(
+  storage: StorageManager,
+  dir: string,
+  namespace: string,
+): ArchitectureSurfaceStorage {
+  return {
+    dir,
+    namespace,
+    readAllMemories: () => storage.readAllMemories(),
+    updateMemory: () => {
+      throw new Error("codegraph export-okf is read-only");
+    },
+    writeSealedMemory: () => {
+      throw new Error("codegraph export-okf is read-only");
+    },
+  };
+}
+
+interface GitHints {
+  readonly repoRoot: string | null;
+  readonly repoName: string;
+  readonly originUrl: string | null;
+}
+
+async function resolveGitHints(cwd: string): Promise<GitHints> {
+  try {
+    const invoker = defaultGitInvoker();
+    const topLevel = await invoker(cwd, ["rev-parse", "--show-toplevel"]);
+    if (topLevel.exitCode !== 0) {
+      return { repoRoot: null, repoName: "codegraph", originUrl: null };
+    }
+    const repoRoot = topLevel.stdout.trim();
+    const origin = await invoker(repoRoot, ["remote", "get-url", "origin"]);
+    const originUrl = origin.exitCode === 0 ? normalizeOriginUrl(origin.stdout) : null;
+    return {
+      repoRoot: repoRoot || null,
+      repoName: (repoRoot && path.basename(repoRoot)) || "codegraph",
+      originUrl: originUrl && originUrl.length > 0 ? originUrl : null,
+    };
+  } catch {
+    return { repoRoot: null, repoName: "codegraph", originUrl: null };
+  }
+}
+
+function moduleResource(git: GitHints, filePath: string): string {
+  if (git.originUrl) return `${git.originUrl}/${filePath}`;
+  if (git.repoRoot) return path.join(git.repoRoot, filePath);
+  return filePath;
+}
+
+function confidenceTier(confidence: number): string {
+  if (confidence >= 0.9) return "high";
+  if (confidence >= 0.5) return "medium";
+  return "low";
+}
+
+function decisionFileStem(record: Pick<DecisionRecord, "id">): string {
+  const safe = record.id.replace(/[^A-Za-z0-9._-]+/g, "_");
+  return safe.length > 0 ? safe : "decision";
+}
+
+function renderModule(
+  file: GraphFileRow,
+  fileNodes: readonly GraphNodeRow[],
+  edges: readonly GraphEdgeRow[],
+  fileIdToPath: ReadonlyMap<number, string>,
+  keptPaths: ReadonlySet<string>,
+  symbolFilter: OkfCodegraphSymbolFilter,
+  git: GitHints,
+  graphIndexedAt: string,
+): string {
+  const visible =
+    symbolFilter === "all"
+      ? [...fileNodes]
+      : symbolFilter === "exported"
+        ? fileNodes.filter((n) => n.is_exported === 1)
+        : [];
+  visible.sort((a, b) => (a.name !== b.name ? a.name.localeCompare(b.name) : a.span_start - b.span_start));
+  const outEdges = edges
+    .filter((e) => e.src_file_id === file.id && fileIdToPath.get(e.src_file_id) === file.path)
+    .map((e) => ({
+      type: e.type,
+      verb: e.type.toLowerCase(),
+      dstPath: e.dst_path,
+      dstName: e.dst_name,
+      tier: confidenceTier(e.confidence),
+    }))
+    .sort((a, b) =>
+      a.type !== b.type
+        ? a.type.localeCompare(b.type)
+        : a.dstPath !== b.dstPath
+          ? a.dstPath.localeCompare(b.dstPath)
+          : a.dstName.localeCompare(b.dstName),
+    );
+  const fields: Record<string, unknown> = {
+    type: OKF_CODE_MODULE_TYPE,
+    title: file.path,
+    description: `${fileNodes.length} symbols, ${file.lang}`,
+    resource: moduleResource(git, file.path),
+    tags: [file.lang],
+    timestamp: graphIndexedAt,
+  };
+  let body = "";
+  if (symbolFilter !== "none") {
+    const rows = visible.map((n) => `| ${n.name} | ${n.label} | ${n.span_start}-${n.span_end} |`).join("\n");
+    body += `# Symbols\n\n| Name | Kind | Span (bytes) |\n|---|---|---|\n${rows}\n\n`;
+  }
+  if (outEdges.length > 0) {
+    const lines = outEdges.map((e) => {
+      // Broken links (target truncated out of the bundle) are legal per OKF
+      // §5.3 — the link records the relationship regardless of target presence.
+      const href = `/modules/${e.dstPath}.md`;
+      const label = e.verb === "calls" ? `${e.dstName}() in ${e.dstPath}` : e.dstPath;
+      const broken = keptPaths.has(e.dstPath) ? "" : " (link target not exported)";
+      return `- ${e.verb}: [${label}](${href}) (confidence: ${e.tier})${broken}`;
+    });
+    body += `# Dependencies\n\n${lines.join("\n")}\n\n`;
+  }
+  return renderFrontmatter(fields) + body.trimEnd() + "\n";
+}
+
+function renderModulesIndex(files: readonly GraphFileRow[]): string {
+  const groups = new Map<string, GraphFileRow[]>();
+  for (const file of files) {
+    const key = file.path.includes("/") ? (file.path.split("/")[0] ?? "") : "(root)";
+    const list = groups.get(key) ?? [];
+    list.push(file);
+    groups.set(key, list);
+  }
+  const sections = [...groups.keys()].sort().map((key) => {
+    const lines = (groups.get(key) ?? [])
+      .sort((a, b) => a.path.localeCompare(b.path))
+      .map((f) => `* [${f.path}](/modules/${f.path}.md)`);
+    return `## ${key}\n\n${lines.join("\n")}`;
+  });
+  return `---\nokf_version: "${OKF_EXPORT_VERSION}"\n---\n\n# Code Modules\n\n${sections.join("\n\n")}\n`;
+}
+
+function renderDecisionsIndex(records: ReadonlyArray<{ record: DecisionRecord }>): string {
+  // ACTIVE set first — the single classification source (rule 53), never a
+  // re-derived list.
+  const orderedStatuses = [
+    ...DECISION_STATUSES.filter((s) => ACTIVE_DECISION_STATUSES.has(s)),
+    ...DECISION_STATUSES.filter((s) => !ACTIVE_DECISION_STATUSES.has(s)),
+  ];
+  const byStatus = new Map<string, { record: DecisionRecord }[]>();
+  for (const entry of records) {
+    const list = byStatus.get(entry.record.status) ?? [];
+    list.push(entry);
+    byStatus.set(entry.record.status, list);
+  }
+  const sections: string[] = [];
+  for (const status of orderedStatuses) {
+    const list = byStatus.get(status);
+    if (!list || list.length === 0) continue;
+    const lines = list
+      .map((e) => e.record)
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .map((r) => `* [${r.title}](/decisions/${decisionFileStem(r)}.md)`);
+    sections.push(`## ${status[0]!.toUpperCase()}${status.slice(1)}\n\n${lines.join("\n")}`);
+  }
+  return `---\nokf_version: "${OKF_EXPORT_VERSION}"\n---\n\n# Decision Records\n\n${sections.join("\n\n")}\n`;
+}
+
+function renderDecision(record: DecisionRecord, timestamp: string): string {
+  const fields: Record<string, unknown> = {
+    id: record.id,
+    title: record.title,
+    status: record.status,
+    context: record.context,
+    decision: record.decision,
+    ...(record.consequences !== undefined ? { consequences: record.consequences } : {}),
+    entityRefs: record.entityRefs,
+    ...(record.supersedes !== undefined ? { supersedes: record.supersedes } : {}),
+    type: OKF_DECISION_RECORD_TYPE,
+    timestamp,
+  };
+  const lines: string[] = [];
+  if (record.context) lines.push(record.context, "");
+  lines.push("# Decision", "");
+  if (record.decision) lines.push(record.decision, "");
+  if (record.consequences && record.consequences.length > 0) {
+    lines.push("# Consequences", "", record.consequences, "");
+  }
+  if (record.supersedes !== undefined) {
+    lines.push(`- supersedes: [${record.supersedes}](/decisions/${decisionFileStem({ id: record.supersedes })}.md)`, "");
+  }
+  return renderFrontmatter(fields) + lines.join("\n").trimEnd() + "\n";
+}
+
+function renderRootIndex(
+  repoName: string,
+  projectId: string,
+  architectureCard: boolean,
+  decisions: number,
+  keptFiles: readonly GraphFileRow[],
+  totalFiles: readonly GraphFileRow[],
+  truncated: boolean,
+): string {
+  const lines: string[] = [
+    `# ${repoName} Code Graph`,
+    "",
+    `- project: ${projectId}`,
+    architectureCard ? "- [Architecture card](/architecture.md)" : "- architecture card: none stored",
+    `- decision records: ${decisions}`,
+    `- code modules: ${keptFiles.length} of ${totalFiles.length} indexed files`,
+    "",
+  ];
+  if (truncated) {
+    lines.push(
+      OKF_CODEGRAPH_TRUNCATION_MARKER,
+      `Truncated to the ${keptFiles.length} files with the most symbols of ${totalFiles.length} in the graph; raise --max-module-concepts to widen.`,
+      "",
+    );
+  }
+  return `---\nokf_version: "${OKF_EXPORT_VERSION}"\n---\n\n${lines.join("\n")}\n`;
+}

--- a/packages/remnic-core/src/okf/render.ts
+++ b/packages/remnic-core/src/okf/render.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared OKF bundle-rendering helpers (issues #1948 + #1950).
+ *
+ * One source of truth for the mechanics every OKF bundle exporter uses:
+ * deterministic frontmatter rendering, staging-directory file writes, the
+ * symlink-guarded atomic publish, and the bundle version stamp. The memory
+ * exporter (transfer/export-okf.ts) and the codegraph exporter
+ * (coding/export-okf-codegraph.ts) both consume this module so their
+ * bundles are byte-compatible in convention (rule 38 — deterministic
+ * rendering discipline; rule 9 — stable seam over shared mechanics).
+ */
+import { lstatSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/** OKF spec version emitted in every bundle root index. */
+export const OKF_EXPORT_VERSION = "0.1";
+
+/**
+ * Render a YAML frontmatter block from a flat field map.
+ *
+ * Key order: the canonical OKF keys first (`type`, `title`, `description`,
+ * `tags`, `timestamp`), everything else alphabetical — one deterministic
+ * layout so identical inputs always render byte-identical files. A key set
+ * to `undefined` is omitted; callers must not pass a key twice.
+ */
+export function renderFrontmatter(fields: Record<string, unknown>): string {
+  const keys = Object.keys(fields).sort((a, b) => {
+    const order = ["type", "title", "description", "tags", "timestamp"];
+    const ai = order.indexOf(a);
+    const bi = order.indexOf(b);
+    if (ai >= 0 || bi >= 0) return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+    return a.localeCompare(b);
+  });
+  const lines = keys.flatMap((key) => yamlLine(key, fields[key]));
+  return `---\n${lines.join("\n")}\n---\n\n`;
+}
+
+function yamlLine(key: string, value: unknown): string[] {
+  if (value === undefined) return [];
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${key}: []`];
+    if (value.every((item) => typeof item !== "object" || item === null)) {
+      return [`${key}:`, ...value.map((item) => `  - ${yamlScalar(item)}`)];
+    }
+    return [`${key}: ${JSON.stringify(value)}`];
+  }
+  if (typeof value === "object" && value !== null) return [`${key}: ${JSON.stringify(value)}`];
+  return [`${key}: ${yamlScalar(value)}`];
+}
+
+function yamlScalar(value: unknown): string {
+  if (typeof value === "string") {
+    if (value === "" || /[:#\n]/.test(value) || value !== value.trim()) return JSON.stringify(value);
+    return value;
+  }
+  return String(value);
+}
+
+/**
+ * Write one file into a bundle staging tree. `rel` is a POSIX-style
+ * bundle-relative path; parent directories are created as needed.
+ */
+export function writeBundleFile(root: string, rel: string, content: string): void {
+  const dest = path.join(root, ...rel.split("/"));
+  mkdirSync(path.dirname(dest), { recursive: true });
+  writeFileSync(dest, content, "utf8");
+}
+
+/**
+ * Publish a staged bundle: refuse a non-empty target without `--force`,
+ * swap via rename so the target is never observed half-written, and keep a
+ * restorable backup when replacing an existing tree.
+ */
+export function publishBundle(staging: string, outDir: string, force: boolean): void {
+  let exists = false;
+  try {
+    const stat = lstatSync(outDir);
+    if (stat.isSymbolicLink()) throw new Error(`--out must not be a symlink: ${outDir}`);
+    exists = true;
+    const entries = readdirSync(outDir).filter((name) => name !== "." && name !== "..");
+    if (entries.length > 0 && !force) {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(`--out ${outDir} is not empty; pass --force to replace it`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  mkdirSync(path.dirname(outDir), { recursive: true });
+  if (exists && force) {
+    const backup = `${outDir}.okf-prev`;
+    try {
+      renameSync(outDir, backup);
+    } catch {
+      rmSync(staging, { recursive: true, force: true });
+      throw new Error(`cannot replace --out ${outDir}`);
+    }
+    try {
+      renameSync(staging, outDir);
+      rmSync(backup, { recursive: true, force: true });
+    } catch (err) {
+      try {
+        renameSync(backup, outDir);
+      } catch {
+        // Keep backup if restore fails.
+      }
+      throw err;
+    }
+    return;
+  }
+  renameSync(staging, outDir);
+}
+
+/**
+ * Reject a --out path with a symlink anywhere in its component chain
+ * (pattern 42 + hermes-shim precedent): a symlinked component could aim
+ * the atomic rename outside the operator's chosen directory.
+ */
+export function rejectSymlinkPath(target: string): void {
+  let current = path.resolve(target);
+  while (true) {
+    try {
+      if (lstatSync(current).isSymbolicLink()) {
+        throw new Error(`--out path component is a symlink: ${current}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+}
+

--- a/packages/remnic-core/src/okf/type-mapping.ts
+++ b/packages/remnic-core/src/okf/type-mapping.ts
@@ -57,6 +57,8 @@ export function okfTypeForEntityKind(kind: string | undefined): string {
 export const OKF_PROFILE_TYPE = "Profile";
 export const OKF_QUESTION_TYPE = "Question";
 export const OKF_DECISION_RECORD_TYPE = "Decision Record";
+export const OKF_ARCHITECTURE_CARD_TYPE = "Architecture Card";
+export const OKF_CODE_MODULE_TYPE = "Code Module";
 
 /**
  * OKF §6/§7 reserve `index.md` and `log.md` for bundle-level files with a

--- a/packages/remnic-core/src/transfer/export-okf.ts
+++ b/packages/remnic-core/src/transfer/export-okf.ts
@@ -1,4 +1,4 @@
-import { lstatSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { rmSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,10 +8,21 @@ import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { normalizeProjectionPreview } from "../memory-projection-format.js";
 import { lintOkfDir } from "../okf/lint.js";
 import { okfTypeForMemory, OKF_PROFILE_TYPE } from "../okf/type-mapping.js";
+import {
+  OKF_EXPORT_VERSION,
+  publishBundle,
+  renderFrontmatter,
+  rejectSymlinkPath,
+  writeBundleFile,
+} from "../okf/render.js";
+// Re-exported for the existing `@remnic/core/export-okf` consumers and tests
+// (one public surface; the value itself now lives in okf/render.ts).
+export { OKF_EXPORT_VERSION };
 import { StorageManager } from "../storage.js";
 import type { MemoryFile, MemoryLink, MemoryStatus } from "../types.js";
 
-export const OKF_EXPORT_VERSION = "0.1";
+// Shared bundle mechanics (frontmatter, publish, symlink guard, file write)
+// live in ../okf/render.ts — one source of truth for every OKF exporter.
 export const OKF_LOG_TRUNCATION_MARKER = "<!-- okf-log-truncated -->";
 export const DEFAULT_OKF_LOG_MAX_ENTRIES = 500;
 
@@ -146,44 +157,6 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
   };
 }
 
-function publishBundle(staging: string, outDir: string, force: boolean): void {
-  let exists = false;
-  try {
-    const stat = lstatSync(outDir);
-    if (stat.isSymbolicLink()) throw new Error(`--out must not be a symlink: ${outDir}`);
-    exists = true;
-    const entries = listNonDot(outDir);
-    if (entries.length > 0 && !force) {
-      rmSync(staging, { recursive: true, force: true });
-      throw new Error(`--out ${outDir} is not empty; pass --force to replace it`);
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-  }
-  mkdirSync(path.dirname(outDir), { recursive: true });
-  if (exists && force) {
-    const backup = `${outDir}.okf-prev`;
-    try {
-      renameSync(outDir, backup);
-    } catch {
-      rmSync(staging, { recursive: true, force: true });
-      throw new Error(`cannot replace --out ${outDir}`);
-    }
-    try {
-      renameSync(staging, outDir);
-      rmSync(backup, { recursive: true, force: true });
-    } catch (err) {
-      try {
-        renameSync(backup, outDir);
-      } catch {
-        // Keep backup if restore fails.
-      }
-      throw err;
-    }
-    return;
-  }
-  renameSync(staging, outDir);
-}
 
 function renderMemory(memory: MemoryFile, rel: string, idToRel: Map<string, string>): string {
   const fm = memory.frontmatter;
@@ -286,38 +259,6 @@ function boldAction(raw: string): string {
   return "Update";
 }
 
-function renderFrontmatter(fields: Record<string, unknown>): string {
-  const keys = Object.keys(fields).sort((a, b) => {
-    const order = ["type", "title", "description", "tags", "timestamp"];
-    const ai = order.indexOf(a);
-    const bi = order.indexOf(b);
-    if (ai >= 0 || bi >= 0) return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
-    return a.localeCompare(b);
-  });
-  const lines = keys.flatMap((key) => yamlLine(key, fields[key]));
-  return `---\n${lines.join("\n")}\n---\n\n`;
-}
-
-function yamlLine(key: string, value: unknown): string[] {
-  if (value === undefined) return [];
-  if (Array.isArray(value)) {
-    if (value.length === 0) return [`${key}: []`];
-    if (value.every((item) => typeof item !== "object" || item === null)) {
-      return [`${key}:`, ...value.map((item) => `  - ${yamlScalar(item)}`)];
-    }
-    return [`${key}: ${JSON.stringify(value)}`];
-  }
-  if (typeof value === "object" && value !== null) return [`${key}: ${JSON.stringify(value)}`];
-  return [`${key}: ${yamlScalar(value)}`];
-}
-
-function yamlScalar(value: unknown): string {
-  if (typeof value === "string") {
-    if (value === "" || /[:#\n]/.test(value) || value !== value.trim()) return JSON.stringify(value);
-    return value;
-  }
-  return String(value);
-}
 
 function firstHeading(content: string): string | undefined {
   for (const line of content.split("\n")) {
@@ -331,15 +272,7 @@ function humanize(value: string): string {
   return value.replace(/[_-]/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
 }
 
-function toRel(abs: string, root: string): string {
-  return path.relative(path.resolve(root), path.resolve(abs)).split(path.sep).join("/");
-}
 
-function writeBundleFile(root: string, rel: string, content: string): void {
-  const dest = path.join(root, ...rel.split("/"));
-  mkdirSync(path.dirname(dest), { recursive: true });
-  writeFileSync(dest, content, "utf8");
-}
 
 function splitCsv(raw: unknown): string[] {
   if (raw === undefined || raw === null || raw === "") return [];
@@ -347,26 +280,7 @@ function splitCsv(raw: unknown): string[] {
   return parts.map((part) => part.trim()).filter((part) => part.length > 0);
 }
 
-function rejectSymlinkPath(target: string): void {
-  let current = path.resolve(target);
-  while (true) {
-    try {
-      if (lstatSync(current).isSymbolicLink()) {
-        throw new Error(`--out path component is a symlink: ${current}`);
-      }
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-    }
-    const parent = path.dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
+function toRel(abs: string, root: string): string {
+  return path.relative(path.resolve(root), path.resolve(abs)).split(path.sep).join("/");
 }
 
-function listNonDot(dir: string): string[] {
-  try {
-    return readdirSync(dir).filter((name) => name !== "." && name !== "..");
-  } catch {
-    return [];
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,11 +51,8 @@ importers:
         specifier: ^6.0.0
         version: 6.45.0(zod@3.25.76)
       zod:
-        specifier: ^3.25.28
+        specifier: ^3.24.0
         version: 3.25.76
-      zod-to-json-schema:
-        specifier: ^3.25.2
-        version: 3.25.2(zod@3.25.76)
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.12.1
@@ -681,8 +678,11 @@ importers:
         specifier: ^6.28.0
         version: 6.28.0
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.28
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -714,7 +714,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.0.0)
+        version: 1.29.0(zod@3.25.76)
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
@@ -3004,28 +3004,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.0.0)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.29
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.0.0
-      zod-to-json-schema: 3.25.2(zod@4.0.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@msgpack/msgpack@3.1.3': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -4469,10 +4447,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.0.0):
-    dependencies:
-      zod: 4.0.0
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Fixes #1950.

## Change

`remnic codegraph export-okf --project <id> --out <dir>` writes architecture, ADRs, and modules as an OKF bundle.

## Regression

`packages/remnic-core/src/coding/export-okf-codegraph.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `remnic codegraph export-okf` to export project architecture, ADRs, and code modules as an OKF bundle.
  - Supports module limits, symbol visibility options, truncation indicators, and force replacement of existing output.
  - Generated bundles include architecture cards, decisions, dependencies, metadata, and Git resources.

- **Reliability**
  - Added validation, deterministic output, safe path handling, atomic publishing, and cleanup when exports fail.
  - Existing OKF exports now use the same standardized rendering and publishing behavior.

- **Tests**
  - Added comprehensive coverage for export contents, filtering, truncation, determinism, and safety safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->