### PR TITLE
feat(cli): activity-privacy retain

### DIFF
--- a/.changeset/2053-activity-cli.md
+++ b/.changeset/2053-activity-cli.md
@@ -1,0 +1,5 @@
+---
+"@remnic/cli": minor
+---
+
+Add `remnic activity-privacy retain` for activity retention checks. `--days` 0 keeps forever, negative days are rejected, and `--enabled false` denies retain. Part of #2053.

--- a/packages/remnic-cli/src/commands/activity-privacy.test.ts
+++ b/packages/remnic-cli/src/commands/activity-privacy.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runActivityPrivacyCommand } from "./activity-privacy.js";
+
+function capture(rest: string[]): { code: number; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = runActivityPrivacyCommand(rest, {
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+  return { code, stdout, stderr };
+}
+
+const captured = "2026-01-01T00:00:00.000Z";
+const now = "2026-01-15T00:00:00.000Z";
+
+test("days 0 always retains", () => {
+  const result = capture(["retain", "--captured", captured, "--now", now, "--days", "0"]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, ["retain=true"]);
+  assert.equal(result.stderr.length, 0);
+});
+
+test("negative days are rejected", () => {
+  const result = capture(["retain", "--captured", captured, "--now", now, "--days", "-1"]);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.length, 0);
+  assert.match(result.stderr.join("\n"), /non-negative integer/);
+});
+
+test("master disabled via --enabled false denies retain", () => {
+  const result = capture([
+    "retain",
+    "--captured",
+    captured,
+    "--now",
+    now,
+    "--days",
+    "0",
+    "--enabled",
+    "false",
+  ]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, ["retain=false"]);
+});
+
+test("age inside the half-open window retains", () => {
+  const result = capture(["retain", "--captured", captured, "--now", now, "--days", "30"]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, ["retain=true"]);
+});
+
+test("exact expiry boundary does not retain", () => {
+  const result = capture([
+    "retain",
+    "--captured",
+    "2026-01-01T00:00:00.000Z",
+    "--now",
+    "2026-01-31T00:00:00.000Z",
+    "--days",
+    "30",
+  ]);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, ["retain=false"]);
+});

--- a/packages/remnic-cli/src/commands/activity-privacy.ts
+++ b/packages/remnic-cli/src/commands/activity-privacy.ts
@@ -1,0 +1,92 @@
+/**
+ * `remnic activity-privacy retain --captured --now --days` (#2053 CLI slice).
+ *
+ * Maps flags onto `shouldRetain`. Prints `retain=true|false`.
+ * `--days 0` keeps forever. Negative days are rejected.
+ * `--enabled false` is the master-off gate.
+ */
+import { parseFlexibleIsoTimestamp, shouldRetain } from "@remnic/core";
+import { hasFlag, resolveFlag } from "../cli-args.js";
+
+export interface ActivityPrivacyIo {
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+const defaultIo: ActivityPrivacyIo = {
+  stdout: (line) => {
+    process.stdout.write(`${line}\n`);
+  },
+  stderr: (line) => {
+    process.stderr.write(`${line}\n`);
+  },
+};
+
+export function activityPrivacyHelp(): string {
+  return `Usage: remnic activity-privacy retain --captured <iso> --now <iso> --days <n> [--enabled <true|false>]
+
+  retain  Print retain=true or retain=false. --days 0 keeps forever.
+`;
+}
+
+function parseEnabled(rest: string[], io: ActivityPrivacyIo): boolean | undefined {
+  const raw = resolveFlag(rest, "--enabled");
+  if (raw === undefined) {
+    if (hasFlag(rest, "--enabled")) {
+      io.stderr("activity-privacy: --enabled requires true or false");
+      return undefined;
+    }
+    return true;
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  io.stderr("activity-privacy: --enabled must be true or false");
+  return undefined;
+}
+
+export function runActivityPrivacyCommand(
+  rest: string[],
+  io: ActivityPrivacyIo = defaultIo,
+): number {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h" || rest[0] === "help") {
+    io.stdout(activityPrivacyHelp().trimEnd());
+    return 0;
+  }
+  if (rest[0] !== "retain") {
+    io.stderr(`activity-privacy: unknown action "${rest[0]}".`);
+    io.stderr(activityPrivacyHelp().trimEnd());
+    return 1;
+  }
+
+  const capturedRaw = resolveFlag(rest, "--captured");
+  const nowRaw = resolveFlag(rest, "--now");
+  const daysRaw = resolveFlag(rest, "--days");
+  if (capturedRaw === undefined || nowRaw === undefined || daysRaw === undefined) {
+    io.stderr("activity-privacy: retain requires --captured <iso>, --now <iso>, and --days <n>");
+    return 1;
+  }
+
+  const capturedAtMs = parseFlexibleIsoTimestamp(capturedRaw);
+  const nowMs = parseFlexibleIsoTimestamp(nowRaw);
+  if (capturedAtMs === null || nowMs === null) {
+    io.stderr("activity-privacy: --captured and --now must be ISO timestamps");
+    return 1;
+  }
+
+  const days = Number(daysRaw);
+  if (!Number.isInteger(days) || days < 0) {
+    io.stderr("activity-privacy: --days must be a non-negative integer");
+    return 1;
+  }
+
+  const enabled = parseEnabled(rest, io);
+  if (enabled === undefined) return 1;
+
+  io.stdout(`retain=${shouldRetain(capturedAtMs, nowMs, days, enabled)}`);
+  return 0;
+}
+
+export async function runActivityPrivacyBinaryCommand(rest: string[]): Promise<void> {
+  const code = runActivityPrivacyCommand(rest);
+  if (code !== 0) process.exitCode = code;
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -175,6 +175,7 @@ import { runCodegraphBinaryCommand } from "./commands/codegraph.js";
 import { runStandupBinaryCommand } from "./commands/standup.js";
 import { runJournalBinaryCommand } from "./commands/journal.js";
 import { runJournalVaultBinaryCommand } from "./commands/journal-vault.js";
+import { runActivityPrivacyBinaryCommand } from "./commands/activity-privacy.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
 import { runDriftBinaryCommand } from "./commands/drift.js";
@@ -442,7 +443,7 @@ type CommandName =
   | "promotion-candidates"
   | "security"
   | "wearables"
-  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "codegraph"
+  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "activity-privacy" | "codegraph"
   | "external-wiki"
   | "capsule"
   | "offline"
@@ -13110,6 +13111,9 @@ Other:
       break;
     case "journal-vault":
       await runJournalVaultBinaryCommand(rest);
+      break;
+    case "activity-privacy":
+      await runActivityPrivacyBinaryCommand(rest);
       break;
     case "codegraph":
       await runCodegraphBinaryCommand(rest);


### PR DESCRIPTION
Part of #2053

## Change
`remnic activity-privacy retain`. days 0 keeps forever. --enabled false denies.

## Test
`packages/remnic-cli/src/commands/activity-privacy.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `activity-privacy retain` command to determine whether activity should be retained based on capture time, current time, and retention period.
  * Added validation for timestamps, retention days, and enabled/disabled settings.
  * Added command help output and clear error reporting.
* **Tests**
  * Added coverage for zero-day, negative, disabled, active-window, and expiry-boundary retention scenarios.
* **Documentation**
  * Documented the new CLI command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->