### PR TITLE
feat(shared-context): stamp provenance actor and at

### DIFF
--- a/.changeset/1957-provenance.md
+++ b/.changeset/1957-provenance.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context provenance stamp (issue #1957). `stampProvenance` copies the item, attaches `{actor, at}`, and rejects an empty actor or a non-ISO/NaN timestamp. Part of #1957.

--- a/packages/remnic-core/src/shared-context/provenance.test.ts
+++ b/packages/remnic-core/src/shared-context/provenance.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { stampProvenance } from "./provenance.js";
+
+const AT = "2026-08-18T12:00:00.000Z";
+
+test("stampProvenance stamps actor and at onto a new object", () => {
+  const item = { id: "item-1", title: "note" };
+  assert.deepEqual(stampProvenance(item, { actor: "agent-a", at: AT }), {
+    id: "item-1",
+    title: "note",
+    provenance: { actor: "agent-a", at: AT },
+  });
+});
+
+test("stampProvenance does not mutate the input item", () => {
+  const item = { id: "item-1" };
+  const stamped = stampProvenance(item, { actor: "agent-a", at: AT });
+  assert.deepEqual(item, { id: "item-1" });
+  assert.equal("provenance" in item, false);
+  assert.notEqual(stamped, item);
+});
+
+test("stampProvenance rejects an empty actor and an invalid at", () => {
+  const item = { id: "item-1" };
+  const valid = { actor: "agent-a", at: AT };
+  assert.throws(() => stampProvenance(item, { ...valid, actor: "" }), /actor/);
+  assert.throws(() => stampProvenance(item, { ...valid, actor: "   " }), /actor/);
+  assert.throws(() => stampProvenance(item, { ...valid, at: "not-a-date" }), /at/);
+  assert.throws(
+    () => stampProvenance(item, { ...valid, at: Number.NaN as unknown as string }),
+    /at/,
+  );
+});

--- a/packages/remnic-core/src/shared-context/provenance.ts
+++ b/packages/remnic-core/src/shared-context/provenance.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared-item provenance stamp (issue #1957).
+ *
+ * First slice: stamp actor + at onto a new object. Curation wiring
+ * comes later. Does not mutate the input.
+ */
+
+export interface ProvenanceStamp {
+  actor: string;
+  at: string;
+}
+
+export interface StampProvenanceOptions {
+  actor: string;
+  at: string;
+}
+
+// Linear ISO instant. No nested quantifiers.
+const ISO_INSTANT =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isStrictIsoTimestamp(value: string): boolean {
+  const match = ISO_INSTANT.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const utc = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  return (
+    Number.isFinite(Date.parse(value)) &&
+    utc.getUTCFullYear() === year &&
+    utc.getUTCMonth() === month - 1 &&
+    utc.getUTCDate() === day &&
+    utc.getUTCHours() === hour &&
+    utc.getUTCMinutes() === minute &&
+    utc.getUTCSeconds() === second
+  );
+}
+
+function requireActor(actor: string): string {
+  if (typeof actor !== "string" || actor.trim().length === 0) {
+    throw new Error("stampProvenance: actor must be a non-empty string");
+  }
+  return actor;
+}
+
+function requireAt(at: unknown): string {
+  if (typeof at !== "string" || !isStrictIsoTimestamp(at)) {
+    throw new Error("stampProvenance: at must be a valid ISO-8601 timestamp");
+  }
+  return at;
+}
+
+export function stampProvenance<T extends object>(
+  item: T,
+  stamp: StampProvenanceOptions,
+): T & { provenance: ProvenanceStamp } {
+  return {
+    ...item,
+    provenance: {
+      actor: requireActor(stamp.actor),
+      at: requireAt(stamp.at),
+    },
+  };
+}


### PR DESCRIPTION
Part of #1957

## Change
`stampProvenance`. New object. Empty actor rejected. Invalid at rejected.

## Test
`packages/remnic-core/src/shared-context/provenance.test.ts`