### PR TITLE
feat(activity): optional timeline card analysis helper

### DIFF
--- a/.changeset/2050-card-analysis.md
+++ b/.changeset/2050-card-analysis.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add an optional injected-provider timeline card analysis helper (issue #2050). Disabled, invalid config, timeout, and bad output leave deterministic cards unchanged. Part of #2050.

--- a/.changeset/2050-card-analysis.md
+++ b/.changeset/2050-card-analysis.md
@@ -2,4 +2,4 @@
 "@remnic/core": minor
 ---
 
-Add an optional injected-provider timeline card analysis helper (issue #2050). Disabled, invalid config, timeout, and bad output leave deterministic cards unchanged. Part of #2050.
+Add an optional injected-provider timeline card analysis helper (issue #2050). Invalid provider, model, completion function, or timeout configuration throws `TimelineAnalysisConfigError`; disabled analysis, timeouts, provider failures, and invalid output return the unchanged deterministic cards. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis.test.ts
@@ -1,0 +1,393 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  TIMELINE_ANALYSIS_BATCH_OVERLAP,
+  TIMELINE_ANALYSIS_BATCH_SIZE,
+  TIMELINE_ANALYSIS_PROMPT_VERSION,
+  TimelineAnalysisConfigError,
+  analyzeTimelineCards,
+} from "./analysis.js";
+import type { TimelineCard, TimelineObservation } from "./types.js";
+
+const DATE = "2026-08-17";
+const TZ = "UTC";
+
+function card(
+  overrides: Partial<TimelineCard> & Pick<TimelineCard, "id" | "startUtc" | "endUtc">,
+): TimelineCard {
+  return {
+    kind: "activity",
+    title: "main.ts — editor",
+    summary: "Code editor on ws-a",
+    categoryId: "development",
+    confidence: 0.8,
+    dayKey: DATE,
+    timezone: TZ,
+    machine: "ws-a",
+    evidenceIds: [1],
+    evidenceRange: {
+      firstKey: "ws-a|2026-08-17T10:00:00.000Z|hash-1",
+      lastKey: "ws-a|2026-08-17T10:00:00.000Z|hash-1",
+    },
+    ...overrides,
+  };
+}
+
+function observation(overrides: Partial<TimelineObservation> = {}): TimelineObservation {
+  return {
+    id: 1,
+    machine: "ws-a",
+    capturedAtUtc: "2026-08-17T10:00:00.000Z",
+    app: "editor",
+    windowTitle: "main.ts — editor",
+    contentHash: "hash-1",
+    ...overrides,
+  };
+}
+
+function sampleCards(): TimelineCard[] {
+  return [
+    card({
+      id: "card-1",
+      startUtc: "2026-08-17T10:00:00.000Z",
+      endUtc: "2026-08-17T10:15:00.000Z",
+    }),
+  ];
+}
+
+test("disabled makes zero provider calls and leaves cards unchanged", async () => {
+  const cards = sampleCards();
+  let calls = 0;
+  const result = await analyzeTimelineCards({
+    enabled: false,
+    cards,
+    observations: [observation()],
+    provider: "local",
+    model: "llama",
+    complete: async () => {
+      calls += 1;
+      return '{"ops":[]}';
+    },
+  });
+  assert.equal(result.status, "disabled");
+  assert.equal(result.cards, cards);
+  assert.equal(calls, 0);
+  assert.equal(result.provider, undefined);
+});
+
+test("invalid provider or model throws a typed error and does not call complete", async () => {
+  const cards = sampleCards();
+  let calls = 0;
+  const complete = async () => {
+    calls += 1;
+    return '{"ops":[]}';
+  };
+  await assert.rejects(
+    () =>
+      analyzeTimelineCards({
+        enabled: true,
+        cards,
+        observations: [observation()],
+        provider: "",
+        model: "llama",
+        complete,
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof TimelineAnalysisConfigError);
+      assert.equal(err.code, "invalid_config");
+      return true;
+    },
+  );
+  await assert.rejects(
+    () =>
+      analyzeTimelineCards({
+        enabled: true,
+        cards,
+        observations: [observation()],
+        provider: "openai",
+        model: "  ",
+        complete,
+      }),
+    TimelineAnalysisConfigError,
+  );
+  await assert.rejects(
+    () =>
+      analyzeTimelineCards({
+        enabled: true,
+        cards,
+        observations: [observation()],
+        provider: "openai",
+        model: "gpt-4.1",
+      }),
+    TimelineAnalysisConfigError,
+  );
+  assert.equal(calls, 0);
+  assert.equal(cards[0]?.title, "main.ts — editor");
+});
+
+test("timeout returns provider_failed and leaves cards unchanged", async () => {
+  const cards = sampleCards();
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "openai",
+    model: "gpt-4.1",
+    timeoutMs: 20,
+    complete: () => Promise.withResolvers<string>().promise,
+  });
+  assert.equal(result.status, "provider_failed");
+  assert.equal(result.cards, cards);
+  assert.equal(result.provider, "openai");
+  assert.equal(result.model, "gpt-4.1");
+});
+
+test("malformed JSON returns invalid_output and leaves cards unchanged", async () => {
+  const cards = sampleCards();
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "local",
+    model: "llama",
+    complete: async () => "not-json {{",
+  });
+  assert.equal(result.status, "invalid_output");
+  assert.equal(result.cards, cards);
+});
+
+test("empty input returns invalid_output with zero provider calls", async () => {
+  const cards: TimelineCard[] = [];
+  let calls = 0;
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [],
+    provider: "local",
+    model: "llama",
+    complete: async () => {
+      calls += 1;
+      return '{"ops":[]}';
+    },
+  });
+  assert.equal(result.status, "invalid_output");
+  assert.equal(result.cards, cards);
+  assert.equal(calls, 0);
+});
+
+test("valid no-op preserves cards and records prompt metadata", async () => {
+  const cards = sampleCards();
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "local",
+    model: "llama",
+    date: DATE,
+    timezone: TZ,
+    complete: async () => '{"ops":[]}',
+  });
+  assert.equal(result.status, "ok");
+  assert.equal(result.cards, cards);
+  assert.equal(result.provider, "local");
+  assert.equal(result.model, "llama");
+  assert.equal(result.promptVersion, TIMELINE_ANALYSIS_PROMPT_VERSION);
+});
+
+test("prompt instructs evidence-only chronology and forbids invention", async () => {
+  let prompt = "";
+  await analyzeTimelineCards({
+    enabled: true,
+    cards: sampleCards(),
+    observations: [observation({ browserUrl: "https://example.test/repo" })],
+    provider: "openai",
+    model: "gpt-4.1",
+    date: DATE,
+    timezone: TZ,
+    complete: async (input) => {
+      prompt = input.prompt;
+      return '{"ops":[]}';
+    },
+  });
+  assert.match(prompt, /only supplied evidence/i);
+  assert.match(prompt, /chronolog/i);
+  assert.match(prompt, /do not invent (people|places|tasks)/i);
+  assert.match(prompt, /strict JSON/i);
+  assert.match(prompt, /productivity|emotional/i);
+  assert.ok(prompt.includes("main.ts — editor"));
+  assert.ok(prompt.includes("https://example.test/repo"));
+});
+
+test("screenshots audio OCR and clipboard are not sent", async () => {
+  let prompt = "";
+  const dirty = {
+    ...observation(),
+    screenshot: "PNG-BYTES",
+    audio: "WAV-BYTES",
+    ocr: "OCR-SECRET",
+    clipboard: "CLIP-SECRET",
+    keystrokes: "KEY-SECRET",
+  } as TimelineObservation;
+  await analyzeTimelineCards({
+    enabled: true,
+    cards: sampleCards(),
+    observations: [dirty],
+    provider: "local",
+    model: "llama",
+    complete: async (input) => {
+      prompt = input.prompt;
+      return '{"ops":[]}';
+    },
+  });
+  assert.equal(prompt.includes("PNG-BYTES"), false);
+  assert.equal(prompt.includes("WAV-BYTES"), false);
+  assert.equal(prompt.includes("OCR-SECRET"), false);
+  assert.equal(prompt.includes("CLIP-SECRET"), false);
+  assert.equal(prompt.includes("KEY-SECRET"), false);
+});
+
+test("rate limit and abort are provider_failed", async () => {
+  const cards = sampleCards();
+  const limited = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "openai",
+    model: "gpt-4.1",
+    complete: async () => {
+      throw new Error("429 rate limit");
+    },
+  });
+  assert.equal(limited.status, "provider_failed");
+  assert.equal(limited.cards, cards);
+
+  const aborted = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "openai",
+    model: "gpt-4.1",
+    complete: async ({ signal }) => {
+      const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+      signal.throwIfAborted?.();
+      throw err;
+    },
+  });
+  assert.equal(aborted.status, "provider_failed");
+  assert.equal(aborted.cards, cards);
+});
+
+test("valid op updates allowed fields and preserves evidence and manual edits", async () => {
+  const locked = card({
+    id: "locked",
+    startUtc: "2026-08-17T10:00:00.000Z",
+    endUtc: "2026-08-17T10:10:00.000Z",
+    title: "Keep this title",
+    manualEdit: { title: "Keep this title", editedAtUtc: "2026-08-17T12:00:00.000Z" },
+  });
+  const open = card({
+    id: "open",
+    startUtc: "2026-08-17T10:10:00.000Z",
+    endUtc: "2026-08-17T10:20:00.000Z",
+    evidenceIds: [2],
+    evidenceRange: {
+      firstKey: "ws-a|2026-08-17T10:10:00.000Z|hash-2",
+      lastKey: "ws-a|2026-08-17T10:10:00.000Z|hash-2",
+    },
+  });
+  const cards = [locked, open];
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [
+      observation(),
+      observation({
+        id: 2,
+        capturedAtUtc: "2026-08-17T10:10:00.000Z",
+        contentHash: "hash-2",
+        windowTitle: "analysis.ts — editor",
+      }),
+    ],
+    provider: "local",
+    model: "llama",
+    complete: async () =>
+      JSON.stringify({
+        ops: [
+          {
+            cardId: "locked",
+            title: "Should not apply",
+            summary: "ignored",
+            categoryId: "browsing",
+            confidence: 0.1,
+            evidenceRange: locked.evidenceRange,
+          },
+          {
+            cardId: "open",
+            title: "analysis.ts — editor",
+            summary: "Edited analysis.ts on ws-a",
+            categoryId: "development",
+            confidence: 0.9,
+            uncertainty: "low",
+            evidenceRange: open.evidenceRange,
+          },
+        ],
+      }),
+  });
+  assert.equal(result.status, "ok");
+  assert.notEqual(result.cards, cards);
+  const nextLocked = result.cards.find((item) => item.id === "locked");
+  const nextOpen = result.cards.find((item) => item.id === "open");
+  assert.equal(nextLocked?.title, "Keep this title");
+  assert.deepEqual(nextLocked?.manualEdit, locked.manualEdit);
+  assert.deepEqual(nextLocked?.evidenceRange, locked.evidenceRange);
+  assert.equal(nextOpen?.title, "analysis.ts — editor");
+  assert.equal(nextOpen?.summary, "Edited analysis.ts on ws-a");
+  assert.equal(nextOpen?.confidence, 0.9);
+  assert.deepEqual(nextOpen?.evidenceIds, [2]);
+  assert.deepEqual(nextOpen?.evidenceRange, open.evidenceRange);
+});
+
+test("ops without evidence ranges are invalid_output", async () => {
+  const cards = sampleCards();
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "local",
+    model: "llama",
+    complete: async () =>
+      JSON.stringify({
+        ops: [{ cardId: "card-1", title: "Invented Alice in Paris", summary: "mood" }],
+      }),
+  });
+  assert.equal(result.status, "invalid_output");
+  assert.equal(result.cards, cards);
+});
+
+test("batch constants stay bounded with explicit overlap", () => {
+  assert.equal(TIMELINE_ANALYSIS_BATCH_SIZE, 40);
+  assert.equal(TIMELINE_ANALYSIS_BATCH_OVERLAP, 2);
+  assert.ok(TIMELINE_ANALYSIS_BATCH_OVERLAP < TIMELINE_ANALYSIS_BATCH_SIZE);
+});
+
+test("local and remote provider ids are forwarded unchanged", async () => {
+  const seen: string[] = [];
+  for (const [provider, model] of [
+    ["local", "llama"],
+    ["openai", "gpt-4.1"],
+  ] as const) {
+    await analyzeTimelineCards({
+      enabled: true,
+      cards: sampleCards(),
+      observations: [observation()],
+      provider,
+      model,
+      complete: async (input) => {
+        seen.push(`${input.provider}/${input.model}`);
+        return '{"ops":[]}';
+      },
+    });
+  }
+  assert.deepEqual(seen, ["local/llama", "openai/gpt-4.1"]);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis.test.ts
@@ -278,6 +278,26 @@ test("rate limit and abort are provider_failed", async () => {
   assert.equal(aborted.cards, cards);
 });
 
+test("pre-aborted caller signal skips provider dispatch", async () => {
+  const cards = sampleCards();
+  let dispatched = false;
+  const result = await analyzeTimelineCards({
+    enabled: true,
+    cards,
+    observations: [observation()],
+    provider: "openai",
+    model: "gpt-4.1",
+    signal: AbortSignal.abort(),
+    complete: async () => {
+      dispatched = true;
+      return '{"ops":[]}';
+    },
+  });
+  assert.equal(dispatched, false);
+  assert.equal(result.status, "provider_failed");
+  assert.equal(result.cards, cards);
+});
+
 test("valid op updates allowed fields and preserves evidence and manual edits", async () => {
   const locked = card({
     id: "locked",

--- a/packages/remnic-core/src/activity/timeline/analysis.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis.ts
@@ -191,9 +191,12 @@ async function callComplete(
     reject(Object.assign(new Error(message), { name }));
   };
   const timer = setTimeout(() => failOnce("timeline analysis timed out", "TimeoutError"), timeoutMs);
+  if (parent?.aborted) {
+    clearTimeout(timer);
+    throw Object.assign(new Error("timeline analysis aborted"), { name: "AbortError" });
+  }
   const onAbort = () => failOnce("timeline analysis aborted", "AbortError");
-  if (parent?.aborted) onAbort();
-  else parent?.addEventListener("abort", onAbort, { once: true });
+  parent?.addEventListener("abort", onAbort, { once: true });
   const signal = parent ? AbortSignal.any([parent, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs);
   try {
     return await Promise.race([complete({ prompt, provider, model, signal }), timeoutPromise]);

--- a/packages/remnic-core/src/activity/timeline/analysis.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis.ts
@@ -1,0 +1,359 @@
+/**
+ * Optional AI analysis over deterministic timeline cards (issue #2050 first slice).
+ *
+ * Injected provider only. parseConfig, registries, and surfaces wait.
+ * Failures leave cards unchanged. Disabled makes zero provider calls.
+ */
+import { extractJsonCandidates } from "../../json-extract.js";
+import { log } from "../../logger.js";
+import { DEFAULT_TIMELINE_CATEGORIES } from "./categories.js";
+import type { TimelineCard, TimelineCategory, TimelineCorrection, TimelineEvidenceRange, TimelineObservation } from "./types.js";
+
+export const TIMELINE_ANALYSIS_PROMPT_VERSION = 1;
+export const TIMELINE_ANALYSIS_BATCH_SIZE = 40;
+export const TIMELINE_ANALYSIS_BATCH_OVERLAP = 2;
+export const TIMELINE_ANALYSIS_DEFAULT_TIMEOUT_MS = 15_000;
+
+export class TimelineAnalysisConfigError extends Error {
+  override readonly name = "TimelineAnalysisConfigError";
+  readonly code = "invalid_config" as const;
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export type TimelineAnalysisStatus = "ok" | "disabled" | "provider_failed" | "invalid_output";
+
+export interface TimelineAnalysisCompleteInput {
+  prompt: string;
+  provider: string;
+  model: string;
+  signal: AbortSignal;
+}
+
+export type TimelineAnalysisComplete = (input: TimelineAnalysisCompleteInput) => Promise<string>;
+
+export interface TimelineAnalysisInput {
+  enabled: boolean;
+  cards: readonly TimelineCard[];
+  observations: readonly TimelineObservation[];
+  provider?: string;
+  model?: string;
+  complete?: TimelineAnalysisComplete;
+  timeoutMs?: number;
+  date?: string;
+  timezone?: string;
+  categories?: readonly TimelineCategory[];
+  preferences?: readonly string[];
+  priorEdits?: readonly TimelineCorrection[];
+  signal?: AbortSignal;
+}
+
+export interface TimelineAnalysisResult {
+  status: TimelineAnalysisStatus;
+  cards: TimelineCard[];
+  provider?: string;
+  model?: string;
+  promptVersion?: number;
+}
+
+interface AnalysisOp {
+  cardId: string;
+  title?: string;
+  summary?: string;
+  categoryId?: string;
+  confidence?: number;
+  uncertainty?: string;
+  evidenceRange: TimelineEvidenceRange;
+}
+
+const INSTRUCTIONS = [
+  "Use only supplied evidence.",
+  "Preserve chronology.",
+  "Do not invent people, places, or tasks.",
+  "Avoid productivity or emotional claims.",
+  "Merge adjacent activity only when the evidence justifies it.",
+  "Return strict JSON: {\"ops\":[...]} with evidenceRange, title, summary, categoryId, confidence, uncertainty.",
+  "Cite evidence ranges for every op. Empty ops is a valid no-op.",
+].join(" ");
+
+function fail(
+  status: Exclude<TimelineAnalysisStatus, "ok" | "disabled">,
+  cards: readonly TimelineCard[],
+  provider: string,
+  model: string,
+): TimelineAnalysisResult {
+  log.info(`timeline analysis status=${status} provider=${provider} model=${model} promptVersion=${TIMELINE_ANALYSIS_PROMPT_VERSION}`);
+  return {
+    status,
+    cards: cards as TimelineCard[],
+    provider,
+    model,
+    promptVersion: TIMELINE_ANALYSIS_PROMPT_VERSION,
+  };
+}
+
+function requiredToken(value: string | undefined, name: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TimelineAnalysisConfigError(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function evidenceKeyOf(observation: TimelineObservation): string {
+  const parsed = Date.parse(observation.capturedAtUtc);
+  const instant = Number.isFinite(parsed) ? new Date(parsed).toISOString() : observation.capturedAtUtc;
+  return `${observation.machine}|${instant}|${observation.contentHash}`;
+}
+
+function sortObservations(observations: readonly TimelineObservation[]): TimelineObservation[] {
+  return [...observations].sort((a, b) => {
+    const time = Date.parse(a.capturedAtUtc) - Date.parse(b.capturedAtUtc);
+    if (time !== 0) return time;
+    if (a.contentHash !== b.contentHash) return a.contentHash < b.contentHash ? -1 : 1;
+    return a.id - b.id;
+  });
+}
+
+function batchObservations(observations: readonly TimelineObservation[]): TimelineObservation[][] {
+  if (observations.length === 0) return [[]];
+  const size = TIMELINE_ANALYSIS_BATCH_SIZE;
+  const overlap = TIMELINE_ANALYSIS_BATCH_OVERLAP;
+  const step = size - overlap;
+  const batches: TimelineObservation[][] = [];
+  for (let start = 0; start < observations.length; start += step) {
+    batches.push(observations.slice(start, start + size));
+    if (start + size >= observations.length) break;
+  }
+  return batches;
+}
+
+function safeObservation(observation: TimelineObservation) {
+  return {
+    id: observation.id,
+    machine: observation.machine,
+    capturedAtUtc: observation.capturedAtUtc,
+    app: observation.app,
+    windowTitle: observation.windowTitle,
+    ...(observation.browserUrl ? { browserUrl: observation.browserUrl } : {}),
+    contentHash: observation.contentHash,
+  };
+}
+
+function safeCard(card: TimelineCard) {
+  return {
+    id: card.id,
+    kind: card.kind,
+    title: card.title,
+    summary: card.summary,
+    categoryId: card.categoryId,
+    confidence: card.confidence,
+    startUtc: card.startUtc,
+    endUtc: card.endUtc,
+    machine: card.machine,
+    evidenceIds: card.evidenceIds,
+    evidenceRange: card.evidenceRange,
+    ...(card.manualEdit ? { manualEdit: card.manualEdit } : {}),
+  };
+}
+
+export function buildTimelineAnalysisPrompt(input: {
+  date?: string;
+  timezone?: string;
+  cards: readonly TimelineCard[];
+  observations: readonly TimelineObservation[];
+  categories: readonly TimelineCategory[];
+  preferences?: readonly string[];
+  priorEdits?: readonly TimelineCorrection[];
+}): string {
+  const payload = {
+    date: input.date ?? null,
+    timezone: input.timezone ?? null,
+    categories: input.categories.map((category) => ({ id: category.id, name: category.name })),
+    preferences: input.preferences ?? [],
+    priorEdits: input.priorEdits ?? [],
+    cards: input.cards.map(safeCard),
+    observations: input.observations.map(safeObservation),
+  };
+  return `${INSTRUCTIONS}\n${JSON.stringify(payload)}`;
+}
+
+async function callComplete(
+  complete: TimelineAnalysisComplete,
+  prompt: string,
+  provider: string,
+  model: string,
+  timeoutMs: number,
+  parent?: AbortSignal,
+): Promise<string> {
+  const { promise: timeoutPromise, reject } = Promise.withResolvers<string>();
+  const failOnce = (message: string, name: string) => {
+    reject(Object.assign(new Error(message), { name }));
+  };
+  const timer = setTimeout(() => failOnce("timeline analysis timed out", "TimeoutError"), timeoutMs);
+  const onAbort = () => failOnce("timeline analysis aborted", "AbortError");
+  if (parent?.aborted) onAbort();
+  else parent?.addEventListener("abort", onAbort, { once: true });
+  const signal = parent ? AbortSignal.any([parent, AbortSignal.timeout(timeoutMs)]) : AbortSignal.timeout(timeoutMs);
+  try {
+    return await Promise.race([complete({ prompt, provider, model, signal }), timeoutPromise]);
+  } finally {
+    clearTimeout(timer);
+    parent?.removeEventListener("abort", onAbort);
+  }
+}
+
+function parseOps(raw: string): AnalysisOp[] | null {
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  for (const candidate of extractJsonCandidates(raw)) {
+    try {
+      const parsed: unknown = JSON.parse(candidate);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !("ops" in parsed)) continue;
+      const ops = parsed.ops;
+      if (!Array.isArray(ops)) continue;
+      const out: AnalysisOp[] = [];
+      let valid = true;
+      for (const item of ops) {
+        const op = asOp(item);
+        if (!op) {
+          valid = false;
+          break;
+        }
+        out.push(op);
+      }
+      if (valid) return out;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function asOp(value: unknown): AnalysisOp | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (!("cardId" in value) || typeof value.cardId !== "string" || value.cardId.length === 0) return null;
+  if (!("evidenceRange" in value)) return null;
+  const range = value.evidenceRange;
+  if (!range || typeof range !== "object" || Array.isArray(range)) return null;
+  if (!("firstKey" in range) || typeof range.firstKey !== "string" || range.firstKey.length === 0) return null;
+  if (!("lastKey" in range) || typeof range.lastKey !== "string" || range.lastKey.length === 0) return null;
+  if ("title" in value && value.title !== undefined && typeof value.title !== "string") return null;
+  if ("summary" in value && value.summary !== undefined && typeof value.summary !== "string") return null;
+  if ("categoryId" in value && value.categoryId !== undefined && typeof value.categoryId !== "string") return null;
+  if ("uncertainty" in value && value.uncertainty !== undefined && typeof value.uncertainty !== "string") return null;
+  if (
+    "confidence" in value &&
+    value.confidence !== undefined &&
+    (typeof value.confidence !== "number" || value.confidence < 0 || value.confidence > 1)
+  ) {
+    return null;
+  }
+  return {
+    cardId: value.cardId,
+    title: "title" in value && typeof value.title === "string" ? value.title : undefined,
+    summary: "summary" in value && typeof value.summary === "string" ? value.summary : undefined,
+    categoryId: "categoryId" in value && typeof value.categoryId === "string" ? value.categoryId : undefined,
+    confidence: "confidence" in value && typeof value.confidence === "number" ? value.confidence : undefined,
+    uncertainty: "uncertainty" in value && typeof value.uncertainty === "string" ? value.uncertainty : undefined,
+    evidenceRange: { firstKey: range.firstKey, lastKey: range.lastKey },
+  };
+}
+
+function knownEvidenceKeys(cards: readonly TimelineCard[], observations: readonly TimelineObservation[]): Set<string> {
+  const keys = new Set<string>();
+  for (const observation of observations) keys.add(evidenceKeyOf(observation));
+  for (const card of cards) {
+    if (card.evidenceRange) {
+      keys.add(card.evidenceRange.firstKey);
+      keys.add(card.evidenceRange.lastKey);
+    }
+  }
+  return keys;
+}
+
+function applyOps(
+  cards: readonly TimelineCard[],
+  ops: readonly AnalysisOp[],
+  categories: readonly TimelineCategory[],
+  evidenceKeys: ReadonlySet<string>,
+): TimelineCard[] | null {
+  if (ops.length === 0) return cards as TimelineCard[];
+  const byId = new Map(cards.map((card) => [card.id, card]));
+  const allowedCategories = new Set(categories.map((category) => category.id));
+  const next = new Map<string, TimelineCard>();
+  for (const op of ops) {
+    const card = byId.get(op.cardId);
+    if (!card) return null;
+    if (!evidenceKeys.has(op.evidenceRange.firstKey) || !evidenceKeys.has(op.evidenceRange.lastKey)) return null;
+    if (op.categoryId !== undefined && !allowedCategories.has(op.categoryId)) return null;
+    if (card.manualEdit) continue;
+    next.set(card.id, {
+      ...card,
+      ...(op.title !== undefined ? { title: op.title } : {}),
+      ...(op.summary !== undefined ? { summary: op.summary } : {}),
+      ...(op.categoryId !== undefined ? { categoryId: op.categoryId } : {}),
+      ...(op.confidence !== undefined ? { confidence: op.confidence } : {}),
+    });
+  }
+  if (next.size === 0) return cards as TimelineCard[];
+  return cards.map((card) => next.get(card.id) ?? card);
+}
+
+/** Analyze one day of cards. Failures return the input cards unchanged. */
+export async function analyzeTimelineCards(input: TimelineAnalysisInput): Promise<TimelineAnalysisResult> {
+  const cards = input.cards as TimelineCard[];
+  if (!input.enabled) {
+    return { status: "disabled", cards };
+  }
+
+  const provider = requiredToken(input.provider, "provider");
+  const model = requiredToken(input.model, "model");
+  const complete = input.complete;
+  if (typeof complete !== "function") {
+    throw new TimelineAnalysisConfigError("complete is required");
+  }
+  const timeoutMs = input.timeoutMs ?? TIMELINE_ANALYSIS_DEFAULT_TIMEOUT_MS;
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TimelineAnalysisConfigError("timeoutMs must be a positive integer");
+  }
+  if (input.cards.length === 0 && input.observations.length === 0) {
+    return fail("invalid_output", cards, provider, model);
+  }
+
+  const categories = input.categories ?? DEFAULT_TIMELINE_CATEGORIES;
+  const ordered = sortObservations(input.observations);
+  const batches = batchObservations(ordered);
+  const merged = new Map<string, AnalysisOp>();
+
+  try {
+    for (const batch of batches) {
+      const prompt = buildTimelineAnalysisPrompt({
+        date: input.date,
+        timezone: input.timezone,
+        cards: input.cards,
+        observations: batch,
+        categories,
+        preferences: input.preferences,
+        priorEdits: input.priorEdits,
+      });
+      const raw = await callComplete(complete, prompt, provider, model, timeoutMs, input.signal);
+      const ops = parseOps(raw);
+      if (!ops) return fail("invalid_output", cards, provider, model);
+      for (const op of ops) merged.set(op.cardId, op);
+    }
+  } catch {
+    return fail("provider_failed", cards, provider, model);
+  }
+
+  const applied = applyOps(cards, [...merged.values()], categories, knownEvidenceKeys(cards, ordered));
+  if (!applied) return fail("invalid_output", cards, provider, model);
+
+  log.info(`timeline analysis status=ok provider=${provider} model=${model} promptVersion=${TIMELINE_ANALYSIS_PROMPT_VERSION}`);
+  return {
+    status: "ok",
+    cards: applied,
+    provider,
+    model,
+    promptVersion: TIMELINE_ANALYSIS_PROMPT_VERSION,
+  };
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -8,3 +8,4 @@ export * from "./query.js";
 export * from "./journal-recap.js";
 export * from "./weekly.js";
 export * from "./weekly-persist.js";
+export * from "./analysis.js";


### PR DESCRIPTION
Part of #2050

## Change
`analyzeTimelineCards`. Disabled = no provider call. Failures leave cards unchanged.

## Out of this PR
parseConfig, live provider registry, CLI/MCP.

## Test
`packages/remnic-core/src/activity/timeline/analysis.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional AI-powered analysis for timeline cards.
  * Supports configurable providers, timeouts, batched observations, and validated card updates.
  * Preserves deterministic results when analysis is disabled, unavailable, times out, or returns invalid data.
  * Protects manually edited cards and sensitive fields during analysis.

* **Bug Fixes**
  * Invalid analysis operations and evidence references are safely rejected without changing timeline cards.

* **Documentation**
  * Added release notes for the optional timeline analysis capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->