### PR TITLE
feat(activity): merge vault note frontmatter keys

### DIFF
--- a/.changeset/1985-vault-frontmatter.md
+++ b/.changeset/1985-vault-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `applyVaultFrontmatter` to merge listed vault YAML keys, sort the result, and leave the original body unchanged when updates are empty. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -21,3 +21,4 @@ export * from "./memory-gen.js";
 export * from "./privacy.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";
+export * from "./vault-frontmatter.js";

--- a/packages/remnic-core/src/activity/vault-frontmatter.test.ts
+++ b/packages/remnic-core/src/activity/vault-frontmatter.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyVaultFrontmatter } from "./vault-frontmatter.js";
+
+test("applyVaultFrontmatter merges listed keys and sorts", () => {
+  const merged = applyVaultFrontmatter("zeta: old\nalpha: keep\n", {
+    zeta: "new",
+    remnic_cards: "3",
+  });
+  assert.equal(merged, "alpha: keep\nremnic_cards: 3\nzeta: new");
+});
+
+test("applyVaultFrontmatter rejects keys with newlines", () => {
+  assert.throws(
+    () => applyVaultFrontmatter("alpha: keep", { "bad\nkey": "1" }),
+    /newline/i,
+  );
+  assert.throws(
+    () => applyVaultFrontmatter("alpha: keep", { "bad\rkey": "1" }),
+    /newline/i,
+  );
+});
+
+test("applyVaultFrontmatter leaves the original body unchanged when updates are empty", () => {
+  const existing = "zeta: 1\n# comment stays\nalpha: 2\n";
+  assert.equal(applyVaultFrontmatter(existing, {}), existing);
+});

--- a/packages/remnic-core/src/activity/vault-frontmatter.ts
+++ b/packages/remnic-core/src/activity/vault-frontmatter.ts
@@ -1,0 +1,39 @@
+/**
+ * Merge vault note frontmatter keys (issue #1985).
+ *
+ * Pure string helper. Empty updates leave the original YAML unchanged.
+ * Listed keys stay. Output keys are sorted. Keys with newlines are rejected.
+ */
+
+function assertNoNewlineKey(key: string): void {
+  if (key.includes("\n") || key.includes("\r")) {
+    throw new RangeError("Vault frontmatter keys must not contain newlines.");
+  }
+}
+
+export function applyVaultFrontmatter(
+  existingYaml: string,
+  updates: Readonly<Record<string, string>>,
+): string {
+  const entries = Object.entries(updates);
+  if (entries.length === 0) return existingYaml;
+
+  const merged = new Map<string, string>();
+  for (const line of existingYaml.split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    if (key.length === 0) continue;
+    assertNoNewlineKey(key);
+    merged.set(key, line.slice(idx + 1).trim());
+  }
+  for (const [key, value] of entries) {
+    assertNoNewlineKey(key);
+    merged.set(key, value);
+  }
+
+  return [...merged.keys()]
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    .map((key) => `${key}: ${merged.get(key)}`)
+    .join("\n");
+}


### PR DESCRIPTION
Part of #1985

## Change
`applyVaultFrontmatter`. Merges listed keys. Rejects newline keys. Empty updates leave YAML unchanged.

## Test
`packages/remnic-core/src/activity/vault-frontmatter.test.ts`