### PR TITLE
feat(recall): budgeted deep-recall policy loop

### DIFF
--- a/.changeset/2332-deep-recall.md
+++ b/.changeset/2332-deep-recall.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add a host-agnostic budgeted REFINE/EXPAND/STOP deep-recall stepper. Policy is injected. Budget 0 stops immediately. No LLM and no orchestrator recall. Part of #2332.

--- a/packages/remnic-core/src/recall-deep.test.ts
+++ b/packages/remnic-core/src/recall-deep.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  runDeepRecall,
+  runDeepRecallStep,
+  type DeepRecallState,
+} from "./recall-deep.js";
+
+function seed(extra: Partial<DeepRecallState> = {}): DeepRecallState {
+  return {
+    query: "who met at the cafe",
+    workingSet: ["m-seed"],
+    frontier: ["m-b", "m-c"],
+    budget: 2,
+    ...extra,
+  };
+}
+
+test("budget 0 stops without calling the policy", () => {
+  const result = runDeepRecall(seed({ budget: 0 }), () => {
+    throw new Error("policy must not run when budget is 0");
+  });
+  assert.equal(result.trace.length, 1);
+  assert.equal(result.trace[0]?.action, "stop");
+  assert.equal(result.state.budget, 0);
+  assert.deepEqual(result.state.workingSet, ["m-seed"]);
+  assert.deepEqual(result.state.frontier, ["m-b", "m-c"]);
+});
+
+test("expand consumes budget and pulls the next frontier item", () => {
+  const result = runDeepRecallStep(seed({ budget: 2 }), "expand");
+  assert.equal(result.step.action, "expand");
+  assert.equal(result.state.budget, 1);
+  assert.deepEqual(result.state.workingSet, ["m-seed", "m-b"]);
+  assert.deepEqual(result.state.frontier, ["m-c"]);
+});
+
+test("stop ends while budget remains", () => {
+  let calls = 0;
+  const result = runDeepRecall(seed({ budget: 4 }), () => {
+    calls += 1;
+    return "stop";
+  });
+  assert.equal(calls, 1);
+  assert.equal(result.trace.length, 1);
+  assert.equal(result.trace[0]?.action, "stop");
+  assert.equal(result.state.budget, 4);
+  assert.deepEqual(result.state.workingSet, ["m-seed"]);
+});
+
+test("unknown action throws", () => {
+  assert.throws(() => runDeepRecallStep(seed(), "rewrite"), /unknown deep recall action/);
+  assert.throws(
+    () => runDeepRecall(seed(), () => "rewrite"),
+    /unknown deep recall action/,
+  );
+});
+
+test("same state and policy produce the same trace", () => {
+  const policy = (state: DeepRecallState) => (state.budget > 1 ? "expand" : "refine");
+  const start = seed({ budget: 3, frontier: ["m-z", "m-a"] });
+  const first = runDeepRecall(start, policy);
+  const second = runDeepRecall(start, policy);
+  assert.deepEqual(first, second);
+  assert.deepEqual(
+    first.trace.map((step) => step.action),
+    ["expand", "expand", "refine", "stop"],
+  );
+  assert.equal(start.budget, 3);
+  assert.deepEqual(start.frontier, ["m-z", "m-a"]);
+});

--- a/packages/remnic-core/src/recall-deep.ts
+++ b/packages/remnic-core/src/recall-deep.ts
@@ -1,0 +1,113 @@
+/**
+ * Budgeted REFINE/EXPAND/STOP loop (issue #2332 first slice).
+ *
+ * Pure state stepper. Policy is injected. No LLM, no orchestrator recall,
+ * no IO. Surfaces and parseConfig wait for a later PR — config.ts is at
+ * its fileSizeGrandfather ceiling.
+ *
+ * Budget 0 stops without calling the policy. Unknown actions throw.
+ */
+export const DEEP_RECALL_ACTIONS = ["refine", "expand", "stop"] as const;
+
+export type DeepRecallAction = (typeof DEEP_RECALL_ACTIONS)[number];
+
+export interface DeepRecallState {
+  query: string;
+  workingSet: readonly string[];
+  frontier: readonly string[];
+  budget: number;
+}
+
+export interface DeepRecallTraceStep {
+  action: DeepRecallAction;
+  budget: number;
+  workingSet: readonly string[];
+  frontier: readonly string[];
+}
+
+export interface DeepRecallStepResult {
+  state: DeepRecallState;
+  step: DeepRecallTraceStep;
+}
+
+export interface DeepRecallResult {
+  state: DeepRecallState;
+  trace: readonly DeepRecallTraceStep[];
+}
+
+export type DeepRecallPolicy = (state: DeepRecallState) => string;
+
+export function isDeepRecallAction(value: unknown): value is DeepRecallAction {
+  return typeof value === "string" && (DEEP_RECALL_ACTIONS as readonly string[]).includes(value);
+}
+
+function snapshot(state: DeepRecallState): DeepRecallState {
+  return {
+    query: state.query,
+    workingSet: [...state.workingSet],
+    frontier: [...state.frontier],
+    budget: state.budget,
+  };
+}
+
+export function runDeepRecallStep(state: DeepRecallState, action: string): DeepRecallStepResult {
+  if (!isDeepRecallAction(action)) {
+    throw new Error(
+      `unknown deep recall action: ${JSON.stringify(action)}. Valid: ${DEEP_RECALL_ACTIONS.join(", ")}`,
+    );
+  }
+  if (!Number.isFinite(state.budget) || state.budget <= 0 || action === "stop") {
+    const stopped = snapshot(state);
+    return {
+      state: stopped,
+      step: {
+        action: "stop",
+        budget: stopped.budget,
+        workingSet: stopped.workingSet,
+        frontier: stopped.frontier,
+      },
+    };
+  }
+
+  const next = snapshot(state);
+  next.budget = state.budget - 1;
+  if (action === "expand") {
+    const [head, ...rest] = next.frontier;
+    if (head !== undefined && !next.workingSet.includes(head)) {
+      next.workingSet = [...next.workingSet, head];
+    }
+    next.frontier = rest;
+  }
+  return {
+    state: next,
+    step: {
+      action,
+      budget: next.budget,
+      workingSet: next.workingSet,
+      frontier: next.frontier,
+    },
+  };
+}
+
+export function runDeepRecall(state: DeepRecallState, policy: DeepRecallPolicy): DeepRecallResult {
+  const trace: DeepRecallTraceStep[] = [];
+  let current = snapshot(state);
+  while (true) {
+    if (!Number.isFinite(current.budget) || current.budget <= 0) {
+      const stopped = snapshot(current);
+      trace.push({
+        action: "stop",
+        budget: stopped.budget,
+        workingSet: stopped.workingSet,
+        frontier: stopped.frontier,
+      });
+      return { state: stopped, trace };
+    }
+    const stepped = runDeepRecallStep(current, policy(current));
+    trace.push(stepped.step);
+    current = stepped.state;
+    if (stepped.step.action === "stop") {
+      return { state: current, trace };
+    }
+  }
+}


### PR DESCRIPTION
Part of #2332

## Change
`runDeepRecall` REFINE/EXPAND/STOP. budget 0 stops. No LLM. Not on the hot path.

## Out of this PR
Access surfaces, prompted policy, graph wiring.

## Test
`packages/remnic-core/src/recall-deep.test.ts`