### PR TITLE
feat(extraction): span-mode apply seam

### DIFF
--- a/.changeset/2333-span-wire.md
+++ b/.changeset/2333-span-wire.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add an extraction seam for span mode. Disabled or `0` returns the whole text. Enabled slices via `parseSpanOffsets`. `extraction.ts` is not wired yet. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-wire.test.ts
+++ b/packages/remnic-core/src/extraction-span-wire.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { applySpanMode } from "./extraction-span-wire.js";
+
+const TEXT = "Alice moved to Seattle";
+
+test("applySpanMode: disabled or 0 is identity", () => {
+  const span = { text: TEXT, start: 6, end: 11 };
+  assert.deepEqual(applySpanMode({ enabled: false, ...span }), { text: TEXT });
+  assert.deepEqual(applySpanMode({ enabled: 0, ...span }), { text: TEXT });
+  assert.deepEqual(applySpanMode(span), { text: TEXT });
+});
+
+test("applySpanMode: enabled slices half-open [start, end)", () => {
+  assert.deepEqual(applySpanMode({ enabled: true, text: TEXT, start: 6, end: 11 }), {
+    text: "moved",
+    start: 6,
+    end: 11,
+  });
+});

--- a/packages/remnic-core/src/extraction-span-wire.ts
+++ b/packages/remnic-core/src/extraction-span-wire.ts
@@ -1,0 +1,17 @@
+/**
+ * Extraction seam for span mode (issue #2333 leftover slice).
+ *
+ * Default off. Callers pass `enabled`. This module does not touch
+ * extraction.ts; Phase A still gates production wiring.
+ */
+
+import { parseSpanOffsets, type ParsedSpan } from "./extraction-span.js";
+
+export function applySpanMode(opts: {
+  enabled?: boolean | 0 | 1;
+  text: string;
+  start: number;
+  end: number;
+}): ParsedSpan {
+  return parseSpanOffsets(opts.text, { start: opts.start, end: opts.end }, opts.enabled);
+}


### PR DESCRIPTION
Part of #2333

## Change
`applySpanMode`. Off or 0 returns full text. Default extraction path unchanged.

## Test
`packages/remnic-core/src/extraction-span-wire.test.ts`