### PR TITLE
feat(activity): sort recap card ids with localeCompare

### DIFF
--- a/.changeset/recap-id-2051.md
+++ b/.changeset/recap-id-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `sortRecapCardIds` to the activity timeline layer: localeCompare-sorted recap card ids, no input mutation, empty strings dropped. Empty input returns `[]`. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-id.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-id.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sortRecapCardIds } from "./recap-id.js";
+
+test("empty input returns an empty array", () => {
+  assert.deepEqual(sortRecapCardIds([]), []);
+});
+
+test("sorts ids with localeCompare", () => {
+  assert.deepEqual(sortRecapCardIds(["card-c", "card-a", "card-b"]), [
+    "card-a",
+    "card-b",
+    "card-c",
+  ]);
+});
+
+test("does not mutate the input array", () => {
+  const input = ["card-c", "card-a"];
+  const snapshot = input.slice();
+  const sorted = sortRecapCardIds(input);
+  assert.deepEqual(input, snapshot);
+  assert.notEqual(sorted, input);
+});
+
+test("drops empty strings", () => {
+  assert.deepEqual(sortRecapCardIds(["b", "", "a", ""]), ["a", "b"]);
+});

--- a/packages/remnic-core/src/activity/timeline/recap-id.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-id.ts
@@ -1,0 +1,10 @@
+/**
+ * Stable recap card-id order (issue #2051 leftover).
+ *
+ * localeCompare sort. Empty input → []. Does not mutate input. Drops empty strings.
+ */
+
+/** Return a new localeCompare-sorted id list. Empty strings are dropped. */
+export function sortRecapCardIds(ids: readonly string[]): string[] {
+  return ids.filter((id) => id !== "").sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
Part of #2051

## Change
sortRecapCardIds. localeCompare. Drops empty strings. Does not mutate input.

## Test
packages/remnic-core/src/activity/timeline/recap-id.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activity timeline sorting for recap card IDs.
  * Empty IDs are excluded, results are locale-sorted, and the original input remains unchanged.
  * Empty inputs return an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->