### PR TITLE
feat(core): add recall-navigate budget take

### DIFF
--- a/.changeset/1956-navigate-budget.md
+++ b/.changeset/1956-navigate-budget.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate budget take. Budget 0 or cost above budget returns budget_exhausted. Negative values throw. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-budget.test.ts
+++ b/packages/remnic-core/src/recall-navigate-budget.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { takeNavigateBudget } from "./recall-navigate-budget.js";
+
+test("budget 0 is exhausted", () => {
+  assert.deepEqual(takeNavigateBudget(0, 0), { ok: false, error: "budget_exhausted" });
+  assert.deepEqual(takeNavigateBudget(0, 1), { ok: false, error: "budget_exhausted" });
+});
+
+test("cost above budget is exhausted", () => {
+  assert.deepEqual(takeNavigateBudget(3, 4), { ok: false, error: "budget_exhausted" });
+});
+
+test("remaining is budget minus cost", () => {
+  assert.deepEqual(takeNavigateBudget(5, 2), { ok: true, remaining: 3 });
+  assert.deepEqual(takeNavigateBudget(4, 4), { ok: true, remaining: 0 });
+});
+
+test("negative budget or cost throws", () => {
+  assert.throws(() => takeNavigateBudget(-1, 0));
+  assert.throws(() => takeNavigateBudget(3, -1));
+});

--- a/packages/remnic-core/src/recall-navigate-budget.ts
+++ b/packages/remnic-core/src/recall-navigate-budget.ts
@@ -1,0 +1,22 @@
+/**
+ * Recall navigation budget take (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. Budget 0 or cost above budget is exhausted.
+ * Negative budget or cost throws.
+ */
+
+export type NavigateBudgetResult =
+  | { ok: true; remaining: number }
+  | { ok: false; error: "budget_exhausted" };
+
+export function takeNavigateBudget(budget: number, cost: number): NavigateBudgetResult {
+  if (budget < 0 || cost < 0) {
+    throw new Error(
+      `navigate budget and cost must be non-negative; got budget=${JSON.stringify(budget)} cost=${JSON.stringify(cost)}`,
+    );
+  }
+  if (budget === 0 || cost > budget) {
+    return { ok: false, error: "budget_exhausted" };
+  }
+  return { ok: true, remaining: budget - cost };
+}


### PR DESCRIPTION
Part of #1956

## Change
takeNavigateBudget. Budget 0 or cost above budget is exhausted. Negative throws.

## Test
packages/remnic-core/src/recall-navigate-budget.test.ts