### PR TITLE
feat(activity): persist weekly analytics snapshots

### DIFF
--- a/.changeset/2052-weekly-persist.md
+++ b/.changeset/2052-weekly-persist.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Persist versioned weekly time/activity snapshots under `activity/weekly/` (issue #2052). Same inputs skip rewrite by content hash. A changed source revision or config hash writes a new namespace-scoped file and does not mutate another week. Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -6,3 +6,5 @@ export * from "./build.js";
 export * from "./corrections.js";
 export * from "./query.js";
 export * from "./journal-recap.js";
+export * from "./weekly.js";
+export * from "./weekly-persist.js";

--- a/packages/remnic-core/src/activity/timeline/weekly-persist.test.ts
+++ b/packages/remnic-core/src/activity/timeline/weekly-persist.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { RECALL_FALLBACK_DIRS } from "../../utils/category-dir.js";
+import type { TimelineCategory } from "./types.js";
+import { persistWeeklySnapshot } from "./weekly-persist.js";
+import { buildWeeklyActivitySummary } from "./weekly.js";
+
+const WEEK_START = "2026-07-13T00:00:00.000Z";
+const WEEK_END = "2026-07-20T00:00:00.000Z";
+const OTHER_WEEK_START = "2026-07-20T00:00:00.000Z";
+const OTHER_WEEK_END = "2026-07-27T00:00:00.000Z";
+
+const CATEGORIES: TimelineCategory[] = [
+  { id: "development", name: "Development", color: "#333333", description: "d", order: 1 },
+];
+
+function summary(weekStartUtc = WEEK_START, weekEndUtc = WEEK_END) {
+  return buildWeeklyActivitySummary([], {
+    timezone: "UTC",
+    weekStartUtc,
+    weekEndUtc,
+    categories: CATEGORIES,
+  });
+}
+
+function withMemoryDir(fn: (memoryDir: string) => void): void {
+  const memoryDir = mkdtempSync(path.join(tmpdir(), "remnic-weekly-persist-"));
+  try {
+    fn(memoryDir);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
+}
+
+function assertOutsideRecallRoots(filePath: string, memoryDir: string): void {
+  const relative = path.relative(memoryDir, filePath);
+  assert.ok(relative.startsWith(`activity${path.sep}weekly${path.sep}`));
+  assert.ok(
+    !RECALL_FALLBACK_DIRS.some((dir) => relative === dir || relative.startsWith(`${dir}${path.sep}`)),
+  );
+}
+
+test("same inputs skip rewrite by content hash", () => {
+  withMemoryDir((memoryDir) => {
+    const input = {
+      memoryDir,
+      namespace: "team",
+      summary: summary(),
+      sourceRevision: "rev-1",
+      configHash: "cfg-1",
+    };
+    const first = persistWeeklySnapshot(input);
+    assert.equal(first.written, true);
+    assertOutsideRecallRoots(first.path, memoryDir);
+    const firstBytes = readFileSync(first.path, "utf8");
+    const firstStat = statSync(first.path);
+    const snapshot = JSON.parse(firstBytes) as { contentHash: string };
+    assert.equal(typeof snapshot.contentHash, "string");
+    assert.equal(snapshot.contentHash.length, 64);
+
+    const second = persistWeeklySnapshot(input);
+    assert.equal(second.written, false);
+    assert.equal(second.path, first.path);
+    assert.equal(readFileSync(first.path, "utf8"), firstBytes);
+    assert.equal(statSync(first.path).mtimeMs, firstStat.mtimeMs);
+  });
+});
+
+test("changed sourceRevision or configHash writes a new file and leaves other weeks", () => {
+  withMemoryDir((memoryDir) => {
+    const base = {
+      memoryDir,
+      namespace: "team",
+      summary: summary(),
+      sourceRevision: "rev-1",
+      configHash: "cfg-1",
+    };
+    const original = persistWeeklySnapshot(base);
+    const originalBytes = readFileSync(original.path, "utf8");
+
+    const revised = persistWeeklySnapshot({ ...base, sourceRevision: "rev-2" });
+    assert.notEqual(revised.path, original.path);
+    assert.equal(revised.written, true);
+    assert.equal(readFileSync(original.path, "utf8"), originalBytes);
+
+    const reconfigured = persistWeeklySnapshot({ ...base, configHash: "cfg-2" });
+    assert.notEqual(reconfigured.path, original.path);
+    assert.notEqual(reconfigured.path, revised.path);
+    assert.equal(readFileSync(original.path, "utf8"), originalBytes);
+
+    const otherWeek = persistWeeklySnapshot({
+      ...base,
+      summary: summary(OTHER_WEEK_START, OTHER_WEEK_END),
+    });
+    assert.notEqual(otherWeek.path, original.path);
+    assert.equal(readFileSync(original.path, "utf8"), originalBytes);
+    assert.equal(JSON.parse(readFileSync(otherWeek.path, "utf8")).summary.weekStartUtc, OTHER_WEEK_START);
+  });
+});
+
+test("snapshots are namespace scoped", () => {
+  withMemoryDir((memoryDir) => {
+    const shared = {
+      memoryDir,
+      summary: summary(),
+      sourceRevision: "rev-1",
+      configHash: "cfg-1",
+    };
+    const alpha = persistWeeklySnapshot({ ...shared, namespace: "alpha" });
+    const beta = persistWeeklySnapshot({ ...shared, namespace: "beta" });
+    assert.notEqual(alpha.path, beta.path);
+    assert.equal(JSON.parse(readFileSync(alpha.path, "utf8")).namespace, "alpha");
+    assert.equal(JSON.parse(readFileSync(beta.path, "utf8")).namespace, "beta");
+    assert.equal(readdirSync(path.dirname(alpha.path)).length, 1);
+    assert.equal(readdirSync(path.dirname(beta.path)).length, 1);
+  });
+});

--- a/packages/remnic-core/src/activity/timeline/weekly-persist.ts
+++ b/packages/remnic-core/src/activity/timeline/weekly-persist.ts
@@ -1,0 +1,103 @@
+/**
+ * Versioned weekly time/activity snapshot store (issue #2052).
+ *
+ * Files live at `<memoryDir>/activity/weekly/<ns>/<week>--<identity>.json`,
+ * outside recall fallback dirs. Same inputs skip rewrite by content hash.
+ * A new sourceRevision or configHash is a new file.
+ */
+import { randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { namespaceIdentityToken } from "../../namespaces/identity.js";
+import { hashActivityBody, isValidActivityDate } from "../digest.js";
+import type { WeeklyActivitySummary } from "./weekly.js";
+
+export const WEEKLY_SNAPSHOT_FORMAT_VERSION = 1;
+export const WEEKLY_SNAPSHOT_DIR = path.join("activity", "weekly");
+
+export interface PersistWeeklySnapshotInput {
+  memoryDir: string;
+  namespace: string;
+  summary: WeeklyActivitySummary;
+  sourceRevision: string;
+  configHash: string;
+}
+
+export interface PersistWeeklySnapshotResult {
+  path: string;
+  written: boolean;
+}
+
+function requireToken(value: string, name: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+export function weeklySnapshotPath(input: PersistWeeklySnapshotInput): string {
+  const memoryDir = requireToken(input.memoryDir, "memoryDir");
+  const namespace = requireToken(input.namespace, "namespace");
+  const sourceRevision = requireToken(input.sourceRevision, "sourceRevision");
+  const configHash = requireToken(input.configHash, "configHash");
+  const weekStartUtc = input.summary?.weekStartUtc;
+  if (typeof weekStartUtc !== "string") {
+    throw new TypeError("summary.weekStartUtc must be an ISO timestamp");
+  }
+  const weekDate = weekStartUtc.slice(0, 10);
+  if (!isValidActivityDate(weekDate)) {
+    throw new RangeError("summary.weekStartUtc must be an ISO timestamp");
+  }
+  const identity = hashActivityBody(
+    `${input.summary.weekStartUtc}\0${input.summary.weekEndUtc}\0${sourceRevision}\0${configHash}`,
+  );
+  return path.join(
+    path.resolve(memoryDir),
+    WEEKLY_SNAPSHOT_DIR,
+    namespaceIdentityToken(namespace),
+    `${weekDate}--${identity}.json`,
+  );
+}
+
+/** Persist one weekly snapshot. Same bytes are a no-op. */
+export function persistWeeklySnapshot(input: PersistWeeklySnapshotInput): PersistWeeklySnapshotResult {
+  const namespace = requireToken(input.namespace, "namespace");
+  const sourceRevision = requireToken(input.sourceRevision, "sourceRevision");
+  const configHash = requireToken(input.configHash, "configHash");
+  const filePath = weeklySnapshotPath(input);
+  const payload = {
+    formatVersion: WEEKLY_SNAPSHOT_FORMAT_VERSION,
+    namespace,
+    sourceRevision,
+    configHash,
+    summary: input.summary,
+  };
+  const contentHash = hashActivityBody(JSON.stringify(payload));
+  const text = `${JSON.stringify({ ...payload, contentHash })}\n`;
+
+  try {
+    if (readFileSync(filePath, "utf8") === text) {
+      return { path: filePath, written: false };
+    }
+  } catch (error) {
+    if (!(typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+
+  mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const tmpPath = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  writeFileSync(tmpPath, text, { encoding: "utf8", mode: 0o600 });
+  try {
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Best-effort cleanup of the temp file.
+    }
+    throw error;
+  }
+  return { path: filePath, written: true };
+}


### PR DESCRIPTION
Part of #2052

## Change
`persistWeeklySnapshot`. Namespace-scoped. Idempotent. New file on revision/config change.

## Out of this PR
Retention delete, CLI/MCP/HTTP.

## Test
`packages/remnic-core/src/activity/timeline/weekly-persist.test.ts`