### PR TITLE
feat(core): add deep-recall one-shot refine gate

### DIFF
--- a/.changeset/2332-deep-refine.md
+++ b/.changeset/2332-deep-refine.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall one-shot refine gate. Already refined or budget 0 refuse. Negative budget throws. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-refine.test.ts
+++ b/packages/remnic-core/src/recall-deep-refine.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mayRefine } from "./recall-deep-refine.js";
+
+test("refined is false", () => {
+  assert.equal(mayRefine({ refined: true, budgetLeft: 3 }), false);
+});
+
+test("budget 0 is false", () => {
+  assert.equal(mayRefine({ refined: false, budgetLeft: 0 }), false);
+});
+
+test("ok is true", () => {
+  assert.equal(mayRefine({ refined: false, budgetLeft: 3 }), true);
+});
+
+test("negative budget throws", () => {
+  assert.throws(
+    () => mayRefine({ refined: false, budgetLeft: -1 }),
+    /negative/,
+  );
+});

--- a/packages/remnic-core/src/recall-deep-refine.ts
+++ b/packages/remnic-core/src/recall-deep-refine.ts
@@ -1,0 +1,19 @@
+/**
+ * Deep-recall one-shot refine gate (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. Already refined or budget 0 refuse.
+ * Negative budget throws.
+ */
+export function mayRefine(input: {
+  refined: boolean;
+  budgetLeft: number;
+}): boolean {
+  if (input.budgetLeft < 0) {
+    throw new Error(
+      `deep recall refine budget must not be negative; got ${JSON.stringify(input.budgetLeft)}`,
+    );
+  }
+  if (input.refined) return false;
+  if (input.budgetLeft === 0) return false;
+  return true;
+}


### PR DESCRIPTION
Part of #2332

## Change
mayRefine. Already refined or budget 0 is false. Negative throws.

## Test
packages/remnic-core/src/recall-deep-refine.test.ts