### PR TITLE
feat(admin-console): Timeline pane day view and date nav

### DIFF
--- a/.changeset/1986-admin-timeline.md
+++ b/.changeset/1986-admin-timeline.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add an admin-console Timeline pane day view with date navigation and a gated empty state.

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -2464,6 +2464,49 @@ function closeReviewDeck() {
   restoreFocusAfterDeck();
 }
 
+// ── Timeline pane (issue #1986) ───────────────────────────────────────────
+// State and date math live in timeline-pane.js. This hook only supplies
+// transport and paints the state it hands back.
+const timelinePaneState = { pane: null };
+
+function createTimelineTransport() {
+  return {
+    enabled: () =>
+      runtimeState.dashboard?.features?.some(
+        (feature) => feature.key === "activity.timeline.enabled" && feature.enabled === true,
+      ) === true,
+    getDay: (date) => fetchJson(`/engram/v1/timeline/day?date=${encodeURIComponent(date)}`),
+  };
+}
+
+function paintTimelinePane() {
+  const api = window.RemnicTimelinePane;
+  const pane = timelinePaneState.pane;
+  if (!api || !pane) return;
+  api.renderTimelinePane($("timelinePane"), pane.getState());
+}
+
+function initTimelinePane() {
+  const api = window.RemnicTimelinePane;
+  if (!api || typeof api.createTimelinePane !== "function") return;
+  const pane = api.createTimelinePane({
+    transport: createTimelineTransport(),
+    now: () => Date.now(),
+  });
+  timelinePaneState.pane = pane;
+  pane.subscribe(paintTimelinePane);
+  paintTimelinePane();
+  $("timelinePrevButton")?.addEventListener("click", () => void pane.prev());
+  $("timelineNextButton")?.addEventListener("click", () => void pane.next());
+  $("timelineTodayButton")?.addEventListener("click", () => void pane.today());
+  $("timelineDateInput")?.addEventListener("change", (event) => void pane.setDate(event.target.value));
+}
+
+async function loadTimelinePane() {
+  if (!timelinePaneState.pane) return;
+  await timelinePaneState.pane.load();
+}
+
 function initReviewDeck() {
   const factory = window.RemnicReviewDeck;
   if (!factory || typeof factory.createReviewDeck !== "function") return;
@@ -2532,6 +2575,7 @@ async function connectAndBootstrap() {
       loadAdminDashboard(),
       loadReviewDeck(),
     ]);
+    await loadTimelinePane();
   } catch (error) {
     setStatus("authStatus", error.message || String(error), "error");
   }
@@ -2608,6 +2652,7 @@ function bootstrap() {
   $("refreshRuntimeButton")?.addEventListener("click", () => void loadAdminDashboard());
   $("saveRuntimeConfigButton")?.addEventListener("click", () => void saveRuntimeConfig());
   initReviewDeck();
+  initTimelinePane();
 
   if (token) {
     void connectAndBootstrap();

--- a/admin-console/public/index.html
+++ b/admin-console/public/index.html
@@ -778,6 +778,13 @@
           grid-template-columns: 1fr;
         }
       }
+      .timeline-card {
+        border-left: 4px solid var(--accent);
+        background: #fffefb;
+        border-radius: 10px;
+        padding: 10px 12px;
+        margin: 8px 0;
+      }
     </style>
   </head>
   <body>
@@ -1120,6 +1127,22 @@
         </div>
       </section>
 
+      <section class="card" style="margin-top: 16px;" id="timelinePane">
+        <h2>Timeline</h2>
+        <div class="toolbar" id="timelineNav">
+          <button class="secondary" id="timelinePrevButton">Previous</button>
+          <button class="secondary" id="timelineTodayButton">Today</button>
+          <button class="secondary" id="timelineNextButton">Next</button>
+          <label>
+            Date
+            <input id="timelineDateInput" type="date" />
+          </label>
+        </div>
+        <div class="status" id="timelineStatus">Timeline will load after connect.</div>
+        <h3 id="timelineWeekHeading">Week</h3>
+        <div class="list" id="timelineCards"></div>
+      </section>
+
       <section class="card" style="margin-top: 16px;">
         <h2>Maintenance</h2>
         <div class="status" id="maintenanceStatus">Not loaded.</div>
@@ -1236,6 +1259,7 @@
       <div class="deck-live" id="reviewDeckLive" role="status" aria-live="polite" aria-atomic="true"></div>
     </div>
     <script src="review-deck.js"></script>
+    <script src="timeline-pane.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/admin-console/public/timeline-pane.js
+++ b/admin-console/public/timeline-pane.js
@@ -1,0 +1,185 @@
+/**
+ * Admin console Timeline pane — day view state machine (issue #1986).
+ *
+ * Pure-ish: no DOM, no fetch, no window/document access in the model.
+ * Everything that touches the outside world is injected:
+ *
+ *   transport { getDay(date), enabled() }  — server calls / feature gate
+ *   now()                                  — clock
+ *
+ * `app.js` owns the real transport and calls `renderTimelinePane`.
+ * This module owns date navigation and the view state the renderer paints.
+ *
+ * Loaded three ways: a browser `<script>` tag (window.RemnicTimelinePane),
+ * a CJS `require` (module.exports), and an ESM `import` for the node test,
+ * which reads the global this IIFE assigns.
+ */
+(function (globalScope) {
+  const EMPTY_STATE = "Timeline is off. Set activity.timeline.enabled to true.";
+  const WEEK_HEADING = "Week";
+  const DATE_KEY = /^\d{4}-\d{2}-\d{2}$/;
+  const MS_PER_DAY = 86_400_000;
+  const MS_PER_MINUTE = 60_000;
+
+  function dateKeyFromNow(now) {
+    const value = now();
+    const date = value instanceof Date ? value : new Date(value);
+    return date.toISOString().slice(0, 10);
+  }
+
+  function shiftDate(dateKey, deltaDays) {
+    const utc = Date.parse(`${dateKey}T00:00:00.000Z`);
+    if (!Number.isFinite(utc)) return dateKey;
+    return new Date(utc + deltaDays * MS_PER_DAY).toISOString().slice(0, 10);
+  }
+
+  function durationMinutes(start, end, fallback) {
+    const startMs = Date.parse(start);
+    const endMs = Date.parse(end);
+    if (Number.isFinite(startMs) && Number.isFinite(endMs)) {
+      return Math.max(0, Math.round((endMs - startMs) / MS_PER_MINUTE));
+    }
+    return typeof fallback === "number" && Number.isFinite(fallback) ? Math.max(0, fallback) : 0;
+  }
+
+  function mapCard(card) {
+    if (!card || typeof card !== "object") return null;
+    const start = card.start || card.startUtc || "";
+    const end = card.end || card.endUtc || "";
+    return {
+      start,
+      end,
+      title: typeof card.title === "string" ? card.title : "",
+      category: card.category || card.categoryId || "",
+      duration: durationMinutes(start, end, card.duration),
+    };
+  }
+
+  function mapCards(day) {
+    const raw = Array.isArray(day) ? day : day && Array.isArray(day.cards) ? day.cards : [];
+    const cards = [];
+    for (const card of raw) {
+      const mapped = mapCard(card);
+      if (mapped) cards.push(mapped);
+    }
+    return cards;
+  }
+
+  function createTimelinePane(options = {}) {
+    const transport = options.transport || {};
+    const now = typeof options.now === "function" ? options.now : () => Date.now();
+    let date = dateKeyFromNow(now);
+    let cards = [];
+    const listeners = [];
+
+    function isEnabled() {
+      return typeof transport.enabled === "function" && transport.enabled() === true;
+    }
+
+    function getState() {
+      if (!isEnabled()) {
+        return { emptyState: EMPTY_STATE };
+      }
+      return { date, cards, weekHeading: WEEK_HEADING };
+    }
+
+    function emit() {
+      const state = getState();
+      for (const listener of listeners) listener(state);
+      return state;
+    }
+
+    async function load() {
+      if (!isEnabled() || typeof transport.getDay !== "function") {
+        cards = [];
+        return emit();
+      }
+      try {
+        cards = mapCards(await transport.getDay(date));
+      } catch {
+        cards = [];
+      }
+      return emit();
+    }
+
+    function subscribe(listener) {
+      if (typeof listener === "function") listeners.push(listener);
+      return () => {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) listeners.splice(index, 1);
+      };
+    }
+
+    function setDate(next) {
+      if (typeof next !== "string" || !DATE_KEY.test(next)) return Promise.resolve(getState());
+      date = next;
+      return load();
+    }
+
+    return {
+      getState,
+      subscribe,
+      load,
+      setDate,
+      prev: () => setDate(shiftDate(date, -1)),
+      next: () => setDate(shiftDate(date, 1)),
+      today: () => setDate(dateKeyFromNow(now)),
+    };
+  }
+
+  // Paint helper lives here so app.js stays under its line ratchet.
+  function renderTimelinePane(root, state) {
+    if (!root || !state) return;
+    const doc = root.ownerDocument || globalScope.document;
+    if (!doc) return;
+    const status = root.querySelector("#timelineStatus");
+    const list = root.querySelector("#timelineCards");
+    const dateInput = root.querySelector("#timelineDateInput");
+    const week = root.querySelector("#timelineWeekHeading");
+    const nav = root.querySelector("#timelineNav");
+    if (state.emptyState) {
+      if (status) status.textContent = state.emptyState;
+      if (list) while (list.firstChild) list.removeChild(list.firstChild);
+      if (week) week.hidden = true;
+      if (nav) nav.hidden = true;
+      return;
+    }
+    if (nav) nav.hidden = false;
+    if (week) {
+      week.hidden = false;
+      week.textContent = state.weekHeading || WEEK_HEADING;
+    }
+    if (dateInput && dateInput.value !== state.date) dateInput.value = state.date || "";
+    if (status) status.textContent = state.date || "";
+    if (!list) return;
+    while (list.firstChild) list.removeChild(list.firstChild);
+    for (const card of state.cards || []) {
+      const el = doc.createElement("article");
+      el.className = "timeline-card";
+      const range = doc.createElement("div");
+      range.className = "meta";
+      range.textContent = `${card.start} – ${card.end}`;
+      const title = doc.createElement("strong");
+      title.textContent = card.title;
+      const detail = doc.createElement("div");
+      detail.className = "status";
+      detail.textContent = `${card.category} · ${card.duration} min`;
+      el.appendChild(range);
+      el.appendChild(title);
+      el.appendChild(detail);
+      list.appendChild(el);
+    }
+  }
+
+  const api = Object.freeze({
+    EMPTY_STATE,
+    WEEK_HEADING,
+    createTimelinePane,
+    renderTimelinePane,
+  });
+
+  globalScope.RemnicTimelinePane = api;
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/admin-console/public/timeline-pane.test.mjs
+++ b/admin-console/public/timeline-pane.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Timeline pane state-machine tests (issue #1986).
+ *
+ * Drives `timeline-pane.js` directly with a fake transport and a fake clock —
+ * no browser, no DOM, no network. Fixtures mirror a `GET /engram/v1/timeline/day`
+ * payload: startUtc/endUtc, title, categoryId.
+ *
+ * Run it with: node admin-console/public/timeline-pane.test.mjs
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+await import(pathToFileURL(path.join(here, "timeline-pane.js")).href);
+const { createTimelinePane, EMPTY_STATE, WEEK_HEADING } = globalThis.RemnicTimelinePane;
+
+const TODAY_MS = Date.parse("2026-06-01T12:00:00.000Z");
+
+function fixtureDay(date = "2026-06-01") {
+  return {
+    formatVersion: 1,
+    date,
+    timezone: "UTC",
+    startUtc: `${date}T00:00:00.000Z`,
+    endUtc: `${date.slice(0, 8)}${String(Number(date.slice(8, 10)) + 1).padStart(2, "0")}T00:00:00.000Z`,
+    cards: [
+      {
+        id: "tlc_fixture_standup",
+        kind: "activity",
+        title: "Morning standup",
+        summary: "Team sync",
+        categoryId: "communication",
+        startUtc: `${date}T09:00:00.000Z`,
+        endUtc: `${date}T09:30:00.000Z`,
+      },
+      {
+        id: "tlc_fixture_focus",
+        kind: "activity",
+        title: "Deep work",
+        summary: "Focused writing",
+        categoryId: "focus",
+        startUtc: `${date}T10:00:00.000Z`,
+        endUtc: `${date}T12:00:00.000Z`,
+      },
+    ],
+  };
+}
+
+function createTransport({ enabled = true, getDay } = {}) {
+  const calls = { getDay: [] };
+  return {
+    calls,
+    enabled: () => enabled,
+    getDay(date) {
+      calls.getDay.push(date);
+      return Promise.resolve(getDay ? getDay(date) : fixtureDay(date));
+    },
+  };
+}
+
+function paneWith(transportOptions = {}, paneOptions = {}) {
+  const transport = createTransport(transportOptions);
+  const pane = createTimelinePane({
+    transport,
+    now: () => TODAY_MS,
+    ...paneOptions,
+  });
+  return { pane, transport };
+}
+
+test("disabled gate is one empty-state string and does not fetch", async () => {
+  const { pane, transport } = paneWith({ enabled: false });
+
+  const state = await pane.load();
+
+  assert.deepEqual(state, { emptyState: EMPTY_STATE });
+  assert.equal(transport.calls.getDay.length, 0);
+  await pane.next();
+  assert.deepEqual(pane.getState(), { emptyState: EMPTY_STATE });
+  assert.equal(transport.calls.getDay.length, 0);
+});
+
+test("enabled day lists fixture cards with start end title category duration", async () => {
+  const { pane, transport } = paneWith();
+
+  const state = await pane.load();
+
+  assert.equal(state.emptyState, undefined);
+  assert.equal(state.date, "2026-06-01");
+  assert.equal(state.weekHeading, WEEK_HEADING);
+  assert.equal(state.cards.length, 2);
+  assert.deepEqual(state.cards[0], {
+    start: "2026-06-01T09:00:00.000Z",
+    end: "2026-06-01T09:30:00.000Z",
+    title: "Morning standup",
+    category: "communication",
+    duration: 30,
+  });
+  assert.deepEqual(state.cards[1], {
+    start: "2026-06-01T10:00:00.000Z",
+    end: "2026-06-01T12:00:00.000Z",
+    title: "Deep work",
+    category: "focus",
+    duration: 120,
+  });
+  assert.deepEqual(transport.calls.getDay, ["2026-06-01"]);
+});
+
+test("date nav prev next today and setDate refetch the selected day", async () => {
+  const { pane, transport } = paneWith();
+  await pane.load();
+
+  const next = await pane.next();
+  assert.equal(next.date, "2026-06-02");
+  assert.equal(next.cards[0].start, "2026-06-02T09:00:00.000Z");
+
+  const prev = await pane.prev();
+  assert.equal(prev.date, "2026-06-01");
+
+  const jumped = await pane.setDate("2026-05-20");
+  assert.equal(jumped.date, "2026-05-20");
+  assert.equal(jumped.cards[0].title, "Morning standup");
+
+  const today = await pane.today();
+  assert.equal(today.date, "2026-06-01");
+
+  assert.deepEqual(transport.calls.getDay, [
+    "2026-06-01",
+    "2026-06-02",
+    "2026-06-01",
+    "2026-05-20",
+    "2026-06-01",
+  ]);
+});
+
+test("setDate ignores a non date key", async () => {
+  const { pane, transport } = paneWith();
+  await pane.load();
+
+  const state = await pane.setDate("not-a-date");
+  assert.equal(state.date, "2026-06-01");
+  assert.deepEqual(transport.calls.getDay, ["2026-06-01"]);
+});


### PR DESCRIPTION
Fixes #1986

## Change
Admin console Timeline pane: day card list, prev/next/today/setDate.
`timeline.enabled: false` is one empty state and does not fetch a day.

## Test
`node admin-console/public/timeline-pane.test.mjs`

## Out of this PR
Recategorize POST, week grid.