### PR TITLE
feat(recall): add navigate access facade

### DIFF
--- a/.changeset/1956-navigate-access.md
+++ b/.changeset/1956-navigate-access.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add an expand/traverse access facade over recall navigation helpers. Budget 0 returns budget_exhausted. Unknown actions are rejected. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-access.test.ts
+++ b/packages/remnic-core/src/recall-navigate-access.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runRecallNavigateAccess } from "./recall-navigate-access.js";
+import type { RecallNavNode } from "./recall-navigate.js";
+
+function node(extra: Partial<RecallNavNode> = {}): RecallNavNode {
+  return {
+    id: "m1",
+    disclosure: "chunk",
+    ...extra,
+  };
+}
+
+test("expand re-renders the next disclosure for the given nodeId", () => {
+  const result = runRecallNavigateAccess({
+    action: "expand",
+    nodeId: "m1",
+    budget: 10,
+    node: node({ payloads: { section: "full section body" } }),
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.result, {
+    status: "ok",
+    node: { id: "m1", disclosure: "section", text: "full section body" },
+  });
+});
+
+test("traverse returns typed neighbors for the given nodeId", () => {
+  const result = runRecallNavigateAccess({
+    action: "traverse",
+    nodeId: "m1",
+    budget: 10,
+    linkType: "contradicts",
+    node: node({
+      links: [
+        { targetId: "z-mem", linkType: "contradicts" },
+        { targetId: "a-mem", linkType: "contradicts" },
+        { targetId: "skip-me", linkType: "supports" },
+      ],
+    }),
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.result.status, "ok");
+  if (result.result.status !== "ok") return;
+  assert.ok("neighbors" in result.result);
+  assert.deepEqual(
+    result.result.neighbors.map((row) => row.id),
+    ["a-mem", "z-mem"],
+  );
+});
+
+test("budget 0 is exhausted before any expand or traverse", () => {
+  const result = runRecallNavigateAccess({
+    action: "expand",
+    nodeId: "m1",
+    budget: 0,
+    node: node({ payloads: { section: "full section body" } }),
+  });
+  assert.deepEqual(result, { ok: false, error: "budget_exhausted" });
+});
+
+test("unknown action is rejected", () => {
+  const result = runRecallNavigateAccess({
+    action: "zoom",
+    nodeId: "m1",
+    budget: 10,
+    node: node(),
+  });
+  assert.deepEqual(result, { ok: false, error: "unknown_action" });
+});

--- a/packages/remnic-core/src/recall-navigate-access.ts
+++ b/packages/remnic-core/src/recall-navigate-access.ts
@@ -1,0 +1,48 @@
+/**
+ * Recall navigation access wrapper (issue #1956 leftover slice).
+ *
+ * Validates the request, gates the budget, and delegates to the pure
+ * helpers in recall-navigate.ts. Never calls orchestrator.recall — the
+ * caller supplies the node for `nodeId`.
+ */
+import {
+  expandRecallNode,
+  traverseRecallLink,
+  type RecallNavExpandResult,
+  type RecallNavNode,
+  type RecallNavTraverseResult,
+} from "./recall-navigate.js";
+
+export type RecallNavigateAccessAction = "expand" | "traverse";
+
+export interface RecallNavigateAccessRequest {
+  action: string;
+  nodeId: string;
+  budget: number;
+  node?: RecallNavNode;
+  linkType?: string;
+}
+
+export type RecallNavigateAccessResult =
+  | { ok: true; result: RecallNavExpandResult | RecallNavTraverseResult }
+  | { ok: false; error: "budget_exhausted" | "unknown_action" | "node_not_found" };
+
+export function runRecallNavigateAccess(request: RecallNavigateAccessRequest): RecallNavigateAccessResult {
+  if (request.action !== "expand" && request.action !== "traverse") {
+    return { ok: false, error: "unknown_action" };
+  }
+  if (!Number.isFinite(request.budget) || request.budget <= 0) {
+    return { ok: false, error: "budget_exhausted" };
+  }
+  const node = request.node;
+  if (node === undefined || node.id !== request.nodeId) {
+    return { ok: false, error: "node_not_found" };
+  }
+  if (request.action === "expand") {
+    return { ok: true, result: expandRecallNode(node, { budget: request.budget }) };
+  }
+  return {
+    ok: true,
+    result: traverseRecallLink(node, request.linkType ?? "", { budget: request.budget }),
+  };
+}


### PR DESCRIPTION
Part of #1956

## Change
`runRecallNavigateAccess`. expand or traverse. budget 0 stops. Does not call orchestrator.recall.

## Test
`packages/remnic-core/src/recall-navigate-access.test.ts`