### PR TITLE
feat(recall): state-view annotator

### DIFF
--- a/.changeset/1952-recall-state-views.md
+++ b/.changeset/1952-recall-state-views.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add a recall state-view annotator that labels current, historical, and transition facts. `recallStateViews` defaults to false and is identity until parseConfig wiring lands.

--- a/packages/remnic-core/src/recall-state-view.test.ts
+++ b/packages/remnic-core/src/recall-state-view.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  annotateStateView,
+  formatSupersededPrefix,
+  isChangeOrientedQuery,
+  parseRecallStateViews,
+  shouldWidenSuperseded,
+  type StateViewChain,
+  type StateViewResult,
+} from "./recall-state-view.js";
+
+function fact(id: string, extra: Partial<StateViewResult> = {}): StateViewResult {
+  return { id, ...extra };
+}
+
+const PAIR: StateViewChain[] = [{ predecessorId: "old-job", successorId: "new-job", supersededAt: "2026-03-01" }];
+
+const PAIR_RESULTS: StateViewResult[] = [
+  fact("new-job", { status: "active" }),
+  fact("old-job", { status: "superseded", supersededBy: "new-job", supersededAt: "2026-03-01" }),
+];
+
+test("change-intent query labels both facts in a superseded pair", () => {
+  const labeled = annotateStateView(PAIR_RESULTS, "when did the job title change", PAIR, { enabled: true });
+  assert.equal(labeled.length, 2);
+  assert.equal(labeled[0]?.id, "new-job");
+  assert.equal(labeled[0]?.stateLabel, "current");
+  assert.equal(labeled[1]?.id, "old-job");
+  assert.equal(labeled[1]?.stateLabel, "historical");
+});
+
+test("change-intent conjugations fire the annotator", () => {
+  const phrases = [
+    "when did we switch",
+    "we used to",
+    "before the move",
+    "after the cutover",
+    "they switched vendors",
+    "she switches stacks",
+    "switching away from it",
+    "the title changed",
+    "it changes next week",
+    "they are changing providers",
+  ];
+  for (const query of phrases) {
+    assert.equal(isChangeOrientedQuery(query), true, query);
+    const labeled = annotateStateView(PAIR_RESULTS, query, PAIR, { enabled: true });
+    assert.equal(labeled[0]?.stateLabel, "current", query);
+    assert.equal(labeled[1]?.stateLabel, "historical", query);
+  }
+});
+
+test("non-change query is identical (same array reference, no labels)", () => {
+  const input = PAIR_RESULTS.map((row) => ({ ...row }));
+  const out = annotateStateView(input, "what is the current job title", PAIR, { enabled: true });
+  assert.equal(out, input);
+  assert.equal(out[0]?.stateLabel, undefined);
+  assert.equal(out[1]?.stateLabel, undefined);
+});
+
+test("recallStateViews false is identity (same array reference)", () => {
+  const input = PAIR_RESULTS.map((row) => ({ ...row }));
+  assert.equal(annotateStateView(input, "when did the job title change", PAIR), input);
+  assert.equal(annotateStateView(input, "when did the job title change", PAIR, { enabled: false }), input);
+  assert.equal(input[0]?.stateLabel, undefined);
+});
+
+test("superseded never appears without its successor", () => {
+  const orphan = [fact("old-job", { status: "superseded", supersededBy: "new-job" })];
+  const out = annotateStateView(orphan, "when did this change", PAIR, { enabled: true });
+  assert.deepEqual(out, []);
+  assert.equal(shouldWidenSuperseded("new-job", new Set(["old-job"])), false);
+  assert.equal(shouldWidenSuperseded("new-job", new Set(["old-job", "new-job"])), true);
+  assert.equal(shouldWidenSuperseded(undefined, new Set(["new-job"])), false);
+});
+
+test("annotateStateView is sort-stable", () => {
+  const reversed = [PAIR_RESULTS[1]!, PAIR_RESULTS[0]!];
+  const labeled = annotateStateView(reversed, "when did the title change", PAIR, { enabled: true });
+  assert.deepEqual(
+    labeled.map((row) => row.id),
+    ["old-job", "new-job"],
+  );
+  assert.equal(labeled[0]?.stateLabel, "historical");
+  assert.equal(labeled[1]?.stateLabel, "current");
+});
+
+test("middle hop of a three-node chain is transition", () => {
+  const chains: StateViewChain[] = [
+    { predecessorId: "v1", successorId: "v2" },
+    { predecessorId: "v2", successorId: "v3" },
+  ];
+  const results = [
+    fact("v1", { status: "superseded", supersededBy: "v2" }),
+    fact("v2", { status: "superseded", supersededBy: "v3" }),
+    fact("v3", { status: "active" }),
+  ];
+  const labeled = annotateStateView(results, "what changed", chains, { enabled: true });
+  assert.deepEqual(
+    labeled.map((row) => [row.id, row.stateLabel]),
+    [
+      ["v1", "historical"],
+      ["v2", "transition"],
+      ["v3", "current"],
+    ],
+  );
+});
+
+test("formatSupersededPrefix matches the injected-block contract", () => {
+  assert.equal(formatSupersededPrefix("2026-03-01", "new-job"), "[superseded 2026-03-01 by new-job]");
+});
+
+test("parseRecallStateViews honors 0/false and defaults off", () => {
+  assert.equal(parseRecallStateViews(undefined), false);
+  assert.equal(parseRecallStateViews(false), false);
+  assert.equal(parseRecallStateViews(0), false);
+  assert.equal(parseRecallStateViews("false"), false);
+  assert.equal(parseRecallStateViews("0"), false);
+  assert.equal(parseRecallStateViews(true), true);
+  assert.equal(parseRecallStateViews(1), true);
+  assert.equal(parseRecallStateViews("true"), true);
+});
+
+test("annotateStateView does not mutate input rows", () => {
+  const input = PAIR_RESULTS.map((row) => ({ ...row }));
+  annotateStateView(input, "when did this change", PAIR, { enabled: true });
+  assert.equal(input[0]?.stateLabel, undefined);
+  assert.equal(input[1]?.stateLabel, undefined);
+});

--- a/packages/remnic-core/src/recall-state-view.ts
+++ b/packages/remnic-core/src/recall-state-view.ts
@@ -30,15 +30,23 @@ export interface StateViewResult {
 
 export const DEFAULT_RECALL_STATE_VIEWS = false;
 
-const CHANGE_PHRASE_RE = /\b(?:when\s+did|used\s+to)\b/i;
-const CHANGE_WORD_RE = /\b(?:before|after|switch(?:es|ed|ing)?|chang(?:e|es|ed|ing))\b/i;
+const CHANGE_WORDS = ["before", "after", "switch", "switches", "switched", "switching", "change", "changes", "changed", "changing"];
 
 export function parseRecallStateViews(raw: unknown): boolean {
   return coerceBooleanLike(raw, "recallStateViews") === true;
 }
 
 export function isChangeOrientedQuery(query: string): boolean {
-  return CHANGE_PHRASE_RE.test(query) || CHANGE_WORD_RE.test(query);
+  const lower = query.toLowerCase();
+  if (lower.includes("when did") || lower.includes("used to")) return true;
+  return CHANGE_WORDS.some((word) => {
+    const idx = lower.indexOf(word);
+    if (idx < 0) return false;
+    const before = idx === 0 || !/[a-z0-9]/.test(lower[idx - 1] ?? "");
+    const afterIdx = idx + word.length;
+    const after = afterIdx >= lower.length || !/[a-z0-9]/.test(lower[afterIdx] ?? "");
+    return before && after;
+  });
 }
 
 export function shouldWidenSuperseded(

--- a/packages/remnic-core/src/recall-state-view.ts
+++ b/packages/remnic-core/src/recall-state-view.ts
@@ -1,0 +1,130 @@
+/**
+ * Recall state views (issue #1952).
+ *
+ * Config key: `recallStateViews` (default false). When false, annotateStateView
+ * is identity: same array reference, no `stateLabel`. config.ts is at its
+ * fileSizeGrandfather ceiling, so parseConfig wiring waits for a later PR.
+ * Call `parseRecallStateViews` at the recall seam when that lands.
+ *
+ * Change-intent morphology lives here (do not grow intent.ts). A superseded
+ * memory is admitted only when its successor is also in the candidate set.
+ */
+import { coerceBooleanLike } from "./connectors/coerce.js";
+
+export type StateLabel = "current" | "historical" | "transition";
+
+export interface StateViewChain {
+  predecessorId: string;
+  successorId: string;
+  supersededAt?: string;
+}
+
+export interface StateViewResult {
+  id?: string;
+  docid?: string;
+  status?: string;
+  supersededBy?: string;
+  supersededAt?: string;
+  stateLabel?: StateLabel;
+}
+
+export const DEFAULT_RECALL_STATE_VIEWS = false;
+
+const CHANGE_PHRASE_RE = /\b(?:when\s+did|used\s+to)\b/i;
+const CHANGE_WORD_RE = /\b(?:before|after|switch(?:es|ed|ing)?|chang(?:e|es|ed|ing))\b/i;
+
+export function parseRecallStateViews(raw: unknown): boolean {
+  return coerceBooleanLike(raw, "recallStateViews") === true;
+}
+
+export function isChangeOrientedQuery(query: string): boolean {
+  return CHANGE_PHRASE_RE.test(query) || CHANGE_WORD_RE.test(query);
+}
+
+export function shouldWidenSuperseded(
+  successorId: string | undefined,
+  candidateIds: ReadonlySet<string>,
+): boolean {
+  return typeof successorId === "string" && successorId.length > 0 && candidateIds.has(successorId);
+}
+
+export function formatSupersededPrefix(date: string, successorId: string): string {
+  return `[superseded ${date} by ${successorId}]`;
+}
+
+export function resultStateViewId(result: StateViewResult): string {
+  return result.id ?? result.docid ?? "";
+}
+
+function buildSuccessorMap(results: readonly StateViewResult[], chains: readonly StateViewChain[]): Map<string, string> {
+  const byPred = new Map<string, string>();
+  for (const chain of chains) {
+    if (chain.predecessorId && chain.successorId) {
+      byPred.set(chain.predecessorId, chain.successorId);
+    }
+  }
+  for (const result of results) {
+    const id = resultStateViewId(result);
+    if (id && result.supersededBy) byPred.set(id, result.supersededBy);
+  }
+  return byPred;
+}
+
+function labelFor(
+  id: string,
+  result: StateViewResult,
+  byPred: Map<string, string>,
+  admittedIds: ReadonlySet<string>,
+): StateLabel {
+  const successorId = result.supersededBy ?? byPred.get(id);
+  const isPred = shouldWidenSuperseded(successorId, admittedIds);
+  let isSucc = false;
+  for (const [predId, succId] of byPred) {
+    if (succId === id && admittedIds.has(predId)) {
+      isSucc = true;
+      break;
+    }
+  }
+  if (isPred && isSucc) return "transition";
+  if (isPred) return "historical";
+  if (isSucc) return "current";
+  return result.status === "superseded" ? "historical" : "current";
+}
+
+export function annotateStateView<T extends StateViewResult>(
+  results: T[],
+  query: string,
+  chains: readonly StateViewChain[],
+  options: { enabled?: boolean } = {},
+): T[] {
+  const enabled = options.enabled === true;
+  if (!enabled || !isChangeOrientedQuery(query)) return results;
+
+  const byPred = buildSuccessorMap(results, chains);
+  const candidateIds = new Set<string>();
+  for (const result of results) {
+    const id = resultStateViewId(result);
+    if (id) candidateIds.add(id);
+  }
+
+  const admitted: T[] = [];
+  for (const result of results) {
+    const id = resultStateViewId(result);
+    const successorId = result.supersededBy ?? byPred.get(id);
+    const superseded = result.status === "superseded" || Boolean(result.supersededBy) || byPred.has(id);
+    if (!superseded || shouldWidenSuperseded(successorId, candidateIds)) {
+      admitted.push(result);
+    }
+  }
+
+  const admittedIds = new Set<string>();
+  for (const result of admitted) {
+    const id = resultStateViewId(result);
+    if (id) admittedIds.add(id);
+  }
+
+  return admitted.map((result) => {
+    const id = resultStateViewId(result);
+    return { ...result, stateLabel: labelFor(id, result, byPred, admittedIds) };
+  });
+}


### PR DESCRIPTION
Part of #1952

## Change
Pure `annotateStateView` / `shouldWidenSuperseded` / change-intent helper.
`recallStateViews` default false is identity.

## Not in this PR
parseConfig + retrieval/orchestrator wiring (file-size ratchets).

## Test
`packages/remnic-core/src/recall-state-view.test.ts`