### PR TITLE
feat(shared-context): add actor authority check

### DIFF
--- a/.changeset/1957-authority.md
+++ b/.changeset/1957-authority.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context actor authority check (issue #1957). `checkAuthority` rejects a missing actor, allows an empty required role, and forbids a mismatch. Part of #1957.

--- a/packages/remnic-core/src/shared-context/authority.test.ts
+++ b/packages/remnic-core/src/shared-context/authority.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { checkAuthority } from "./authority.js";
+
+test("checkAuthority rejects a missing actor", () => {
+  assert.deepEqual(checkAuthority({ actor: "", required: "agent-a" }), {
+    ok: false,
+    error: "missing_actor",
+  });
+  assert.deepEqual(checkAuthority({ required: "agent-a" }), {
+    ok: false,
+    error: "missing_actor",
+  });
+  assert.deepEqual(checkAuthority({ actor: "   ", required: "agent-a" }), {
+    ok: false,
+    error: "missing_actor",
+  });
+});
+
+test("checkAuthority allows an empty required role", () => {
+  assert.deepEqual(checkAuthority({ actor: "agent-a", required: "" }), { ok: true });
+  assert.deepEqual(checkAuthority({ actor: "agent-a" }), { ok: true });
+});
+
+test("checkAuthority allows a matching actor", () => {
+  assert.deepEqual(checkAuthority({ actor: "agent-a", required: "agent-a" }), { ok: true });
+});
+
+test("checkAuthority rejects a mismatched actor", () => {
+  assert.deepEqual(checkAuthority({ actor: "agent-a", required: "agent-b" }), {
+    ok: false,
+    error: "forbidden",
+  });
+});

--- a/packages/remnic-core/src/shared-context/authority.ts
+++ b/packages/remnic-core/src/shared-context/authority.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared-item actor authority (issue #1957).
+ *
+ * Pure helper. Empty required means no gate. Missing actor always fails.
+ */
+
+export type AuthorityCheckError = "missing_actor" | "forbidden";
+
+export type AuthorityCheck =
+  | { ok: true }
+  | { ok: false; error: AuthorityCheckError };
+
+export interface CheckAuthorityInput {
+  actor?: string;
+  required?: string;
+}
+
+export function checkAuthority(input: CheckAuthorityInput): AuthorityCheck {
+  const actor = input.actor?.trim() ?? "";
+  if (actor.length === 0) return { ok: false, error: "missing_actor" };
+  const required = input.required?.trim() ?? "";
+  if (required.length === 0) return { ok: true };
+  if (actor !== required) return { ok: false, error: "forbidden" };
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #1957

## Change
checkAuthority. Empty actor is missing. Mismatch is forbidden. Empty required allows.

## Test
packages/remnic-core/src/shared-context/authority.test.ts