### PR TITLE
feat(activity): deterministic recap JSON export

### DIFF
--- a/.changeset/recap-export-2051.md
+++ b/.changeset/recap-export-2051.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": minor
+---
+
+Add `exportDeterministicRecap` to the activity timeline layer: a pure,
+byte-stable JSON recap document (`date`, `timezone`, cards sorted by id) for
+one local day. No LLM, no I/O, no persistence — same cards always produce the
+same bytes (issue #2051).

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -10,4 +10,5 @@ export * from "./journal-recap-persist.js";
 export * from "./weekly.js";
 export * from "./weekly-persist.js";
 export * from "./analysis.js";
+export * from "./recap-export.js";
 export * from "./analysis-batch.js";

--- a/packages/remnic-core/src/activity/timeline/recap-export.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-export.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { TimelineCard } from "./types.js";
+import { exportDeterministicRecap } from "./recap-export.js";
+
+const DATE = "2026-08-17";
+
+function card(
+  overrides: Partial<TimelineCard> & Pick<TimelineCard, "id">,
+): TimelineCard {
+  return {
+    kind: "activity",
+    title: "Title",
+    summary: "Summary",
+    categoryId: "work",
+    confidence: 0.9,
+    startUtc: "2026-08-17T09:00:00.000Z",
+    endUtc: "2026-08-17T10:00:00.000Z",
+    dayKey: DATE,
+    timezone: "UTC",
+    machine: "machine-a",
+    evidenceIds: [1],
+    evidenceRange: null,
+    ...overrides,
+  };
+}
+
+test("empty cards export date and timezone with an empty card list", () => {
+  const recap = exportDeterministicRecap({
+    date: DATE,
+    timezone: "UTC",
+    cards: [],
+  });
+  assert.deepEqual(recap, { date: DATE, timezone: "UTC", cards: [] });
+  assert.equal(JSON.stringify(recap), `{"date":"${DATE}","timezone":"UTC","cards":[]}`);
+});
+
+test("cards are sorted by id regardless of input order", () => {
+  const recap = exportDeterministicRecap({
+    date: DATE,
+    timezone: "UTC",
+    cards: [
+      card({ id: "card-c" }),
+      card({ id: "card-a" }),
+      card({ id: "card-b" }),
+    ],
+  });
+  assert.deepEqual(
+    recap.cards.map((c) => c.id),
+    ["card-a", "card-b", "card-c"],
+  );
+});
+
+test("timezone is echoed verbatim, not normalized", () => {
+  const recap = exportDeterministicRecap({
+    date: DATE,
+    timezone: "America/Chicago",
+    cards: [],
+  });
+  assert.equal(recap.timezone, "America/Chicago");
+});
+
+test("input cards are not mutated and reruns are stable", () => {
+  const input = [card({ id: "card-b" }), card({ id: "card-a" })];
+  const first = exportDeterministicRecap({
+    date: DATE,
+    timezone: "UTC",
+    cards: input,
+  });
+  const second = exportDeterministicRecap({
+    date: DATE,
+    timezone: "UTC",
+    cards: input,
+  });
+  assert.deepEqual(input.map((c) => c.id), ["card-b", "card-a"]);
+  assert.equal(JSON.stringify(first), JSON.stringify(second));
+});

--- a/packages/remnic-core/src/activity/timeline/recap-export.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-export.ts
@@ -1,0 +1,41 @@
+/**
+ * Deterministic machine-readable recap export from timeline cards (issue #2051).
+ *
+ * Pure: cards + date + timezone in, stable JSON out. No LLM, no I/O, no
+ * persistence. Same cards always serialize to the same bytes, regardless of
+ * input array order: cards are sorted by id before serialization.
+ */
+import type { TimelineCard } from "./types.js";
+
+export interface DeterministicRecapOptions {
+  date: string;
+  timezone: string;
+  cards: readonly TimelineCard[];
+}
+
+export interface DeterministicRecap {
+  date: string;
+  timezone: string;
+  cards: TimelineCard[];
+}
+
+function compareCardIds(a: TimelineCard, b: TimelineCard): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+/**
+ * Build the byte-stable JSON recap document for one local day.
+ * Callers may `JSON.stringify` the returned object; construction order
+ * (date, timezone, cards) is fixed, so serialization is deterministic.
+ */
+export function exportDeterministicRecap(
+  options: DeterministicRecapOptions,
+): DeterministicRecap {
+  return {
+    date: options.date,
+    timezone: options.timezone,
+    cards: [...options.cards].sort(compareCardIds),
+  };
+}


### PR DESCRIPTION
Part of #2051

## Change
`exportDeterministicRecap`. Stable JSON. Cards sorted by id. No persist or LLM.

## Test
`packages/remnic-core/src/activity/timeline/recap-export.test.ts`