### PR TITLE
feat(recall): render deep-recall traces as markdown

### DIFF
--- a/.changeset/2332-deep-recall-render.md
+++ b/.changeset/2332-deep-recall-render.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deterministic markdown renderer for deep-recall traces. Empty working set prints (empty). Part of #2332.

--- a/packages/remnic-core/src/recall-deep-render.test.ts
+++ b/packages/remnic-core/src/recall-deep-render.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  runDeepRecall,
+  type DeepRecallState,
+} from "./recall-deep.js";
+import { renderDeepRecallTrace } from "./recall-deep-render.js";
+
+function seed(extra: Partial<DeepRecallState> = {}): DeepRecallState {
+  return {
+    query: "who met at the cafe",
+    workingSet: [],
+    frontier: ["m-b", "m-c"],
+    budget: 2,
+    ...extra,
+  };
+}
+
+test("empty working set prints (empty)", () => {
+  const result = runDeepRecall(seed({ budget: 0 }), () => {
+    throw new Error("policy must not run when budget is 0");
+  });
+  assert.equal(
+    renderDeepRecallTrace(result),
+    [
+      "# Deep recall",
+      "",
+      "- query: who met at the cafe",
+      "- budget: 0",
+      "- stop: budget exhausted",
+      "",
+      "## Steps",
+      "",
+      "1. stop budget=0 workingSet=(empty) frontier=m-b, m-c",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("expand then stop snapshot", () => {
+  const result = runDeepRecall(seed({ workingSet: ["m-seed"], budget: 2 }), (state) =>
+    state.workingSet.includes("m-b") ? "stop" : "expand",
+  );
+  assert.equal(
+    renderDeepRecallTrace(result),
+    [
+      "# Deep recall",
+      "",
+      "- query: who met at the cafe",
+      "- budget: 1",
+      "- stop: stop",
+      "",
+      "## Steps",
+      "",
+      "1. expand budget=1 workingSet=m-seed, m-b frontier=m-c",
+      "2. stop budget=1 workingSet=m-seed, m-b frontier=m-c",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("same result renders the same bytes", () => {
+  const policy = () => "stop";
+  const first = renderDeepRecallTrace(runDeepRecall(seed({ budget: 3 }), policy));
+  const second = renderDeepRecallTrace(runDeepRecall(seed({ budget: 3 }), policy));
+  assert.equal(first, second);
+});

--- a/packages/remnic-core/src/recall-deep-render.ts
+++ b/packages/remnic-core/src/recall-deep-render.ts
@@ -1,0 +1,32 @@
+/**
+ * Markdown renderer for a deep-recall trace (issue #2332 leftover).
+ *
+ * Deterministic. Surfaces wait. Empty working set prints (empty).
+ */
+
+import type { DeepRecallResult } from "./recall-deep.js";
+
+export function renderDeepRecallTrace(result: DeepRecallResult): string {
+  const last = result.trace[result.trace.length - 1];
+  const stop = !last ? "none" : last.budget <= 0 ? "budget exhausted" : last.action;
+  const steps =
+    result.trace.length === 0
+      ? ["(empty)"]
+      : result.trace.map((step, index) => {
+          const workingSet = step.workingSet.length === 0 ? "(empty)" : step.workingSet.join(", ");
+          const frontier = step.frontier.length === 0 ? "(empty)" : step.frontier.join(", ");
+          return `${index + 1}. ${step.action} budget=${step.budget} workingSet=${workingSet} frontier=${frontier}`;
+        });
+  return [
+    "# Deep recall",
+    "",
+    `- query: ${result.state.query}`,
+    `- budget: ${result.state.budget}`,
+    `- stop: ${stop}`,
+    "",
+    "## Steps",
+    "",
+    ...steps,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
Part of #2332

## Change
`renderDeepRecallTrace`. Query, budget, steps, stop reason. Empty working set prints (empty).

## Test
`packages/remnic-core/src/recall-deep-render.test.ts`