### PR TITLE
feat(shared-context): envelope staleness helpers

### DIFF
--- a/.changeset/1957-envelope-stale.md
+++ b/.changeset/1957-envelope-stale.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context staleness helpers (issue #1957). `filterLiveEnvelopes` drops expired items on a half-open bound, and `markSupersededCirculation` flags superseded items that still circulate. Never deletes files. Part of #1957.

--- a/packages/remnic-core/src/shared-context/staleness.test.ts
+++ b/packages/remnic-core/src/shared-context/staleness.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { filterLiveEnvelopes, markSupersededCirculation } from "./staleness.js";
+
+test("filterLiveEnvelopes drops at the expiry instant (half-open)", () => {
+  const expiresAt = "2026-08-18T12:00:00.000Z";
+  const at = Date.parse(expiresAt);
+  const live = { id: "keep", expiresAt };
+  const forever = { id: "legacy" };
+  const items = [live, forever];
+
+  assert.deepEqual(filterLiveEnvelopes(items, at - 1), items);
+  assert.deepEqual(filterLiveEnvelopes(items, at), [forever]);
+  assert.deepEqual(filterLiveEnvelopes(items, at + 1), [forever]);
+  assert.equal(items.length, 2);
+});
+
+test("markSupersededCirculation flags targets that still circulate", () => {
+  const older = { id: "item-1", expiresAt: "2026-08-19T00:00:00.000Z" };
+  const newer = { id: "item-2", supersedes: "item-1" };
+  const other = { id: "item-3" };
+  const items = [older, newer, other];
+
+  const marked = markSupersededCirculation(items);
+  assert.equal(marked[0]?.circulating, true);
+  assert.equal(marked[1]?.circulating, undefined);
+  assert.equal(marked[2]?.circulating, undefined);
+  assert.equal(older.circulating, undefined);
+  assert.notEqual(marked[0], older);
+});

--- a/packages/remnic-core/src/shared-context/staleness.test.ts
+++ b/packages/remnic-core/src/shared-context/staleness.test.ts
@@ -1,14 +1,18 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { filterLiveEnvelopes, markSupersededCirculation } from "./staleness.js";
+import {
+  filterLiveEnvelopes,
+  markSupersededCirculation,
+  type SharedStalenessItem,
+} from "./staleness.js";
 
 test("filterLiveEnvelopes drops at the expiry instant (half-open)", () => {
   const expiresAt = "2026-08-18T12:00:00.000Z";
   const at = Date.parse(expiresAt);
-  const live = { id: "keep", expiresAt };
-  const forever = { id: "legacy" };
-  const items = [live, forever];
+  const live: SharedStalenessItem = { id: "keep", expiresAt };
+  const forever: SharedStalenessItem = { id: "legacy" };
+  const items: SharedStalenessItem[] = [live, forever];
 
   assert.deepEqual(filterLiveEnvelopes(items, at - 1), items);
   assert.deepEqual(filterLiveEnvelopes(items, at), [forever]);
@@ -17,10 +21,11 @@ test("filterLiveEnvelopes drops at the expiry instant (half-open)", () => {
 });
 
 test("markSupersededCirculation flags targets that still circulate", () => {
-  const older = { id: "item-1", expiresAt: "2026-08-19T00:00:00.000Z" };
-  const newer = { id: "item-2", supersedes: "item-1" };
-  const other = { id: "item-3" };
-  const items = [older, newer, other];
+  const older: SharedStalenessItem = { id: "item-1", expiresAt: "2026-08-19T00:00:00.000Z" };
+  const newer: SharedStalenessItem = { id: "item-2", supersedes: "item-1" };
+  const other: SharedStalenessItem = { id: "item-3" };
+  const items: SharedStalenessItem[] = [older, newer, other];
+
 
   const marked = markSupersededCirculation(items);
   assert.equal(marked[0]?.circulating, true);

--- a/packages/remnic-core/src/shared-context/staleness.ts
+++ b/packages/remnic-core/src/shared-context/staleness.ts
@@ -4,7 +4,7 @@
  * Pure helpers. Expired items drop; superseded items that still circulate
  * get a marker. Callers never `rm`.
  */
-import { isExpired, type SharedEnvelope } from "./governance.js";
+import { isExpired } from "./governance.js";
 
 export interface SharedStalenessItem {
   id: string;
@@ -14,7 +14,7 @@ export interface SharedStalenessItem {
 }
 
 /** Drop expired items. Half-open: `nowMs >= expiresAt` is expired. */
-export function filterLiveEnvelopes<T extends Pick<SharedEnvelope, "expiresAt">>(
+export function filterLiveEnvelopes<T extends { expiresAt?: string }>(
   items: readonly T[],
   nowMs: number,
 ): T[] {

--- a/packages/remnic-core/src/shared-context/staleness.ts
+++ b/packages/remnic-core/src/shared-context/staleness.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared-item staleness (issue #1957).
+ *
+ * Pure helpers. Expired items drop; superseded items that still circulate
+ * get a marker. Callers never `rm`.
+ */
+import { isExpired, type SharedEnvelope } from "./governance.js";
+
+export interface SharedStalenessItem {
+  id: string;
+  expiresAt?: string;
+  supersedes?: string;
+  circulating?: boolean;
+}
+
+/** Drop expired items. Half-open: `nowMs >= expiresAt` is expired. */
+export function filterLiveEnvelopes<T extends Pick<SharedEnvelope, "expiresAt">>(
+  items: readonly T[],
+  nowMs: number,
+): T[] {
+  return items.filter((item) => !isExpired(item, nowMs));
+}
+
+/**
+ * Mark items whose id appears in another item's `supersedes`.
+ * Returns a new array. Does not mutate input and does not delete files.
+ */
+export function markSupersededCirculation<T extends SharedStalenessItem>(
+  items: readonly T[],
+): T[] {
+  const supersededIds = new Set<string>();
+  for (const item of items) {
+    if (item.supersedes) supersededIds.add(item.supersedes);
+  }
+  return items.map((item) =>
+    supersededIds.has(item.id) ? { ...item, circulating: true } : item,
+  );
+}


### PR DESCRIPTION
Part of #1957

## Change
`filterLiveEnvelopes` half-open expiry. `markSupersededCirculation`. No deletes.

## Test
`packages/remnic-core/src/shared-context/staleness.test.ts`