### PR TITLE
fix(plugin-openclaw): scope flush write restriction to plugin state

### DIFF
--- a/.changeset/2547-flush-write-scope.md
+++ b/.changeset/2547-flush-write-scope.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Advertise `writeRestrictPrefix` on the OpenClaw flush plan so a host can scope flush-turn writes to Remnic plugin state. Soften flush planner prompts so they no longer ban other workspace writes.

--- a/packages/plugin-openclaw/src/memory-flush-plan.test.ts
+++ b/packages/plugin-openclaw/src/memory-flush-plan.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildMemoryFlushPlan } from "./memory-flush-plan.js";
+
+test("flush plan keeps relativePath and scopes writeRestrictPrefix to plugin state", () => {
+  const plan = buildMemoryFlushPlan({ serviceId: "openclaw-remnic" });
+  const prompts = `${plan.prompt}\n${plan.systemPrompt}`;
+
+  assert.equal(plan.relativePath, "state/plugins/openclaw-remnic/flush-plan.md");
+  assert.equal(plan.writeRestrictPrefix, "state/plugins/openclaw-remnic/");
+  assert.match(prompts, /flush-plan file/i);
+  assert.match(prompts, /dated memory paths/i);
+  assert.match(prompts, /credentials/i);
+  assert.doesNotMatch(prompts, /\bonly\b/i);
+});

--- a/packages/plugin-openclaw/src/memory-flush-plan.ts
+++ b/packages/plugin-openclaw/src/memory-flush-plan.ts
@@ -2,10 +2,11 @@
  * Flush-plan resolver for the OpenClaw memory-slot capability.
  *
  * The host asks the memory plugin how to spill a long transcript into durable
- * memory: thresholds, the model to plan with, and the single file the write
- * tool is allowed to append to. The answer is pure configuration, so both
- * bridge modes resolve it identically — a delegate-side copy would drift the
- * prompts and the allowed path apart from the embedded ones.
+ * memory: thresholds, the model to plan with, and the flush-plan file that
+ * Remnic later ingests. `writeRestrictPrefix` is an unknown-safe extra field
+ * so a host can scope its write guard to Remnic plugin state instead of the
+ * whole workspace (issue #2547). Hosts that ignore extra fields still key
+ * the guard off `relativePath`.
  */
 
 export type MemoryFlushPlan = {
@@ -16,6 +17,11 @@ export type MemoryFlushPlan = {
   prompt: string;
   systemPrompt: string;
   relativePath: string;
+  /**
+   * Prefix a host may use to scope flush-turn writes to Remnic plugin state.
+   * Optional in the type so older hosts can ignore it.
+   */
+  writeRestrictPrefix?: string;
 };
 
 export type MemoryFlushPlanOptions = {
@@ -36,9 +42,9 @@ const DEFAULT_MAX_TURN_CHARS = 8_000;
 const MIN_MAX_TURN_CHARS = 1_000;
 
 const FLUSH_PROMPT =
-  "Flush the recent OpenClaw transcript into Remnic memory by appending to the allowed flush-plan file only. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.";
+  "Flush the recent OpenClaw transcript into Remnic memory by appending durable notes to the flush-plan file. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.";
 const FLUSH_SYSTEM_PROMPT =
-  "You are Remnic's memory flush planner. Read the transcript and append concise durable memory notes to the file the write tool allows. Do not create files, directories, or dated paths; use only the allowed flush-plan file. Ignore runtime metadata, credentials, transient command noise, and content that is not worth remembering.";
+  "You are Remnic's memory flush planner. Read the transcript and append concise durable memory notes to the flush-plan file. Do not create dated memory paths or write credentials. Ignore runtime metadata, transient command noise, and content that is not worth remembering.";
 
 export function buildMemoryFlushPlan(options: MemoryFlushPlanOptions): MemoryFlushPlan {
   const maxTurnChars =
@@ -58,5 +64,6 @@ export function buildMemoryFlushPlan(options: MemoryFlushPlanOptions): MemoryFlu
     prompt: FLUSH_PROMPT,
     systemPrompt: FLUSH_SYSTEM_PROMPT,
     relativePath: ["state", "plugins", options.serviceId, "flush-plan.md"].join("/"),
+    writeRestrictPrefix: ["state", "plugins", options.serviceId, ""].join("/"),
   };
 }

--- a/tests/openclaw-registration-capture.test.ts
+++ b/tests/openclaw-registration-capture.test.ts
@@ -135,7 +135,7 @@ test("flush plan pins configured gateway task model", async () => {
   });
 });
 
-test("flush plan prompt constrains writes to the allowed flush-plan file", async () => {
+test("flush plan advertises writeRestrictPrefix and does not ban workspace writes", async () => {
   await withCapturedRegistration((plugin) => {
     const capture = captureOpenClawRegistrationApi();
 
@@ -148,8 +148,11 @@ test("flush plan prompt constrains writes to the allowed flush-plan file", async
     const prompt = `${String(plan.prompt)}\n${String(plan.systemPrompt)}`;
 
     assert.equal(plan.relativePath, "state/plugins/openclaw-remnic/flush-plan.md");
-    assert.match(prompt, /allowed flush-plan file/i);
-    assert.match(prompt, /Do not create files, directories, or dated paths/i);
+    assert.equal(plan.writeRestrictPrefix, "state/plugins/openclaw-remnic/");
+    assert.match(prompt, /flush-plan file/i);
+    assert.match(prompt, /dated memory paths/i);
+    assert.match(prompt, /credentials/i);
+    assert.doesNotMatch(prompt, /\bonly\b/i);
     assert.doesNotMatch(prompt, /memory-candidates/i);
     assert.doesNotMatch(prompt, /memory candidates/i);
   });


### PR DESCRIPTION
Fixes #2547

## Change
Flush plan still targets `state/plugins/<id>/flush-plan.md`.
Adds `writeRestrictPrefix: state/plugins/<id>/`.
Prompts no longer ban other workspace writes.

A host that ignores the extra field still keys the tool guard off `relativePath`.

## Test
`packages/plugin-openclaw/src/memory-flush-plan.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped write protection for memory flush operations.
  * Flush guidance now supports durable notes in the designated plan file while allowing related workspace writes.
  * Added clearer references to dated memory paths and credential handling.

* **Bug Fixes**
  * Removed overly restrictive instructions that prevented valid workspace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->