### PR TITLE
feat(activity): resolve vault note path templates

### DIFF
--- a/.changeset/1985-vault-paths.md
+++ b/.changeset/1985-vault-paths.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add vault note path templates that expand date tokens and reject `..` and absolute paths. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -19,3 +19,4 @@ export * from "./journal.js";
 export * from "./journal-vault-read.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";
+export * from "./vault-path.js";

--- a/packages/remnic-core/src/activity/vault-path.test.ts
+++ b/packages/remnic-core/src/activity/vault-path.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveVaultNotePath } from "./vault-path.js";
+
+test("resolveVaultNotePath expands date tokens", () => {
+  assert.equal(resolveVaultNotePath("{yyyy}-{MM}-{dd}.md", "2026-08-18"), "2026-08-18.md");
+  assert.equal(
+    resolveVaultNotePath("Daily Notes/{yyyy}/{MM}/{yyyy}-{MM}-{dd}.md", "2026-08-18"),
+    "Daily Notes/2026/08/2026-08-18.md",
+  );
+  assert.equal(resolveVaultNotePath("{yy}/{M}/{d}.md", "2026-08-08"), "26/8/8.md");
+  assert.equal(
+    resolveVaultNotePath("{yyyy}-{MM}-{dd}.md", "2026-08-18", { timezone: "America/Chicago" }),
+    "2026-08-18.md",
+  );
+});
+
+test("resolveVaultNotePath expands ISO week {ww} as zero-padded", () => {
+  assert.equal(resolveVaultNotePath("W{ww}.md", "2021-01-01"), "W53.md");
+  assert.equal(resolveVaultNotePath("W{ww}.md", "2024-01-01"), "W01.md");
+  assert.equal(
+    resolveVaultNotePath("{yyyy}/W{ww}/{yyyy}-{MM}-{dd}.md", "2021-01-01"),
+    "2021/W53/2021-01-01.md",
+  );
+});
+
+test("resolveVaultNotePath rejects traversal and absolute templates", () => {
+  assert.throws(() => resolveVaultNotePath("../outside/{yyyy}.md", "2026-08-18"), /\.\.|absolute|traversal/i);
+  assert.throws(() => resolveVaultNotePath("{yyyy}/../../secret.md", "2026-08-18"), /\.\.|absolute|traversal/i);
+  assert.throws(() => resolveVaultNotePath("/abs/{yyyy}.md", "2026-08-18"), /\.\.|absolute|traversal/i);
+  assert.throws(() => resolveVaultNotePath("C:/vault/{yyyy}.md", "2026-08-18"), /\.\.|absolute|traversal/i);
+});
+
+test("resolveVaultNotePath requires a real YYYY-MM-DD date", () => {
+  assert.throws(() => resolveVaultNotePath("{yyyy}.md", "2026-02-30"), /YYYY-MM-DD/);
+  assert.throws(() => resolveVaultNotePath("{yyyy}.md", "20260818"), /YYYY-MM-DD/);
+});

--- a/packages/remnic-core/src/activity/vault-path.ts
+++ b/packages/remnic-core/src/activity/vault-path.ts
@@ -1,0 +1,59 @@
+/**
+ * Vault note path templates (issue #1985).
+ *
+ * Expands date tokens on a YYYY-MM-DD day. Returns a vault-relative path.
+ * Rejects `..` segments and absolute templates.
+ */
+import path from "node:path";
+
+import { assertValidTimezone, isValidActivityDate } from "./digest.js";
+
+const TOKEN_RE = /\{yyyy\}|\{yy\}|\{MM\}|\{dd\}|\{M\}|\{d\}|\{ww\}/g;
+
+export function resolveVaultNotePath(
+  template: string,
+  date: string,
+  options?: { timezone?: string },
+): string {
+  if (!isValidActivityDate(date)) {
+    throw new RangeError(`Invalid vault date "${date}"; expected YYYY-MM-DD.`);
+  }
+  if (options?.timezone !== undefined) {
+    assertValidTimezone(options.timezone);
+  }
+  if (typeof template !== "string" || template.length === 0) {
+    throw new RangeError("Vault note path template must be a non-empty relative path.");
+  }
+  if (path.posix.isAbsolute(template) || path.win32.isAbsolute(template)) {
+    throw new RangeError("Vault note path template must be relative; absolute templates are rejected.");
+  }
+
+  const [yyyy, mm, dd] = date.split("-");
+  const tokens: Record<string, string> = {
+    "{yyyy}": yyyy,
+    "{yy}": yyyy.slice(2),
+    "{MM}": mm,
+    "{dd}": dd,
+    "{M}": String(Number(mm)),
+    "{d}": String(Number(dd)),
+    "{ww}": isoWeekNumber(date),
+  };
+  const expanded = template.replace(TOKEN_RE, (token) => tokens[token] ?? token);
+  if (expanded.split(/[\\/]/).some((segment) => segment === "..")) {
+    throw new RangeError("Vault note path template must not contain `..` segments.");
+  }
+  if (path.posix.isAbsolute(expanded) || path.win32.isAbsolute(expanded)) {
+    throw new RangeError("Vault note path template must be relative; absolute templates are rejected.");
+  }
+  return expanded;
+}
+
+function isoWeekNumber(date: string): string {
+  const [year, month, day] = date.split("-").map(Number);
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  const dayNum = utc.getUTCDay() || 7;
+  utc.setUTCDate(utc.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((utc.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return String(weekNo).padStart(2, "0");
+}


### PR DESCRIPTION
Part of #1985

## Change
`resolveVaultNotePath`. Tokens yyyy/yy/MM/dd/M/d/ww. Rejects `..` and absolute templates.

## Test
`packages/remnic-core/src/activity/vault-path.test.ts`