### PR TITLE
feat(activity): extract unique ATX journal sections

### DIFF
--- a/.changeset/1987-journal-section.md
+++ b/.changeset/1987-journal-section.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure ATX heading extractor for vault journal sections. A unique heading returns the body until the next same-or-higher heading. A missing heading returns null. Duplicate or empty headings are refused. No filesystem. Part of #1987.

--- a/packages/remnic-core/src/activity/journal-section.test.ts
+++ b/packages/remnic-core/src/activity/journal-section.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractJournalSection } from "./journal-section.js";
+
+test("extractJournalSection returns null when the heading is missing", () => {
+  const markdown = ["# Day", "## Notes", "cards", ""].join("\n");
+  assert.equal(extractJournalSection(markdown, "Journal"), null);
+});
+
+test("extractJournalSection returns the unique heading body until the next same-or-higher heading", () => {
+  const markdown = [
+    "# Day",
+    "## Journal",
+    "walked the dog",
+    "### Nested",
+    "still journal",
+    "## Notes",
+    "not journal",
+    "",
+  ].join("\n");
+  assert.equal(
+    extractJournalSection(markdown, "Journal"),
+    ["walked the dog", "### Nested", "still journal"].join("\n"),
+  );
+});
+
+test("extractJournalSection refuses a duplicate heading", () => {
+  const markdown = ["# Day", "## Journal", "first", "## Notes", "## Journal", "second", ""].join("\n");
+  assert.deepEqual(extractJournalSection(markdown, "Journal"), { error: "duplicate_heading" });
+});
+
+test("extractJournalSection rejects an empty heading", () => {
+  const markdown = ["## Journal", "hi", ""].join("\n");
+  assert.deepEqual(extractJournalSection(markdown, ""), { error: "empty_heading" });
+  assert.deepEqual(extractJournalSection(markdown, "   "), { error: "empty_heading" });
+});

--- a/packages/remnic-core/src/activity/journal-section.ts
+++ b/packages/remnic-core/src/activity/journal-section.ts
@@ -1,0 +1,75 @@
+/**
+ * Extract a unique ATX heading section (issue #1987).
+ *
+ * Pure string helper. No filesystem. Missing heading returns null.
+ * Duplicate headings refuse. Empty headings are rejected.
+ */
+
+export type ExtractJournalSectionResult =
+  | string
+  | null
+  | { error: "duplicate_heading" }
+  | { error: "empty_heading" };
+
+export function extractJournalSection(
+  markdown: string,
+  heading: string,
+): ExtractJournalSectionResult {
+  const wanted = heading.trim();
+  if (wanted.length === 0) return { error: "empty_heading" };
+
+  const lines = splitFileLines(markdown);
+  const hits: number[] = [];
+  const levels: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseAtxHeading(lines[i]!);
+    if (parsed && parsed.text === wanted) {
+      hits.push(i);
+      levels.push(parsed.level);
+    }
+  }
+  if (hits.length === 0) return null;
+  if (hits.length > 1) return { error: "duplicate_heading" };
+
+  const headingIndex = hits[0]!;
+  const level = levels[0]!;
+  let endIndex = lines.length;
+  for (let i = headingIndex + 1; i < lines.length; i++) {
+    const parsed = parseAtxHeading(lines[i]!);
+    if (parsed && parsed.level <= level) {
+      endIndex = i;
+      break;
+    }
+  }
+  return lines.slice(headingIndex + 1, endIndex).join("\n");
+}
+
+function splitFileLines(fileText: string): string[] {
+  const lines = fileText.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.endsWith("\r")) lines[i] = line.slice(0, -1);
+  }
+  return lines;
+}
+
+function parseAtxHeading(line: string): { level: number; text: string } | null {
+  let level = 0;
+  while (level < line.length && level < 6 && line[level] === "#") level++;
+  if (level === 0) return null;
+  const after = line[level];
+  if (after !== " " && after !== "\t") return null;
+
+  let start = level + 1;
+  let end = line.length;
+  while (start < end && (line[start] === " " || line[start] === "\t")) start++;
+  while (end > start && (line[end - 1] === " " || line[end - 1] === "\t")) end--;
+
+  let hashEnd = end;
+  while (hashEnd > start && line[hashEnd - 1] === "#") hashEnd--;
+  if (hashEnd < end && hashEnd > start && (line[hashEnd - 1] === " " || line[hashEnd - 1] === "\t")) {
+    end = hashEnd;
+    while (end > start && (line[end - 1] === " " || line[end - 1] === "\t")) end--;
+  }
+  return { level, text: line.slice(start, end) };
+}


### PR DESCRIPTION
Part of #1987

## Change
`extractJournalSection`. Unique ATX heading until next same-or-higher. Missing is null. Duplicate fails.

## Test
`packages/remnic-core/src/activity/journal-section.test.ts`