### PR TITLE
feat(activity): add formatRegionMarkers helper

### DIFF
--- a/.changeset/1985-vault-marker.md
+++ b/.changeset/1985-vault-marker.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": minor
+---
+
+Add `formatRegionMarkers` to emit `<!-- remnic:begin NAME -->` / `<!-- remnic:end NAME -->`. Empty, newline, and `-->` names throw.
+Part of #1985.

--- a/packages/remnic-core/src/activity/vault-marker.test.ts
+++ b/packages/remnic-core/src/activity/vault-marker.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatRegionMarkers } from "./vault-marker.js";
+
+test("formatRegionMarkers returns begin and end HTML comments", () => {
+  assert.deepEqual(formatRegionMarkers("timeline"), {
+    begin: "<!-- remnic:begin timeline -->",
+    end: "<!-- remnic:end timeline -->",
+  });
+});
+
+test("formatRegionMarkers rejects an empty name", () => {
+  assert.throws(() => formatRegionMarkers(""), /empty/i);
+});
+
+test("formatRegionMarkers rejects a newline in the name", () => {
+  assert.throws(() => formatRegionMarkers("time\nline"), /newline/i);
+});
+
+test("formatRegionMarkers rejects marker text in the name", () => {
+  assert.throws(() => formatRegionMarkers("foo-->bar"), /-->/);
+});

--- a/packages/remnic-core/src/activity/vault-marker.ts
+++ b/packages/remnic-core/src/activity/vault-marker.ts
@@ -1,0 +1,27 @@
+/**
+ * Format managed-region HTML comment markers (issue #1985).
+ *
+ * Rejects empty names, newlines, and `-->` so the closer cannot leak
+ * out of `<!-- remnic:begin NAME -->`.
+ */
+
+export type RegionMarkers = {
+  begin: string;
+  end: string;
+};
+
+export function formatRegionMarkers(name: string): RegionMarkers {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new RangeError("Region name must be non-empty.");
+  }
+  if (name.includes("\n") || name.includes("\r")) {
+    throw new RangeError("Region name must not contain a newline.");
+  }
+  if (name.includes("-->")) {
+    throw new RangeError("Region name must not contain -->.");
+  }
+  return {
+    begin: `<!-- remnic:begin ${name} -->`,
+    end: `<!-- remnic:end ${name} -->`,
+  };
+}


### PR DESCRIPTION
Part of #1985

## Change
formatRegionMarkers. Begin and end HTML comments. Rejects empty, newline, marker text.

## Test
packages/remnic-core/src/activity/vault-marker.test.ts