### PR TITLE
feat(core): parse recall navigate link types

### DIFF
--- a/.changeset/1956-navigate-link.md
+++ b/.changeset/1956-navigate-link.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate link-type parser. Allowed types are supports, contradicts, elaborates, causes, and caused_by. Unknown or empty returns unknown_link. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-link.test.ts
+++ b/packages/remnic-core/src/recall-navigate-link.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseNavigateLinkType } from "./recall-navigate-link.js";
+
+test("parses each allowed link type", () => {
+  for (const type of ["supports", "contradicts", "elaborates", "causes", "caused_by"] as const) {
+    assert.deepEqual(parseNavigateLinkType(type), { ok: true, type });
+  }
+});
+
+test("unknown link is unknown_link", () => {
+  assert.deepEqual(parseNavigateLinkType("supersedes"), { ok: false, error: "unknown_link" });
+  assert.deepEqual(parseNavigateLinkType("related"), { ok: false, error: "unknown_link" });
+});
+
+test("empty link is unknown_link", () => {
+  assert.deepEqual(parseNavigateLinkType(""), { ok: false, error: "unknown_link" });
+});

--- a/packages/remnic-core/src/recall-navigate-link.ts
+++ b/packages/remnic-core/src/recall-navigate-link.ts
@@ -1,0 +1,26 @@
+/**
+ * Recall navigation link-type parse (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. Unknown or empty is unknown_link.
+ */
+
+const NAVIGATE_LINK_TYPES = [
+  "supports",
+  "contradicts",
+  "elaborates",
+  "causes",
+  "caused_by",
+] as const;
+
+export type NavigateLinkType = (typeof NAVIGATE_LINK_TYPES)[number];
+
+export type ParseNavigateLinkTypeResult =
+  | { ok: true; type: NavigateLinkType }
+  | { ok: false; error: "unknown_link" };
+
+export function parseNavigateLinkType(value: string): ParseNavigateLinkTypeResult {
+  if ((NAVIGATE_LINK_TYPES as readonly string[]).includes(value)) {
+    return { ok: true, type: value as NavigateLinkType };
+  }
+  return { ok: false, error: "unknown_link" };
+}


### PR DESCRIPTION
Part of #1956

## Change
parseNavigateLinkType. Allow-list only. Unknown or empty fails.

## Test
packages/remnic-core/src/recall-navigate-link.test.ts