### PR TITLE
feat(dedup): add merge-judge skip-threshold helper

### DIFF
--- a/.changeset/2330-merge-threshold.md
+++ b/.changeset/2330-merge-threshold.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-judge skip-threshold helper. Disabled merge skips the judge. `skipThreshold` 0 never skips on score. Scores at or above the skip band skip. Invalid unit-interval inputs throw. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-threshold.test.ts
+++ b/packages/remnic-core/src/dedup/merge-threshold.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldSkipMergeJudge } from "./merge-threshold.js";
+
+test("disabled merge skips the judge", () => {
+  assert.equal(shouldSkipMergeJudge({ enabled: false, score: 0.85, skipThreshold: 0.92 }), true);
+});
+
+test("skipThreshold 0 never skips on score", () => {
+  assert.equal(shouldSkipMergeJudge({ enabled: true, score: 1, skipThreshold: 0 }), false);
+  assert.equal(shouldSkipMergeJudge({ enabled: true, score: 0, skipThreshold: 0 }), false);
+});
+
+test("score at or above skipThreshold skips", () => {
+  assert.equal(shouldSkipMergeJudge({ enabled: true, score: 0.92, skipThreshold: 0.92 }), true);
+  assert.equal(shouldSkipMergeJudge({ enabled: true, score: 0.99, skipThreshold: 0.92 }), true);
+  assert.equal(shouldSkipMergeJudge({ enabled: true, score: 0.91, skipThreshold: 0.92 }), false);
+});
+
+test("invalid score or threshold throws", () => {
+  assert.throws(
+    () => shouldSkipMergeJudge({ enabled: true, score: Number.NaN, skipThreshold: 0.92 }),
+    /invalid merge score/,
+  );
+  assert.throws(
+    () => shouldSkipMergeJudge({ enabled: true, score: -0.1, skipThreshold: 0.92 }),
+    /invalid merge score/,
+  );
+  assert.throws(
+    () => shouldSkipMergeJudge({ enabled: true, score: 1.1, skipThreshold: 0.92 }),
+    /invalid merge score/,
+  );
+  assert.throws(
+    () => shouldSkipMergeJudge({ enabled: true, score: 0.5, skipThreshold: Number.NaN }),
+    /invalid merge skipThreshold/,
+  );
+  assert.throws(
+    () => shouldSkipMergeJudge({ enabled: true, score: 0.5, skipThreshold: -0.01 }),
+    /invalid merge skipThreshold/,
+  );
+  assert.throws(
+    () => shouldSkipMergeJudge({ enabled: true, score: 0.5, skipThreshold: 1.01 }),
+    /invalid merge skipThreshold/,
+  );
+});

--- a/packages/remnic-core/src/dedup/merge-threshold.ts
+++ b/packages/remnic-core/src/dedup/merge-threshold.ts
@@ -1,0 +1,26 @@
+/**
+ * Merge-judge skip predicate (issue #2330 leftover).
+ *
+ * Pure. Disabled merge skips the judge (create). skipThreshold 0 never
+ * skips on score. score >= skipThreshold skips. Invalid units throw.
+ */
+
+export interface MergeThresholdInput {
+  enabled: boolean;
+  score: number;
+  skipThreshold: number;
+}
+
+function assertUnitInterval(value: number, name: string): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`invalid merge ${name}: ${value}`);
+  }
+}
+
+export function shouldSkipMergeJudge(input: MergeThresholdInput): boolean {
+  assertUnitInterval(input.score, "score");
+  assertUnitInterval(input.skipThreshold, "skipThreshold");
+  if (!input.enabled) return true;
+  if (input.skipThreshold === 0) return false;
+  return input.score >= input.skipThreshold;
+}


### PR DESCRIPTION
Part of #2330

## Change
`shouldSkipMergeJudge`. Off skips. Threshold 0 never skips on score. Invalid unit throws.

## Test
`packages/remnic-core/src/dedup/merge-threshold.test.ts`