### PR TITLE
feat(activity): deterministic week snapshot markdown

### DIFF
--- a/.changeset/week-snapshot-2052.md
+++ b/.changeset/week-snapshot-2052.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": minor
+---
+
+Add `renderWeekSnapshot` to the activity timeline layer: a pure,
+byte-stable markdown week document (`weekStart`, `timezone`, days sorted by date).
+Empty days print heading + (empty). No LLM, no I/O, no persistence.
+Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -12,5 +12,6 @@ export * from "./weekly-persist.js";
 export * from "./analysis.js";
 export * from "./recap-export.js";
 export * from "./week-export.js";
+export * from "./week-snapshot.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";

--- a/packages/remnic-core/src/activity/timeline/week-snapshot.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-snapshot.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderWeekSnapshot } from "./week-snapshot.js";
+
+const WEEK_START = "2026-07-13";
+
+test("empty days print heading + (empty)", () => {
+  assert.equal(
+    renderWeekSnapshot({
+      weekStart: WEEK_START,
+      timezone: "UTC",
+      days: [],
+    }),
+    [
+      "# Week snapshot",
+      "",
+      `- weekStart: ${WEEK_START}`,
+      "- timezone: UTC",
+      "",
+      "## Days",
+      "(empty)",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("days are sorted by date regardless of input order", () => {
+  const markdown = renderWeekSnapshot({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: [{ date: "2026-07-15" }, { date: "2026-07-13" }, { date: "2026-07-14" }],
+  });
+  const headings = [...markdown.matchAll(/^## (.+)$/gm)].map((match) => match[1]);
+  assert.deepEqual(headings, ["2026-07-13", "2026-07-14", "2026-07-15"]);
+  assert.match(markdown, /## 2026-07-13\n\(empty\)/);
+});
+
+test("timezone is echoed verbatim, not normalized", () => {
+  const markdown = renderWeekSnapshot({
+    weekStart: WEEK_START,
+    timezone: "America/Chicago",
+    days: [],
+  });
+  assert.match(markdown, /^- timezone: America\/Chicago$/m);
+  assert.doesNotMatch(markdown, /America\/Chicago\/|UTC/);
+});
+
+test("input days are not mutated and reruns are stable", () => {
+  const input = [{ date: "2026-07-15" }, { date: "2026-07-13" }];
+  const first = renderWeekSnapshot({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: input,
+  });
+  const second = renderWeekSnapshot({
+    weekStart: WEEK_START,
+    timezone: "UTC",
+    days: input,
+  });
+  assert.deepEqual(
+    input.map((day) => day.date),
+    ["2026-07-15", "2026-07-13"],
+  );
+  assert.equal(first, second);
+});

--- a/packages/remnic-core/src/activity/timeline/week-snapshot.ts
+++ b/packages/remnic-core/src/activity/timeline/week-snapshot.ts
@@ -1,0 +1,40 @@
+/**
+ * Deterministic markdown week snapshot from daily totals (issue #2052 leftover).
+ *
+ * Pure: weekStart + timezone + days in, stable markdown out. No LLM, no I/O, no
+ * persistence. Days are sorted by date. Empty days print heading + (empty).
+ */
+
+export interface WeekSnapshotDay {
+  date: string;
+}
+
+export interface WeekSnapshotOptions {
+  weekStart: string;
+  timezone: string;
+  days: readonly WeekSnapshotDay[];
+}
+
+function compareDates(a: WeekSnapshotDay, b: WeekSnapshotDay): number {
+  if (a.date < b.date) return -1;
+  if (a.date > b.date) return 1;
+  return 0;
+}
+
+/** Render a byte-stable Markdown week snapshot. */
+export function renderWeekSnapshot(options: WeekSnapshotOptions): string {
+  const days = [...options.days].sort(compareDates);
+  const body =
+    days.length === 0
+      ? ["## Days", "(empty)"]
+      : days.flatMap((day) => [`## ${day.date}`, "(empty)", ""]);
+  return [
+    "# Week snapshot",
+    "",
+    `- weekStart: ${options.weekStart}`,
+    `- timezone: ${options.timezone}`,
+    "",
+    ...body,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
Part of #2052

## Change
renderWeekSnapshot. Deterministic markdown. Days sorted by date. No persist or LLM.

## Test
packages/remnic-core/src/activity/timeline/week-snapshot.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added week snapshot rendering in Markdown.
  * Displays the week start, timezone, and daily sections in chronological order.
  * Clearly marks days with no activity.
  * Produces consistent output while preserving the provided timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->