### PR TITLE
feat(activity): add deterministic analysis prompt builder

### DIFF
--- a/.changeset/2050-analysis-prompt.md
+++ b/.changeset/2050-analysis-prompt.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deterministic timeline analysis prompt builder. `buildAnalysisPrompt` sorts observations by id, renders an empty list as `(empty)`, and includes only `id` and `capturedAtUtc`. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-prompt.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-prompt.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildAnalysisPrompt } from "./analysis-prompt.js";
+
+test("empty observations render (empty)", () => {
+  const first = buildAnalysisPrompt({ observations: [] });
+  const second = buildAnalysisPrompt({ observations: [] });
+  assert.match(first, /\(empty\)/);
+  assert.equal(first, second);
+  assert.doesNotMatch(first, /\[\s*\{/);
+});
+
+test("observations sort by id, not input order", () => {
+  const prompt = buildAnalysisPrompt({
+    observations: [
+      { id: 3, capturedAtUtc: "2026-08-17T12:00:00.000Z" },
+      { id: 1, capturedAtUtc: "2026-08-17T10:00:00.000Z" },
+      { id: 2, capturedAtUtc: "2026-08-17T11:00:00.000Z" },
+    ],
+  });
+  const first = prompt.indexOf('"id":1');
+  const second = prompt.indexOf('"id":2');
+  const third = prompt.indexOf('"id":3');
+  assert.ok(first >= 0 && second > first && third > second);
+  assert.match(prompt, /2026-08-17T10:00:00.000Z/);
+  assert.match(prompt, /2026-08-17T11:00:00.000Z/);
+  assert.match(prompt, /2026-08-17T12:00:00.000Z/);
+});
+
+test("free-text body and extra fields do not leak", () => {
+  const prompt = buildAnalysisPrompt({
+    observations: [
+      {
+        id: 9,
+        capturedAtUtc: "2026-08-17T09:00:00.000Z",
+        body: "SECRET-BODY",
+        text: "SECRET-TEXT",
+        windowTitle: "SECRET-TITLE",
+        app: "SECRET-APP",
+      } as { id: number; capturedAtUtc: string },
+    ],
+  });
+  assert.equal(prompt.includes("SECRET-BODY"), false);
+  assert.equal(prompt.includes("SECRET-TEXT"), false);
+  assert.equal(prompt.includes("SECRET-TITLE"), false);
+  assert.equal(prompt.includes("SECRET-APP"), false);
+  assert.match(prompt, /"id":9/);
+  assert.match(prompt, /2026-08-17T09:00:00.000Z/);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-prompt.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-prompt.ts
@@ -1,0 +1,24 @@
+/**
+ * Deterministic evidence-only analysis prompt (issue #2050).
+ * No LLM call. Prompt lists observation id and capturedAtUtc only.
+ */
+export type AnalysisPromptObservation = {
+  id: number;
+  capturedAtUtc: string;
+};
+
+const INSTRUCTIONS =
+  "Use only supplied evidence. Preserve chronology. Do not invent people, places, or tasks. Return strict JSON.";
+
+function listedObservation(observation: AnalysisPromptObservation): AnalysisPromptObservation {
+  return { id: observation.id, capturedAtUtc: observation.capturedAtUtc };
+}
+
+/** Build a deterministic prompt. Observations sort by id. Empty lists render as (empty). */
+export function buildAnalysisPrompt(input: {
+  observations: readonly AnalysisPromptObservation[];
+}): string {
+  const listed = [...input.observations].sort((a, b) => a.id - b.id).map(listedObservation);
+  const body = listed.length === 0 ? "(empty)" : JSON.stringify(listed);
+  return `${INSTRUCTIONS}\nObservations: ${body}`;
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -16,3 +16,4 @@ export * from "./week-export.js";
 export * from "./week-snapshot.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";
+export * from "./analysis-prompt.js";


### PR DESCRIPTION
Part of #2050

## Change
buildAnalysisPrompt. Sorted by id. Empty list prints (empty). No body text.

## Test
packages/remnic-core/src/activity/timeline/analysis-prompt.test.ts