### PR TITLE
feat(recall): render navigate results as markdown

### DIFF
--- a/.changeset/1956-navigate-render.md
+++ b/.changeset/1956-navigate-render.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deterministic markdown renderer for recall navigate steps. Empty children prints (empty). Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-render.test.ts
+++ b/packages/remnic-core/src/recall-navigate-render.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderNavigateResult } from "./recall-navigate-render.js";
+
+test("expand empty children prints (empty)", () => {
+  assert.equal(
+    renderNavigateResult({
+      action: "expand",
+      nodeId: "m1",
+      children: [],
+      stopReason: "empty",
+    }),
+    [
+      "# Navigate",
+      "",
+      "- action: expand",
+      "- nodeId: m1",
+      "- children: (empty)",
+      "- stop: empty",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("traverse path lists node ids in order", () => {
+  assert.equal(
+    renderNavigateResult({
+      action: "traverse",
+      nodeId: "m1",
+      path: ["a-mem", "z-mem"],
+      stopReason: "ok",
+    }),
+    [
+      "# Navigate",
+      "",
+      "- action: traverse",
+      "- nodeId: m1",
+      "- path: a-mem, z-mem",
+      "- stop: ok",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("error prints the stop reason", () => {
+  assert.equal(
+    renderNavigateResult({
+      action: "expand",
+      nodeId: "missing",
+      stopReason: "node_not_found",
+    }),
+    [
+      "# Navigate",
+      "",
+      "- action: expand",
+      "- nodeId: missing",
+      "- children: (empty)",
+      "- stop: node_not_found",
+      "",
+    ].join("\n"),
+  );
+});

--- a/packages/remnic-core/src/recall-navigate-render.ts
+++ b/packages/remnic-core/src/recall-navigate-render.ts
@@ -1,0 +1,31 @@
+/**
+ * Markdown renderer for a recall navigate step (issue #1956 leftover).
+ *
+ * Deterministic. Surfaces wait. Empty children prints (empty).
+ */
+
+export type NavigateResult = {
+  action: string;
+  nodeId: string;
+  children?: readonly string[];
+  path?: readonly string[];
+  stopReason: string;
+};
+
+function formatList(items: readonly string[] | undefined): string {
+  if (items === undefined || items.length === 0) return "(empty)";
+  return items.join(", ");
+}
+
+export function renderNavigateResult(result: NavigateResult): string {
+  const usePath = result.action === "traverse" || result.path !== undefined;
+  return [
+    "# Navigate",
+    "",
+    `- action: ${result.action}`,
+    `- nodeId: ${result.nodeId}`,
+    usePath ? `- path: ${formatList(result.path)}` : `- children: ${formatList(result.children)}`,
+    `- stop: ${result.stopReason}`,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
Part of #1956

## Change
`renderNavigateResult`. Action, nodeId, children or path. Empty children prints (empty).

## Test
`packages/remnic-core/src/recall-navigate-render.test.ts`