### PR TITLE
feat(cli): remnic activity-export

### DIFF
--- a/.changeset/2053-activity-export.md
+++ b/.changeset/2053-activity-export.md
@@ -1,0 +1,5 @@
+---
+"@remnic/cli": minor
+---
+
+Add `remnic activity-export` for a half-open `[from, to)` JSON export of `{id, capturedAt}`. Missing `--from` exits 1, and `--enabled false` denies. Does not persist. Part of #2053.

--- a/packages/remnic-cli/src/commands/activity-export.test.ts
+++ b/packages/remnic-cli/src/commands/activity-export.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runActivityExportCommand, type ActivityExportItem } from "./activity-export.js";
+
+function capture(
+  rest: string[],
+  items: readonly ActivityExportItem[] = [],
+  nowMs?: number,
+): { code: number; stdout: string[]; stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = runActivityExportCommand(
+    rest,
+    {
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    },
+    items,
+    nowMs,
+  );
+  return { code, stdout, stderr };
+}
+
+const from = "2026-01-01T00:00:00.000Z";
+const mid = "2026-01-02T00:00:00.000Z";
+const to = "2026-01-03T00:00:00.000Z";
+const items: ActivityExportItem[] = [
+  { id: "before", capturedAt: "2025-12-31T23:59:59.000Z" },
+  { id: "start", capturedAt: from },
+  { id: "inside", capturedAt: mid },
+  { id: "end", capturedAt: to },
+];
+
+test("missing --from exits 1", () => {
+  const result = capture(["--to", to, "--format", "json"], items);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout.length, 0);
+  assert.match(result.stderr.join("\n"), /--from/);
+});
+
+test("enabled false denies with an empty array", () => {
+  const result = capture(
+    ["--from", from, "--to", to, "--format", "json", "--enabled", "false"],
+    items,
+  );
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.stdout, ["[]"]);
+});
+
+test("half-open window prints id and capturedAt", () => {
+  const result = capture(["--from", from, "--to", to, "--format", "json"], items);
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.join("")), [
+    { id: "start", capturedAt: from },
+    { id: "inside", capturedAt: mid },
+  ]);
+});
+
+test("omitted --to uses now", () => {
+  const nowMs = Date.parse(to);
+  const result = capture(["--from", from, "--format", "json"], items, nowMs);
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout.join("")), [
+    { id: "start", capturedAt: from },
+    { id: "inside", capturedAt: mid },
+  ]);
+});

--- a/packages/remnic-cli/src/commands/activity-export.ts
+++ b/packages/remnic-cli/src/commands/activity-export.ts
@@ -1,0 +1,120 @@
+/**
+ * `remnic activity-export --from --to --format json` (#2053 export slice).
+ *
+ * Half-open [from, to). Missing --from exits 1. --to omitted is now.
+ * `--enabled false` denies (prints []). Does not persist.
+ * Prints a JSON array of {id, capturedAt}.
+ */
+import { observationsForExport, parseActivityPrivacy, parseFlexibleIsoTimestamp } from "@remnic/core";
+import { hasFlag, resolveFlag } from "../cli-args.js";
+
+export interface ActivityExportIo {
+  stdout(line: string): void;
+  stderr(line: string): void;
+}
+
+export interface ActivityExportItem {
+  id: string | number;
+  capturedAt: string;
+}
+
+const defaultIo: ActivityExportIo = {
+  stdout: (line) => {
+    process.stdout.write(`${line}\n`);
+  },
+  stderr: (line) => {
+    process.stderr.write(`${line}\n`);
+  },
+};
+
+export function activityExportHelp(): string {
+  return `Usage: remnic activity-export --from <iso> [--to <iso>] [--format json] [--enabled <true|false>]
+
+  Print a JSON array of {id, capturedAt} in the half-open [from, to) window.
+`;
+}
+
+function parseEnabled(rest: string[], io: ActivityExportIo): boolean | undefined {
+  const raw = resolveFlag(rest, "--enabled");
+  if (raw === undefined) {
+    if (hasFlag(rest, "--enabled")) {
+      io.stderr("activity-export: --enabled requires true or false");
+      return undefined;
+    }
+    return true;
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  io.stderr("activity-export: --enabled must be true or false");
+  return undefined;
+}
+
+export function runActivityExportCommand(
+  rest: string[],
+  io: ActivityExportIo = defaultIo,
+  items: readonly ActivityExportItem[] = [],
+  nowMs: number = Date.now(),
+): number {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h" || rest[0] === "help") {
+    io.stdout(activityExportHelp().trimEnd());
+    return 0;
+  }
+
+  const fromRaw = resolveFlag(rest, "--from");
+  if (fromRaw === undefined) {
+    io.stderr("activity-export: --from <iso> is required");
+    return 1;
+  }
+  const fromMs = parseFlexibleIsoTimestamp(fromRaw);
+  if (fromMs === null) {
+    io.stderr("activity-export: --from must be an ISO timestamp");
+    return 1;
+  }
+
+  const toRaw = resolveFlag(rest, "--to");
+  let toMs: number;
+  if (toRaw === undefined) {
+    if (hasFlag(rest, "--to")) {
+      io.stderr("activity-export: --to requires an ISO timestamp");
+      return 1;
+    }
+    toMs = nowMs;
+  } else {
+    const parsed = parseFlexibleIsoTimestamp(toRaw);
+    if (parsed === null) {
+      io.stderr("activity-export: --to must be an ISO timestamp");
+      return 1;
+    }
+    toMs = parsed;
+  }
+
+  const format = resolveFlag(rest, "--format");
+  if (format === undefined) {
+    if (hasFlag(rest, "--format")) {
+      io.stderr("activity-export: --format requires json");
+      return 1;
+    }
+  } else if (format !== "json") {
+    io.stderr("activity-export: --format must be json");
+    return 1;
+  }
+
+  const enabled = parseEnabled(rest, io);
+  if (enabled === undefined) return 1;
+
+  const policy = parseActivityPrivacy({ enabled, exportIncludeObservations: true });
+  const exported = observationsForExport(items, policy)
+    .filter((item) => {
+      const at = parseFlexibleIsoTimestamp(item.capturedAt);
+      return at !== null && at >= fromMs && at < toMs;
+    })
+    .map((item) => ({ id: item.id, capturedAt: item.capturedAt }));
+
+  io.stdout(JSON.stringify(exported));
+  return 0;
+}
+
+export async function runActivityExportBinaryCommand(rest: string[]): Promise<void> {
+  const code = runActivityExportCommand(rest);
+  if (code !== 0) process.exitCode = code;
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -176,6 +176,7 @@ import { runStandupBinaryCommand } from "./commands/standup.js";
 import { runJournalBinaryCommand } from "./commands/journal.js";
 import { runJournalVaultBinaryCommand } from "./commands/journal-vault.js";
 import { runActivityPrivacyBinaryCommand } from "./commands/activity-privacy.js";
+import { runActivityExportBinaryCommand } from "./commands/activity-export.js";
 import { runVaultPublishBinaryCommand } from "./commands/vault-publish.js";
 import { runExternalWikiBinaryCommand } from "./commands/external-wiki.js";
 import { runProceduralBinaryCommand } from "./commands/procedural.js";
@@ -444,7 +445,7 @@ type CommandName =
   | "promotion-candidates"
   | "security"
   | "wearables"
-  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "activity-privacy" | "vault-publish" | "codegraph"
+  | "meetings" | "timeline" | "okf" | "location" | "export" | "standup" | "journal" | "journal-vault" | "activity-privacy" | "activity-export" | "vault-publish" | "codegraph"
   | "external-wiki"
   | "capsule"
   | "offline"
@@ -13115,6 +13116,9 @@ Other:
       break;
     case "activity-privacy":
       await runActivityPrivacyBinaryCommand(rest);
+      break;
+    case "activity-export":
+      await runActivityExportBinaryCommand(rest);
       break;
     case "vault-publish":
       await runVaultPublishBinaryCommand(rest);


### PR DESCRIPTION
Part of #2053

## Change
`remnic activity-export --from --to --format json`. Half-open window. Missing --from exits 1. Does not persist.

## Test
`packages/remnic-cli/src/commands/activity-export.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `remnic activity-export` command for exporting activity records as JSON.
  * Supports required start dates, optional end dates, date-range filtering, and configurable enabled-state handling.
  * Displays helpful usage information and clear validation errors for invalid options.

* **Bug Fixes**
  * Disabled exports now return an empty JSON array without persisting activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->