### PR TITLE
feat(core): add stripVaultMdSuffix helper

### DIFF
--- a/.changeset/1985-vault-suffix.md
+++ b/.changeset/1985-vault-suffix.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `stripVaultMdSuffix` to drop a trailing `.md` from a vault note path. Empty input throws. `.markdown` is left unchanged. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -25,3 +25,4 @@ export * from "./vault-publish.js";
 export * from "./vault-frontmatter.js";
 export * from "./vault-wikilink.js";
 export * from "./vault-region.js";
+export * from "./vault-suffix.js";

--- a/packages/remnic-core/src/activity/vault-suffix.test.ts
+++ b/packages/remnic-core/src/activity/vault-suffix.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stripVaultMdSuffix } from "./vault-suffix.js";
+
+test("stripVaultMdSuffix drops a trailing .md", () => {
+  assert.equal(stripVaultMdSuffix("Daily Notes/2026-08-18.md"), "Daily Notes/2026-08-18");
+});
+
+test("stripVaultMdSuffix leaves a path with no suffix unchanged", () => {
+  assert.equal(stripVaultMdSuffix("Daily Notes/2026-08-18"), "Daily Notes/2026-08-18");
+});
+
+test("stripVaultMdSuffix throws on empty input", () => {
+  assert.throws(() => stripVaultMdSuffix(""), /empty/i);
+});
+
+test("stripVaultMdSuffix does not strip .markdown", () => {
+  assert.equal(stripVaultMdSuffix("Daily Notes/2026-08-18.markdown"), "Daily Notes/2026-08-18.markdown");
+});

--- a/packages/remnic-core/src/activity/vault-suffix.ts
+++ b/packages/remnic-core/src/activity/vault-suffix.ts
@@ -1,0 +1,12 @@
+/**
+ * Strip a trailing `.md` suffix from a vault note path (issue #1985).
+ *
+ * Case-sensitive. Does not strip `.markdown`. Empty input is rejected.
+ */
+
+export function stripVaultMdSuffix(notePath: string): string {
+  if (typeof notePath !== "string" || notePath.length === 0) {
+    throw new RangeError("Vault path must be non-empty.");
+  }
+  return notePath.endsWith(".md") ? notePath.slice(0, -3) : notePath;
+}


### PR DESCRIPTION
Part of #1985

## Change
stripVaultMdSuffix. Drops trailing .md only. Empty throws. .markdown stays.

## Test
packages/remnic-core/src/activity/vault-suffix.test.ts