### PR TITLE
fix(ci): write parsed-keys snapshot atomically

### DIFF
--- a/.changeset/ci-snapshot-write.md
+++ b/.changeset/ci-snapshot-write.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Atomic `--write` for parsed-keys snapshot regeneration. Do not redirect stdout onto the snapshot file.

--- a/scripts/config-contract/extract-parsed-keys.ts
+++ b/scripts/config-contract/extract-parsed-keys.ts
@@ -1089,27 +1089,34 @@ export function extractRealConfigKeys(repoRoot: string): ExtractedConfigKeys {
   };
 }
 
-// ---------------------------------------------------------------------------
-// CLI entry: print the extraction for the REAL config surface as sorted JSON.
-// ---------------------------------------------------------------------------
+// CLI: print JSON, or `npx tsx scripts/config-contract/extract-parsed-keys.ts --write`
+// to replace the snapshot atomically. Never redirect stdout onto the snapshot —
+// a failed extract would empty the file (this run, 8d64a716a).
 const invokedDirectly =
   process.argv[1] !== undefined &&
-  // pathToFileURL normalizes drive letters and separators on every
-  // platform — `URL.pathname` comparison broke on Windows (review finding).
   pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
 
 if (invokedDirectly) {
   const repoRoot = process.cwd();
   const result = extractRealConfigKeys(repoRoot);
-  // Omit the volatile `line` from the committed snapshot: the stable `id`
-  // identifies each construct, so an unrelated edit that merely shifts lines no
-  // longer forces snapshot churn / a preflight failure (issue #1990 review).
   const snapshot = {
     ...result,
     unparseable: result.unparseable.map(({ file, reason, id }) => ({ file, reason, id })),
   };
-  process.stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+  if (snapshot.keys.length === 0) {
+    throw new Error("extract-parsed-keys: refused to emit an empty key list");
+  }
+  const json = `${JSON.stringify(snapshot, null, 2)}\n`;
+  if (process.argv.includes("--write")) {
+    const target = path.join(repoRoot, "scripts", "config-contract", "parsed-keys.snapshot.json");
+    const tmp = `${target}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, json);
+    fs.renameSync(tmp, target);
+  } else {
+    process.stdout.write(json);
+  }
 }
+
 
 /** All module-parser files the real extraction should include. */
 export function collectModuleParserFiles(repoRoot: string): string[] {

--- a/scripts/validate-config-contract.ts
+++ b/scripts/validate-config-contract.ts
@@ -381,17 +381,17 @@ function main() {
     if (JSON.stringify(extracted.keys) !== JSON.stringify(snapshot.keys)) {
       failures.push({
         message:
-          "[snapshot] parsed-keys.snapshot.json is stale — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts > scripts/config-contract/parsed-keys.snapshot.json`",
+          "[snapshot] parsed-keys.snapshot.json is stale — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts --write`",
       });
     }
     if (JSON.stringify(extractedUnparseable) !== JSON.stringify(snapshot.unparseable)) {
       failures.push({
-        message: "[snapshot] parsed-keys.snapshot.json unparseable list drifted — regenerate the snapshot",
+        message: "[snapshot] parsed-keys.snapshot.json unparseable list drifted — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts --write`",
       });
     }
     if (JSON.stringify(extracted.ambiguousValueMembers) !== JSON.stringify(snapshot.ambiguousValueMembers)) {
       failures.push({
-        message: "[snapshot] parsed-keys.snapshot.json ambiguousValueMembers drifted — regenerate the snapshot",
+        message: "[snapshot] parsed-keys.snapshot.json ambiguousValueMembers drifted — regenerate with `npx tsx scripts/config-contract/extract-parsed-keys.ts --write`",
       });
     }
   }


### PR DESCRIPTION
This run emptied `parsed-keys.snapshot.json` by redirecting extractor stdout onto the file.

## Change
`npx tsx scripts/config-contract/extract-parsed-keys.ts --write` writes via temp+rename.
Refuses an empty key list.
Contract errors name `--write`, not a stdout redirect.

## Other hits this run (not in this PR)
- New `parseConfig` keys need schema + docs in the same commit
- Do not add `config.*Enabled` reads outside capabilities.ts
- `\s+` in regex literals fails regex-safety
- Sibling `activity.timeline.*` keys conflict on rebase