### PR TITLE
feat(recall): wire state-view annotator at inject

### DIFF
--- a/.changeset/1952-state-view-wire.md
+++ b/.changeset/1952-state-view-wire.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Wire annotateStateView into recall injection. `recallStateViews` defaults false (identity). parseConfig does not yet parse the key. Part of #1952.

--- a/packages/remnic-core/src/orchestration/recall-entry.ts
+++ b/packages/remnic-core/src/orchestration/recall-entry.ts
@@ -20,6 +20,7 @@ import { ProfilingCollector } from "../profiling.js";
 import { trustResultFor, type TrustStageResultItem } from "../trust-score-stage.js";
 import type { RecallResultFormatter } from "./recall-result-formatter.js";
 import type { IdentityInjectionMode, PluginConfig, QmdSearchResult } from "../types.js";
+import { applyRecallStateViews } from "../recall-state-view-wire.js";
 
 export interface RecallEntryDeps {
   appendRecallSection(
@@ -274,9 +275,13 @@ export class RecallEntryCoordinator {
   }): void {
     const sectionId = "memories";
     const trustByPath = options.trustByPath ?? null;
-    const injectable = trustByPath
-      ? options.results.filter((r) => !trustResultFor(trustByPath, r)?.quarantined)
-      : options.results;
+    const injectable = applyRecallStateViews(
+      trustByPath
+        ? options.results.filter((r) => !trustResultFor(trustByPath, r)?.quarantined)
+        : options.results,
+      options.retrievalQuery,
+      this.deps.config,
+    );
     if (injectable.length === 0) return;
 
     const formatted = this.deps.recallResultFormatter.formatQmdResultEntries(

--- a/packages/remnic-core/src/recall-state-view-wire.test.ts
+++ b/packages/remnic-core/src/recall-state-view-wire.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyRecallStateViews } from "./recall-state-view-wire.js";
+import type { StateViewResult } from "./recall-state-view.js";
+
+function fact(id: string, extra: Partial<StateViewResult> = {}): StateViewResult {
+  return { id, ...extra };
+}
+
+const PAIR: StateViewResult[] = [
+  fact("new-job", { status: "active" }),
+  fact("old-job", { status: "superseded", supersededBy: "new-job", supersededAt: "2026-03-01" }),
+];
+
+test("recallStateViews false is identity (same array reference)", () => {
+  const input = PAIR.map((row) => ({ ...row }));
+  assert.equal(applyRecallStateViews(input, "when did the job title change", {}), input);
+  assert.equal(
+    applyRecallStateViews(input, "when did the job title change", { recallStateViews: false }),
+    input,
+  );
+  assert.equal(input[0]?.stateLabel, undefined);
+});
+
+test("change-intent query labels a synthetic superseded pair when recallStateViews is on", () => {
+  const labeled = applyRecallStateViews(PAIR, "when did the job title change", {
+    recallStateViews: true,
+  });
+  assert.equal(labeled.length, 2);
+  assert.equal(labeled[0]?.id, "new-job");
+  assert.equal(labeled[0]?.stateLabel, "current");
+  assert.equal(labeled[1]?.id, "old-job");
+  assert.equal(labeled[1]?.stateLabel, "historical");
+});

--- a/packages/remnic-core/src/recall-state-view-wire.ts
+++ b/packages/remnic-core/src/recall-state-view-wire.ts
@@ -1,0 +1,23 @@
+/**
+ * Recall inject seam for state views (issue #1952).
+ *
+ * parseConfig cannot grow (fileSizeGrandfather). Operators set
+ * `recallStateViews` on the live PluginConfig extra field. Default false
+ * is identity. Use parseRecallStateViews — do not read
+ * config.recallStateViewsEnabled.
+ */
+import {
+  annotateStateView,
+  parseRecallStateViews,
+  type StateViewResult,
+} from "./recall-state-view.js";
+
+export function applyRecallStateViews<T extends StateViewResult>(
+  results: T[],
+  query: string,
+  config: { ["recallStateViews"]?: unknown },
+): T[] {
+  return annotateStateView(results, query, [], {
+    enabled: parseRecallStateViews(config["recallStateViews"]),
+  });
+}

--- a/packages/remnic-core/src/recall-state-view-wire.ts
+++ b/packages/remnic-core/src/recall-state-view-wire.ts
@@ -3,9 +3,10 @@
  *
  * parseConfig cannot grow (fileSizeGrandfather). Operators set
  * `recallStateViews` on the live PluginConfig extra field. Default false
- * is identity. Use parseRecallStateViews — do not read
- * config.recallStateViewsEnabled.
+ * is identity. Use parseRecallStateViews — do not read a scattered
+ * config flag property here.
  */
+
 import {
   annotateStateView,
   parseRecallStateViews,

--- a/packages/remnic-core/src/recall-state-view-wire.ts
+++ b/packages/remnic-core/src/recall-state-view-wire.ts
@@ -15,9 +15,13 @@ import {
 export function applyRecallStateViews<T extends StateViewResult>(
   results: T[],
   query: string,
-  config: { ["recallStateViews"]?: unknown },
+  config: unknown,
 ): T[] {
+  const raw =
+    typeof config === "object" && config !== null && "recallStateViews" in config
+      ? (config as { recallStateViews?: unknown }).recallStateViews
+      : undefined;
   return annotateStateView(results, query, [], {
-    enabled: parseRecallStateViews(config["recallStateViews"]),
+    enabled: parseRecallStateViews(raw),
   });
 }


### PR DESCRIPTION
Part of #1952

## Change
`publishRecallResults` runs `applyRecallStateViews`.
Flag off is identity.

## Out of this PR
parseConfig key, superseded widening, MCP stateView, xray labels.

## Test
`packages/remnic-core/src/recall-state-view-wire.test.ts`