### PR TITLE
feat(core): add deep-recall budget clamp

### DIFF
--- a/.changeset/2332-deep-budget.md
+++ b/.changeset/2332-deep-budget.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall budget clamp. 0 stays 0. Positive integers pass through. Negative, non-finite, and non-integer values throw. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-budget.test.ts
+++ b/packages/remnic-core/src/recall-deep-budget.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { clampDeepRecallBudget } from "./recall-deep-budget.js";
+
+test("budget 0 stays 0", () => {
+  assert.equal(clampDeepRecallBudget(0), 0);
+});
+
+test("budget 3 stays 3", () => {
+  assert.equal(clampDeepRecallBudget(3), 3);
+});
+
+test("invalid budget throws", () => {
+  assert.throws(() => clampDeepRecallBudget(-1), /non-negative integer/);
+  assert.throws(() => clampDeepRecallBudget(1.5), /non-negative integer/);
+  assert.throws(() => clampDeepRecallBudget(Number.NaN), /non-negative integer/);
+  assert.throws(() => clampDeepRecallBudget(Number.POSITIVE_INFINITY), /non-negative integer/);
+});

--- a/packages/remnic-core/src/recall-deep-budget.ts
+++ b/packages/remnic-core/src/recall-deep-budget.ts
@@ -1,0 +1,14 @@
+/**
+ * Deep-recall budget clamp (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. 0 stays 0. Positive integers pass through.
+ * Negative, non-finite, and non-integer values throw.
+ */
+export function clampDeepRecallBudget(n: number): number {
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(
+      `deep recall budget must be a non-negative integer; got ${JSON.stringify(n)}`,
+    );
+  }
+  return n;
+}


### PR DESCRIPTION
Part of #2332

## Change
clampDeepRecallBudget. 0 stays 0. Negative or non-integer throws.

## Test
packages/remnic-core/src/recall-deep-budget.test.ts