### PR TITLE
feat(core): add deep-recall one-shot expand gate

### DIFF
--- a/.changeset/2332-deep-expand.md
+++ b/.changeset/2332-deep-expand.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall one-shot expand gate. Already expanded or budget 0 refuse. Negative budget throws. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-expand.test.ts
+++ b/packages/remnic-core/src/recall-deep-expand.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mayExpandOnce } from "./recall-deep-expand.js";
+
+test("already expanded is false", () => {
+  assert.equal(mayExpandOnce({ alreadyExpanded: true, budgetLeft: 3 }), false);
+});
+
+test("budget 0 is false", () => {
+  assert.equal(mayExpandOnce({ alreadyExpanded: false, budgetLeft: 0 }), false);
+});
+
+test("ok is true", () => {
+  assert.equal(mayExpandOnce({ alreadyExpanded: false, budgetLeft: 3 }), true);
+});
+
+test("negative budget throws", () => {
+  assert.throws(
+    () => mayExpandOnce({ alreadyExpanded: false, budgetLeft: -1 }),
+    /negative/,
+  );
+});

--- a/packages/remnic-core/src/recall-deep-expand.ts
+++ b/packages/remnic-core/src/recall-deep-expand.ts
@@ -1,0 +1,19 @@
+/**
+ * Deep-recall one-shot expand gate (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. Already expanded or budget 0 refuse.
+ * Negative budget throws.
+ */
+export function mayExpandOnce(input: {
+  alreadyExpanded: boolean;
+  budgetLeft: number;
+}): boolean {
+  if (input.budgetLeft < 0) {
+    throw new Error(
+      `deep recall expand budget must not be negative; got ${JSON.stringify(input.budgetLeft)}`,
+    );
+  }
+  if (input.alreadyExpanded) return false;
+  if (input.budgetLeft === 0) return false;
+  return true;
+}


### PR DESCRIPTION
Part of #2332

## Change
mayExpandOnce. Already expanded or budget 0 is false. Negative throws.

## Test
packages/remnic-core/src/recall-deep-expand.test.ts