### PR TITLE
feat(activity): normalize recap timezone strings

### DIFF
--- a/.changeset/recap-tz-2051.md
+++ b/.changeset/recap-tz-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `normalizeRecapTimezone` to the activity timeline layer: trim, reject empty as `missing_timezone`, and reject strings outside a bounded `[A-Za-z0-9_+/-]{1,64}` class as `invalid_timezone`. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-tz.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-tz.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeRecapTimezone } from "./recap-tz.js";
+
+test("accepts a trimmed IANA-shaped timezone", () => {
+  assert.deepEqual(normalizeRecapTimezone("America/Chicago"), {
+    ok: true,
+    timezone: "America/Chicago",
+  });
+});
+
+test("empty and whitespace-only values are missing_timezone", () => {
+  assert.deepEqual(normalizeRecapTimezone(""), { ok: false, error: "missing_timezone" });
+  assert.deepEqual(normalizeRecapTimezone("   "), { ok: false, error: "missing_timezone" });
+});
+
+test("rejects characters outside the bounded class", () => {
+  assert.deepEqual(normalizeRecapTimezone("America/Chicago!"), {
+    ok: false,
+    error: "invalid_timezone",
+  });
+  assert.deepEqual(normalizeRecapTimezone("America Chicago"), {
+    ok: false,
+    error: "invalid_timezone",
+  });
+  assert.deepEqual(normalizeRecapTimezone("A".repeat(65)), {
+    ok: false,
+    error: "invalid_timezone",
+  });
+});
+
+test("trims surrounding whitespace before validating", () => {
+  assert.deepEqual(normalizeRecapTimezone("  UTC  "), { ok: true, timezone: "UTC" });
+});

--- a/packages/remnic-core/src/activity/timeline/recap-tz.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-tz.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalize a recap timezone string (issue #2051 leftover).
+ *
+ * Trim first. Empty → missing_timezone. Bounded charset only (no ReDoS).
+ */
+
+export type RecapTimezoneResult =
+  | { ok: true; timezone: string }
+  | { ok: false; error: "missing_timezone" | "invalid_timezone" };
+
+const RECAP_TIMEZONE = /^[A-Za-z0-9_+/-]{1,64}$/;
+
+/** Trim and accept an IANA-shaped timezone, or return a typed error. */
+export function normalizeRecapTimezone(value: string): RecapTimezoneResult {
+  const timezone = value.trim();
+  if (timezone.length === 0) return { ok: false, error: "missing_timezone" };
+  if (!RECAP_TIMEZONE.test(timezone)) return { ok: false, error: "invalid_timezone" };
+  return { ok: true, timezone };
+}


### PR DESCRIPTION
Part of #2051

## Change
normalizeRecapTimezone. Empty fails. Bounded character class. Trims value.

## Test
packages/remnic-core/src/activity/timeline/recap-tz.test.ts