### PR TITLE
feat(activity): privacy retention and export helper

### DIFF
--- a/.changeset/2053-timeline-privacy.md
+++ b/.changeset/2053-timeline-privacy.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add a pure activity privacy helper for retention and export gates (issue #2053). `retentionDays` 0 keeps forever, the expiry window is half-open, and a disabled master denies retain and empties export. Part of #2053.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -17,3 +17,4 @@ export * from "./reindex.js";
 export * from "./timeline/index.js";
 export * from "./journal.js";
 export * from "./memory-gen.js";
+export * from "./privacy.js";

--- a/packages/remnic-core/src/activity/privacy.test.ts
+++ b/packages/remnic-core/src/activity/privacy.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MS_PER_DAY,
+  observationsForExport,
+  parseActivityPrivacy,
+  shouldRetain,
+} from "./privacy.js";
+
+test("retentionDays 0 keeps forever", () => {
+  const policy = parseActivityPrivacy({ enabled: true, retentionDays: 0 });
+  assert.equal(policy.retentionDays, 0);
+  const now = 1_700_000_000_000;
+  assert.equal(shouldRetain(now - 400 * MS_PER_DAY, now, policy.retentionDays), true);
+  assert.equal(shouldRetain(now, now, 0), true);
+});
+
+test("negative retentionDays throws", () => {
+  assert.throws(() => parseActivityPrivacy({ retentionDays: -1 }), /non-negative integer/);
+  assert.throws(() => parseActivityPrivacy({ retentionDays: -30 }), /non-negative integer/);
+  assert.throws(() => shouldRetain(0, 0, -1), /non-negative integer/);
+});
+
+test("exact expiry boundary is half-open", () => {
+  const now = 1_700_000_000_000;
+  const days = 30;
+  const captured = now - days * MS_PER_DAY;
+  assert.equal(shouldRetain(captured, now, days), false);
+  assert.equal(shouldRetain(captured + 1, now, days), true);
+  assert.equal(shouldRetain(captured - 1, now, days), false);
+});
+
+test("disabled master denies retain and empties export", () => {
+  const policy = parseActivityPrivacy({
+    enabled: false,
+    retentionDays: 0,
+    exportIncludeObservations: true,
+  });
+  assert.equal(policy.enabled, false);
+  assert.equal(shouldRetain(1_700_000_000_000, 1_700_000_000_000, policy.retentionDays, policy.enabled), false);
+  assert.deepEqual(observationsForExport(["obs"], policy), []);
+  assert.equal(parseActivityPrivacy(undefined).enabled, false);
+});
+
+test("exportIncludeObservations defaults false", () => {
+  assert.equal(parseActivityPrivacy(undefined).exportIncludeObservations, false);
+  assert.equal(parseActivityPrivacy({ enabled: true }).exportIncludeObservations, false);
+  const policy = parseActivityPrivacy({ enabled: true });
+  assert.deepEqual(observationsForExport(["obs"], policy), []);
+  const included = parseActivityPrivacy({ enabled: true, exportIncludeObservations: true });
+  assert.deepEqual(observationsForExport(["obs"], included), ["obs"]);
+});

--- a/packages/remnic-core/src/activity/privacy.ts
+++ b/packages/remnic-core/src/activity/privacy.ts
@@ -1,0 +1,80 @@
+/**
+ * Activity retention and export policy (issue #2053 first slice).
+ *
+ * Pure helpers. Surfaces and parseConfig wiring wait for a later PR.
+ * Master `activity.enabled` false denies retain and empties export.
+ */
+import { coerceBooleanLike, coerceNumber } from "../connectors/coerce.js";
+
+export const MS_PER_DAY = 86_400_000;
+
+export interface ActivityPrivacyPolicy {
+  enabled: boolean;
+  /** `0` keeps forever. */
+  retentionDays: number;
+  exportIncludeObservations: boolean;
+}
+
+function asRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseGate(value: unknown, key: string, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  const parsed = coerceBooleanLike(value, key);
+  if (parsed === undefined) throw new TypeError(`${key} must be a boolean`);
+  return parsed;
+}
+
+/** Parse retention and export knobs. Independent of timeline/journal/weekly blocks. */
+export function parseActivityPrivacy(raw?: unknown): ActivityPrivacyPolicy {
+  if (raw === undefined || raw === null) {
+    return { enabled: false, retentionDays: 0, exportIncludeObservations: false };
+  }
+  const config = asRecord(raw, "activity");
+  const enabled = parseGate(config.enabled, "activity.enabled", false);
+  let retentionDays = 0;
+  if (config.retentionDays !== undefined) {
+    const parsed = coerceNumber(config.retentionDays, "activity.retentionDays");
+    if (parsed === undefined || !Number.isInteger(parsed) || parsed < 0) {
+      throw new RangeError("activity.retentionDays must be a non-negative integer");
+    }
+    retentionDays = parsed;
+  }
+  const exportIncludeObservations = parseGate(
+    config.exportIncludeObservations,
+    "activity.exportIncludeObservations",
+    false,
+  );
+  return { enabled, retentionDays, exportIncludeObservations };
+}
+
+/**
+ * Half-open retain window: keep when age is in `[0, retentionDays)`.
+ * `retentionDays === 0` keeps forever. Master off denies.
+ */
+export function shouldRetain(
+  capturedAtMs: number,
+  nowMs: number,
+  retentionDays: number,
+  enabled = true,
+): boolean {
+  if (!enabled) return false;
+  if (retentionDays < 0 || !Number.isInteger(retentionDays)) {
+    throw new RangeError("activity.retentionDays must be a non-negative integer");
+  }
+  if (retentionDays === 0) return true;
+  return nowMs - capturedAtMs < retentionDays * MS_PER_DAY;
+}
+
+/** Export payload. Master off or the export gate off returns empty. */
+export function observationsForExport<T>(
+  observations: readonly T[],
+  policy: Pick<ActivityPrivacyPolicy, "enabled" | "exportIncludeObservations">,
+): readonly T[] {
+  if (!policy.enabled || !policy.exportIncludeObservations) return [];
+  return observations;
+}


### PR DESCRIPTION
Part of #2053

## Change
`retentionDays: 0` keeps forever. Half-open expiry. Export observations default off.

## Out of this PR
CLI/MCP/HTTP, parseConfig keys.

## Test
`packages/remnic-core/src/activity/privacy.test.ts`