### PR TITLE
feat(recall): named-policy deep-recall access facade

### DIFF
--- a/.changeset/2332-deep-recall-access.md
+++ b/.changeset/2332-deep-recall-access.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add a named-policy access facade for the deep-recall stepper. Allow-list is `stop` and `expand-once`. Budget 0 returns a tagged refusal. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-access.test.ts
+++ b/packages/remnic-core/src/recall-deep-access.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runDeepRecallAccess } from "./recall-deep-access.js";
+
+const QUERY = "who met at the cafe";
+
+test("budget 0 stops immediately with a tagged refusal", () => {
+  const result = runDeepRecallAccess({ query: QUERY, budget: 0, policyName: "expand-once" });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.refusal, { tag: "budget_exhausted" });
+  assert.equal(result.trace.length, 1);
+  assert.equal(result.trace[0]?.action, "stop");
+  assert.equal(result.state.budget, 0);
+  assert.equal(result.state.query, QUERY);
+  assert.deepEqual(result.state.workingSet, []);
+  assert.deepEqual(result.state.frontier, []);
+  assert.equal(result.traceJson, JSON.stringify(result.trace));
+});
+
+test("unknown policyName is rejected", () => {
+  assert.throws(
+    () => runDeepRecallAccess({ query: QUERY, budget: 2, policyName: "refine-twice" }),
+    /unknown deep recall access policy/,
+  );
+  assert.throws(
+    () => runDeepRecallAccess({ query: QUERY, budget: 2, policyName: "refine-twice" }),
+    /stop, expand-once/,
+  );
+});
+
+test("stop policy ends without expanding", () => {
+  const result = runDeepRecallAccess({ query: QUERY, budget: 3, policyName: "stop" });
+  assert.equal(result.ok, true);
+  assert.equal(result.refusal, undefined);
+  assert.equal(result.trace.length, 1);
+  assert.equal(result.trace[0]?.action, "stop");
+  assert.equal(result.state.budget, 3);
+  assert.deepEqual(result.state.workingSet, []);
+});
+
+test("expand-once expands once then stops", () => {
+  const result = runDeepRecallAccess({ query: QUERY, budget: 3, policyName: "expand-once" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    result.trace.map((step) => step.action),
+    ["expand", "stop"],
+  );
+  assert.equal(result.state.budget, 2);
+});
+
+test("same input produces the same trace JSON", () => {
+  const input = { query: QUERY, budget: 4, policyName: "expand-once" as const };
+  const first = runDeepRecallAccess(input);
+  const second = runDeepRecallAccess(input);
+  assert.equal(first.traceJson, second.traceJson);
+  assert.equal(first.traceJson, JSON.stringify(first.trace));
+});

--- a/packages/remnic-core/src/recall-deep-access.ts
+++ b/packages/remnic-core/src/recall-deep-access.ts
@@ -1,0 +1,71 @@
+/**
+ * Named-policy access facade for the deep-recall stepper (issue #2332 leftover).
+ *
+ * Not the hot path. Surfaces and parseConfig wait. Policy names are
+ * allow-listed. Budget 0 returns a tagged refusal without a policy call.
+ */
+
+import { runDeepRecall, type DeepRecallResult, type DeepRecallState } from "./recall-deep.js";
+
+export const DEEP_RECALL_ACCESS_POLICIES = ["stop", "expand-once"] as const;
+
+export type DeepRecallAccessPolicyName = (typeof DEEP_RECALL_ACCESS_POLICIES)[number];
+
+export interface DeepRecallAccessInput {
+  query: string;
+  budget: number;
+  policyName: string;
+}
+
+export interface DeepRecallAccessRefusal {
+  tag: "budget_exhausted";
+}
+
+export interface DeepRecallAccessResult {
+  ok: boolean;
+  refusal?: DeepRecallAccessRefusal;
+  state: DeepRecallState;
+  trace: DeepRecallResult["trace"];
+  traceJson: string;
+}
+
+export function isDeepRecallAccessPolicyName(value: unknown): value is DeepRecallAccessPolicyName {
+  return typeof value === "string" && (DEEP_RECALL_ACCESS_POLICIES as readonly string[]).includes(value);
+}
+
+export function runDeepRecallAccess(input: DeepRecallAccessInput): DeepRecallAccessResult {
+  if (!isDeepRecallAccessPolicyName(input.policyName)) {
+    throw new Error(
+      `unknown deep recall access policy: ${JSON.stringify(input.policyName)}. Valid: ${DEEP_RECALL_ACCESS_POLICIES.join(", ")}`,
+    );
+  }
+
+  const start: DeepRecallState = { query: input.query, workingSet: [], frontier: [], budget: input.budget };
+  if (!Number.isFinite(input.budget) || input.budget <= 0) {
+    const result = runDeepRecall(start, () => {
+      throw new Error("policy must not run when budget is 0");
+    });
+    return {
+      ok: false,
+      refusal: { tag: "budget_exhausted" },
+      state: result.state,
+      trace: result.trace,
+      traceJson: JSON.stringify(result.trace),
+    };
+  }
+
+  let expanded = false;
+  const result = runDeepRecall(start, () => {
+    if (input.policyName === "expand-once" && !expanded) {
+      expanded = true;
+      return "expand";
+    }
+    return "stop";
+  });
+  return {
+    ok: true,
+    state: result.state,
+    trace: result.trace,
+    traceJson: JSON.stringify(result.trace),
+  };
+}


### PR DESCRIPTION
Part of #2332

## Change
`runDeepRecallAccess`. budget 0 stops. Policies: stop, expand-once. Not on the hot path.

## Test
`packages/remnic-core/src/recall-deep-access.test.ts`