### PR TITLE
feat(activity): add weekRange half-open calendar week

### DIFF
--- a/.changeset/2052-week-range.md
+++ b/.changeset/2052-week-range.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `weekRange` for a half-open `[start, start+7)` calendar week.
+Parse YYYY-MM-DD. Invalid dates throw.
+Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/week-range.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-range.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { weekRange } from "./week-range.js";
+
+test("monday week is [start, start+7)", () => {
+  assert.deepEqual(weekRange({ weekStartIso: "2026-07-13" }), {
+    start: "2026-07-13",
+    endExclusive: "2026-07-20",
+  });
+});
+
+test("invalid date throws", () => {
+  assert.throws(() => weekRange({ weekStartIso: "2026-02-30" }), /YYYY-MM-DD/);
+  assert.throws(() => weekRange({ weekStartIso: "not-a-date" }), /YYYY-MM-DD/);
+});
+
+test("exclusive end is the next week start", () => {
+  const first = weekRange({ weekStartIso: "2026-07-13" });
+  const next = weekRange({ weekStartIso: first.endExclusive });
+  assert.equal(next.start, first.endExclusive);
+  assert.equal(next.endExclusive, "2026-07-27");
+});

--- a/packages/remnic-core/src/activity/timeline/week-range.ts
+++ b/packages/remnic-core/src/activity/timeline/week-range.ts
@@ -1,0 +1,26 @@
+/**
+ * Half-open week range from a YYYY-MM-DD start (issue #2052).
+ */
+import { isValidActivityDate } from "../digest.js";
+
+export interface WeekRangeInput {
+  weekStartIso: string;
+}
+
+export interface WeekRange {
+  start: string;
+  endExclusive: string;
+}
+
+/** Parse `weekStartIso` as YYYY-MM-DD. Return `[start, start+7)`. */
+export function weekRange({ weekStartIso }: WeekRangeInput): WeekRange {
+  if (!isValidActivityDate(weekStartIso)) {
+    throw new RangeError(`Invalid week start "${weekStartIso}"; expected YYYY-MM-DD.`);
+  }
+  const parsed = new Date(`${weekStartIso}T00:00:00Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + 7);
+  return {
+    start: weekStartIso,
+    endExclusive: parsed.toISOString().slice(0, 10),
+  };
+}


### PR DESCRIPTION
Part of #2052

## Change
weekRange. YYYY-MM-DD start. endExclusive is start plus 7 days. Invalid date throws.

## Test
packages/remnic-core/src/activity/timeline/week-range.test.ts