### PR TITLE
feat(core): parse state-view successor ids

### DIFF
--- a/.changeset/1952-successor-id.md
+++ b/.changeset/1952-successor-id.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add parseSuccessorId for state-view successor ids. Empty after trim is missing_successor. An embedded newline is invalid_successor. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-successor.test.ts
+++ b/packages/remnic-core/src/recall-state-view-successor.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSuccessorId } from "./recall-state-view-successor.js";
+
+test("ok successor id returns trimmed successorId", () => {
+  assert.deepEqual(parseSuccessorId("mem-2"), { ok: true, successorId: "mem-2" });
+});
+
+test("empty successor id is missing_successor", () => {
+  assert.deepEqual(parseSuccessorId(""), { ok: false, error: "missing_successor" });
+  assert.deepEqual(parseSuccessorId("   "), { ok: false, error: "missing_successor" });
+});
+
+test("newline in successor id is invalid_successor", () => {
+  assert.deepEqual(parseSuccessorId("mem-1\nmem-2"), { ok: false, error: "invalid_successor" });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseSuccessorId("  mem-2  "), { ok: true, successorId: "mem-2" });
+});

--- a/packages/remnic-core/src/recall-state-view-successor.ts
+++ b/packages/remnic-core/src/recall-state-view-successor.ts
@@ -1,0 +1,16 @@
+/**
+ * Recall state-view successor-id parse (issue #1952 leftover).
+ *
+ * Pure. Surfaces wait. Empty is missing_successor. Newline is invalid_successor.
+ */
+
+export type ParseSuccessorIdResult =
+  | { ok: true; successorId: string }
+  | { ok: false; error: "missing_successor" | "invalid_successor" };
+
+export function parseSuccessorId(value: string): ParseSuccessorIdResult {
+  const successorId = value.trim();
+  if (successorId.length === 0) return { ok: false, error: "missing_successor" };
+  if (successorId.includes("\n")) return { ok: false, error: "invalid_successor" };
+  return { ok: true, successorId };
+}


### PR DESCRIPTION
Part of #1952

## Change
parseSuccessorId. Empty fails. Newline fails. Trims id.

## Test
packages/remnic-core/src/recall-state-view-successor.test.ts