### PR TITLE
feat(recall): prefix historical state-view inject lines

### DIFF
--- a/.changeset/1952-state-view-render.md
+++ b/.changeset/1952-state-view-render.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Prefix historical and transition recall lines with `[superseded <date> by <id>]`. Current lines and a disabled flag stay identity. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-render.test.ts
+++ b/packages/remnic-core/src/recall-state-view-render.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderStateViewLine } from "./recall-state-view-render.js";
+
+const TEXT = "Was a baker";
+const DATE = "2026-03-01";
+const SUCCESSOR = "new-job";
+
+test("historical line gets the superseded prefix", () => {
+  const line = renderStateViewLine(
+    {
+      id: "old-job",
+      text: TEXT,
+      stateLabel: "historical",
+      supersededAt: DATE,
+      supersededBy: SUCCESSOR,
+    },
+    { enabled: true },
+  );
+  assert.equal(line, `[superseded ${DATE} by ${SUCCESSOR}] ${TEXT}`);
+});
+
+test("transition line gets the superseded prefix", () => {
+  const line = renderStateViewLine(
+    {
+      id: "mid-job",
+      text: TEXT,
+      stateLabel: "transition",
+      supersededAt: DATE,
+      supersededBy: SUCCESSOR,
+    },
+    { enabled: true },
+  );
+  assert.equal(line, `[superseded ${DATE} by ${SUCCESSOR}] ${TEXT}`);
+});
+
+test("current line is identity text", () => {
+  assert.equal(
+    renderStateViewLine(
+      {
+        id: "new-job",
+        text: TEXT,
+        stateLabel: "current",
+        supersededAt: DATE,
+        supersededBy: SUCCESSOR,
+      },
+      { enabled: true },
+    ),
+    TEXT,
+  );
+});
+
+test("missing date is identity text", () => {
+  assert.equal(
+    renderStateViewLine(
+      {
+        id: "old-job",
+        text: TEXT,
+        stateLabel: "historical",
+        supersededBy: SUCCESSOR,
+      },
+      { enabled: true },
+    ),
+    TEXT,
+  );
+});
+
+test("missing successor is identity text", () => {
+  assert.equal(
+    renderStateViewLine(
+      {
+        id: "old-job",
+        text: TEXT,
+        stateLabel: "historical",
+        supersededAt: DATE,
+      },
+      { enabled: true },
+    ),
+    TEXT,
+  );
+});
+
+test("enabled false is identity text", () => {
+  const historical = {
+    id: "old-job",
+    text: TEXT,
+    stateLabel: "historical" as const,
+    supersededAt: DATE,
+    supersededBy: SUCCESSOR,
+  };
+  assert.equal(renderStateViewLine(historical), TEXT);
+  assert.equal(renderStateViewLine(historical, { enabled: false }), TEXT);
+});

--- a/packages/remnic-core/src/recall-state-view-render.ts
+++ b/packages/remnic-core/src/recall-state-view-render.ts
@@ -1,0 +1,24 @@
+/**
+ * Recall inject-line renderer for state views (issue #1952).
+ *
+ * Historical and transition rows get `[superseded <date> by <id>]` when both
+ * supersededAt and supersededBy are present. Current rows and a disabled
+ * flag are identity.
+ */
+import { formatSupersededPrefix, type StateViewResult } from "./recall-state-view.js";
+
+export type StateViewLineResult = StateViewResult & { text?: string };
+
+export function renderStateViewLine(
+  result: StateViewLineResult,
+  options: { enabled?: boolean } = {},
+): string {
+  const text = typeof result.text === "string" ? result.text : "";
+  if (options.enabled !== true) return text;
+  const label = result.stateLabel;
+  if (label !== "historical" && label !== "transition") return text;
+  const date = result.supersededAt;
+  const successor = result.supersededBy;
+  if (!date || !successor) return text;
+  return `${formatSupersededPrefix(date, successor)} ${text}`;
+}


### PR DESCRIPTION
Part of #1952

## Change
`renderStateViewLine`. Historical/transition get a superseded prefix. Current is identity.

## Test
`packages/remnic-core/src/recall-state-view-render.test.ts`