### PR TITLE
feat(core): add spanLength helper

### DIFF
--- a/.changeset/2333-span-length.md
+++ b/.changeset/2333-span-length.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-length helper. Half-open `[start, end)` is `end - start`. Empty spans return `0`. Inverted spans and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-length.test.ts
+++ b/packages/remnic-core/src/extraction-span-length.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spanLength } from "./extraction-span-length.js";
+
+test("spanLength: empty span is zero", () => {
+  assert.equal(spanLength({ start: 0, end: 0 }), 0);
+  assert.equal(spanLength({ start: 4, end: 4 }), 0);
+});
+
+test("spanLength: mid span is half-open end-start", () => {
+  assert.equal(spanLength({ start: 1, end: 4 }), 3);
+  assert.equal(spanLength({ start: 0, end: 5 }), 5);
+  assert.equal(spanLength({ start: 4, end: 5 }), 1);
+});
+
+test("spanLength: inverted span throws", () => {
+  assert.throws(() => spanLength({ start: 3, end: 2 }), /inverted/i);
+  assert.throws(() => spanLength({ start: 1, end: 0 }), /inverted/i);
+});
+
+test("spanLength: non-integers throw", () => {
+  assert.throws(() => spanLength({ start: 1.5, end: 3 }), /integers/);
+  assert.throws(() => spanLength({ start: 0, end: 3.2 }), /integers/);
+  assert.throws(() => spanLength({ start: Number.NaN, end: 3 }), /integers/);
+});

--- a/packages/remnic-core/src/extraction-span-length.ts
+++ b/packages/remnic-core/src/extraction-span-length.ts
@@ -1,0 +1,16 @@
+/**
+ * Isolated span-length helper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export function spanLength(opts: { start: number; end: number }): number {
+  const { start, end } = opts;
+  if (!Number.isInteger(start) || !Number.isInteger(end)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (end < start) {
+    throw new RangeError("span offsets inverted");
+  }
+  return end - start;
+}


### PR DESCRIPTION
Part of #2333

## Change
spanLength. Half-open end-start. Empty range is 0. Inverted throws.

## Test
packages/remnic-core/src/extraction-span-length.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added span-length calculation using half-open intervals, where the length is calculated as end offset minus start offset.
  - Empty spans return zero.

- **Bug Fixes**
  - Added validation for invalid spans, including inverted ranges and non-integer offsets, with clear errors.

- **Tests**
  - Added coverage for empty, standard, inverted, and invalid spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->