### PR TITLE
feat(activity): add formatVaultWikilink for vault-relative notes

### DIFF
--- a/.changeset/1985-vault-wikilink.md
+++ b/.changeset/1985-vault-wikilink.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `formatVaultWikilink` to wrap a relative vault path as `[[path]]`. The helper strips `.md` and rejects absolute, empty, newline, and `..` paths. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -23,3 +23,4 @@ export * from "./privacy-window.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";
 export * from "./vault-frontmatter.js";
+export * from "./vault-wikilink.js";

--- a/packages/remnic-core/src/activity/vault-wikilink.test.ts
+++ b/packages/remnic-core/src/activity/vault-wikilink.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatVaultWikilink } from "./vault-wikilink.js";
+
+test("formatVaultWikilink returns a wikilink without the .md suffix", () => {
+  assert.equal(formatVaultWikilink("Daily Notes/2026-08-18.md"), "[[Daily Notes/2026-08-18]]");
+  assert.equal(formatVaultWikilink("Places/ACME Office"), "[[Places/ACME Office]]");
+});
+
+test("formatVaultWikilink rejects absolute paths", () => {
+  assert.throws(() => formatVaultWikilink("/abs/note.md"), /absolute/i);
+  assert.throws(() => formatVaultWikilink("C:/vault/note.md"), /absolute/i);
+});
+
+test("formatVaultWikilink rejects parent segments", () => {
+  assert.throws(() => formatVaultWikilink("../outside.md"), /\.\./);
+  assert.throws(() => formatVaultWikilink("notes/../../secret.md"), /\.\./);
+});
+
+test("formatVaultWikilink rejects empty and newline paths", () => {
+  assert.throws(() => formatVaultWikilink(""), /empty/i);
+  assert.throws(() => formatVaultWikilink("   "), /empty/i);
+  assert.throws(() => formatVaultWikilink(".md"), /empty/i);
+  assert.throws(() => formatVaultWikilink("foo\nbar.md"), /newline/i);
+  assert.throws(() => formatVaultWikilink("foo\rbar.md"), /newline/i);
+});

--- a/packages/remnic-core/src/activity/vault-wikilink.ts
+++ b/packages/remnic-core/src/activity/vault-wikilink.ts
@@ -1,0 +1,28 @@
+/**
+ * Format a vault-relative note path as an Obsidian wikilink (issue #1985).
+ *
+ * Relative paths only. Rejects absolute paths, `..` segments, empty input,
+ * and newlines. Strips a trailing `.md` suffix.
+ */
+import path from "node:path";
+
+export function formatVaultWikilink(notePath: string): string {
+  if (typeof notePath !== "string" || notePath.trim().length === 0) {
+    throw new RangeError("Vault wikilink path must be a non-empty relative path.");
+  }
+  if (notePath.includes("\n") || notePath.includes("\r")) {
+    throw new RangeError("Vault wikilink path must not contain newlines.");
+  }
+  if (path.posix.isAbsolute(notePath) || path.win32.isAbsolute(notePath)) {
+    throw new RangeError("Vault wikilink path must be relative; absolute paths are rejected.");
+  }
+  if (notePath.split(/[\\/]/).some((segment) => segment === "..")) {
+    throw new RangeError("Vault wikilink path must not contain `..` segments.");
+  }
+
+  const stripped = notePath.endsWith(".md") ? notePath.slice(0, -3) : notePath;
+  if (stripped.length === 0) {
+    throw new RangeError("Vault wikilink path must be a non-empty relative path.");
+  }
+  return `[[${stripped}]]`;
+}


### PR DESCRIPTION
Part of #1985

## Change
formatVaultWikilink. Relative path only. Rejects absolute, .., empty, newlines.

## Test
packages/remnic-core/src/activity/vault-wikilink.test.ts