### PR TITLE
feat(dedup): persist-facing merge-on-write wire

### DIFF
--- a/.changeset/2330-merge-on-write-wire.md
+++ b/.changeset/2330-merge-on-write-wire.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a persist seam for merge-on-write. Disabled or `mergeMin=0` writes a new fact. A merge updates the existing id. `extraction-persist` is not wired yet. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-on-write-wire.test.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write-wire.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { MergeOnWritePair } from "./merge-on-write.js";
+import type { MergeJudge, MergeJudgeVerdict, MergeOnWritePair } from "./merge-on-write.js";
 import { applyMergeOnWriteAtPersist } from "./merge-on-write-wire.js";
+
+type PersistResult = { action: "merged"; id: string } | { action: "created" };
 
 function pair(overrides: Partial<MergeOnWritePair> = {}): MergeOnWritePair {
   return {
@@ -20,16 +22,19 @@ function trackers() {
   return {
     merged,
     created,
-    writeMerged: async (id: string) => {
+    writeMerged: async (id: string): Promise<PersistResult> => {
       merged.push(id);
-      return { action: "merged" as const, id };
+      return { action: "merged", id };
     },
-    writeNew: async () => {
+    writeNew: async (): Promise<PersistResult> => {
       created.push(1);
-      return { action: "created" as const };
+      return { action: "created" };
     },
   };
 }
+
+const mergeJudge: MergeJudge = async (): Promise<MergeJudgeVerdict> => "merge";
+const createJudge: MergeJudge = async (): Promise<MergeJudgeVerdict> => "create";
 
 test("merge-on-write-wire: disabled writes a new fact", async () => {
   let judged = 0;
@@ -37,7 +42,7 @@ test("merge-on-write-wire: disabled writes a new fact", async () => {
   const result = await applyMergeOnWriteAtPersist({
     enabled: false,
     pair: pair(),
-    judge: async () => {
+    judge: async (): Promise<MergeJudgeVerdict> => {
       judged += 1;
       return "merge";
     },
@@ -57,10 +62,7 @@ test("merge-on-write-wire: mergeMin 0 writes a new fact", async () => {
     enabled: true,
     mergeMin: 0,
     pair: pair(),
-    judge: async () => {
-      judged += 1;
-      return "merge";
-    },
+    judge: mergeJudge,
     writeMerged: io.writeMerged,
     writeNew: io.writeNew,
   });
@@ -75,7 +77,7 @@ test("merge-on-write-wire: merge updates the existing id", async () => {
   const result = await applyMergeOnWriteAtPersist({
     enabled: true,
     pair: pair(),
-    judge: async () => "merge",
+    judge: mergeJudge,
     writeMerged: io.writeMerged,
     writeNew: io.writeNew,
   });
@@ -89,7 +91,7 @@ test("merge-on-write-wire: create writes a new fact", async () => {
   const result = await applyMergeOnWriteAtPersist({
     enabled: true,
     pair: pair(),
-    judge: async () => "create",
+    judge: createJudge,
     writeMerged: io.writeMerged,
     writeNew: io.writeNew,
   });

--- a/packages/remnic-core/src/dedup/merge-on-write-wire.test.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write-wire.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MergeOnWritePair } from "./merge-on-write.js";
+import { applyMergeOnWriteAtPersist } from "./merge-on-write-wire.js";
+
+function pair(overrides: Partial<MergeOnWritePair> = {}): MergeOnWritePair {
+  return {
+    category: "fact",
+    score: 0.85,
+    incomingContent: "User prefers dark mode on laptops.",
+    existingContent: "User likes dark mode.",
+    existingId: "mem-1",
+    ...overrides,
+  };
+}
+
+function trackers() {
+  const merged: string[] = [];
+  const created: number[] = [];
+  return {
+    merged,
+    created,
+    writeMerged: async (id: string) => {
+      merged.push(id);
+      return { action: "merged" as const, id };
+    },
+    writeNew: async () => {
+      created.push(1);
+      return { action: "created" as const };
+    },
+  };
+}
+
+test("merge-on-write-wire: disabled writes a new fact", async () => {
+  let judged = 0;
+  const io = trackers();
+  const result = await applyMergeOnWriteAtPersist({
+    enabled: false,
+    pair: pair(),
+    judge: async () => {
+      judged += 1;
+      return "merge";
+    },
+    writeMerged: io.writeMerged,
+    writeNew: io.writeNew,
+  });
+  assert.equal(result.action, "created");
+  assert.deepEqual(io.merged, []);
+  assert.equal(io.created.length, 1);
+  assert.equal(judged, 0);
+});
+
+test("merge-on-write-wire: mergeMin 0 writes a new fact", async () => {
+  let judged = 0;
+  const io = trackers();
+  const result = await applyMergeOnWriteAtPersist({
+    enabled: true,
+    mergeMin: 0,
+    pair: pair(),
+    judge: async () => {
+      judged += 1;
+      return "merge";
+    },
+    writeMerged: io.writeMerged,
+    writeNew: io.writeNew,
+  });
+  assert.equal(result.action, "created");
+  assert.deepEqual(io.merged, []);
+  assert.equal(io.created.length, 1);
+  assert.equal(judged, 0);
+});
+
+test("merge-on-write-wire: merge updates the existing id", async () => {
+  const io = trackers();
+  const result = await applyMergeOnWriteAtPersist({
+    enabled: true,
+    pair: pair(),
+    judge: async () => "merge",
+    writeMerged: io.writeMerged,
+    writeNew: io.writeNew,
+  });
+  assert.deepEqual(result, { action: "merged", id: "mem-1" });
+  assert.deepEqual(io.merged, ["mem-1"]);
+  assert.equal(io.created.length, 0);
+});
+
+test("merge-on-write-wire: create writes a new fact", async () => {
+  const io = trackers();
+  const result = await applyMergeOnWriteAtPersist({
+    enabled: true,
+    pair: pair(),
+    judge: async () => "create",
+    writeMerged: io.writeMerged,
+    writeNew: io.writeNew,
+  });
+  assert.equal(result.action, "created");
+  assert.deepEqual(io.merged, []);
+  assert.equal(io.created.length, 1);
+});

--- a/packages/remnic-core/src/dedup/merge-on-write-wire.ts
+++ b/packages/remnic-core/src/dedup/merge-on-write-wire.ts
@@ -1,0 +1,34 @@
+/**
+ * Persist seam for merge-on-write (issue #2330 leftover slice).
+ *
+ * Default off. Failures and disabled gates create. Persist callers inject
+ * writeMerged / writeNew. This module does not touch extraction-persist.
+ */
+
+import {
+  applyMergeOnWrite,
+  type MergeJudge,
+  type MergeOnWritePair,
+} from "./merge-on-write.js";
+
+export async function applyMergeOnWriteAtPersist<T>(opts: {
+  enabled?: boolean;
+  pair: MergeOnWritePair;
+  judge: MergeJudge;
+  mergeMin?: number;
+  skipThreshold?: number;
+  writeMerged: (id: string) => T | Promise<T>;
+  writeNew: () => T | Promise<T>;
+}): Promise<T> {
+  const decision = await applyMergeOnWrite({
+    enabled: opts.enabled,
+    pair: opts.pair,
+    judge: opts.judge,
+    mergeMin: opts.mergeMin,
+    skipThreshold: opts.skipThreshold,
+  });
+  if (decision === "merge" && opts.pair.existingId) {
+    return opts.writeMerged(opts.pair.existingId);
+  }
+  return opts.writeNew();
+}


### PR DESCRIPTION
Part of #2330

## Change
`applyMergeOnWriteAtPersist`. Off or mergeMin 0 writes new.

## Out of this PR
extraction-persist hook.

## Test
`packages/remnic-core/src/dedup/merge-on-write-wire.test.ts`