### PR TITLE
chore(plugin-openclaw): drop unused observe chunk floor

### DIFF
--- a/.changeset/2395-dead-chunk-const.md
+++ b/.changeset/2395-dead-chunk-const.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Remove unused MIN_OBSERVE_CHUNK_BYTES from flush-plan ingest.

--- a/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
+++ b/packages/plugin-openclaw/src/delegate-flush-plan-ingest.ts
@@ -48,8 +48,7 @@ import { postJsonWithStatus } from "./delegate-http.js";
  * `maxBodyBytes` (131072) so the JSON envelope around the notes still fits.
  */
 const MAX_OBSERVE_CHUNK_BYTES = 96 * 1024;
-/** The floor the adaptive halving stops at — below this a single note. */
-const MIN_OBSERVE_CHUNK_BYTES = 4 * 1024;
+
 /** Bounded wait for the flush-plan lock; a contended flush declines instead. */
 const LOCK_MAX_WAIT_MS = 5_000;
 const LOCK_STALE_MS = 60_000;

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -3803,9 +3803,9 @@ test("a symlinked snapshot sidecar is refused before it is read", async () => {
 });
 
 test("a daemon limit below the chunk floor splits instead of quarantining good notes", async () => {
-  // With maxBodyBytes under MIN_OBSERVE_CHUNK_BYTES, reaching the floor does
-  // NOT mean the chunk is one line — it can still be a multi-line batch. The
-  // trigger for quarantine is the chunk's shape, not a byte floor (#2303).
+  // With maxBodyBytes under the observe chunk size, a small daemon limit
+  // does NOT mean the chunk is one line — it can still be a multi-line batch.
+  // The trigger for quarantine is the chunk's shape, not a byte floor (#2303).
   const delivered: string[] = [];
   const limit = 200;
   const overLimit = (body: Record<string, unknown>): boolean =>


### PR DESCRIPTION
Fixes #2395

Deletes unused `MIN_OBSERVE_CHUNK_BYTES`. Adaptive 413 halving does not use it.

Supersedes the unfinished drive-by PR #2451.