### PR TITLE
feat(recall): add state-view label helper

### DIFF
--- a/.changeset/1952-state-label.md
+++ b/.changeset/1952-state-label.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure state-view labeler. Current stays current. Historical and transition keep their kind only when both supersession fields are set. Missing either field is current. Unknown kind throws. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-label.test.ts
+++ b/packages/remnic-core/src/recall-state-view-label.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { labelStateView } from "./recall-state-view-label.js";
+
+const DATE = "2026-03-01";
+const SUCCESSOR = "new-job";
+
+test("kind current is current", () => {
+  assert.equal(
+    labelStateView({ kind: "current", supersededAt: DATE, successorId: SUCCESSOR }),
+    "current",
+  );
+});
+
+test("kind historical with both fields is historical", () => {
+  assert.equal(
+    labelStateView({ kind: "historical", supersededAt: DATE, successorId: SUCCESSOR }),
+    "historical",
+  );
+});
+
+test("missing supersededAt or successorId is current", () => {
+  assert.equal(
+    labelStateView({ kind: "historical", successorId: SUCCESSOR }),
+    "current",
+  );
+  assert.equal(
+    labelStateView({ kind: "transition", supersededAt: DATE }),
+    "current",
+  );
+});
+
+test("unknown kind throws", () => {
+  assert.throws(() => labelStateView({ kind: "ghost" }), /unknown state view kind/);
+});

--- a/packages/remnic-core/src/recall-state-view-label.ts
+++ b/packages/remnic-core/src/recall-state-view-label.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure state-view labeler (issue #1952 leftover).
+ *
+ * Surfaces wait. `current` stays current. `historical` and `transition`
+ * keep their kind only when both supersededAt and successorId are set.
+ * Missing either field is current. Unknown kind throws.
+ */
+import type { StateLabel } from "./recall-state-view.js";
+
+export function labelStateView(input: {
+  kind: string;
+  supersededAt?: string;
+  successorId?: string;
+}): StateLabel {
+  const { kind, supersededAt, successorId } = input;
+  if (kind === "current") return "current";
+  if (kind === "historical" || kind === "transition") {
+    if (!supersededAt || !successorId) return "current";
+    return kind;
+  }
+  throw new Error(`unknown state view kind: ${JSON.stringify(kind)}`);
+}


### PR DESCRIPTION
Part of #1952

## Change
labelStateView. Missing dates stay current. Unknown kind throws.

## Test
packages/remnic-core/src/recall-state-view-label.test.ts