### PR TITLE
feat(recall): expand and traverse helpers

### DIFF
--- a/.changeset/1956-navigable-recall.md
+++ b/.changeset/1956-navigable-recall.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add expand/traverse helpers over recall disclosure and typed links. Budget 0 is off. Unknown link types are rejected. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate.test.ts
+++ b/packages/remnic-core/src/recall-navigate.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  expandRecallNode,
+  traverseRecallLink,
+  type RecallNavNode,
+} from "./recall-navigate.js";
+
+function node(extra: Partial<RecallNavNode> = {}): RecallNavNode {
+  return {
+    id: "m1",
+    disclosure: "chunk",
+    ...extra,
+  };
+}
+
+test("expandRecallNode budget 0 is a no-op unavailable", () => {
+  const source = node({
+    payloads: { section: "full section body" },
+  });
+  const result = expandRecallNode(source, { budget: 0 });
+  assert.equal(result.status, "unavailable");
+  if (result.status === "unavailable") {
+    assert.equal(result.reason, "budget_off");
+  }
+  assert.equal("node" in result, false);
+  assert.equal(source.disclosure, "chunk");
+});
+
+test("traverseRecallLink budget 0 is a no-op unavailable", () => {
+  const result = traverseRecallLink(
+    node({
+      links: [{ targetId: "m2", linkType: "supports" }],
+    }),
+    "supports",
+    { budget: 0 },
+  );
+  assert.equal(result.status, "unavailable");
+  if (result.status === "unavailable") {
+    assert.equal(result.reason, "budget_off");
+  }
+  assert.equal("neighbors" in result, false);
+});
+
+test("unknown linkType throws", () => {
+  assert.throws(
+    () => traverseRecallLink(node({ links: [] }), "related", { budget: 10 }),
+    /unknown recall nav linkType/,
+  );
+});
+
+test("traverseRecallLink returns neighbors in deterministic targetId order", () => {
+  const result = traverseRecallLink(
+    node({
+      links: [
+        { targetId: "z-mem", linkType: "contradicts" },
+        { targetId: "a-mem", linkType: "contradicts" },
+        { targetId: "m-mem", linkType: "contradicts" },
+        { targetId: "skip-me", linkType: "supports" },
+      ],
+    }),
+    "contradicts",
+    { budget: 100 },
+  );
+  assert.equal(result.status, "ok");
+  if (result.status !== "ok") return;
+  assert.deepEqual(
+    result.neighbors.map((row) => row.id),
+    ["a-mem", "m-mem", "z-mem"],
+  );
+});
+
+test("no matching links is empty, not unavailable", () => {
+  const result = traverseRecallLink(
+    node({
+      links: [{ targetId: "x", linkType: "supports" }],
+    }),
+    "contradicts",
+    { budget: 10 },
+  );
+  assert.equal(result.status, "empty");
+  assert.equal("neighbors" in result, false);
+});

--- a/packages/remnic-core/src/recall-navigate.ts
+++ b/packages/remnic-core/src/recall-navigate.ts
@@ -1,0 +1,100 @@
+/**
+ * Recall navigation helpers (issue #1956 first slice).
+ *
+ * Pure expand/traverse over disclosure levels and typed links. No LLM, no IO.
+ * Surfaces (MCP/HTTP/CLI) and parseConfig wiring wait for a later PR —
+ * config.ts is at its fileSizeGrandfather ceiling.
+ *
+ * Budget 0 is off (unavailable). Empty means the step ran and found nothing.
+ */
+import {
+  RECALL_DISCLOSURE_LEVELS,
+  type RecallDisclosure,
+} from "./types.js";
+
+export const RECALL_NAV_LINK_TYPES = [
+  "supports",
+  "contradicts",
+  "elaborates",
+  "supersedes",
+  "causes",
+] as const;
+
+export type RecallNavLinkType = (typeof RECALL_NAV_LINK_TYPES)[number];
+
+export interface RecallNavBudget {
+  budget: number;
+}
+
+export interface RecallNavEdge {
+  targetId: string;
+  linkType: string;
+  preview?: string;
+}
+
+export interface RecallNavNode {
+  id: string;
+  disclosure: RecallDisclosure;
+  payloads?: Partial<Record<RecallDisclosure, string>>;
+  links?: readonly RecallNavEdge[];
+}
+
+export interface RecallNavNeighbor {
+  id: string;
+  linkType: RecallNavLinkType;
+  preview?: string;
+}
+
+export type RecallNavExpandResult =
+  | { status: "ok"; node: { id: string; disclosure: RecallDisclosure; text: string } }
+  | { status: "empty" }
+  | { status: "unavailable"; reason: "budget_off" };
+
+export type RecallNavTraverseResult =
+  | { status: "ok"; neighbors: readonly RecallNavNeighbor[] }
+  | { status: "empty" }
+  | { status: "unavailable"; reason: "budget_off" };
+
+export function isRecallNavLinkType(value: unknown): value is RecallNavLinkType {
+  return typeof value === "string" && (RECALL_NAV_LINK_TYPES as readonly string[]).includes(value);
+}
+
+export function expandRecallNode(
+  node: RecallNavNode,
+  options: RecallNavBudget,
+): RecallNavExpandResult {
+  if (!Number.isFinite(options.budget) || options.budget <= 0) {
+    return { status: "unavailable", reason: "budget_off" };
+  }
+  const current = RECALL_DISCLOSURE_LEVELS.indexOf(node.disclosure);
+  const next = current >= 0 ? RECALL_DISCLOSURE_LEVELS[current + 1] : undefined;
+  if (next === undefined) return { status: "empty" };
+  const text = node.payloads?.[next];
+  if (typeof text !== "string") return { status: "empty" };
+  return { status: "ok", node: { id: node.id, disclosure: next, text } };
+}
+
+export function traverseRecallLink(
+  from: RecallNavNode,
+  linkType: string,
+  options: RecallNavBudget,
+): RecallNavTraverseResult {
+  if (!isRecallNavLinkType(linkType)) {
+    throw new Error(
+      `unknown recall nav linkType: ${JSON.stringify(linkType)}. Valid: ${RECALL_NAV_LINK_TYPES.join(", ")}`,
+    );
+  }
+  if (!Number.isFinite(options.budget) || options.budget <= 0) {
+    return { status: "unavailable", reason: "budget_off" };
+  }
+  const neighbors = (from.links ?? [])
+    .filter((link) => link.linkType === linkType)
+    .map((link) => {
+      const neighbor: RecallNavNeighbor = { id: link.targetId, linkType };
+      if (link.preview !== undefined) neighbor.preview = link.preview;
+      return neighbor;
+    })
+    .sort((a, b) => a.id.localeCompare(b.id, "en"));
+  if (neighbors.length === 0) return { status: "empty" };
+  return { status: "ok", neighbors };
+}


### PR DESCRIPTION
Part of #1956

## Change
`expandRecallNode` and `traverseRecallLink`.
`budget: 0` is off. Unknown link types throw.

## Out of this PR
MCP/HTTP/CLI, parseConfig, orchestrator.

## Test
`packages/remnic-core/src/recall-navigate.test.ts`