### PR TITLE
feat(cli): remnic recall expand and traverse

### DIFF
--- a/.changeset/1956-navigate-cli.md
+++ b/.changeset/1956-navigate-cli.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": minor
+"@remnic/cli": minor
+---
+
+Add `remnic recall expand|traverse` over the existing disclosure and typed-link helpers. Budget 0 prints a tagged refusal. Unknown link types are rejected. Part of #1956.

--- a/packages/remnic-cli/src/commands/recall-navigate.test.ts
+++ b/packages/remnic-cli/src/commands/recall-navigate.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RECALL_NAV_UNAVAILABLE_TAG,
+  runRecallNavigate,
+} from "./recall-navigate.js";
+
+function capture(rest: string[]): { code: number; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = runRecallNavigate(rest, {
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+  return { code, stdout, stderr };
+}
+
+const chunkNode = JSON.stringify({
+  id: "m1",
+  disclosure: "chunk",
+  payloads: { section: "full section body" },
+  links: [
+    { targetId: "m2", linkType: "supports", preview: "ally" },
+    { targetId: "m3", linkType: "contradicts" },
+  ],
+});
+
+test("expand --budget 0 prints tagged refusal and does not emit a node", () => {
+  const result = capture(["expand", "--node", chunkNode, "--budget", "0"]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, [RECALL_NAV_UNAVAILABLE_TAG]);
+  assert.equal(result.stderr.length, 0);
+  assert.equal(result.stdout.join("").includes("full section body"), false);
+});
+
+test("traverse --budget 0 prints tagged refusal", () => {
+  const result = capture([
+    "traverse",
+    "--node",
+    chunkNode,
+    "--type",
+    "supports",
+    "--budget",
+    "0",
+  ]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, [RECALL_NAV_UNAVAILABLE_TAG]);
+  assert.equal(result.stdout.join("").includes("m2"), false);
+});
+
+test("unknown --type is rejected", () => {
+  const result = capture([
+    "traverse",
+    "--node",
+    chunkNode,
+    "--type",
+    "related",
+    "--budget",
+    "10",
+  ]);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.length, 0);
+  assert.match(result.stderr.join("\n"), /unknown recall nav linkType/);
+});
+
+test("expand maps --node and --budget onto the next disclosure", () => {
+  const result = capture(["expand", "--node", chunkNode, "--budget", "10"]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout[0] ?? ""), {
+    status: "ok",
+    node: { id: "m1", disclosure: "section", text: "full section body" },
+  });
+});
+
+test("traverse maps --type onto neighbors", () => {
+  const result = capture([
+    "traverse",
+    "--node",
+    chunkNode,
+    "--type",
+    "supports",
+    "--budget",
+    "10",
+  ]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout[0] ?? ""), {
+    status: "ok",
+    neighbors: [{ id: "m2", linkType: "supports", preview: "ally" }],
+  });
+});

--- a/packages/remnic-cli/src/commands/recall-navigate.ts
+++ b/packages/remnic-cli/src/commands/recall-navigate.ts
@@ -1,0 +1,125 @@
+/**
+ * `remnic recall expand|traverse` (issue #1956 CLI slice).
+ *
+ * Maps flags onto the pure core helpers. No orchestrator, no IO besides
+ * the injected stdout/stderr. Budget 0 is off (tagged refusal).
+ */
+import {
+  expandRecallNode,
+  traverseRecallLink,
+  type RecallNavNode,
+} from "@remnic/core";
+
+export interface RecallNavigateIo {
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+export const RECALL_NAV_UNAVAILABLE_TAG = "[unavailable] budget_off";
+
+export function recallNavigateHelp(): string {
+  return `Usage: remnic recall <expand|traverse> --node <json> [--budget <n>] [--type <linkType>]
+
+  expand    Re-render one node at the next disclosure level
+  traverse  Follow typed links from a node
+
+  --budget 0 turns navigation off and prints ${RECALL_NAV_UNAVAILABLE_TAG}
+  --type    required for traverse: supports, contradicts, elaborates, supersedes, causes
+`;
+}
+
+function takeFlag(rest: string[], name: string): string | undefined {
+  const index = rest.indexOf(name);
+  if (index < 0) return undefined;
+  const value = rest[index + 1];
+  if (value === undefined || value.startsWith("-")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function parseBudget(rest: string[]): number {
+  if (!rest.includes("--budget")) return 1;
+  const raw = takeFlag(rest, "--budget");
+  const budget = Number(raw);
+  if (!Number.isFinite(budget)) {
+    throw new Error(`--budget must be a number (got ${JSON.stringify(raw)})`);
+  }
+  return budget;
+}
+
+function parseNode(raw: string): RecallNavNode {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error("--node must be JSON");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("--node must be a JSON object");
+  }
+  const node = value as Partial<RecallNavNode>;
+  if (typeof node.id !== "string" || node.id.length === 0) {
+    throw new Error("--node.id must be a non-empty string");
+  }
+  if (typeof node.disclosure !== "string") {
+    throw new Error("--node.disclosure is required");
+  }
+  return node as RecallNavNode;
+}
+
+function emitUnavailable(io: RecallNavigateIo): number {
+  io.stdout(RECALL_NAV_UNAVAILABLE_TAG);
+  return 0;
+}
+
+/**
+ * Flag mapper for `remnic recall`. Returns an exit code; does not touch
+ * `process.exitCode` so tests can call it without a process-global leak.
+ */
+export function runRecallNavigate(rest: string[], io: RecallNavigateIo): number {
+  const action = rest[0];
+  if (
+    rest.length === 0 ||
+    action === "--help" ||
+    action === "-h" ||
+    action === "help"
+  ) {
+    io.stdout(recallNavigateHelp());
+    return 0;
+  }
+  try {
+    const budget = parseBudget(rest);
+    const nodeRaw = takeFlag(rest, "--node");
+    if (nodeRaw === undefined) throw new Error("--node is required");
+    const node = parseNode(nodeRaw);
+    if (action === "expand") {
+      const result = expandRecallNode(node, { budget });
+      if (result.status === "unavailable") return emitUnavailable(io);
+      io.stdout(JSON.stringify(result));
+      return 0;
+    }
+    if (action === "traverse") {
+      const linkType = takeFlag(rest, "--type");
+      if (linkType === undefined) throw new Error("traverse requires --type");
+      const result = traverseRecallLink(node, linkType, { budget });
+      if (result.status === "unavailable") return emitUnavailable(io);
+      io.stdout(JSON.stringify(result));
+      return 0;
+    }
+    io.stderr(`recall: unknown action "${action}".`);
+    io.stderr(recallNavigateHelp());
+    return 1;
+  } catch (err) {
+    io.stderr(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}
+
+export async function runRecallNavigateCommand(rest: string[]): Promise<void> {
+  const code = runRecallNavigate(rest, {
+    stdout: (line) => console.log(line),
+    stderr: (line) => console.error(line),
+  });
+  if (code !== 0) process.exitCode = code;
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -177,6 +177,7 @@ import { runJournalBinaryCommand } from "./commands/journal.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
 import { runDriftBinaryCommand } from "./commands/drift.js";
+import { runRecallNavigateCommand } from "./commands/recall-navigate.js";
 // @remnic/export-weclone is an optional install surface (training:export
 // only uses it). Load lazily so the CLI works without it — see
 // optional-weclone-export.ts for the install-hint behaviour.
@@ -406,6 +407,7 @@ type CommandName =
   | "migrate"
   | "status"
   | "query"
+  | "recall"
   | "doctor"
   | "config"
   | "daemon"
@@ -12699,6 +12701,9 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
       await cmdQuery(queryText, json, explain);
       break;
     }
+    case "recall":
+      await runRecallNavigateCommand(rest);
+      break;
 
     case "action-confidence":
       await cmdActionConfidence(rest);

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -1458,3 +1458,4 @@ export * from "./maintenance/atomic-file.js";
 export * from "./eval-trajectory.js";
 export { MemoryControllerCoordinator, chooseAction, computeEvidenceReportHash, controllerConfigHash, evaluateActiveGates, hashControllerState, verifyEvidenceReport } from "./memory-controller.js";
 export type { ActiveContextAdapter, ActiveContextMessage, ActiveContextPlan, MemoryControllerActionFamily, MemoryControllerChoice, MemoryControllerConfig, MemoryControllerDeps, MemoryControllerEvent, MemoryControllerEvidence, MemoryControllerEvidenceReport, MemoryControllerExecutors, MemoryControllerMode, MemoryControllerPairedSeedEvidence, MemoryControllerReceipt, MemoryControllerRecorder, MemoryControllerReportReader, MemoryControllerRunResult, MemoryControllerState } from "./memory-controller.js";
+export * from "./recall-navigate.js";


### PR DESCRIPTION
Part of #1956

## Change
`remnic recall expand|traverse` over existing helpers. budget 0 is off.

## Out of this PR
MCP/HTTP, session authority.

## Test
`packages/remnic-cli/src/commands/recall-navigate.test.ts`