### PR TITLE
feat(cli): remnic vault-publish apply

### DIFF
--- a/.changeset/1985-vault-cli.md
+++ b/.changeset/1985-vault-cli.md
@@ -1,0 +1,6 @@
+---
+"@remnic/cli": minor
+"@remnic/core": patch
+---
+
+Add `remnic vault-publish apply --file --name --content` to replace a marked vault region. Missing markers exit 1 with `no_marker`. Missing files are not created. Part of #1985.

--- a/packages/remnic-cli/src/commands/vault-publish.test.ts
+++ b/packages/remnic-cli/src/commands/vault-publish.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { withTempDirSync } from "../testing/tmp-dir.js";
+import { runVaultPublishCommand } from "./vault-publish.js";
+
+const START = "<!-- remnic:timeline:start -->";
+const END = "<!-- remnic:timeline:end -->";
+
+function capture(rest: string[]): { code: number; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = runVaultPublishCommand(rest, {
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+  return { code, stdout, stderr };
+}
+
+test("apply replaces the marked region and prints ok", () => {
+  withTempDirSync("vault-publish-apply", (dir) => {
+    const file = path.join(dir, "daily.md");
+    fs.writeFileSync(file, ["# Daily", START, "old cards", END, "## Notes", ""].join("\n"));
+    const result = capture(["apply", "--file", file, "--name", "timeline", "--content", "new cards"]);
+    assert.equal(result.code, 0);
+    assert.deepEqual(result.stdout, ["ok"]);
+    assert.equal(result.stderr.length, 0);
+    assert.equal(
+      fs.readFileSync(file, "utf8"),
+      ["# Daily", START, "new cards", END, "## Notes", ""].join("\n"),
+    );
+  });
+});
+
+test("missing markers exit 1 with no_marker and do not write", () => {
+  withTempDirSync("vault-publish-no-marker", (dir) => {
+    const file = path.join(dir, "daily.md");
+    const original = "# Daily\nno region\n";
+    fs.writeFileSync(file, original);
+    const result = capture(["apply", "--file", file, "--name", "timeline", "--content", "new cards"]);
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout.length, 0);
+    assert.deepEqual(result.stderr, ["no_marker"]);
+    assert.equal(fs.readFileSync(file, "utf8"), original);
+  });
+});
+
+test("missing file exits 1 and is not created", () => {
+  withTempDirSync("vault-publish-missing", (dir) => {
+    const missing = path.join(dir, "absent.md");
+    const result = capture([
+      "apply",
+      "--file",
+      missing,
+      "--name",
+      "timeline",
+      "--content",
+      "new cards",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout.length, 0);
+    assert.deepEqual(result.stderr, ["missing_file"]);
+    assert.equal(fs.existsSync(missing), false);
+  });
+});
+
+test("apply without required flags is a usage error", () => {
+  const result = capture(["apply"]);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.length, 0);
+  assert.match(result.stderr.join("\n"), /--file/);
+});

--- a/packages/remnic-cli/src/commands/vault-publish.ts
+++ b/packages/remnic-cli/src/commands/vault-publish.ts
@@ -1,0 +1,76 @@
+/**
+ * `remnic vault-publish apply --file --name --content` (#1985 CLI slice).
+ *
+ * Replaces a marker-managed region. Missing markers print `no_marker`.
+ * Missing files are not created.
+ */
+import fs from "node:fs";
+import { applyManagedRegion } from "@remnic/core";
+import { resolveFlag } from "../cli-args.js";
+
+export interface VaultPublishIo {
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+const defaultIo: VaultPublishIo = {
+  stdout: (line) => {
+    process.stdout.write(`${line}\n`);
+  },
+  stderr: (line) => {
+    process.stderr.write(`${line}\n`);
+  },
+};
+
+export function vaultPublishHelp(): string {
+  return `Usage: remnic vault-publish apply --file <path> --name <region> --content <text>
+
+  apply  Replace the marked region. Missing markers print no_marker.
+`;
+}
+
+export function runVaultPublishCommand(rest: string[], io: VaultPublishIo = defaultIo): number {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h" || rest[0] === "help") {
+    io.stdout(vaultPublishHelp().trimEnd());
+    return 0;
+  }
+  if (rest[0] !== "apply") {
+    io.stderr(`vault-publish: unknown action "${rest[0]}".`);
+    io.stderr(vaultPublishHelp().trimEnd());
+    return 1;
+  }
+
+  const filePath = resolveFlag(rest, "--file");
+  const name = resolveFlag(rest, "--name");
+  const content = resolveFlag(rest, "--content");
+  if (filePath === undefined || name === undefined || content === undefined) {
+    io.stderr("vault-publish: apply requires --file <path>, --name <region>, and --content <text>");
+    return 1;
+  }
+
+  let fileText: string;
+  try {
+    fileText = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      io.stderr("missing_file");
+      return 1;
+    }
+    io.stderr(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+
+  const applied = applyManagedRegion(fileText, { strategy: "markers", name, content });
+  if (!applied.ok) {
+    io.stderr(applied.reason);
+    return 1;
+  }
+  if (applied.text !== fileText) fs.writeFileSync(filePath, applied.text);
+  io.stdout("ok");
+  return 0;
+}
+
+export async function runVaultPublishBinaryCommand(rest: string[]): Promise<void> {
+  const code = runVaultPublishCommand(rest);
+  if (code !== 0) process.exitCode = code;
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -176,6 +176,7 @@ import { runStandupBinaryCommand } from "./commands/standup.js";
 import { runJournalBinaryCommand } from "./commands/journal.js";
 import { runJournalVaultBinaryCommand } from "./commands/journal-vault.js";
 import { runActivityPrivacyBinaryCommand } from "./commands/activity-privacy.js";
+import { runVaultPublishBinaryCommand } from "./commands/vault-publish.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
 import { runDriftBinaryCommand } from "./commands/drift.js";
@@ -443,7 +444,7 @@ type CommandName =
   | "promotion-candidates"
   | "security"
   | "wearables"
-  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "activity-privacy" | "codegraph"
+  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "activity-privacy" | "vault-publish" | "codegraph"
   | "external-wiki"
   | "capsule"
   | "offline"
@@ -13114,6 +13115,9 @@ Other:
       break;
     case "activity-privacy":
       await runActivityPrivacyBinaryCommand(rest);
+      break;
+    case "vault-publish":
+      await runVaultPublishBinaryCommand(rest);
       break;
     case "codegraph":
       await runCodegraphBinaryCommand(rest);

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -20,3 +20,4 @@ export * from "./journal-vault-read.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";
 export * from "./vault-path.js";
+export * from "./vault-publish.js";


### PR DESCRIPTION
Part of #1985

## Change
`remnic vault-publish apply --file --name --content`. Missing markers → exit 1. Does not create files.

## Test
`packages/remnic-cli/src/commands/vault-publish.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `vault-publish apply` command to update marked regions in existing files.
  - Supports specifying the target file, region name, and replacement content.
  - Reports clear success and error messages, including missing files or markers.
  - Prevents unnecessary file changes when content is already up to date.

- **Tests**
  - Added coverage for successful updates, invalid inputs, missing files, missing markers, and safe file handling.

- **Documentation**
  - Added release documentation for the new command and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->