### PR TITLE
feat(activity): bounded overlapping analysis batches

### DIFF
--- a/.changeset/2050-analysis-batch.md
+++ b/.changeset/2050-analysis-batch.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a bounded overlapping observation batcher for timeline analysis. `maxBatch` 0 returns no batches. Negative overlap and overlap that meets or exceeds `maxBatch` are rejected. Observations sort by capture time then id. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-batch.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-batch.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { batchObservations } from "./analysis-batch.js";
+import type { TimelineBatchObservation } from "./analysis-batch.js";
+
+function obs(id: number, capturedAtUtc: string): TimelineBatchObservation {
+  return { id, capturedAtUtc };
+}
+
+test("empty observations return no batches", () => {
+  assert.deepEqual(batchObservations([], { maxBatch: 3, overlap: 1 }), []);
+});
+
+test("maxBatch 0 returns no batches", () => {
+  assert.deepEqual(
+    batchObservations([obs(1, "2026-08-17T10:00:00.000Z")], { maxBatch: 0, overlap: 0 }),
+    [],
+  );
+});
+
+test("overlap shares the trailing window with the next batch", () => {
+  const items = [1, 2, 3, 4, 5].map((id) => obs(id, `2026-08-17T10:0${id}:00.000Z`));
+  const batches = batchObservations(items, { maxBatch: 3, overlap: 1 });
+  assert.deepEqual(
+    batches.map((batch) => batch.map((item) => item.id)),
+    [
+      [1, 2, 3],
+      [3, 4, 5],
+    ],
+  );
+});
+
+test("order is capturedAtUtc then id, not input order", () => {
+  const items = [
+    obs(3, "2026-08-17T12:00:00.000Z"),
+    obs(2, "2026-08-17T10:00:00.000Z"),
+    obs(1, "2026-08-17T10:00:00.000Z"),
+  ];
+  const batches = batchObservations(items, { maxBatch: 3, overlap: 0 });
+  assert.deepEqual(
+    batches.map((batch) => batch.map((item) => item.id)),
+    [[1, 2, 3]],
+  );
+});
+
+test("maxBatch below 1 is rejected except 0", () => {
+  assert.throws(() => batchObservations([], { maxBatch: -1, overlap: 0 }), RangeError);
+  assert.throws(() => batchObservations([], { maxBatch: 0.5, overlap: 0 }), RangeError);
+});
+
+test("negative overlap and overlap covering the batch are rejected", () => {
+  assert.throws(() => batchObservations([], { maxBatch: 3, overlap: -1 }), RangeError);
+  assert.throws(() => batchObservations([], { maxBatch: 3, overlap: 3 }), RangeError);
+  assert.throws(() => batchObservations([], { maxBatch: 3, overlap: 4 }), RangeError);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-batch.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-batch.ts
@@ -1,0 +1,45 @@
+/**
+ * Bounded overlapping observation batches for timeline analysis (issue #2050).
+ */
+import type { TimelineObservation } from "./types.js";
+
+export type TimelineBatchObservation = Pick<TimelineObservation, "id" | "capturedAtUtc">;
+
+export interface BatchObservationsOptions {
+  maxBatch: number;
+  overlap: number;
+}
+
+function compareObservations(a: TimelineBatchObservation, b: TimelineBatchObservation): number {
+  const time = Date.parse(a.capturedAtUtc) - Date.parse(b.capturedAtUtc);
+  if (time !== 0) return time;
+  return a.id - b.id;
+}
+
+/** Split observations into overlapping windows. Order is capturedAtUtc, then id. */
+export function batchObservations<T extends TimelineBatchObservation>(
+  observations: readonly T[],
+  options: BatchObservationsOptions,
+): T[][] {
+  const { maxBatch, overlap } = options;
+  if (!Number.isInteger(overlap) || overlap < 0) {
+    throw new RangeError("overlap must be a non-negative integer");
+  }
+  if (maxBatch === 0) return [];
+  if (!Number.isInteger(maxBatch) || maxBatch < 1) {
+    throw new RangeError("maxBatch must be 0 or a positive integer");
+  }
+  if (overlap >= maxBatch) {
+    throw new RangeError("overlap must be less than maxBatch");
+  }
+  if (observations.length === 0) return [];
+
+  const ordered = [...observations].sort(compareObservations);
+  const step = maxBatch - overlap;
+  const batches: T[][] = [];
+  for (let start = 0; start < ordered.length; start += step) {
+    batches.push(ordered.slice(start, start + maxBatch));
+    if (start + maxBatch >= ordered.length) break;
+  }
+  return batches;
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -10,3 +10,4 @@ export * from "./journal-recap-persist.js";
 export * from "./weekly.js";
 export * from "./weekly-persist.js";
 export * from "./analysis.js";
+export * from "./analysis-batch.js";


### PR DESCRIPTION
Part of #2050

## Change
`batchObservations`. maxBatch 0 is empty. overlap must be < maxBatch.

## Test
`packages/remnic-core/src/activity/timeline/analysis-batch.test.ts`