### PR TITLE
feat(core): parse recall state-view kinds

### DIFF
--- a/.changeset/1952-state-kind.md
+++ b/.changeset/1952-state-kind.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall state-view kind parser. Allowed kinds are current, historical, and transition. Unknown or empty returns unknown_kind. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-kind.test.ts
+++ b/packages/remnic-core/src/recall-state-view-kind.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseStateViewKind } from "./recall-state-view-kind.js";
+
+test("parses each allowed kind", () => {
+  for (const kind of ["current", "historical", "transition"] as const) {
+    assert.deepEqual(parseStateViewKind(kind), { ok: true, kind });
+  }
+});
+
+test("unknown kind is unknown_kind", () => {
+  assert.deepEqual(parseStateViewKind("ghost"), { ok: false, error: "unknown_kind" });
+  assert.deepEqual(parseStateViewKind("superseded"), { ok: false, error: "unknown_kind" });
+});
+
+test("empty kind is unknown_kind", () => {
+  assert.deepEqual(parseStateViewKind(""), { ok: false, error: "unknown_kind" });
+});

--- a/packages/remnic-core/src/recall-state-view-kind.ts
+++ b/packages/remnic-core/src/recall-state-view-kind.ts
@@ -1,0 +1,20 @@
+/**
+ * Recall state-view kind parse (issue #1952 leftover).
+ *
+ * Pure. Surfaces wait. Unknown or empty is unknown_kind.
+ */
+
+const STATE_VIEW_KINDS = ["current", "historical", "transition"] as const;
+
+export type StateViewKind = (typeof STATE_VIEW_KINDS)[number];
+
+export type ParseStateViewKindResult =
+  | { ok: true; kind: StateViewKind }
+  | { ok: false; error: "unknown_kind" };
+
+export function parseStateViewKind(value: string): ParseStateViewKindResult {
+  if ((STATE_VIEW_KINDS as readonly string[]).includes(value)) {
+    return { ok: true, kind: value as StateViewKind };
+  }
+  return { ok: false, error: "unknown_kind" };
+}


### PR DESCRIPTION
Part of #1952

## Change
parseStateViewKind. Allow current, historical, transition. Unknown fails.

## Test
packages/remnic-core/src/recall-state-view-kind.test.ts