### PR TITLE
feat(core): parse recall navigate node ids

### DIFF
--- a/.changeset/1956-navigate-node.md
+++ b/.changeset/1956-navigate-node.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate node-id parser. Empty is missing_node. Newline is invalid_node. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-node.test.ts
+++ b/packages/remnic-core/src/recall-navigate-node.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseNavigateNodeId } from "./recall-navigate-node.js";
+
+test("ok node id returns trimmed nodeId", () => {
+  assert.deepEqual(parseNavigateNodeId("mem-1"), { ok: true, nodeId: "mem-1" });
+});
+
+test("empty node id is missing_node", () => {
+  assert.deepEqual(parseNavigateNodeId(""), { ok: false, error: "missing_node" });
+  assert.deepEqual(parseNavigateNodeId("   "), { ok: false, error: "missing_node" });
+});
+
+test("newline in node id is invalid_node", () => {
+  assert.deepEqual(parseNavigateNodeId("mem-1\nmem-2"), { ok: false, error: "invalid_node" });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseNavigateNodeId("  mem-1  "), { ok: true, nodeId: "mem-1" });
+});

--- a/packages/remnic-core/src/recall-navigate-node.ts
+++ b/packages/remnic-core/src/recall-navigate-node.ts
@@ -1,0 +1,16 @@
+/**
+ * Recall navigation node-id parse (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. Empty is missing_node. Newline is invalid_node.
+ */
+
+export type ParseNavigateNodeIdResult =
+  | { ok: true; nodeId: string }
+  | { ok: false; error: "missing_node" | "invalid_node" };
+
+export function parseNavigateNodeId(value: string): ParseNavigateNodeIdResult {
+  const nodeId = value.trim();
+  if (nodeId.length === 0) return { ok: false, error: "missing_node" };
+  if (nodeId.includes("\n")) return { ok: false, error: "invalid_node" };
+  return { ok: true, nodeId };
+}


### PR DESCRIPTION
Part of #1956

## Change
parseNavigateNodeId. Empty fails. Newline fails. Trims id.

## Test
packages/remnic-core/src/recall-navigate-node.test.ts