### PR TITLE
feat(core): add shared-context envelope remaining TTL

### DIFF
--- a/.changeset/1957-envelope-ttl.md
+++ b/.changeset/1957-envelope-ttl.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context envelope remaining TTL (issue #1957). `remainingTtlMs` returns null when `expiresAt` is missing, 0 at or after expiry, otherwise the remaining milliseconds, and throws on an invalid timestamp. Part of #1957.

--- a/packages/remnic-core/src/shared-context/envelope-ttl.test.ts
+++ b/packages/remnic-core/src/shared-context/envelope-ttl.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { remainingTtlMs } from "./envelope-ttl.js";
+
+const EXPIRES_AT = "2026-08-18T12:00:00.000Z";
+const AT = Date.parse(EXPIRES_AT);
+
+test("remainingTtlMs returns null when expiresAt is missing", () => {
+  assert.equal(remainingTtlMs({ nowMs: AT }), null);
+  assert.equal(remainingTtlMs({ expiresAt: undefined, nowMs: AT }), null);
+});
+
+test("remainingTtlMs returns 0 at and after expiry", () => {
+  assert.equal(remainingTtlMs({ expiresAt: EXPIRES_AT, nowMs: AT }), 0);
+  assert.equal(remainingTtlMs({ expiresAt: EXPIRES_AT, nowMs: AT + 1 }), 0);
+  assert.equal(remainingTtlMs({ expiresAt: AT, nowMs: AT }), 0);
+});
+
+test("remainingTtlMs returns expiresAt minus nowMs before expiry", () => {
+  assert.equal(remainingTtlMs({ expiresAt: EXPIRES_AT, nowMs: AT - 1 }), 1);
+  assert.equal(remainingTtlMs({ expiresAt: AT, nowMs: AT - 25 }), 25);
+});
+
+test("remainingTtlMs throws on an invalid expiresAt", () => {
+  assert.throws(() => remainingTtlMs({ expiresAt: "not-a-date", nowMs: AT }), /expiresAt/);
+  assert.throws(() => remainingTtlMs({ expiresAt: "", nowMs: AT }), /expiresAt/);
+  assert.throws(() => remainingTtlMs({ expiresAt: Number.NaN, nowMs: AT }), /expiresAt/);
+});

--- a/packages/remnic-core/src/shared-context/envelope-ttl.ts
+++ b/packages/remnic-core/src/shared-context/envelope-ttl.ts
@@ -1,0 +1,35 @@
+/**
+ * Remaining envelope TTL in milliseconds (issue #1957).
+ *
+ * Missing expiresAt means no expiry. Half-open: nowMs >= expiresAt is 0.
+ * Invalid expiresAt throws.
+ */
+
+export interface RemainingTtlMsInput {
+  expiresAt?: string | number;
+  nowMs: number;
+}
+
+export function remainingTtlMs(input: RemainingTtlMsInput): number | null {
+  if (input.expiresAt === undefined) return null;
+  const expiresAtMs = parseExpiresAt(input.expiresAt);
+  if (input.nowMs >= expiresAtMs) return 0;
+  return expiresAtMs - input.nowMs;
+}
+
+function parseExpiresAt(expiresAt: string | number): number {
+  if (typeof expiresAt === "number") {
+    if (!Number.isFinite(expiresAt)) {
+      throw new Error("remainingTtlMs: expiresAt must be a valid timestamp");
+    }
+    return expiresAt;
+  }
+  if (typeof expiresAt !== "string" || expiresAt.trim().length === 0) {
+    throw new Error("remainingTtlMs: expiresAt must be a valid timestamp");
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    throw new Error("remainingTtlMs: expiresAt must be a valid timestamp");
+  }
+  return expiresAtMs;
+}


### PR DESCRIPTION
Part of #1957

## Change
remainingTtlMs. Missing expiry is null. Expired is 0. Invalid date throws.

## Test
packages/remnic-core/src/shared-context/envelope-ttl.test.ts