### PR TITLE
feat(cli): remnic journal-vault show

### DIFF
--- a/.changeset/1987-journal-vault-cli.md
+++ b/.changeset/1987-journal-vault-cli.md
@@ -1,0 +1,6 @@
+---
+"@remnic/cli": minor
+"@remnic/core": patch
+---
+
+Add `remnic journal-vault show --file --section` to print a stripped vault journal section. Duplicate headings exit non-zero with line numbers. Part of #1987.

--- a/packages/remnic-cli/src/commands/journal-vault.test.ts
+++ b/packages/remnic-cli/src/commands/journal-vault.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { withTempDirSync } from "../testing/tmp-dir.js";
+import { runJournalVaultCommand } from "./journal-vault.js";
+
+const START = "<!-- remnic:timeline:start -->";
+const END = "<!-- remnic:timeline:end -->";
+
+function capture(rest: string[]): { code: number; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = runJournalVaultCommand(rest, {
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+  return { code, stdout, stderr };
+}
+
+test("show prints the stripped section and does not write", () => {
+  withTempDirSync("journal-vault-show", (dir) => {
+    const file = path.join(dir, "daily.md");
+    const original = [
+      "## Journal",
+      "user text",
+      START,
+      "published",
+      END,
+      "## Notes",
+      "",
+    ].join("\n");
+    fs.writeFileSync(file, original);
+    const result = capture(["show", "--file", file, "--section", "Journal"]);
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout.join("\n"), "user text");
+    assert.equal(result.stderr.length, 0);
+    assert.equal(fs.readFileSync(file, "utf8"), original);
+  });
+});
+
+test("missing file and missing heading print exists:false and do not create a file", () => {
+  withTempDirSync("journal-vault-missing", (dir) => {
+    const missing = path.join(dir, "absent.md");
+    const missingFile = capture(["show", "--file", missing, "--section", "Journal"]);
+    assert.equal(missingFile.code, 0);
+    assert.deepEqual(missingFile.stdout, ["exists:false"]);
+    assert.equal(fs.existsSync(missing), false);
+
+    const file = path.join(dir, "daily.md");
+    fs.writeFileSync(file, "## Notes\nonly notes\n");
+    const before = fs.readFileSync(file, "utf8");
+    const missingHeading = capture(["show", "--file", file, "--section", "Journal"]);
+    assert.equal(missingHeading.code, 0);
+    assert.deepEqual(missingHeading.stdout, ["exists:false"]);
+    assert.equal(fs.readFileSync(file, "utf8"), before);
+  });
+});
+
+test("duplicate heading exits non-zero and lists line numbers", () => {
+  withTempDirSync("journal-vault-dup", (dir) => {
+    const file = path.join(dir, "daily.md");
+    const original = ["# Day", "## Journal", "first", "## Notes", "## Journal", "second", ""].join(
+      "\n",
+    );
+    fs.writeFileSync(file, original);
+    const result = capture(["show", "--file", file, "--section", "Journal"]);
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout.length, 0);
+    assert.match(result.stderr.join("\n"), /duplicate heading at lines 2, 5/);
+    assert.equal(fs.readFileSync(file, "utf8"), original);
+  });
+});
+
+test("show without --file or --section is a usage error", () => {
+  const result = capture(["show"]);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.length, 0);
+  assert.match(result.stderr.join("\n"), /--file/);
+});

--- a/packages/remnic-cli/src/commands/journal-vault.ts
+++ b/packages/remnic-cli/src/commands/journal-vault.ts
@@ -1,0 +1,76 @@
+/**
+ * `remnic journal-vault show --file <path> --section <heading>` (#1987 CLI slice).
+ *
+ * Read-only. Prints the stripped vault-journal section or `exists:false`.
+ * Duplicate headings exit non-zero and list line numbers.
+ */
+import fs from "node:fs";
+import { readVaultJournal } from "@remnic/core";
+import { resolveFlag } from "../cli-args.js";
+
+export interface JournalVaultIo {
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+const defaultIo: JournalVaultIo = {
+  stdout: (line) => {
+    process.stdout.write(`${line}\n`);
+  },
+  stderr: (line) => {
+    process.stderr.write(`${line}\n`);
+  },
+};
+
+export function journalVaultHelp(): string {
+  return `Usage: remnic journal-vault show --file <path> --section <heading>
+
+  show  Print the stripped journal section. Missing file or heading prints exists:false.
+`;
+}
+
+export function runJournalVaultCommand(rest: string[], io: JournalVaultIo = defaultIo): number {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h" || rest[0] === "help") {
+    io.stdout(journalVaultHelp().trimEnd());
+    return 0;
+  }
+  if (rest[0] !== "show") {
+    io.stderr(`journal-vault: unknown action "${rest[0]}".`);
+    io.stderr(journalVaultHelp().trimEnd());
+    return 1;
+  }
+
+  const filePath = resolveFlag(rest, "--file");
+  const section = resolveFlag(rest, "--section");
+  if (filePath === undefined || section === undefined) {
+    io.stderr("journal-vault: show requires --file <path> and --section <heading>");
+    return 1;
+  }
+
+  let fileText: string | null = null;
+  try {
+    fileText = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      io.stderr(err instanceof Error ? err.message : String(err));
+      return 1;
+    }
+  }
+
+  const result = readVaultJournal({ fileText, journalSection: section });
+  if (!result.ok) {
+    io.stderr(`journal-vault: duplicate heading at lines ${result.lines.join(", ")}`);
+    return 1;
+  }
+  if (!result.exists) {
+    io.stdout("exists:false");
+    return 0;
+  }
+  io.stdout(result.text);
+  return 0;
+}
+
+export async function runJournalVaultBinaryCommand(rest: string[]): Promise<void> {
+  const code = runJournalVaultCommand(rest);
+  if (code !== 0) process.exitCode = code;
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -174,6 +174,7 @@ import { runExportOkfBinaryCommand } from "./commands/export-okf.js";
 import { runCodegraphBinaryCommand } from "./commands/codegraph.js";
 import { runStandupBinaryCommand } from "./commands/standup.js";
 import { runJournalBinaryCommand } from "./commands/journal.js";
+import { runJournalVaultBinaryCommand } from "./commands/journal-vault.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
 import { runDriftBinaryCommand } from "./commands/drift.js";
@@ -441,7 +442,7 @@ type CommandName =
   | "promotion-candidates"
   | "security"
   | "wearables"
-  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "codegraph"
+  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "codegraph"
   | "external-wiki"
   | "capsule"
   | "offline"
@@ -13106,6 +13107,9 @@ Other:
       break;
     case "journal":
       await runJournalBinaryCommand(rest);
+      break;
+    case "journal-vault":
+      await runJournalVaultBinaryCommand(rest);
       break;
     case "codegraph":
       await runCodegraphBinaryCommand(rest);

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -16,5 +16,6 @@ export * from "./config.js";
 export * from "./reindex.js";
 export * from "./timeline/index.js";
 export * from "./journal.js";
+export * from "./journal-vault-read.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";


### PR DESCRIPTION
Part of #1987

## Change
`remnic journal-vault show --file --section`. Read-only. Duplicate headings fail.

## Out of this PR
journal.source=vault config.

## Test
`packages/remnic-cli/src/commands/journal-vault.test.ts`