### PR TITLE
feat(activity): add validateRegionName helper

### DIFF
--- a/.changeset/1985-vault-region.md
+++ b/.changeset/1985-vault-region.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `validateRegionName` to reject empty, newline, and `-->` managed-region names before they are interpolated into HTML comment markers. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -24,3 +24,4 @@ export * from "./vault-path.js";
 export * from "./vault-publish.js";
 export * from "./vault-frontmatter.js";
 export * from "./vault-wikilink.js";
+export * from "./vault-region.js";

--- a/packages/remnic-core/src/activity/vault-region.test.ts
+++ b/packages/remnic-core/src/activity/vault-region.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateRegionName } from "./vault-region.js";
+
+test("validateRegionName trims a valid name", () => {
+  assert.deepEqual(validateRegionName("timeline"), { ok: true, name: "timeline" });
+  assert.deepEqual(validateRegionName("  weekly  "), { ok: true, name: "weekly" });
+});
+
+test("validateRegionName rejects empty and whitespace-only names", () => {
+  assert.deepEqual(validateRegionName(""), { ok: false, error: "invalid_name" });
+  assert.deepEqual(validateRegionName("   "), { ok: false, error: "invalid_name" });
+});
+
+test("validateRegionName rejects names with newlines", () => {
+  assert.deepEqual(validateRegionName("time\nline"), { ok: false, error: "invalid_name" });
+  assert.deepEqual(validateRegionName("time\rline"), { ok: false, error: "invalid_name" });
+});
+
+test("validateRegionName rejects the HTML comment closer", () => {
+  assert.deepEqual(validateRegionName("foo-->bar"), { ok: false, error: "invalid_name" });
+  assert.deepEqual(validateRegionName("timeline-->"), { ok: false, error: "invalid_name" });
+});

--- a/packages/remnic-core/src/activity/vault-region.ts
+++ b/packages/remnic-core/src/activity/vault-region.ts
@@ -1,0 +1,24 @@
+/**
+ * Validate a managed-region name for vault markers (issue #1985).
+ *
+ * Empty, whitespace-only, newline, and `-->` names are rejected so they
+ * cannot break `<!-- remnic:<name>:start -->` markers.
+ */
+
+export type ValidateRegionNameResult =
+  | { ok: true; name: string }
+  | { ok: false; error: "invalid_name" };
+
+export function validateRegionName(name: string): ValidateRegionNameResult {
+  if (typeof name !== "string") {
+    return { ok: false, error: "invalid_name" };
+  }
+  if (name.includes("\n") || name.includes("\r") || name.includes("-->")) {
+    return { ok: false, error: "invalid_name" };
+  }
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: "invalid_name" };
+  }
+  return { ok: true, name: trimmed };
+}


### PR DESCRIPTION
Part of #1985

## Change
validateRegionName. Rejects empty, newlines, and marker text. Trims name.

## Test
packages/remnic-core/src/activity/vault-region.test.ts