### PR TITLE
feat(activity): deterministic week JSON export

### DIFF
--- a/.changeset/week-export-2052.md
+++ b/.changeset/week-export-2052.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": minor
+---
+
+Add `exportDeterministicWeek` to the activity timeline layer: a pure,
+byte-stable JSON week document (`weekStart`, `timezone`, days sorted by date).
+No LLM, no I/O, no persistence — same days always produce the same bytes.
+Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -11,4 +11,5 @@ export * from "./weekly.js";
 export * from "./weekly-persist.js";
 export * from "./analysis.js";
 export * from "./recap-export.js";
+export * from "./week-export.js";
 export * from "./analysis-batch.js";

--- a/packages/remnic-core/src/activity/timeline/week-export.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-export.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { exportDeterministicWeek } from "./week-export.js";
+
+const WEEK_START = "2026-07-13";
+
+test("empty days export weekStart and timezone with an empty day list", () => {
+  const week = exportDeterministicWeek({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: [],
+  });
+  assert.deepEqual(week, { weekStart: WEEK_START, timezone: "UTC", days: [] });
+  assert.equal(
+    JSON.stringify(week),
+    `{"weekStart":"${WEEK_START}","timezone":"UTC","days":[]}`,
+  );
+});
+
+test("days are sorted by date regardless of input order", () => {
+  const week = exportDeterministicWeek({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: [{ date: "2026-07-15" }, { date: "2026-07-13" }, { date: "2026-07-14" }],
+  });
+  assert.deepEqual(
+    week.days.map((day) => day.date),
+    ["2026-07-13", "2026-07-14", "2026-07-15"],
+  );
+});
+
+test("timezone is echoed verbatim, not normalized", () => {
+  const week = exportDeterministicWeek({
+    weekStart: WEEK_START,
+    timezone: "America/Chicago",
+    days: [],
+  });
+  assert.equal(week.timezone, "America/Chicago");
+});
+
+test("input days are not mutated and reruns are stable", () => {
+  const input = [{ date: "2026-07-15" }, { date: "2026-07-13" }];
+  const first = exportDeterministicWeek({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: input,
+  });
+  const second = exportDeterministicWeek({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: input,
+  });
+  assert.deepEqual(
+    input.map((day) => day.date),
+    ["2026-07-15", "2026-07-13"],
+  );
+  assert.equal(JSON.stringify(first), JSON.stringify(second));
+});

--- a/packages/remnic-core/src/activity/timeline/week-export.ts
+++ b/packages/remnic-core/src/activity/timeline/week-export.ts
@@ -1,0 +1,44 @@
+/**
+ * Deterministic machine-readable week export from daily totals (issue #2052).
+ *
+ * Pure: weekStart + timezone + days in, stable JSON out. No LLM, no I/O, no
+ * persistence. Same days always serialize to the same bytes, regardless of
+ * input array order: days are sorted by date before serialization.
+ */
+
+export interface DeterministicWeekDay {
+  date: string;
+}
+
+export interface DeterministicWeekOptions {
+  weekStart: string;
+  timezone: string;
+  days: readonly DeterministicWeekDay[];
+}
+
+export interface DeterministicWeek {
+  weekStart: string;
+  timezone: string;
+  days: DeterministicWeekDay[];
+}
+
+function compareDates(a: DeterministicWeekDay, b: DeterministicWeekDay): number {
+  if (a.date < b.date) return -1;
+  if (a.date > b.date) return 1;
+  return 0;
+}
+
+/**
+ * Build the byte-stable JSON week document.
+ * Callers may `JSON.stringify` the returned object; construction order
+ * (weekStart, timezone, days) is fixed, so serialization is deterministic.
+ */
+export function exportDeterministicWeek(
+  options: DeterministicWeekOptions,
+): DeterministicWeek {
+  return {
+    weekStart: options.weekStart,
+    timezone: options.timezone,
+    days: [...options.days].sort(compareDates),
+  };
+}


### PR DESCRIPTION
Part of #2052

## Change
`exportDeterministicWeek`. Stable JSON. Days sorted by date. No persist or LLM.

## Test
`packages/remnic-core/src/activity/timeline/week-export.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic weekly activity exports with a consistent JSON structure.
  * Weekly data includes the week start, timezone, and dates sorted chronologically.
  * Preserves the provided timezone and leaves source data unchanged.
  * Produces stable results for identical inputs, including empty weeks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->