### PR TITLE
feat(activity): parse timeline analysis claim observation ids

### DIFF
--- a/.changeset/2050-analysis-claim.md
+++ b/.changeset/2050-analysis-claim.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Parse timeline analysis claim `observationId` values. Missing or empty ids return `missing_observation`. Non-empty ids are trimmed. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-claim.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-claim.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseClaimObservationId } from "./analysis-claim.js";
+
+test("ok claim returns trimmed observationId", () => {
+  assert.deepEqual(parseClaimObservationId({ observationId: "obs-1" }), {
+    ok: true,
+    observationId: "obs-1",
+  });
+});
+
+test("missing observationId is missing_observation", () => {
+  assert.deepEqual(parseClaimObservationId({}), { ok: false, error: "missing_observation" });
+});
+
+test("empty observationId is missing_observation", () => {
+  assert.deepEqual(parseClaimObservationId({ observationId: "" }), {
+    ok: false,
+    error: "missing_observation",
+  });
+});
+
+test("trims observationId and treats whitespace as missing", () => {
+  assert.deepEqual(parseClaimObservationId({ observationId: "  obs-1  " }), {
+    ok: true,
+    observationId: "obs-1",
+  });
+  assert.deepEqual(parseClaimObservationId({ observationId: "   " }), {
+    ok: false,
+    error: "missing_observation",
+  });
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-claim.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-claim.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse a timeline analysis claim's observationId (issue #2050).
+ */
+export type ParseClaimObservationIdResult =
+  | { ok: true; observationId: string }
+  | { ok: false; error: "missing_observation" };
+
+export function parseClaimObservationId(claim: {
+  observationId?: string | null;
+}): ParseClaimObservationIdResult {
+  const raw = claim.observationId;
+  if (raw == null) return { ok: false, error: "missing_observation" };
+  const observationId = raw.trim();
+  if (observationId.length === 0) return { ok: false, error: "missing_observation" };
+  return { ok: true, observationId };
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -17,3 +17,4 @@ export * from "./week-snapshot.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";
 export * from "./analysis-prompt.js";
+export * from "./analysis-claim.js";


### PR DESCRIPTION
Part of #2050

## Change
parseClaimObservationId. Missing or empty observationId fails. Trims id.

## Test
packages/remnic-core/src/activity/timeline/analysis-claim.test.ts