### PR TITLE
feat(activity): add sumDwellSeconds for half-open dwell spans

### DIFF
--- a/.changeset/2053-activity-dwell.md
+++ b/.changeset/2053-activity-dwell.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `sumDwellSeconds` for half-open activity dwell spans.
+Negative durations are skipped. Overlaps add. Empty input is 0.
+Part of #2053.

--- a/packages/remnic-core/src/activity/dwell.test.ts
+++ b/packages/remnic-core/src/activity/dwell.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sumDwellSeconds } from "./dwell.js";
+
+test("empty spans sum to 0", () => {
+  assert.equal(sumDwellSeconds([]), 0);
+});
+
+test("skips negative duration", () => {
+  assert.equal(
+    sumDwellSeconds([
+      { startMs: 0, endMs: 1000 },
+      { startMs: 2000, endMs: 1000 },
+    ]),
+    1,
+  );
+});
+
+test("two spans add without merging overlaps", () => {
+  assert.equal(
+    sumDwellSeconds([
+      { startMs: 0, endMs: 2000 },
+      { startMs: 1000, endMs: 3000 },
+    ]),
+    4,
+  );
+});

--- a/packages/remnic-core/src/activity/dwell.ts
+++ b/packages/remnic-core/src/activity/dwell.ts
@@ -1,0 +1,22 @@
+/**
+ * Sum half-open activity dwell spans (issue #2053).
+ */
+export interface DwellSpan {
+  startMs: number;
+  endMs: number;
+}
+
+/**
+ * Sum span durations in seconds.
+ * Half-open `[startMs, endMs)`. Negative duration is skipped.
+ * Overlaps add. Empty input is 0.
+ */
+export function sumDwellSeconds(spans: readonly DwellSpan[]): number {
+  let total = 0;
+  for (const { startMs, endMs } of spans) {
+    const durationMs = endMs - startMs;
+    if (durationMs < 0) continue;
+    total += durationMs / 1000;
+  }
+  return total;
+}


### PR DESCRIPTION
Part of #2053

## Change
sumDwellSeconds. Half-open spans. Negative duration skipped. Overlaps add.

## Test
packages/remnic-core/src/activity/dwell.test.ts