### PR TITLE
feat(core): add spanContainsOffset helper

### DIFF
--- a/.changeset/2333-span-contains.md
+++ b/.changeset/2333-span-contains.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-contains helper. Half-open `[start, end)` includes `start` and excludes `end`. Inverted spans and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-contains.test.ts
+++ b/packages/remnic-core/src/extraction-span-contains.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spanContainsOffset } from "./extraction-span-contains.js";
+
+test("spanContainsOffset: inside is true", () => {
+  assert.equal(spanContainsOffset({ start: 1, end: 4, offset: 2 }), true);
+  assert.equal(spanContainsOffset({ start: 1, end: 4, offset: 3 }), true);
+});
+
+test("spanContainsOffset: start is inclusive", () => {
+  assert.equal(spanContainsOffset({ start: 1, end: 4, offset: 1 }), true);
+  assert.equal(spanContainsOffset({ start: 0, end: 5, offset: 0 }), true);
+});
+
+test("spanContainsOffset: end is exclusive", () => {
+  assert.equal(spanContainsOffset({ start: 1, end: 4, offset: 4 }), false);
+  assert.equal(spanContainsOffset({ start: 0, end: 5, offset: 5 }), false);
+});
+
+test("spanContainsOffset: inverted span throws", () => {
+  assert.throws(() => spanContainsOffset({ start: 3, end: 2, offset: 2 }), /inverted/i);
+  assert.throws(() => spanContainsOffset({ start: 1, end: 0, offset: 0 }), /inverted/i);
+});
+
+test("spanContainsOffset: non-integers throw", () => {
+  assert.throws(() => spanContainsOffset({ start: 1.5, end: 3, offset: 2 }), /integers/);
+  assert.throws(() => spanContainsOffset({ start: 0, end: 3.2, offset: 1 }), /integers/);
+  assert.throws(() => spanContainsOffset({ start: 0, end: 3, offset: 1.1 }), /integers/);
+  assert.throws(() => spanContainsOffset({ start: Number.NaN, end: 3, offset: 1 }), /integers/);
+});

--- a/packages/remnic-core/src/extraction-span-contains.ts
+++ b/packages/remnic-core/src/extraction-span-contains.ts
@@ -1,0 +1,20 @@
+/**
+ * Isolated span-contains helper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export function spanContainsOffset(opts: {
+  start: number;
+  end: number;
+  offset: number;
+}): boolean {
+  const { start, end, offset } = opts;
+  if (!Number.isInteger(start) || !Number.isInteger(end) || !Number.isInteger(offset)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (end < start) {
+    throw new RangeError("span offsets inverted");
+  }
+  return offset >= start && offset < end;
+}


### PR DESCRIPTION
Part of #2333

## Change
spanContainsOffset. Half-open [start, end). Inverted range throws.

## Test
packages/remnic-core/src/extraction-span-contains.test.ts