### PR TITLE
feat(dedup): add merge-tie breaker

### DIFF
--- a/.changeset/2330-merge-tie.md
+++ b/.changeset/2330-merge-tie.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-tie breaker. Lower id by localeCompare wins. Same id returns aId. Empty id throws. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-tie.test.ts
+++ b/packages/remnic-core/src/dedup/merge-tie.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { breakMergeTie } from "./merge-tie.js";
+
+test("a wins when aId is lower", () => {
+  assert.equal(breakMergeTie("alpha", "zeta"), "alpha");
+});
+
+test("b wins when bId is lower", () => {
+  assert.equal(breakMergeTie("zeta", "alpha"), "alpha");
+});
+
+test("same id returns aId", () => {
+  assert.equal(breakMergeTie("alpha", "alpha"), "alpha");
+});
+
+test("empty id throws", () => {
+  assert.throws(() => breakMergeTie("", "alpha"), /empty merge id/);
+  assert.throws(() => breakMergeTie("alpha", ""), /empty merge id/);
+  assert.throws(() => breakMergeTie("", ""), /empty merge id/);
+});

--- a/packages/remnic-core/src/dedup/merge-tie.ts
+++ b/packages/remnic-core/src/dedup/merge-tie.ts
@@ -1,0 +1,13 @@
+/**
+ * Merge-tie breaker (issue #2330 leftover).
+ *
+ * Returns the lower id by localeCompare. Same id returns aId.
+ * Empty id throws.
+ */
+
+export function breakMergeTie(aId: string, bId: string): string {
+  if (aId === "" || bId === "") {
+    throw new Error("empty merge id");
+  }
+  return aId.localeCompare(bId) <= 0 ? aId : bId;
+}


### PR DESCRIPTION
Part of #2330

## Change
breakMergeTie. Lower localeCompare id wins. Empty id throws.

## Test
packages/remnic-core/src/dedup/merge-tie.test.ts