### PR TITLE
feat(activity): add normalizeJournalHeading helper

### DIFF
--- a/.changeset/1987-journal-heading.md
+++ b/.changeset/1987-journal-heading.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `normalizeJournalHeading` to trim a vault journal section heading. Empty and newline headings fail. Part of #1987.

--- a/packages/remnic-core/src/activity/journal-heading.test.ts
+++ b/packages/remnic-core/src/activity/journal-heading.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeJournalHeading } from "./journal-heading.js";
+
+test("normalizeJournalHeading accepts a heading", () => {
+  assert.deepEqual(normalizeJournalHeading("Journal"), { ok: true, heading: "Journal" });
+});
+
+test("normalizeJournalHeading rejects an empty heading", () => {
+  assert.deepEqual(normalizeJournalHeading(""), { ok: false, error: "empty_heading" });
+  assert.deepEqual(normalizeJournalHeading("   "), { ok: false, error: "empty_heading" });
+});
+
+test("normalizeJournalHeading rejects a heading with a newline", () => {
+  assert.deepEqual(normalizeJournalHeading("Jour\nnal"), { ok: false, error: "invalid_heading" });
+  assert.deepEqual(normalizeJournalHeading("Jour\rnal"), { ok: false, error: "invalid_heading" });
+});
+
+test("normalizeJournalHeading trims surrounding whitespace", () => {
+  assert.deepEqual(normalizeJournalHeading("  Journal  "), { ok: true, heading: "Journal" });
+});

--- a/packages/remnic-core/src/activity/journal-heading.ts
+++ b/packages/remnic-core/src/activity/journal-heading.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalize a journal section heading (issue #1987 leftover).
+ *
+ * Trim. Empty is empty_heading. Newline is invalid_heading.
+ */
+
+export type NormalizeJournalHeadingResult =
+  | { ok: true; heading: string }
+  | { ok: false; error: "empty_heading" | "invalid_heading" };
+
+export function normalizeJournalHeading(value: string): NormalizeJournalHeadingResult {
+  const heading = value.trim();
+  if (heading.length === 0) return { ok: false, error: "empty_heading" };
+  if (heading.includes("\n") || heading.includes("\r")) {
+    return { ok: false, error: "invalid_heading" };
+  }
+  return { ok: true, heading };
+}


### PR DESCRIPTION
Part of #1987

## Change
normalizeJournalHeading. Empty and newline fail. Trims heading.

## Test
packages/remnic-core/src/activity/journal-heading.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added journal heading normalization that removes surrounding whitespace.
  * Invalid headings, including empty, whitespace-only, or newline-containing values, are now rejected with clear typed errors.
* **Bug Fixes**
  * Improved consistency and validation when entering journal headings.
* **Tests**
  * Added coverage for valid headings, trimming, and invalid input scenarios.
* **Chores**
  * Documented the minor release containing these journal heading improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->