### PR TITLE
feat(activity): managed-region vault publisher

### DIFF
--- a/.changeset/1985-vault-publisher.md
+++ b/.changeset/1985-vault-publisher.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add a managed-region vault publisher that replaces only the bytes between `<!-- remnic:<name>:start -->` and `<!-- remnic:<name>:end -->`. Missing markers and missing notes are no-ops. Part of #1985.

--- a/packages/remnic-core/src/activity/vault-publish.test.ts
+++ b/packages/remnic-core/src/activity/vault-publish.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { applyManagedRegion, publishVaultRegion } from "./vault-publish.js";
+
+const START = "<!-- remnic:timeline:start -->";
+const END = "<!-- remnic:timeline:end -->";
+
+function withVault(fn: (vaultPath: string) => void): void {
+  const vaultPath = mkdtempSync(path.join(tmpdir(), "remnic-vault-"));
+  try {
+    fn(vaultPath);
+  } finally {
+    rmSync(vaultPath, { recursive: true, force: true });
+  }
+}
+
+test("applyManagedRegion replaces only the marked region", () => {
+  const fileText = [
+    "---",
+    "title: daily",
+    "---",
+    "",
+    "human notes",
+    START,
+    "old cards",
+    END,
+    "more human",
+    "",
+  ].join("\n");
+  const result = applyManagedRegion(fileText, {
+    strategy: "markers",
+    name: "timeline",
+    content: "new cards",
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(
+    result.text,
+    [
+      "---",
+      "title: daily",
+      "---",
+      "",
+      "human notes",
+      START,
+      "new cards",
+      END,
+      "more human",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("applyManagedRegion is a no-op when markers are missing", () => {
+  const fileText = "no managed region here\n";
+  const result = applyManagedRegion(fileText, {
+    strategy: "markers",
+    name: "timeline",
+    content: "new cards",
+  });
+  assert.deepEqual(result, { ok: false, reason: "no_marker", text: fileText });
+});
+
+test("applyManagedRegion preserves CRLF outside and inside the owned region", () => {
+  const fileText = [
+    "---",
+    "title: daily",
+    "---",
+    "",
+    "human notes",
+    START,
+    "old cards",
+    END,
+    "more human",
+    "",
+  ].join("\r\n");
+  const result = applyManagedRegion(fileText, {
+    strategy: "markers",
+    name: "timeline",
+    content: "new cards\nline two",
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(
+    result.text,
+    [
+      "---",
+      "title: daily",
+      "---",
+      "",
+      "human notes",
+      START,
+      "new cards",
+      "line two",
+      END,
+      "more human",
+      "",
+    ].join("\r\n"),
+  );
+  assert.equal(result.text.includes("\n") && !result.text.includes("\r\n"), false);
+});
+
+test("applyManagedRegion keeps every outside byte identical", () => {
+  const prefix = "---\nkeep: me\n---\n\n- [ ] task\n```dataview\nLIST\n```\n";
+  const suffix = "\n<!-- other-agent:start -->\nleave this\n<!-- other-agent:end -->\n  trailing  \n";
+  const fileText = `${prefix}${START}\nold\n${END}${suffix}`;
+  const startAt = fileText.indexOf(START);
+  const endAt = fileText.indexOf(END);
+  const before = Buffer.from(fileText.slice(0, startAt + START.length), "utf8");
+  const after = Buffer.from(fileText.slice(endAt), "utf8");
+  const result = applyManagedRegion(fileText, {
+    strategy: "markers",
+    name: "timeline",
+    content: "replacement",
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  const nextStart = result.text.indexOf(START);
+  const nextEnd = result.text.indexOf(END);
+  assert.deepEqual(Buffer.from(result.text.slice(0, nextStart + START.length), "utf8"), before);
+  assert.deepEqual(Buffer.from(result.text.slice(nextEnd), "utf8"), after);
+});
+
+test("publishVaultRegion updates an existing note and skips an unchanged rewrite", () => {
+  withVault((vaultPath) => {
+    const relativeFile = "Daily Notes/2026-08-17.md";
+    const dest = path.join(vaultPath, relativeFile);
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, `intro\n${START}\nold\n${END}\noutro\n`);
+    const first = publishVaultRegion({
+      vaultPath,
+      relativeFile,
+      name: "timeline",
+      content: "new cards",
+    });
+    assert.deepEqual(first, { ok: true, status: "updated" });
+    assert.equal(readFileSync(dest, "utf8"), `intro\n${START}\nnew cards\n${END}\noutro\n`);
+    const mtime = statSync(dest).mtimeMs;
+    const second = publishVaultRegion({
+      vaultPath,
+      relativeFile,
+      name: "timeline",
+      content: "new cards",
+    });
+    assert.deepEqual(second, { ok: true, status: "unchanged" });
+    assert.equal(statSync(dest).mtimeMs, mtime);
+  });
+});
+
+test("publishVaultRegion never creates a missing file", () => {
+  withVault((vaultPath) => {
+    const relativeFile = "missing.md";
+    const result = publishVaultRegion({
+      vaultPath,
+      relativeFile,
+      name: "timeline",
+      content: "new cards",
+    });
+    assert.deepEqual(result, { ok: false, reason: "missing_file" });
+    assert.equal(existsSync(path.join(vaultPath, relativeFile)), false);
+  });
+});

--- a/packages/remnic-core/src/activity/vault-publish.ts
+++ b/packages/remnic-core/src/activity/vault-publish.ts
@@ -1,0 +1,101 @@
+/**
+ * Managed-region vault publisher (issue #1985 first slice).
+ *
+ * Replaces only the bytes between `<!-- remnic:<name>:start -->` and
+ * `<!-- remnic:<name>:end -->`. Missing markers leave the file unchanged.
+ * `activity.timeline.vault.enabled` stays default-false until a later parse
+ * slice; this module does not read config.
+ */
+import { createHash, randomBytes } from "node:crypto";
+import { readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { expandTildePath } from "../utils/path.js";
+
+export type ApplyManagedRegionResult =
+  | { ok: true; text: string }
+  | { ok: false; reason: "no_marker"; text: string };
+
+export type PublishVaultRegionResult =
+  | { ok: true; status: "updated" | "unchanged" }
+  | { ok: false; reason: "no_marker" | "missing_file" | "not_directory" };
+
+export function applyManagedRegion(
+  fileText: string,
+  opts: { strategy: "markers"; name: string; content: string },
+): ApplyManagedRegionResult {
+  const startMarker = `<!-- remnic:${opts.name}:start -->`;
+  const endMarker = `<!-- remnic:${opts.name}:end -->`;
+  const startIdx = fileText.indexOf(startMarker);
+  if (startIdx === -1) return { ok: false, reason: "no_marker", text: fileText };
+  const endIdx = fileText.indexOf(endMarker, startIdx + startMarker.length);
+  if (endIdx === -1) return { ok: false, reason: "no_marker", text: fileText };
+
+  const eol = fileText.includes("\r\n") ? "\r\n" : "\n";
+  let body = opts.content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (eol === "\r\n") body = body.replace(/\n/g, "\r\n");
+  if (body.endsWith(eol)) body = body.slice(0, -eol.length);
+
+  return {
+    ok: true,
+    text: `${fileText.slice(0, startIdx + startMarker.length)}${eol}${body}${eol}${fileText.slice(endIdx)}`,
+  };
+}
+
+export function publishVaultRegion(input: {
+  vaultPath: string;
+  relativeFile: string;
+  name: string;
+  content: string;
+}): PublishVaultRegionResult {
+  const vault = expandTildePath(input.vaultPath);
+  try {
+    if (!statSync(vault).isDirectory()) return { ok: false, reason: "not_directory" };
+  } catch {
+    return { ok: false, reason: "not_directory" };
+  }
+
+  if (input.relativeFile.length === 0 || path.isAbsolute(input.relativeFile)) {
+    return { ok: false, reason: "missing_file" };
+  }
+  const root = path.resolve(vault);
+  const dest = path.resolve(root, input.relativeFile);
+  const rel = path.relative(root, dest);
+  if (rel.length === 0 || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return { ok: false, reason: "missing_file" };
+  }
+
+  let existing: string;
+  try {
+    if (!statSync(dest).isFile()) return { ok: false, reason: "missing_file" };
+    existing = readFileSync(dest, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { ok: false, reason: "missing_file" };
+    throw err;
+  }
+
+  const applied = applyManagedRegion(existing, {
+    strategy: "markers",
+    name: input.name,
+    content: input.content,
+  });
+  if (!applied.ok) return { ok: false, reason: applied.reason };
+
+  const prevHash = createHash("sha256").update(existing, "utf8").digest("hex");
+  const nextHash = createHash("sha256").update(applied.text, "utf8").digest("hex");
+  if (prevHash === nextHash) return { ok: true, status: "unchanged" };
+
+  const tmpPath = path.join(path.dirname(dest), `.remnic-vault-${randomBytes(8).toString("hex")}.tmp`);
+  writeFileSync(tmpPath, applied.text);
+  try {
+    renameSync(tmpPath, dest);
+  } catch (renameErr) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // temp cleanup is best-effort
+    }
+    throw renameErr;
+  }
+  return { ok: true, status: "updated" };
+}


### PR DESCRIPTION
Part of #1985

## Change
`applyManagedRegion` / `publishVaultRegion`.
Marker replace only. Missing markers skip. Atomic write. No file create.

## Out of this PR
Heading strategy, CLI, standup/weekly/locations, wikilinks, frontmatter.

## Test
`packages/remnic-core/src/activity/vault-publish.test.ts`