### PR TITLE
feat(extraction): add span-bench sampling gate

### DIFF
--- a/.changeset/extraction-span-bench-gate-2333.md
+++ b/.changeset/extraction-span-bench-gate-2333.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+---
+
+Add `shouldRunSpanBench` sampling gate for the extraction span benchmark (issue #2333). Standalone predicate; the default extraction path is unchanged.
+

--- a/packages/remnic-core/src/extraction-span-bench.test.ts
+++ b/packages/remnic-core/src/extraction-span-bench.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldRunSpanBench } from "./extraction-span-bench.js";
+
+test("shouldRunSpanBench: disabled or zero rate never samples (issue #2333)", () => {
+	assert.equal(shouldRunSpanBench({ enabled: false, sampleRate: 1 }), false);
+	assert.equal(shouldRunSpanBench({ enabled: false, sampleRate: 0 }), false);
+	assert.equal(shouldRunSpanBench({ enabled: true, sampleRate: 0 }), false);
+});
+
+test("shouldRunSpanBench: enabled with full rate always samples (issue #2333)", () => {
+	assert.equal(shouldRunSpanBench({ enabled: true, sampleRate: 1 }), true);
+});
+
+test("shouldRunSpanBench: rejects sampleRate outside [0, 1] or non-finite (issue #2333)", () => {
+	const invalid: number[] = [-0.1, 1.0001, Number.NaN, Number.POSITIVE_INFINITY];
+	for (const sampleRate of invalid) {
+		assert.throws(() => shouldRunSpanBench({ enabled: true, sampleRate }));
+	}
+	assert.throws(() =>
+		shouldRunSpanBench({ enabled: true, sampleRate: "0.5" as unknown as number }),
+	);
+	assert.throws(() =>
+		shouldRunSpanBench({ enabled: true, sampleRate: undefined as unknown as number }),
+	);
+});

--- a/packages/remnic-core/src/extraction-span-bench.ts
+++ b/packages/remnic-core/src/extraction-span-bench.ts
@@ -1,0 +1,28 @@
+/**
+ * Sampling gate for the extraction span benchmark (issue #2333).
+ *
+ * Pure predicate, deliberately standalone: it does not import the extraction
+ * engine and is not wired into the default extraction path. A future caller
+ * opts in explicitly; until then this module changes nothing at runtime.
+ */
+
+export interface SpanBenchOptions {
+	enabled: boolean;
+	sampleRate: number;
+}
+
+export function shouldRunSpanBench({ enabled, sampleRate }: SpanBenchOptions): boolean {
+	if (
+		typeof sampleRate !== "number" ||
+		!Number.isFinite(sampleRate) ||
+		sampleRate < 0 ||
+		sampleRate > 1
+	) {
+		throw new Error(
+			`extraction-span-bench: sampleRate must be a finite number in [0, 1], got ${String(sampleRate)}`,
+		);
+	}
+	if (!enabled || sampleRate === 0) return false;
+	if (sampleRate === 1) return true;
+	return Math.random() < sampleRate;
+}


### PR DESCRIPTION
Part of #2333

## Change
`shouldRunSpanBench`. Off or sampleRate 0 is false. Rate 1 is true. Default extraction path unchanged.

## Test
`packages/remnic-core/src/extraction-span-bench.test.ts`