### PR TITLE
feat(shared-context): shared-item authority envelope

### DIFF
--- a/.changeset/1957-shared-item-envelope.md
+++ b/.changeset/1957-shared-item-envelope.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add the shared-item authority envelope (parse, default, expiry). Binding requires an explicit flag. Legacy items stay informational with no expiry. Part of #1957.

--- a/packages/remnic-core/src/shared-context/governance.test.ts
+++ b/packages/remnic-core/src/shared-context/governance.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  applyDefaultEnvelope,
+  isExpired,
+  parseSharedEnvelope,
+} from "./governance.js";
+
+test("applyDefaultEnvelope defaults to informational with no expiry", () => {
+  assert.deepEqual(applyDefaultEnvelope(), { authority: "informational" });
+  assert.deepEqual(applyDefaultEnvelope({}), { authority: "informational" });
+  assert.deepEqual(applyDefaultEnvelope({ authority: "advisory", sharedBy: "agent-a" }), {
+    authority: "advisory",
+    sharedBy: "agent-a",
+  });
+});
+
+test("applyDefaultEnvelope rejects binding without an explicit flag", () => {
+  assert.throws(() => applyDefaultEnvelope({ authority: "binding" }), /binding/);
+  assert.deepEqual(applyDefaultEnvelope({ authority: "binding" }, { binding: true }), {
+    authority: "binding",
+  });
+});
+
+test("isExpired treats expiresAt as a half-open upper bound", () => {
+  const expiresAt = "2026-08-18T12:00:00.000Z";
+  const at = Date.parse(expiresAt);
+  const envelope = { authority: "informational" as const, expiresAt };
+  assert.equal(isExpired(envelope, at - 1), false);
+  assert.equal(isExpired(envelope, at), true);
+  assert.equal(isExpired({ authority: "informational" }, at), false);
+});
+
+test("parseSharedEnvelope treats a missing legacy envelope as informational with no expiry", () => {
+  assert.deepEqual(parseSharedEnvelope(undefined), { authority: "informational" });
+  assert.deepEqual(parseSharedEnvelope(null), { authority: "informational" });
+  assert.deepEqual(parseSharedEnvelope({ title: "legacy output" }), { authority: "informational" });
+  assert.deepEqual(
+    parseSharedEnvelope({
+      sharedBy: "agent-a",
+      authority: "advisory",
+      expiresAt: "2026-08-18T12:00:00.000Z",
+      supersedes: "item-1",
+    }),
+    {
+      sharedBy: "agent-a",
+      authority: "advisory",
+      expiresAt: "2026-08-18T12:00:00.000Z",
+      supersedes: "item-1",
+    },
+  );
+});

--- a/packages/remnic-core/src/shared-context/governance.test.ts
+++ b/packages/remnic-core/src/shared-context/governance.test.ts
@@ -29,7 +29,7 @@ test("isExpired treats expiresAt as a half-open upper bound", () => {
   const envelope = { authority: "informational" as const, expiresAt };
   assert.equal(isExpired(envelope, at - 1), false);
   assert.equal(isExpired(envelope, at), true);
-  assert.equal(isExpired({ authority: "informational" }, at), false);
+  assert.equal(isExpired({}, at), false);
 });
 
 test("parseSharedEnvelope treats a missing legacy envelope as informational with no expiry", () => {

--- a/packages/remnic-core/src/shared-context/governance.ts
+++ b/packages/remnic-core/src/shared-context/governance.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared-item authority envelope (issue #1957).
+ *
+ * First slice: parse + default + expiry only. Write-path wiring and
+ * curation come later. Binding is never inferred.
+ */
+
+export const SHARED_AUTHORITIES = ["informational", "advisory", "binding"] as const;
+export type SharedAuthority = (typeof SHARED_AUTHORITIES)[number];
+
+export interface SharedEnvelope {
+  sharedBy?: string;
+  authority: SharedAuthority;
+  expiresAt?: string;
+  supersedes?: string;
+}
+
+export interface SharedEnvelopeInput {
+  sharedBy?: string;
+  authority?: string;
+  expiresAt?: string;
+  supersedes?: string;
+}
+
+export interface ApplyDefaultEnvelopeOptions {
+  binding?: boolean;
+}
+
+function isSharedAuthority(value: string): value is SharedAuthority {
+  return (SHARED_AUTHORITIES as readonly string[]).includes(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function withOptionalFields(
+  authority: SharedAuthority,
+  source: { sharedBy?: unknown; expiresAt?: unknown; supersedes?: unknown },
+): SharedEnvelope {
+  const envelope: SharedEnvelope = { authority };
+  const sharedBy = optionalString(source.sharedBy);
+  const expiresAt = optionalString(source.expiresAt);
+  const supersedes = optionalString(source.supersedes);
+  if (sharedBy) envelope.sharedBy = sharedBy;
+  if (expiresAt) envelope.expiresAt = expiresAt;
+  if (supersedes) envelope.supersedes = supersedes;
+  return envelope;
+}
+
+export function applyDefaultEnvelope(
+  input: SharedEnvelopeInput = {},
+  options: ApplyDefaultEnvelopeOptions = {},
+): SharedEnvelope {
+  const requested = optionalString(input.authority);
+  if (requested !== undefined && !isSharedAuthority(requested)) {
+    throw new Error(
+      `applyDefaultEnvelope: authority must be informational, advisory, or binding; got ${JSON.stringify(requested)}`,
+    );
+  }
+  if (requested === "binding" && options.binding !== true) {
+    throw new Error("applyDefaultEnvelope: authority \"binding\" requires an explicit binding flag");
+  }
+  return withOptionalFields(requested ?? "informational", input);
+}
+
+export function parseSharedEnvelope(raw: unknown): SharedEnvelope {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { authority: "informational" };
+  }
+  const record = raw as Record<string, unknown>;
+  const requested = optionalString(record.authority);
+  const authority = requested !== undefined && isSharedAuthority(requested) ? requested : "informational";
+  return withOptionalFields(authority, record);
+}
+
+export function isExpired(envelope: Pick<SharedEnvelope, "expiresAt">, nowMs: number): boolean {
+  if (!Number.isFinite(nowMs)) return false;
+  const expiresAt = envelope.expiresAt?.trim();
+  if (!expiresAt) return false;
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) return false;
+  return expiresAtMs <= nowMs;
+}


### PR DESCRIPTION
Part of #1957

## Change
Authority envelope: informational/advisory/binding. Binding needs an explicit flag.
Half-open expiry. Legacy items stay informational with no expiry.

## Out of this PR
Curation rewrite, trajectory repo, manager wiring.

## Test
`packages/remnic-core/src/shared-context/governance.test.ts`