### PR TITLE
feat(core): parse deep-recall stop reasons

### DIFF
--- a/.changeset/2332-deep-stop-reason.md
+++ b/.changeset/2332-deep-stop-reason.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall stop-reason parser. Allow budget_exhausted, policy_stop, expand_once, and refine_done. Unknown or empty values return unknown_reason. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-stop-reason.test.ts
+++ b/packages/remnic-core/src/recall-deep-stop-reason.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDeepStopReason } from "./recall-deep-stop-reason.js";
+
+test("budget_exhausted is allowed", () => {
+  assert.deepEqual(parseDeepStopReason("budget_exhausted"), {
+    ok: true,
+    reason: "budget_exhausted",
+  });
+});
+
+test("policy_stop is allowed", () => {
+  assert.deepEqual(parseDeepStopReason("policy_stop"), {
+    ok: true,
+    reason: "policy_stop",
+  });
+});
+
+test("expand_once is allowed", () => {
+  assert.deepEqual(parseDeepStopReason("expand_once"), {
+    ok: true,
+    reason: "expand_once",
+  });
+});
+
+test("refine_done is allowed", () => {
+  assert.deepEqual(parseDeepStopReason("refine_done"), {
+    ok: true,
+    reason: "refine_done",
+  });
+});
+
+test("unknown reason is unknown_reason", () => {
+  assert.deepEqual(parseDeepStopReason("stop"), {
+    ok: false,
+    error: "unknown_reason",
+  });
+});
+
+test("empty reason is unknown_reason", () => {
+  assert.deepEqual(parseDeepStopReason(""), {
+    ok: false,
+    error: "unknown_reason",
+  });
+});

--- a/packages/remnic-core/src/recall-deep-stop-reason.ts
+++ b/packages/remnic-core/src/recall-deep-stop-reason.ts
@@ -1,0 +1,27 @@
+/**
+ * Parse a deep-recall stop reason (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. Unknown or empty values fail closed.
+ */
+export const DEEP_STOP_REASONS = [
+  "budget_exhausted",
+  "policy_stop",
+  "expand_once",
+  "refine_done",
+] as const;
+
+export type DeepStopReason = (typeof DEEP_STOP_REASONS)[number];
+
+export type ParseDeepStopReasonResult =
+  | { ok: true; reason: DeepStopReason }
+  | { ok: false; error: "unknown_reason" };
+
+export function parseDeepStopReason(value: unknown): ParseDeepStopReasonResult {
+  if (typeof value !== "string" || value.length === 0) {
+    return { ok: false, error: "unknown_reason" };
+  }
+  if (!(DEEP_STOP_REASONS as readonly string[]).includes(value)) {
+    return { ok: false, error: "unknown_reason" };
+  }
+  return { ok: true, reason: value as DeepStopReason };
+}


### PR DESCRIPTION
Part of #2332

## Change
parseDeepStopReason. Allow-list only. Unknown or empty fails.

## Test
packages/remnic-core/src/recall-deep-stop-reason.test.ts