### PR TITLE
feat(activity): normalize privacy drop keys

### DIFF
--- a/.changeset/2053-privacy-keys.md
+++ b/.changeset/2053-privacy-keys.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `normalizeDropKeys` to trim, drop empty, unique, and sort activity privacy drop keys.
+Does not mutate the input list.
+Part of #2053.

--- a/packages/remnic-core/src/activity/privacy-keys.test.ts
+++ b/packages/remnic-core/src/activity/privacy-keys.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeDropKeys } from "./privacy-keys.js";
+
+test("empty keys return []", () => {
+  assert.deepEqual(normalizeDropKeys([]), []);
+});
+
+test("trims keys and drops empty", () => {
+  assert.deepEqual(normalizeDropKeys(["  secret  ", "", "  ", "title"]), ["secret", "title"]);
+});
+
+test("unique keys sort by localeCompare", () => {
+  assert.deepEqual(normalizeDropKeys(["zeta", "alpha", "zeta", "beta"]), ["alpha", "beta", "zeta"]);
+});
+
+test("does not mutate the input list", () => {
+  const keys = ["  zeta  ", "alpha", "alpha"];
+  normalizeDropKeys(keys);
+  assert.deepEqual(keys, ["  zeta  ", "alpha", "alpha"]);
+});

--- a/packages/remnic-core/src/activity/privacy-keys.ts
+++ b/packages/remnic-core/src/activity/privacy-keys.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalize activity privacy drop keys (issue #2053).
+ *
+ * Trim, drop empty, unique, localeCompare sort.
+ * Does not mutate the input list.
+ */
+
+export function normalizeDropKeys(keys: readonly string[]): string[] {
+  const unique = [...new Set(keys.map((key) => key.trim()).filter((key) => key.length > 0))];
+  unique.sort((a, b) => a.localeCompare(b));
+  return unique;
+}


### PR DESCRIPTION
Part of #2053

## Change
normalizeDropKeys. Trim, unique, sort. Does not mutate input.

## Test
packages/remnic-core/src/activity/privacy-keys.test.ts