### PR TITLE
feat(core): add sliceSpanText helper

### DIFF
--- a/.changeset/2333-span-slice.md
+++ b/.changeset/2333-span-slice.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-text slicer. Half-open `[start, end)` returns the source slice. Empty spans return `""`. Out-of-range offsets and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-slice.test.ts
+++ b/packages/remnic-core/src/extraction-span-slice.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { sliceSpanText } from "./extraction-span-slice.js";
+
+const TEXT = "hello";
+
+test("sliceSpanText: empty span is empty string", () => {
+  assert.equal(sliceSpanText({ text: TEXT, start: 2, end: 2 }), "");
+  assert.equal(sliceSpanText({ text: TEXT, start: 0, end: 0 }), "");
+  assert.equal(sliceSpanText({ text: TEXT, start: TEXT.length, end: TEXT.length }), "");
+  assert.equal(sliceSpanText({ text: "", start: 0, end: 0 }), "");
+});
+
+test("sliceSpanText: mid span is half-open [start, end)", () => {
+  assert.equal(sliceSpanText({ text: TEXT, start: 1, end: 4 }), "ell");
+  assert.equal(sliceSpanText({ text: TEXT, start: 0, end: 5 }), "hello");
+  assert.equal(sliceSpanText({ text: TEXT, start: 0, end: 1 }), "h");
+  assert.equal(sliceSpanText({ text: TEXT, start: 4, end: 5 }), "o");
+});
+
+test("sliceSpanText: out of range throws", () => {
+  assert.throws(() => sliceSpanText({ text: TEXT, start: -1, end: 2 }), /out of range/i);
+  assert.throws(() => sliceSpanText({ text: TEXT, start: 0, end: 6 }), /out of range/i);
+  assert.throws(() => sliceSpanText({ text: TEXT, start: 3, end: 2 }), /out of range/i);
+  assert.throws(() => sliceSpanText({ text: TEXT, start: 6, end: 6 }), /out of range/i);
+});
+
+test("sliceSpanText: non-integers throw", () => {
+  assert.throws(() => sliceSpanText({ text: TEXT, start: 1.5, end: 3 }), /integers/);
+  assert.throws(() => sliceSpanText({ text: TEXT, start: 0, end: 3.2 }), /integers/);
+  assert.throws(() => sliceSpanText({ text: TEXT, start: Number.NaN, end: 3 }), /integers/);
+});

--- a/packages/remnic-core/src/extraction-span-slice.ts
+++ b/packages/remnic-core/src/extraction-span-slice.ts
@@ -1,0 +1,20 @@
+/**
+ * Isolated span slicer (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export function sliceSpanText(opts: {
+  text: string;
+  start: number;
+  end: number;
+}): string {
+  const { text, start, end } = opts;
+  if (!Number.isInteger(start) || !Number.isInteger(end)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (start < 0 || end < start || end > text.length) {
+    throw new RangeError("span offsets out of range");
+  }
+  return text.slice(start, end);
+}


### PR DESCRIPTION
Part of #2333

## Change
sliceSpanText. Half-open [start, end). Empty range is empty string. Out of range throws.

## Test
packages/remnic-core/src/extraction-span-slice.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added span-text slicing that returns the portion of text between specified start and end offsets.
  * Supports half-open ranges and returns an empty string for empty spans.
  * Provides clear errors for negative, reversed, out-of-range, or non-integer offsets.

* **Tests**
  * Added coverage for valid slicing, empty spans, boundary violations, and invalid offset values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->