### PR TITLE
feat(shared-context): detect claim contradiction pairs

### DIFF
--- a/.changeset/1957-contradictions.md
+++ b/.changeset/1957-contradictions.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context contradiction detection (issue #1957). `detectContradictionPair` reports `same` for identical ids, `conflict` with the overlapping claim keys whose values differ (sorted), and `none` otherwise. Pure helper; never deletes or persists. Part of #1957.

--- a/packages/remnic-core/src/shared-context/contradictions.test.ts
+++ b/packages/remnic-core/src/shared-context/contradictions.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  detectContradictionPair,
+  type SharedClaimItem,
+} from "./contradictions.js";
+
+test("detectContradictionPair returns same for identical ids", () => {
+  const a: SharedClaimItem = { id: "item-1", claims: { host: "alpha" } };
+  const b: SharedClaimItem = { id: "item-1", claims: { host: "beta" } };
+
+  assert.deepEqual(detectContradictionPair(a, b), { kind: "same" });
+});
+
+test("detectContradictionPair returns conflict with the unequal overlapping keys", () => {
+  const a: SharedClaimItem = {
+    id: "item-1",
+    claims: { tier: "high", host: "alpha", region: "us" },
+  };
+  const b: SharedClaimItem = {
+    id: "item-2",
+    claims: { tier: "high", host: "beta", owner: "ops" },
+  };
+
+  assert.deepEqual(detectContradictionPair(a, b), {
+    kind: "conflict",
+    keys: ["host"],
+  });
+});
+
+test("detectContradictionPair returns none when overlap is absent or equal", () => {
+  const disjoint: SharedClaimItem = { id: "item-1", claims: { host: "alpha" } };
+  const other: SharedClaimItem = { id: "item-2", claims: { owner: "ops" } };
+  const agreeing: SharedClaimItem = { id: "item-3", claims: { host: "alpha" } };
+
+  assert.deepEqual(detectContradictionPair(disjoint, other), { kind: "none" });
+  assert.deepEqual(detectContradictionPair(disjoint, agreeing), { kind: "none" });
+});

--- a/packages/remnic-core/src/shared-context/contradictions.ts
+++ b/packages/remnic-core/src/shared-context/contradictions.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared-item contradiction detection (issue #1957).
+ *
+ * Pure helper. Same-id items are one item; overlapping claim keys with
+ * unequal values are a conflict. No deletes, no persistence.
+ */
+
+export interface SharedClaimItem {
+  id: string;
+  claims: Record<string, string>;
+}
+
+export type ContradictionPairResult =
+  | { kind: "same" }
+  | { kind: "conflict"; keys: string[] }
+  | { kind: "none" };
+
+export function detectContradictionPair(
+  a: SharedClaimItem,
+  b: SharedClaimItem,
+): ContradictionPairResult {
+  if (a.id === b.id) {
+    return { kind: "same" };
+  }
+  const keys: string[] = [];
+  for (const key of Object.keys(a.claims)) {
+    if (key in b.claims && a.claims[key] !== b.claims[key]) {
+      keys.push(key);
+    }
+  }
+  return keys.length > 0 ? { kind: "conflict", keys: keys.sort() } : { kind: "none" };
+}


### PR DESCRIPTION
Part of #1957

## Change
`detectContradictionPair`. Same id is same. Overlapping unequal keys are conflict. No deletes.

## Test
`packages/remnic-core/src/shared-context/contradictions.test.ts`