### PR TITLE
feat(activity): drop analysis claims without observation evidence

### DIFF
--- a/.changeset/2050-analysis-evidence.md
+++ b/.changeset/2050-analysis-evidence.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Drop timeline analysis claims whose `observationId` is not in the supplied observations. `boundEvidence` keeps claim order and returns no claims when the observation list is empty (issue #2050).

--- a/packages/remnic-core/src/activity/timeline/analysis-evidence.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-evidence.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { boundEvidence } from "./analysis-evidence.js";
+
+function claim(observationId: number, title: string) {
+  return { observationId, title };
+}
+
+function observation(id: number) {
+  return { id };
+}
+
+test("drops claims whose observationId is missing", () => {
+  const kept = boundEvidence(
+    [claim(1, "first"), claim(99, "ghost"), claim(2, "second")],
+    [observation(1), observation(2)],
+  );
+  assert.deepEqual(kept, [claim(1, "first"), claim(2, "second")]);
+});
+
+test("keeps claim order", () => {
+  const kept = boundEvidence(
+    [claim(3, "third"), claim(1, "first"), claim(2, "second")],
+    [observation(1), observation(2), observation(3)],
+  );
+  assert.deepEqual(kept, [claim(3, "third"), claim(1, "first"), claim(2, "second")]);
+});
+
+test("empty observations return no claims", () => {
+  assert.deepEqual(boundEvidence([claim(1, "first")], []), []);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-evidence.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-evidence.ts
@@ -1,0 +1,20 @@
+/**
+ * Drop analysis claims that do not cite a supplied observation (issue #2050).
+ */
+export interface TimelineEvidenceClaim {
+  observationId: number;
+}
+
+export interface TimelineEvidenceObservation {
+  id: number;
+}
+
+/** Keep claims whose observationId is present. Preserve claim order. */
+export function boundEvidence<T extends TimelineEvidenceClaim>(
+  claims: readonly T[],
+  observations: readonly TimelineEvidenceObservation[],
+): T[] {
+  if (observations.length === 0) return [];
+  const ids = new Set(observations.map((observation) => observation.id));
+  return claims.filter((claim) => ids.has(claim.observationId));
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -12,3 +12,4 @@ export * from "./weekly-persist.js";
 export * from "./analysis.js";
 export * from "./recap-export.js";
 export * from "./analysis-batch.js";
+export * from "./analysis-evidence.js";


### PR DESCRIPTION
Part of #2050

## Change
`boundEvidence`. Drops claims whose observationId is missing. Keeps claim order.

## Test
`packages/remnic-core/src/activity/timeline/analysis-evidence.test.ts`