### PR TITLE
feat(recall): widen superseded state-view hits

### DIFF
--- a/.changeset/1952-state-view-widen.md
+++ b/.changeset/1952-state-view-widen.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Admit a superseded recall hit only when its successor is already in the candidate set. Change-intent queries label both facts. Flag off and non-change queries stay identity. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-widen.test.ts
+++ b/packages/remnic-core/src/recall-state-view-widen.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyRecallStateViews } from "./recall-state-view-wire.js";
+import { widenRecallStateViews } from "./recall-state-view-widen.js";
+import type { StateViewResult } from "./recall-state-view.js";
+
+function fact(id: string, extra: Partial<StateViewResult> = {}): StateViewResult {
+  return { id, ...extra };
+}
+
+const CURRENT = fact("new-job", { status: "active" });
+const HISTORICAL = fact("old-job", {
+  status: "superseded",
+  supersededBy: "new-job",
+  supersededAt: "2026-03-01",
+});
+const ORPHAN = fact("orphan-job", {
+  status: "superseded",
+  supersededBy: "missing-job",
+});
+const ON = { recallStateViews: true } as const;
+const CHANGE = "when did the job title change";
+const NON_CHANGE = "what is the current job title";
+
+test("change-intent query labels both facts when successor is in the set", () => {
+  const labeled = widenRecallStateViews([CURRENT], CHANGE, ON, [HISTORICAL]);
+  assert.equal(labeled.length, 2);
+  assert.equal(labeled[0]?.id, "new-job");
+  assert.equal(labeled[0]?.stateLabel, "current");
+  assert.equal(labeled[1]?.id, "old-job");
+  assert.equal(labeled[1]?.stateLabel, "historical");
+  assert.deepEqual(
+    applyRecallStateViews([CURRENT, HISTORICAL], CHANGE, ON).map((row) => [
+      row.id,
+      row.stateLabel,
+    ]),
+    [
+      ["new-job", "current"],
+      ["old-job", "historical"],
+    ],
+  );
+});
+
+test("non-change query is identical (same array reference)", () => {
+  const input = [CURRENT, HISTORICAL];
+  assert.equal(widenRecallStateViews(input, NON_CHANGE, ON, [ORPHAN]), input);
+  assert.equal(applyRecallStateViews(input, NON_CHANGE, ON), input);
+  assert.equal(input[0]?.stateLabel, undefined);
+});
+
+test("recallStateViews false is identity (same array reference)", () => {
+  const input = [CURRENT];
+  assert.equal(widenRecallStateViews(input, CHANGE, {}, [HISTORICAL]), input);
+  assert.equal(widenRecallStateViews(input, CHANGE, { recallStateViews: false }, [HISTORICAL]), input);
+  assert.equal(applyRecallStateViews(input, CHANGE, { recallStateViews: false }), input);
+  assert.equal(input[0]?.stateLabel, undefined);
+});
+
+test("superseded without successor is dropped", () => {
+  assert.deepEqual(widenRecallStateViews([ORPHAN], CHANGE, ON), []);
+  assert.deepEqual(widenRecallStateViews([CURRENT], CHANGE, ON, [ORPHAN]), [
+    { ...CURRENT, stateLabel: "current" },
+  ]);
+  assert.deepEqual(applyRecallStateViews([ORPHAN], CHANGE, ON), []);
+});

--- a/packages/remnic-core/src/recall-state-view-widen.ts
+++ b/packages/remnic-core/src/recall-state-view-widen.ts
@@ -1,0 +1,49 @@
+/**
+ * Recall state-view widening (issue #1952).
+ *
+ * When recallStateViews is on and the query is change-oriented, admit a
+ * superseded memory only if its successor is already in the candidate set.
+ * Flag off / non-change queries are identity.
+ */
+import {
+  annotateStateView,
+  isChangeOrientedQuery,
+  parseRecallStateViews,
+  resultStateViewId,
+  shouldWidenSuperseded,
+  type StateViewResult,
+} from "./recall-state-view.js";
+
+export function widenRecallStateViews<T extends StateViewResult>(
+  results: T[],
+  query: string,
+  config: unknown,
+  pool: readonly T[] = [],
+): T[] {
+  const raw =
+    typeof config === "object" && config !== null && "recallStateViews" in config
+      ? config.recallStateViews
+      : undefined;
+  const enabled = parseRecallStateViews(raw);
+  if (!enabled || !isChangeOrientedQuery(query)) return results;
+
+  const candidateIds = new Set<string>();
+  for (const result of results) {
+    const id = resultStateViewId(result);
+    if (id) candidateIds.add(id);
+  }
+
+  const seen = new Set(candidateIds);
+  const extra: T[] = [];
+  for (const item of pool) {
+    const id = resultStateViewId(item);
+    if (!id || seen.has(id)) continue;
+    if (!shouldWidenSuperseded(item.supersededBy, candidateIds)) continue;
+    extra.push(item);
+    seen.add(id);
+  }
+
+  return annotateStateView(extra.length > 0 ? results.concat(extra) : results, query, [], {
+    enabled: true,
+  });
+}

--- a/packages/remnic-core/src/recall-state-view-wire.ts
+++ b/packages/remnic-core/src/recall-state-view-wire.ts
@@ -1,28 +1,18 @@
 /**
  * Recall inject seam for state views (issue #1952).
  *
- * parseConfig cannot grow (fileSizeGrandfather). Operators set
- * `recallStateViews` on the live PluginConfig extra field. Default false
- * is identity. Use parseRecallStateViews — do not read a scattered
- * config flag property here.
+ * Widening lives in recall-state-view-widen.ts. parseConfig cannot grow.
+ * Operators set `recallStateViews` on the live PluginConfig extra field.
+ * Default false is identity.
  */
 
-import {
-  annotateStateView,
-  parseRecallStateViews,
-  type StateViewResult,
-} from "./recall-state-view.js";
+import { widenRecallStateViews } from "./recall-state-view-widen.js";
+import type { StateViewResult } from "./recall-state-view.js";
 
 export function applyRecallStateViews<T extends StateViewResult>(
   results: T[],
   query: string,
   config: unknown,
 ): T[] {
-  const raw =
-    typeof config === "object" && config !== null && "recallStateViews" in config
-      ? (config as { recallStateViews?: unknown }).recallStateViews
-      : undefined;
-  return annotateStateView(results, query, [], {
-    enabled: parseRecallStateViews(raw),
-  });
+  return widenRecallStateViews(results, query, config);
 }


### PR DESCRIPTION
Part of #1952

## Change
Change-intent widening admits superseded only with successor in the set.

## Out of this PR
MCP stateView, parseConfig, xray labels.

## Test
`packages/remnic-core/src/recall-state-view-widen.test.ts`