### PR TITLE
feat(dedup): add merge-pair id orderer

### DIFF
--- a/.changeset/2330-merge-pair.md
+++ b/.changeset/2330-merge-pair.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-pair id orderer. Returns [lower, higher] by localeCompare. Same id returns [id, id]. Empty id throws. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-pair.test.ts
+++ b/packages/remnic-core/src/dedup/merge-pair.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { orderMergePair } from "./merge-pair.js";
+
+test("orders ids by localeCompare", () => {
+  assert.deepEqual(orderMergePair("zeta", "alpha"), ["alpha", "zeta"]);
+  assert.deepEqual(orderMergePair("alpha", "zeta"), ["alpha", "zeta"]);
+});
+
+test("same id returns both sides", () => {
+  assert.deepEqual(orderMergePair("alpha", "alpha"), ["alpha", "alpha"]);
+});
+
+test("empty id throws", () => {
+  assert.throws(() => orderMergePair("", "alpha"), /empty merge id/);
+  assert.throws(() => orderMergePair("alpha", ""), /empty merge id/);
+  assert.throws(() => orderMergePair("", ""), /empty merge id/);
+});

--- a/packages/remnic-core/src/dedup/merge-pair.ts
+++ b/packages/remnic-core/src/dedup/merge-pair.ts
@@ -1,0 +1,13 @@
+/**
+ * Merge-pair id orderer (issue #2330 leftover).
+ *
+ * Returns [lower, higher] by localeCompare. Same id returns [id, id].
+ * Empty id throws.
+ */
+
+export function orderMergePair(aId: string, bId: string): [string, string] {
+  if (aId === "" || bId === "") {
+    throw new Error("empty merge id");
+  }
+  return aId.localeCompare(bId) <= 0 ? [aId, bId] : [bId, aId];
+}


### PR DESCRIPTION
Part of #2330

## Change
orderMergePair. localeCompare order. Empty id throws.

## Test
packages/remnic-core/src/dedup/merge-pair.test.ts