### PR TITLE
feat(core): add deep-recall stop predicate

### DIFF
--- a/.changeset/2332-deep-stop.md
+++ b/.changeset/2332-deep-stop.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure deep-recall stop predicate. Budget 0, the stop policy, and expand-once after one expansion halt. Unknown policy names throw. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-stop.test.ts
+++ b/packages/remnic-core/src/recall-deep-stop.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldStopDeepRecall } from "./recall-deep-stop.js";
+
+test("budgetLeft 0 stops", () => {
+  assert.equal(shouldStopDeepRecall({ budgetLeft: 0, policy: "expand-once" }), true);
+});
+
+test("stop policy stops", () => {
+  assert.equal(shouldStopDeepRecall({ budgetLeft: 3, policy: "stop" }), true);
+});
+
+test("expand-once stops only after one expansion", () => {
+  assert.equal(
+    shouldStopDeepRecall({ budgetLeft: 3, policy: "expand-once", alreadyExpanded: false }),
+    false,
+  );
+  assert.equal(
+    shouldStopDeepRecall({ budgetLeft: 3, policy: "expand-once", alreadyExpanded: true }),
+    true,
+  );
+});
+
+test("unknown policy throws", () => {
+  assert.throws(
+    () => shouldStopDeepRecall({ budgetLeft: 3, policy: "refine-twice" }),
+    /unknown deep recall stop policy/,
+  );
+  assert.throws(
+    () => shouldStopDeepRecall({ budgetLeft: 3, policy: "refine-twice" }),
+    /stop, expand-once/,
+  );
+});

--- a/packages/remnic-core/src/recall-deep-stop.ts
+++ b/packages/remnic-core/src/recall-deep-stop.ts
@@ -1,0 +1,31 @@
+/**
+ * Deep-recall stop predicate (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. Budget 0, stop policy, and expand-once after
+ * one expansion halt. Unknown policy throws.
+ */
+
+export const DEEP_RECALL_STOP_POLICIES = ["stop", "expand-once"] as const;
+
+export type DeepRecallStopPolicy = (typeof DEEP_RECALL_STOP_POLICIES)[number];
+
+export interface DeepRecallStopInput {
+  budgetLeft: number;
+  policy: string;
+  alreadyExpanded?: boolean;
+}
+
+export function isDeepRecallStopPolicy(value: unknown): value is DeepRecallStopPolicy {
+  return typeof value === "string" && (DEEP_RECALL_STOP_POLICIES as readonly string[]).includes(value);
+}
+
+export function shouldStopDeepRecall(input: DeepRecallStopInput): boolean {
+  if (!isDeepRecallStopPolicy(input.policy)) {
+    throw new Error(
+      `unknown deep recall stop policy: ${JSON.stringify(input.policy)}. Valid: ${DEEP_RECALL_STOP_POLICIES.join(", ")}`,
+    );
+  }
+  if (input.budgetLeft <= 0) return true;
+  if (input.policy === "stop") return true;
+  return input.alreadyExpanded === true;
+}


### PR DESCRIPTION
Part of #2332

## Change
`shouldStopDeepRecall`. budget 0 or policy stop ends. Unknown policy throws.

## Test
`packages/remnic-core/src/recall-deep-stop.test.ts`