### PR TITLE
feat(shared-context): add trajectory publish gate

### DIFF
--- a/.changeset/1957-trajectories.md
+++ b/.changeset/1957-trajectories.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context trajectory publish (issue #1957). `publishTrajectory` gates on `off` / `review` / `auto` (default `review`), rejects unknown modes, and keeps the summary string only. Part of #1957.

--- a/packages/remnic-core/src/shared-context/trajectories.test.ts
+++ b/packages/remnic-core/src/shared-context/trajectories.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { publishTrajectory } from "./trajectories.js";
+
+test("publishTrajectory defaults to review and lands pending_review", () => {
+  const result = publishTrajectory({
+    trajectoryId: "traj-1",
+    summary: "ran the check",
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    status: "pending_review",
+    trajectoryId: "traj-1",
+    summary: "ran the check",
+  });
+});
+
+test("publishTrajectory review mode lands pending_review", () => {
+  const result = publishTrajectory({
+    mode: "review",
+    trajectoryId: "traj-1",
+    summary: "ran the check",
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.status, "pending_review");
+});
+
+test("publishTrajectory auto mode lands active", () => {
+  const result = publishTrajectory({
+    mode: "auto",
+    trajectoryId: "traj-1",
+    summary: "ran the check",
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.status, "active");
+});
+
+test("publishTrajectory off mode returns disabled", () => {
+  assert.deepEqual(
+    publishTrajectory({
+      mode: "off",
+      trajectoryId: "traj-1",
+      summary: "ran the check",
+    }),
+    { ok: false, error: "disabled" },
+  );
+});
+
+test("publishTrajectory rejects an unknown mode", () => {
+  assert.deepEqual(
+    publishTrajectory({
+      mode: "publish",
+      trajectoryId: "traj-1",
+      summary: "ran the check",
+    }),
+    { ok: false, error: "unknown_mode" },
+  );
+});
+
+test("publishTrajectory keeps the summary string and strips tool output", () => {
+  const dirty = {
+    mode: "auto",
+    trajectoryId: "traj-1",
+    summary: "ran the check",
+    toolOutput: "stdout: secret fixture dump",
+  };
+  const result = publishTrajectory(dirty);
+  assert.deepEqual(result, {
+    ok: true,
+    status: "active",
+    trajectoryId: "traj-1",
+    summary: "ran the check",
+  });
+  assert.equal(JSON.stringify(result).includes("stdout"), false);
+  assert.equal("toolOutput" in result, false);
+});

--- a/packages/remnic-core/src/shared-context/trajectories.ts
+++ b/packages/remnic-core/src/shared-context/trajectories.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared-context trajectory publish (issue #1957).
+ *
+ * First slice: mode gate + sanitization only. Persistence and
+ * findTrajectories come later.
+ */
+
+export const TRAJECTORY_SHARE_MODES = ["off", "review", "auto"] as const;
+export type TrajectoryShareMode = (typeof TRAJECTORY_SHARE_MODES)[number];
+
+export interface PublishTrajectoryInput {
+  mode?: string;
+  trajectoryId: string;
+  summary: string;
+}
+
+export type PublishTrajectoryResult =
+  | { ok: false; error: "disabled" | "unknown_mode" }
+  | {
+      ok: true;
+      status: "pending_review" | "active";
+      trajectoryId: string;
+      summary: string;
+    };
+
+const MODE_STATUS = {
+  review: "pending_review",
+  auto: "active",
+} as const;
+
+function isTrajectoryShareMode(value: string): value is TrajectoryShareMode {
+  return (TRAJECTORY_SHARE_MODES as readonly string[]).includes(value);
+}
+
+export function publishTrajectory(input: PublishTrajectoryInput): PublishTrajectoryResult {
+  const mode = input.mode ?? "review";
+  if (!isTrajectoryShareMode(mode)) {
+    return { ok: false, error: "unknown_mode" };
+  }
+  if (mode === "off") {
+    return { ok: false, error: "disabled" };
+  }
+  return {
+    ok: true,
+    status: MODE_STATUS[mode],
+    trajectoryId: input.trajectoryId,
+    summary: input.summary,
+  };
+}


### PR DESCRIPTION
Part of #1957

## Change
`publishTrajectory`. off refuses. review default. auto active. Drops tool output.

## Test
`packages/remnic-core/src/shared-context/trajectories.test.ts`