### PR TITLE
feat(dedup): isolated merge-on-write judge helper

### DIFF
--- a/.changeset/2330-merge-on-write.md
+++ b/.changeset/2330-merge-on-write.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a default-off merge-on-write judge helper. Scores in `[0.80, 0.92)` may merge. Skip-band scores, refused categories, judge failure, and `mergeMin=0` stay create. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-on-write.test.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write.test.ts
@@ -4,8 +4,10 @@ import {
   applyMergeOnWrite,
   judgeMergeDecision,
   shouldConsiderMerge,
+  type MergeJudgeVerdict,
   type MergeOnWritePair,
 } from "./merge-on-write.js";
+
 
 function pair(overrides: Partial<MergeOnWritePair> = {}): MergeOnWritePair {
   return {
@@ -63,7 +65,7 @@ test("merge-on-write: judge throw creates", async () => {
 });
 
 test("merge-on-write: uncertain judge creates", async () => {
-  const decision = await judgeMergeDecision(pair(), async () => "uncertain");
+  const decision = await judgeMergeDecision(pair(), async (): Promise<MergeJudgeVerdict> => "uncertain");
   assert.equal(decision, "create");
 });
 

--- a/packages/remnic-core/src/dedup/merge-on-write.test.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  applyMergeOnWrite,
+  judgeMergeDecision,
+  shouldConsiderMerge,
+  type MergeOnWritePair,
+} from "./merge-on-write.js";
+
+function pair(overrides: Partial<MergeOnWritePair> = {}): MergeOnWritePair {
+  return {
+    category: "fact",
+    score: 0.85,
+    incomingContent: "User prefers dark mode on laptops.",
+    existingContent: "User likes dark mode.",
+    existingId: "mem-1",
+    ...overrides,
+  };
+}
+
+const mergeJudge = async () => "merge" as const;
+
+test("merge-on-write: skip band is not considered", () => {
+  assert.equal(shouldConsiderMerge({ score: 0.92 }), false);
+  assert.equal(shouldConsiderMerge({ score: 0.99 }), false);
+});
+
+test("merge-on-write: merge band is considered", () => {
+  assert.equal(shouldConsiderMerge({ score: 0.8 }), true);
+  assert.equal(shouldConsiderMerge({ score: 0.85 }), true);
+  assert.equal(shouldConsiderMerge({ score: 0.919 }), true);
+});
+
+test("merge-on-write: score below mergeMin is not considered", () => {
+  assert.equal(shouldConsiderMerge({ score: 0.79 }), false);
+});
+
+test("merge-on-write: refused categories always create", async () => {
+  for (const category of ["procedure", "reasoning_trace", "moment", "correction"]) {
+    const decision = await applyMergeOnWrite({
+      enabled: true,
+      pair: pair({ category }),
+      judge: mergeJudge,
+    });
+    assert.equal(decision, "create", category);
+  }
+});
+
+test("merge-on-write: judge throw creates", async () => {
+  const viaJudge = await judgeMergeDecision(pair(), async () => {
+    throw new Error("timeout");
+  });
+  assert.equal(viaJudge, "create");
+
+  const viaApply = await applyMergeOnWrite({
+    enabled: true,
+    pair: pair(),
+    judge: async () => {
+      throw new Error("timeout");
+    },
+  });
+  assert.equal(viaApply, "create");
+});
+
+test("merge-on-write: uncertain judge creates", async () => {
+  const decision = await judgeMergeDecision(pair(), async () => "uncertain");
+  assert.equal(decision, "create");
+});
+
+test("merge-on-write: disabled or mergeMin 0 creates", async () => {
+  let called = 0;
+  const judge = async () => {
+    called += 1;
+    return "merge" as const;
+  };
+
+  assert.equal(await applyMergeOnWrite({ pair: pair(), judge }), "create");
+  assert.equal(
+    await applyMergeOnWrite({ enabled: false, pair: pair(), judge }),
+    "create",
+  );
+  assert.equal(
+    await applyMergeOnWrite({ enabled: true, mergeMin: 0, pair: pair(), judge }),
+    "create",
+  );
+  assert.equal(called, 0);
+});
+
+test("merge-on-write: enabled in-band merge applies", async () => {
+  const decision = await applyMergeOnWrite({
+    enabled: true,
+    pair: pair(),
+    judge: mergeJudge,
+  });
+  assert.equal(decision, "merge");
+});

--- a/packages/remnic-core/src/dedup/merge-on-write.test.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write.test.ts
@@ -1,13 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  type MergeJudgeVerdict,
+  type MergeOnWritePair,
   applyMergeOnWrite,
   judgeMergeDecision,
   shouldConsiderMerge,
-  type MergeJudgeVerdict,
-  type MergeOnWritePair,
 } from "./merge-on-write.js";
-
 
 function pair(overrides: Partial<MergeOnWritePair> = {}): MergeOnWritePair {
   return {
@@ -77,14 +76,8 @@ test("merge-on-write: disabled or mergeMin 0 creates", async () => {
   };
 
   assert.equal(await applyMergeOnWrite({ pair: pair(), judge }), "create");
-  assert.equal(
-    await applyMergeOnWrite({ enabled: false, pair: pair(), judge }),
-    "create",
-  );
-  assert.equal(
-    await applyMergeOnWrite({ enabled: true, mergeMin: 0, pair: pair(), judge }),
-    "create",
-  );
+  assert.equal(await applyMergeOnWrite({ enabled: false, pair: pair(), judge }), "create");
+  assert.equal(await applyMergeOnWrite({ enabled: true, mergeMin: 0, pair: pair(), judge }), "create");
   assert.equal(called, 0);
 });
 

--- a/packages/remnic-core/src/dedup/merge-on-write.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write.ts
@@ -1,0 +1,75 @@
+/**
+ * Isolated merge-on-write judge (issue #2330 first slice).
+ *
+ * Default off. Persist wiring comes later. Failures create.
+ */
+
+export const DEFAULT_MERGE_MIN = 0.8;
+export const DEFAULT_SKIP_THRESHOLD = 0.92;
+
+export const REFUSED_MERGE_CATEGORIES = [
+  "procedure",
+  "reasoning_trace",
+  "moment",
+  "correction",
+] as const;
+
+export type MergeOnWriteDecision = "merge" | "create";
+export type MergeJudgeVerdict = MergeOnWriteDecision | "uncertain";
+
+export interface MergeOnWritePair {
+  category: string;
+  score: number;
+  incomingContent?: string;
+  existingContent?: string;
+  existingId?: string;
+}
+
+export type MergeJudge = (
+  pair: MergeOnWritePair,
+) => Promise<MergeJudgeVerdict> | MergeJudgeVerdict;
+
+export function shouldConsiderMerge(opts: {
+  score: number;
+  skipThreshold?: number;
+  mergeMin?: number;
+}): boolean {
+  const mergeMin = opts.mergeMin ?? DEFAULT_MERGE_MIN;
+  const skipThreshold = opts.skipThreshold ?? DEFAULT_SKIP_THRESHOLD;
+  if (!(mergeMin > 0)) return false;
+  if (!Number.isFinite(opts.score) || !Number.isFinite(skipThreshold)) return false;
+  return mergeMin <= opts.score && opts.score < skipThreshold;
+}
+
+export async function judgeMergeDecision(
+  pair: MergeOnWritePair,
+  judge: MergeJudge,
+): Promise<MergeOnWriteDecision> {
+  try {
+    const verdict = await judge(pair);
+    return verdict === "merge" ? "merge" : "create";
+  } catch {
+    return "create";
+  }
+}
+
+export async function applyMergeOnWrite(opts: {
+  pair: MergeOnWritePair;
+  judge: MergeJudge;
+  enabled?: boolean;
+  mergeMin?: number;
+  skipThreshold?: number;
+}): Promise<MergeOnWriteDecision> {
+  if (opts.enabled !== true) return "create";
+  if ((REFUSED_MERGE_CATEGORIES as readonly string[]).includes(opts.pair.category)) return "create";
+  if (
+    !shouldConsiderMerge({
+      score: opts.pair.score,
+      mergeMin: opts.mergeMin,
+      skipThreshold: opts.skipThreshold,
+    })
+  ) {
+    return "create";
+  }
+  return judgeMergeDecision(opts.pair, opts.judge);
+}


### PR DESCRIPTION
Part of #2330

## Change
`shouldConsiderMerge` / `applyMergeOnWrite`. Default off. Judge throw → create.

## Out of this PR
extraction-persist wiring, parseConfig keys.

## Test
`packages/remnic-core/src/dedup/merge-on-write.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional merge-on-write capability for duplicate records.
  * The feature is disabled by default and only merges when confidence scores fall within the supported range.
  * Certain categories are excluded from merging automatically.
  * Uncertain results, judge failures, and disabled or zero-threshold configurations safely create new records instead.

* **Bug Fixes**
  * Added safeguards to prevent unsafe or unintended merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->