### PR TITLE
feat(activity): persist deterministic journal recap

### DIFF
--- a/.changeset/2051-journal-recap-persist.md
+++ b/.changeset/2051-journal-recap-persist.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Persist deterministic daily journal recaps through the existing journal write ownership (Part of #2051). Writes `journal/<YYYY-MM-DD>.md` only when the file is absent, unless force is set. Body is the deterministic recap renderer. AI mode stays later.

--- a/packages/remnic-core/src/activity/journal.ts
+++ b/packages/remnic-core/src/activity/journal.ts
@@ -87,7 +87,7 @@ function renderJournalSeed(date: string, cards: readonly JournalSeedCard[]): str
 }
 
 /** The only journal write. Stats first; existing files are a no-op unless force. */
-function writeJournalFile(filePath: string, content: string, force: boolean): boolean {
+export function writeJournalFile(filePath: string, content: string, force: boolean): boolean {
   let exists = false;
   try {
     statSync(filePath);

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -6,6 +6,7 @@ export * from "./build.js";
 export * from "./corrections.js";
 export * from "./query.js";
 export * from "./journal-recap.js";
+export * from "./journal-recap-persist.js";
 export * from "./weekly.js";
 export * from "./weekly-persist.js";
 export * from "./analysis.js";

--- a/packages/remnic-core/src/activity/timeline/journal-recap-persist.test.ts
+++ b/packages/remnic-core/src/activity/timeline/journal-recap-persist.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { journalPath } from "../journal.js";
+import { persistDeterministicJournal } from "./journal-recap-persist.js";
+import { renderDeterministicJournal } from "./journal-recap.js";
+import type { TimelineCard } from "./types.js";
+
+const DATE = "2026-08-17";
+const TZ = "UTC";
+
+function card(
+  overrides: Partial<TimelineCard> & Pick<TimelineCard, "id" | "startUtc" | "endUtc">,
+): TimelineCard {
+  return {
+    kind: "activity",
+    title: "Untitled",
+    summary: "none",
+    categoryId: "development",
+    confidence: 1,
+    dayKey: DATE,
+    timezone: TZ,
+    machine: "ws-a",
+    evidenceIds: [],
+    evidenceRange: null,
+    ...overrides,
+  };
+}
+
+function activityCards(): TimelineCard[] {
+  return [
+    card({
+      id: "act-1",
+      title: "Terminal",
+      startUtc: "2026-08-17T14:00:00.000Z",
+      endUtc: "2026-08-17T15:30:00.000Z",
+    }),
+  ];
+}
+
+function otherCards(): TimelineCard[] {
+  return [
+    card({
+      id: "act-2",
+      title: "Browser",
+      startUtc: "2026-08-17T16:00:00.000Z",
+      endUtc: "2026-08-17T17:00:00.000Z",
+    }),
+  ];
+}
+
+function withMemoryDir(fn: (memoryDir: string) => void): void {
+  const memoryDir = mkdtempSync(path.join(tmpdir(), "remnic-journal-recap-persist-"));
+  try {
+    fn(memoryDir);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
+}
+
+test("persist is a hard no-op without force", () => {
+  withMemoryDir((memoryDir) => {
+    const first = persistDeterministicJournal({
+      memoryDir,
+      date: DATE,
+      cards: activityCards(),
+      timezone: TZ,
+    });
+    assert.equal(first.wrote, true);
+    assert.equal(first.path, journalPath(memoryDir, DATE));
+    const original = readFileSync(first.path);
+    assert.equal(
+      original.toString("utf8"),
+      renderDeterministicJournal(activityCards(), { date: DATE, timezone: TZ }),
+    );
+
+    const second = persistDeterministicJournal({
+      memoryDir,
+      date: DATE,
+      cards: otherCards(),
+      timezone: TZ,
+    });
+    assert.equal(second.wrote, false);
+    assert.equal(second.path, first.path);
+    assert.deepEqual(readFileSync(second.path), original);
+  });
+});
+
+test("persist with force overwrites the existing file", () => {
+  withMemoryDir((memoryDir) => {
+    persistDeterministicJournal({
+      memoryDir,
+      date: DATE,
+      cards: activityCards(),
+      timezone: TZ,
+    });
+    const original = readFileSync(journalPath(memoryDir, DATE), "utf8");
+    const forced = persistDeterministicJournal({
+      memoryDir,
+      date: DATE,
+      cards: otherCards(),
+      timezone: TZ,
+      force: true,
+    });
+    assert.equal(forced.wrote, true);
+    const next = readFileSync(forced.path, "utf8");
+    assert.notEqual(next, original);
+    assert.equal(next, renderDeterministicJournal(otherCards(), { date: DATE, timezone: TZ }));
+  });
+});
+
+test("empty day still writes a valid journal file", () => {
+  withMemoryDir((memoryDir) => {
+    const result = persistDeterministicJournal({
+      memoryDir,
+      date: DATE,
+      cards: [],
+      timezone: TZ,
+    });
+    assert.equal(result.wrote, true);
+    const relative = path.relative(memoryDir, result.path).replace(/\\/g, "/");
+    assert.equal(relative, "journal/2026-08-17.md");
+    assert.equal(
+      readFileSync(result.path, "utf8"),
+      renderDeterministicJournal([], { date: DATE, timezone: TZ }),
+    );
+  });
+});
+
+test("existing foreign file without force stays byte-identical", () => {
+  withMemoryDir((memoryDir) => {
+    const filePath = journalPath(memoryDir, DATE);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, "user notes\n");
+    const original = readFileSync(filePath);
+    const result = persistDeterministicJournal({
+      memoryDir,
+      date: DATE,
+      cards: activityCards(),
+      timezone: TZ,
+    });
+    assert.equal(result.wrote, false);
+    assert.deepEqual(readFileSync(filePath), original);
+  });
+});

--- a/packages/remnic-core/src/activity/timeline/journal-recap-persist.ts
+++ b/packages/remnic-core/src/activity/timeline/journal-recap-persist.ts
@@ -1,0 +1,37 @@
+/**
+ * Persist a deterministic daily journal recap (issue #2051).
+ *
+ * Writes journal/<YYYY-MM-DD>.md through writeJournalFile. Existing files
+ * stay byte-identical unless force is set. Body is renderDeterministicJournal.
+ */
+import { journalPath, writeJournalFile } from "../journal.js";
+import { renderDeterministicJournal } from "./journal-recap.js";
+import type { TimelineCard } from "./types.js";
+
+export interface PersistDeterministicJournalInput {
+  memoryDir: string;
+  date: string;
+  cards: readonly TimelineCard[];
+  timezone: string;
+  force?: boolean;
+}
+
+export interface PersistDeterministicJournalResult {
+  path: string;
+  wrote: boolean;
+}
+
+export function persistDeterministicJournal(
+  input: PersistDeterministicJournalInput,
+): PersistDeterministicJournalResult {
+  const filePath = journalPath(input.memoryDir, input.date);
+  const wrote = writeJournalFile(
+    filePath,
+    renderDeterministicJournal(input.cards, {
+      date: input.date,
+      timezone: input.timezone,
+    }),
+    input.force === true,
+  );
+  return { path: filePath, wrote };
+}


### PR DESCRIPTION
Part of #2051

## Change
`persistDeterministicJournal` writes via existing `writeJournalFile`.
No second journal writer.

## Out of this PR
AI mode, edit merge, export surfaces.

## Test
`packages/remnic-core/src/activity/timeline/journal-recap-persist.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic daily journal recap persistence.
  - Recaps are saved as dated journal files and include timeline cards for the selected date and timezone.
  - Existing journal files are preserved by default, with an option to force overwrites.
  - Empty-day journals are created when no activity is available.

- **Tests**
  - Added coverage for file creation, overwrite behavior, deterministic content, expected paths, and preservation of existing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->