### PR TITLE
feat(activity): add redactActivityFields helper

### DIFF
--- a/.changeset/2053-privacy-redact.md
+++ b/.changeset/2053-privacy-redact.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `redactActivityFields` to drop listed keys from one activity item.
+Unknown keys are ignored. Empty `dropKeys` is a shallow copy.
+Part of #2053.

--- a/packages/remnic-core/src/activity/privacy-redact.test.ts
+++ b/packages/remnic-core/src/activity/privacy-redact.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { redactActivityFields } from "./privacy-redact.js";
+
+test("drops listed keys and ignores unknown keys", () => {
+  const item = { id: "a", title: "kept", secret: "drop-me" };
+  const redacted = redactActivityFields(item, {
+    dropKeys: ["secret", "missing"],
+  });
+  assert.deepEqual(redacted, { id: "a", title: "kept" });
+});
+
+test("does not mutate the input item", () => {
+  const item = { id: "a", secret: "drop-me" };
+  redactActivityFields(item, { dropKeys: ["secret"] });
+  assert.deepEqual(item, { id: "a", secret: "drop-me" });
+});
+
+test("empty dropKeys returns a shallow copy", () => {
+  const item = { id: "a", title: "kept" };
+  const redacted = redactActivityFields(item, { dropKeys: [] });
+  assert.deepEqual(redacted, item);
+  assert.notEqual(redacted, item);
+});

--- a/packages/remnic-core/src/activity/privacy-redact.ts
+++ b/packages/remnic-core/src/activity/privacy-redact.ts
@@ -1,0 +1,23 @@
+/**
+ * Drop listed keys from one activity item (issue #2053).
+ */
+
+export interface ActivityRedactOptions {
+  dropKeys: readonly string[];
+}
+
+/**
+ * Return a shallow copy without `dropKeys`.
+ * Unknown keys are ignored. Empty `dropKeys` is a shallow copy.
+ * Does not mutate `item`.
+ */
+export function redactActivityFields<T extends Record<string, unknown>>(
+  item: T,
+  options: ActivityRedactOptions,
+): T {
+  const result: Record<string, unknown> = { ...item };
+  for (const key of options.dropKeys) {
+    delete result[key];
+  }
+  return result as T;
+}


### PR DESCRIPTION
Part of #2053

## Change
redactActivityFields. Drops listed keys. Does not mutate input.

## Test
packages/remnic-core/src/activity/privacy-redact.test.ts