### PR TITLE
feat(core): parse recall navigate actions

### DIFF
--- a/.changeset/1956-navigate-action.md
+++ b/.changeset/1956-navigate-action.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate action parser. Allowed actions are expand and traverse. Unknown or empty returns unknown_action. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-action.test.ts
+++ b/packages/remnic-core/src/recall-navigate-action.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseNavigateAction } from "./recall-navigate-action.js";
+
+test("expand is allowed", () => {
+  assert.deepEqual(parseNavigateAction("expand"), {
+    ok: true,
+    action: "expand",
+  });
+});
+
+test("traverse is allowed", () => {
+  assert.deepEqual(parseNavigateAction("traverse"), {
+    ok: true,
+    action: "traverse",
+  });
+});
+
+test("unknown action is unknown_action", () => {
+  assert.deepEqual(parseNavigateAction("refine"), {
+    ok: false,
+    error: "unknown_action",
+  });
+});
+
+test("empty action is unknown_action", () => {
+  assert.deepEqual(parseNavigateAction(""), {
+    ok: false,
+    error: "unknown_action",
+  });
+});

--- a/packages/remnic-core/src/recall-navigate-action.ts
+++ b/packages/remnic-core/src/recall-navigate-action.ts
@@ -1,0 +1,20 @@
+/**
+ * Recall navigation action parse (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. Unknown or empty is unknown_action.
+ */
+
+const NAVIGATE_ACTIONS = ["expand", "traverse"] as const;
+
+export type NavigateAction = (typeof NAVIGATE_ACTIONS)[number];
+
+export type ParseNavigateActionResult =
+  | { ok: true; action: NavigateAction }
+  | { ok: false; error: "unknown_action" };
+
+export function parseNavigateAction(value: string): ParseNavigateActionResult {
+  if ((NAVIGATE_ACTIONS as readonly string[]).includes(value)) {
+    return { ok: true, action: value as NavigateAction };
+  }
+  return { ok: false, error: "unknown_action" };
+}


### PR DESCRIPTION
Part of #1956

## Change
parseNavigateAction. Allow expand or traverse. Unknown or empty fails.

## Test
packages/remnic-core/src/recall-navigate-action.test.ts