### PR TITLE
feat(activity): render recap cards as deterministic markdown

### DIFF
--- a/.changeset/recap-markdown-2051.md
+++ b/.changeset/recap-markdown-2051.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": minor
+---
+
+Add `renderRecapMarkdown` to the activity timeline layer: a pure, byte-stable
+Markdown recap (`date`, `timezone`, cards sorted by id) for one local day.
+Empty days print heading plus `(empty)`. No LLM, no I/O, no persistence.
+Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -11,6 +11,7 @@ export * from "./weekly.js";
 export * from "./weekly-persist.js";
 export * from "./analysis.js";
 export * from "./recap-export.js";
+export * from "./recap-markdown.js";
 export * from "./week-export.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";

--- a/packages/remnic-core/src/activity/timeline/recap-markdown.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-markdown.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderRecapMarkdown } from "./recap-markdown.js";
+import type { TimelineCard } from "./types.js";
+
+const DATE = "2026-08-17";
+
+function card(
+  overrides: Partial<TimelineCard> & Pick<TimelineCard, "id">,
+): TimelineCard {
+  return {
+    kind: "activity",
+    title: "Title",
+    summary: "Summary",
+    categoryId: "work",
+    confidence: 0.9,
+    startUtc: "2026-08-17T09:00:00.000Z",
+    endUtc: "2026-08-17T10:00:00.000Z",
+    dayKey: DATE,
+    timezone: "UTC",
+    machine: "machine-a",
+    evidenceIds: [1],
+    evidenceRange: null,
+    ...overrides,
+  };
+}
+
+test("empty cards print heading plus (empty)", () => {
+  assert.equal(
+    renderRecapMarkdown({ date: DATE, timezone: "UTC", cards: [] }),
+    [`# Recap — ${DATE} (UTC)`, "", "(empty)", ""].join("\n"),
+  );
+});
+
+test("cards are sorted by id regardless of input order", () => {
+  const input = [card({ id: "card-c" }), card({ id: "card-a" }), card({ id: "card-b" })];
+  const first = renderRecapMarkdown({ date: DATE, timezone: "UTC", cards: input });
+  const second = renderRecapMarkdown({ date: DATE, timezone: "UTC", cards: input });
+  assert.equal(
+    first,
+    [`# Recap — ${DATE} (UTC)`, "", "- card-a", "- card-b", "- card-c", ""].join("\n"),
+  );
+  assert.deepEqual(
+    input.map((row) => row.id),
+    ["card-c", "card-a", "card-b"],
+  );
+  assert.equal(first, second);
+});
+
+test("timezone is echoed verbatim, not normalized", () => {
+  assert.equal(
+    renderRecapMarkdown({ date: DATE, timezone: "America/Chicago", cards: [] }),
+    [`# Recap — ${DATE} (America/Chicago)`, "", "(empty)", ""].join("\n"),
+  );
+});

--- a/packages/remnic-core/src/activity/timeline/recap-markdown.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-markdown.ts
@@ -1,0 +1,26 @@
+/**
+ * Deterministic Markdown recap from timeline cards (issue #2051 leftover).
+ *
+ * Pure: date + timezone + cards in, Markdown out. No LLM, no I/O, no
+ * persistence. Cards are sorted by id. Empty cards print (empty).
+ */
+import type { TimelineCard } from "./types.js";
+
+export interface RecapMarkdownOptions {
+  date: string;
+  timezone: string;
+  cards: readonly TimelineCard[];
+}
+
+function compareCardIds(a: TimelineCard, b: TimelineCard): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+/** Render a byte-stable Markdown recap for one local day. */
+export function renderRecapMarkdown(options: RecapMarkdownOptions): string {
+  const cards = [...options.cards].sort(compareCardIds);
+  const body = cards.length === 0 ? ["(empty)"] : cards.map((card) => `- ${card.id}`);
+  return [`# Recap — ${options.date} (${options.timezone})`, "", ...body, ""].join("\n");
+}


### PR DESCRIPTION
Part of #2051

## Change
renderRecapMarkdown. Cards sorted by id. Empty cards print (empty).

## Test
packages/remnic-core/src/activity/timeline/recap-markdown.test.ts