### PR TITLE
feat(activity): deterministic daily journal recap

### DIFF
--- a/.changeset/2051-deterministic-journal-recap.md
+++ b/.changeset/2051-deterministic-journal-recap.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add a deterministic daily journal recap renderer over timeline cards (Part of #2051). Same cards produce the same Markdown. Empty days still yield a valid body. No AI mode and no MCP/HTTP in this slice.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -5,3 +5,4 @@ export * from "./classify.js";
 export * from "./build.js";
 export * from "./corrections.js";
 export * from "./query.js";
+export * from "./journal-recap.js";

--- a/packages/remnic-core/src/activity/timeline/journal-recap.test.ts
+++ b/packages/remnic-core/src/activity/timeline/journal-recap.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { TimelineCard } from "./types.js";
+import { renderDeterministicJournal } from "./journal-recap.js";
+
+const DATE = "2026-08-17";
+const TZ = "UTC";
+
+function card(
+  overrides: Partial<TimelineCard> & Pick<TimelineCard, "id" | "startUtc" | "endUtc">,
+): TimelineCard {
+  return {
+    kind: "activity",
+    title: "Untitled",
+    summary: "none",
+    categoryId: "development",
+    confidence: 1,
+    dayKey: DATE,
+    timezone: TZ,
+    machine: "ws-a",
+    evidenceIds: [],
+    evidenceRange: null,
+    ...overrides,
+  };
+}
+
+const EMPTY_DAY = [
+  `# Journal — ${DATE} (${TZ})`,
+  "",
+  "## Categories",
+  "",
+  "_No categories._",
+  "",
+  "## Cards",
+  "",
+  "_No cards._",
+  "",
+  "## Gaps / idle / pause",
+  "",
+  "- Gaps: 1",
+  "- Idle: 0",
+  "- Pause: 0",
+  "",
+].join("\n");
+
+const ONE_ACTIVITY_PLUS_IDLE = [
+  `# Journal — ${DATE} (${TZ})`,
+  "",
+  "## Categories",
+  "",
+  "- 90m development",
+  "- 15m system.idle",
+  "",
+  "## Cards",
+  "",
+  "- 90m Terminal",
+  "- 15m Idle",
+  "",
+  "## Gaps / idle / pause",
+  "",
+  "- Gaps: 2",
+  "- Idle: 1",
+  "- Pause: 0",
+  "",
+].join("\n");
+
+function activityPlusIdle(): TimelineCard[] {
+  return [
+    card({
+      id: "idle-1",
+      kind: "idle",
+      title: "Idle",
+      categoryId: "system.idle",
+      startUtc: "2026-08-17T15:30:00.000Z",
+      endUtc: "2026-08-17T15:45:00.000Z",
+    }),
+    card({
+      id: "act-1",
+      title: "Terminal",
+      startUtc: "2026-08-17T14:00:00.000Z",
+      endUtc: "2026-08-17T15:30:00.000Z",
+    }),
+  ];
+}
+
+test("empty day still produces a valid journal body", () => {
+  const body = renderDeterministicJournal([], { date: DATE, timezone: TZ });
+  assert.equal(body, EMPTY_DAY);
+  assert.match(body, /^# Journal — /);
+  assert.equal(body.endsWith("\n"), true);
+});
+
+test("one activity plus idle lists durations, titles, and gap counts", () => {
+  const body = renderDeterministicJournal(activityPlusIdle(), { date: DATE, timezone: TZ });
+  assert.equal(body, ONE_ACTIVITY_PLUS_IDLE);
+});
+
+test("same cards render byte-stable on rerun", () => {
+  const cards = activityPlusIdle();
+  const first = renderDeterministicJournal(cards, { date: DATE, timezone: TZ });
+  const second = renderDeterministicJournal(cards, { date: DATE, timezone: TZ });
+  assert.equal(first, second);
+  assert.equal(Buffer.byteLength(first), Buffer.byteLength(second));
+});
+
+test("recap does not invent people or mood claims", () => {
+  const body = renderDeterministicJournal(activityPlusIdle(), { date: DATE, timezone: TZ });
+  assert.equal(/Alice|Bob|Charlie|meeting with/i.test(body), false);
+  assert.equal(/productivity|mood|intent|score/i.test(body), false);
+  assert.match(body, /Terminal/);
+  assert.match(body, /Idle/);
+});

--- a/packages/remnic-core/src/activity/timeline/journal-recap.ts
+++ b/packages/remnic-core/src/activity/timeline/journal-recap.ts
@@ -1,0 +1,130 @@
+/**
+ * Deterministic daily journal recap from timeline cards (issue #2051).
+ *
+ * Pure: cards + date + timezone in, Markdown out. No LLM, no I/O.
+ * Same cards always produce the same bytes. Empty days still yield a
+ * valid file body. Does not invent people, mood, or productivity claims.
+ */
+import { activityDayWindow } from "../digest.js";
+import type { TimelineCard } from "./types.js";
+
+export interface DeterministicJournalOptions {
+  date: string;
+  timezone: string;
+}
+
+interface ClippedCard {
+  card: TimelineCard;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+}
+
+function formatMinutes(ms: number): string {
+  return `${Math.round(ms / 60_000)}m`;
+}
+
+function clipToWindow(
+  cards: readonly TimelineCard[],
+  winStart: number,
+  winEnd: number,
+): ClippedCard[] {
+  const clipped: ClippedCard[] = [];
+  for (const card of cards) {
+    const start = Date.parse(card.startUtc);
+    const end = Date.parse(card.endUtc);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
+    const startMs = Math.max(start, winStart);
+    const endMs = Math.min(end, winEnd);
+    if (endMs <= startMs) continue;
+    clipped.push({ card, startMs, endMs, durationMs: endMs - startMs });
+  }
+  clipped.sort((left, right) => {
+    const byStart = left.startMs - right.startMs;
+    if (byStart !== 0) return byStart;
+    const byTitle = left.card.title.localeCompare(right.card.title);
+    if (byTitle !== 0) return byTitle;
+    return left.card.id.localeCompare(right.card.id);
+  });
+  return clipped;
+}
+
+function categoryLines(clipped: readonly ClippedCard[]): string[] {
+  const totals = new Map<string, number>();
+  for (const row of clipped) {
+    totals.set(row.card.categoryId, (totals.get(row.card.categoryId) ?? 0) + row.durationMs);
+  }
+  const rows = [...totals.entries()].sort((left, right) => {
+    const byDuration = right[1] - left[1];
+    return byDuration !== 0 ? byDuration : left[0].localeCompare(right[0]);
+  });
+  if (rows.length === 0) return ["_No categories._"];
+  return rows.map(([categoryId, durationMs]) => `- ${formatMinutes(durationMs)} ${categoryId}`);
+}
+
+function mergeIntervals(intervals: readonly (readonly [number, number])[]): Array<[number, number]> {
+  const ordered = [...intervals].sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+  const merged: Array<[number, number]> = [];
+  for (const [start, end] of ordered) {
+    const last = merged[merged.length - 1];
+    if (!last || start > last[1]) merged.push([start, end]);
+    else last[1] = Math.max(last[1], end);
+  }
+  return merged;
+}
+
+function countGaps(
+  winStart: number,
+  winEnd: number,
+  intervals: readonly (readonly [number, number])[],
+): number {
+  const merged = mergeIntervals(intervals);
+  let gaps = 0;
+  let cursor = winStart;
+  for (const [start, end] of merged) {
+    if (start > cursor) gaps += 1;
+    cursor = Math.max(cursor, end);
+  }
+  if (cursor < winEnd) gaps += 1;
+  return gaps;
+}
+
+/** Render a byte-stable Markdown journal for one local day. */
+export function renderDeterministicJournal(
+  cards: readonly TimelineCard[],
+  options: DeterministicJournalOptions,
+): string {
+  const window = activityDayWindow(options.date, options.timezone);
+  const winStart = Date.parse(window.startUtc);
+  const winEnd = Date.parse(window.endUtc);
+  const clipped = clipToWindow(cards, winStart, winEnd);
+  const idle = clipped.filter((row) => row.card.kind === "idle").length;
+  const pause = clipped.filter((row) => row.card.kind === "pause").length;
+  const gaps = countGaps(
+    winStart,
+    winEnd,
+    clipped.map((row) => [row.startMs, row.endMs]),
+  );
+  const cardLines =
+    clipped.length === 0
+      ? ["_No cards._"]
+      : clipped.map((row) => `- ${formatMinutes(row.durationMs)} ${row.card.title}`);
+  return [
+    `# Journal — ${options.date} (${options.timezone})`,
+    "",
+    "## Categories",
+    "",
+    ...categoryLines(clipped),
+    "",
+    "## Cards",
+    "",
+    ...cardLines,
+    "",
+    "## Gaps / idle / pause",
+    "",
+    `- Gaps: ${gaps}`,
+    `- Idle: ${idle}`,
+    `- Pause: ${pause}`,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
Part of #2051

## Change
`renderDeterministicJournal` from timeline cards. No LLM. Byte-stable.

## Out of this PR
AI mode, MCP/HTTP, file persistence.

## Test
`packages/remnic-core/src/activity/timeline/journal-recap.test.ts`