### PR TITLE
feat(dedup): pick lowest merge target id

### DIFF
--- a/.changeset/2330-merge-id.md
+++ b/.changeset/2330-merge-id.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-target id picker. Empty candidates return null. Otherwise the lowest id by localeCompare wins. The input list is not mutated. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-id.test.ts
+++ b/packages/remnic-core/src/dedup/merge-id.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { pickMergeTargetId } from "./merge-id.js";
+
+test("empty candidates return null", () => {
+  assert.equal(pickMergeTargetId([]), null);
+});
+
+test("picks lowest id by localeCompare", () => {
+  assert.equal(pickMergeTargetId(["zeta", "alpha", "beta"]), "alpha");
+});
+
+test("does not mutate candidates", () => {
+  const candidates = ["zeta", "alpha", "beta"];
+  pickMergeTargetId(candidates);
+  assert.deepEqual(candidates, ["zeta", "alpha", "beta"]);
+});

--- a/packages/remnic-core/src/dedup/merge-id.ts
+++ b/packages/remnic-core/src/dedup/merge-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Merge-target id picker (issue #2330 leftover).
+ *
+ * Empty candidates return null. Otherwise the lowest id by localeCompare.
+ * Does not mutate the input list.
+ */
+
+export function pickMergeTargetId(candidates: readonly string[]): string | null {
+  let lowest: string | undefined;
+  for (const id of candidates) {
+    if (lowest === undefined || id.localeCompare(lowest) < 0) lowest = id;
+  }
+  return lowest ?? null;
+}


### PR DESCRIPTION
Part of #2330

## Change
pickMergeTargetId. Empty is null. Lowest localeCompare. No mutate.

## Test
packages/remnic-core/src/dedup/merge-id.test.ts