### PR TITLE
feat(activity): add half-open privacy window filter

### DIFF
--- a/.changeset/2053-privacy-window.md
+++ b/.changeset/2053-privacy-window.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `filterPrivacyWindow` for a half-open `[fromMs, toMs)` activity window.
+`retainDays` 0 keeps all ages. `retainDays` N drops items older than N days before `toMs`.
+Part of #2053.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -19,6 +19,7 @@ export * from "./journal.js";
 export * from "./journal-vault-read.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";
+export * from "./privacy-window.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";
 export * from "./vault-frontmatter.js";

--- a/packages/remnic-core/src/activity/privacy-window.test.ts
+++ b/packages/remnic-core/src/activity/privacy-window.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MS_PER_DAY } from "./privacy.js";
+import { filterPrivacyWindow } from "./privacy-window.js";
+
+function item(capturedAtMs: number, id = capturedAtMs) {
+  return { id, capturedAtMs };
+}
+
+test("window is half-open [fromMs, toMs)", () => {
+  const fromMs = 1_000;
+  const toMs = 2_000;
+  const kept = filterPrivacyWindow(
+    [item(fromMs - 1), item(fromMs), item(toMs - 1), item(toMs)],
+    { fromMs, toMs, retainDays: 0 },
+  );
+  assert.deepEqual(
+    kept.map((entry) => entry.capturedAtMs),
+    [fromMs, toMs - 1],
+  );
+});
+
+test("retainDays 0 keeps all ages inside the window", () => {
+  const toMs = 400 * MS_PER_DAY;
+  const old = item(toMs - 390 * MS_PER_DAY, 1);
+  const kept = filterPrivacyWindow([old], { fromMs: 0, toMs, retainDays: 0 });
+  assert.deepEqual(kept, [old]);
+});
+
+test("retainDays N drops older than N days before toMs", () => {
+  const toMs = 10 * MS_PER_DAY;
+  const fromMs = 0;
+  const cutoff = toMs - 3 * MS_PER_DAY;
+  const kept = filterPrivacyWindow(
+    [item(cutoff - 1, 1), item(cutoff, 2), item(cutoff + 1, 3), item(toMs - 1, 4)],
+    { fromMs, toMs, retainDays: 3 },
+  );
+  assert.deepEqual(
+    kept.map((entry) => entry.id),
+    [3, 4],
+  );
+});
+
+test("empty items or inverted window return []", () => {
+  assert.deepEqual(filterPrivacyWindow([], { fromMs: 0, toMs: 10, retainDays: 0 }), []);
+  assert.deepEqual(filterPrivacyWindow([item(5)], { fromMs: 10, toMs: 10, retainDays: 0 }), []);
+  assert.deepEqual(filterPrivacyWindow([item(5)], { fromMs: 10, toMs: 0, retainDays: 0 }), []);
+});

--- a/packages/remnic-core/src/activity/privacy-window.ts
+++ b/packages/remnic-core/src/activity/privacy-window.ts
@@ -1,0 +1,32 @@
+/**
+ * Half-open activity privacy window (issue #2053).
+ */
+import { shouldRetain } from "./privacy.js";
+
+export interface PrivacyWindowItem {
+  capturedAtMs: number;
+}
+
+export interface PrivacyWindowOptions {
+  fromMs: number;
+  toMs: number;
+  retainDays: number;
+}
+
+/**
+ * Keep items in `[fromMs, toMs)`.
+ * `retainDays` 0 keeps all ages. `retainDays` N drops older than N days before `toMs`.
+ * `toMs <= fromMs` returns `[]`.
+ */
+export function filterPrivacyWindow<T extends PrivacyWindowItem>(
+  items: readonly T[],
+  options: PrivacyWindowOptions,
+): T[] {
+  const { fromMs, toMs, retainDays } = options;
+  if (toMs <= fromMs) return [];
+  return items.filter((item) => {
+    const capturedAtMs = item.capturedAtMs;
+    if (capturedAtMs < fromMs || capturedAtMs >= toMs) return false;
+    return shouldRetain(capturedAtMs, toMs, retainDays);
+  });
+}


### PR DESCRIPTION
Part of #2053

## Change
`filterPrivacyWindow`. Half-open [from, to). retainDays 0 keeps all ages.

## Test
`packages/remnic-core/src/activity/privacy-window.test.ts`