### PR TITLE
feat(core): add span offset validator

### DIFF
--- a/.changeset/2333-span-validate.md
+++ b/.changeset/2333-span-validate.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-offset validator. Empty spans and out-of-range offsets return `{ok:false}`. Non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-validate.test.ts
+++ b/packages/remnic-core/src/extraction-span-validate.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { validateSpanOffsets } from "./extraction-span-validate.js";
+
+test("validateSpanOffsets: empty span", () => {
+  assert.deepEqual(validateSpanOffsets({ start: 0, end: 0, textLength: 5 }), {
+    ok: false,
+    error: "empty",
+  });
+  assert.deepEqual(validateSpanOffsets({ start: 3, end: 3, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+});
+
+test("validateSpanOffsets: out of range", () => {
+  assert.deepEqual(validateSpanOffsets({ start: -1, end: 2, textLength: 8 }), {
+    ok: false,
+    error: "out_of_range",
+  });
+  assert.deepEqual(validateSpanOffsets({ start: 5, end: 3, textLength: 8 }), {
+    ok: false,
+    error: "out_of_range",
+  });
+  assert.deepEqual(validateSpanOffsets({ start: 0, end: 9, textLength: 8 }), {
+    ok: false,
+    error: "out_of_range",
+  });
+});
+
+test("validateSpanOffsets: ok half-open span", () => {
+  assert.deepEqual(validateSpanOffsets({ start: 0, end: 5, textLength: 8 }), { ok: true });
+  assert.deepEqual(validateSpanOffsets({ start: 0, end: 8, textLength: 8 }), { ok: true });
+  assert.deepEqual(validateSpanOffsets({ start: 7, end: 8, textLength: 8 }), { ok: true });
+});
+
+test("validateSpanOffsets: non-integers throw", () => {
+  assert.throws(() => validateSpanOffsets({ start: 1.5, end: 3, textLength: 8 }), /integers/);
+  assert.throws(() => validateSpanOffsets({ start: 0, end: 3.2, textLength: 8 }), /integers/);
+  assert.throws(() => validateSpanOffsets({ start: 0, end: 3, textLength: 8.1 }), /integers/);
+  assert.throws(() => validateSpanOffsets({ start: Number.NaN, end: 3, textLength: 8 }), /integers/);
+});

--- a/packages/remnic-core/src/extraction-span-validate.ts
+++ b/packages/remnic-core/src/extraction-span-validate.ts
@@ -1,0 +1,27 @@
+/**
+ * Isolated span-offset validator (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export type SpanValidateOk = { ok: true };
+export type SpanValidateErr = { ok: false; error: "out_of_range" | "empty" };
+export type SpanValidateResult = SpanValidateOk | SpanValidateErr;
+
+export function validateSpanOffsets(opts: {
+  start: number;
+  end: number;
+  textLength: number;
+}): SpanValidateResult {
+  const { start, end, textLength } = opts;
+  if (!Number.isInteger(start) || !Number.isInteger(end) || !Number.isInteger(textLength)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (start < 0 || end < start || end > textLength) {
+    return { ok: false, error: "out_of_range" };
+  }
+  if (start === end) {
+    return { ok: false, error: "empty" };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #2333

## Change
validateSpanOffsets. Empty and out-of-range fail. Non-integers throw.

## Test
packages/remnic-core/src/extraction-span-validate.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added span-offset validation for text extraction.
  * Valid spans are accepted, while empty or out-of-range spans return clear validation errors.
  * Invalid non-integer offsets are rejected with an error.

* **Tests**
  * Added coverage for valid spans, empty spans, reversed or out-of-range offsets, and invalid input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->