### PR TITLE
feat(extraction): isolated span offset parser

### DIFF
--- a/.changeset/2333-span-extraction.md
+++ b/.changeset/2333-span-extraction.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a default-off span offset parser. Disabled or `0` returns the whole text. Enabled slices half-open `[start, end)` and rejects reversed or out-of-range offsets. Default extraction path is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span.test.ts
+++ b/packages/remnic-core/src/extraction-span.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseSpanOffsets } from "./extraction-span.js";
+
+const TEXT = "Alice moved to Seattle";
+
+test("parseSpanOffsets: disabled or 0 is identity", () => {
+  const offsets = { start: 6, end: 11 };
+  assert.deepEqual(parseSpanOffsets(TEXT, offsets, false), { text: TEXT });
+  assert.deepEqual(parseSpanOffsets(TEXT, offsets, 0), { text: TEXT });
+  assert.deepEqual(parseSpanOffsets(TEXT, offsets), { text: TEXT });
+});
+
+test("parseSpanOffsets: enabled slices half-open [start, end)", () => {
+  assert.deepEqual(parseSpanOffsets(TEXT, { start: 6, end: 11 }, true), {
+    text: "moved",
+    start: 6,
+    end: 11,
+  });
+});
+
+test("parseSpanOffsets: boundary offsets stay inside the string", () => {
+  assert.deepEqual(parseSpanOffsets(TEXT, { start: 0, end: TEXT.length }, true), {
+    text: TEXT,
+    start: 0,
+    end: TEXT.length,
+  });
+  assert.deepEqual(parseSpanOffsets(TEXT, { start: 0, end: 1 }, true), {
+    text: "A",
+    start: 0,
+    end: 1,
+  });
+  assert.deepEqual(parseSpanOffsets(TEXT, { start: TEXT.length - 1, end: TEXT.length }, true), {
+    text: "e",
+    start: TEXT.length - 1,
+    end: TEXT.length,
+  });
+});
+
+test("parseSpanOffsets: reversed and out-of-range offsets reject", () => {
+  assert.throws(() => parseSpanOffsets(TEXT, { start: 12, end: 6 }, true), /reversed|out of range|invalid span/i);
+  assert.throws(() => parseSpanOffsets(TEXT, { start: -1, end: 6 }, true), /out of range|invalid span/i);
+  assert.throws(() => parseSpanOffsets(TEXT, { start: 0, end: TEXT.length + 1 }, true), /out of range|invalid span/i);
+});
+
+test("parseSpanOffsets: empty source and empty span", () => {
+  assert.deepEqual(parseSpanOffsets("", { start: 0, end: 0 }, false), { text: "" });
+  assert.deepEqual(parseSpanOffsets("", { start: 0, end: 0 }, true), {
+    text: "",
+    start: 0,
+    end: 0,
+  });
+  assert.deepEqual(parseSpanOffsets(TEXT, { start: 6, end: 6 }, true), {
+    text: "",
+    start: 6,
+    end: 6,
+  });
+  assert.throws(() => parseSpanOffsets("", { start: 0, end: 1 }, true), /out of range|invalid span/i);
+});

--- a/packages/remnic-core/src/extraction-span.ts
+++ b/packages/remnic-core/src/extraction-span.ts
@@ -1,0 +1,39 @@
+/**
+ * Isolated span-offset parser (issue #2333 first slice).
+ *
+ * Default off. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export interface SpanOffsets {
+  start: number;
+  end: number;
+}
+
+export interface ParsedSpan {
+  text: string;
+  start?: number;
+  end?: number;
+}
+
+export function parseSpanOffsets(
+  text: string,
+  offsets: SpanOffsets,
+  spanModeEnabled: boolean | 0 | 1 = false,
+): ParsedSpan {
+  if (spanModeEnabled !== true && spanModeEnabled !== 1) {
+    return { text };
+  }
+
+  const { start, end } = offsets;
+  if (!Number.isInteger(start) || !Number.isInteger(end)) {
+    throw new RangeError("invalid span: out of range");
+  }
+  if (start > end) {
+    throw new RangeError("invalid span: reversed");
+  }
+  if (start < 0 || end > text.length) {
+    throw new RangeError("invalid span: out of range");
+  }
+
+  return { text: text.slice(start, end), start, end };
+}


### PR DESCRIPTION
Part of #2333

## Change
`parseSpanOffsets`. Half-open. Disabled or 0 is identity. Default extraction path unchanged.

## Out of this PR
Two-phase extractor wiring, bench gate.

## Test
`packages/remnic-core/src/extraction-span.test.ts`