### PR TITLE
feat(core): parse shared-context envelope actor

### DIFF
--- a/.changeset/1957-envelope-actor.md
+++ b/.changeset/1957-envelope-actor.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context envelope actor parse (issue #1957). `parseEnvelopeActor` trims the value, rejects empty as `missing_actor`, rejects an embedded newline as `invalid_actor`, and otherwise returns the actor. Part of #1957.

--- a/packages/remnic-core/src/shared-context/envelope-actor.test.ts
+++ b/packages/remnic-core/src/shared-context/envelope-actor.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseEnvelopeActor } from "./envelope-actor.js";
+
+test("ok actor returns trimmed actor", () => {
+  assert.deepEqual(parseEnvelopeActor("agent-a"), { ok: true, actor: "agent-a" });
+});
+
+test("empty actor is missing_actor", () => {
+  assert.deepEqual(parseEnvelopeActor(""), { ok: false, error: "missing_actor" });
+  assert.deepEqual(parseEnvelopeActor("   "), { ok: false, error: "missing_actor" });
+});
+
+test("newline in actor is invalid_actor", () => {
+  assert.deepEqual(parseEnvelopeActor("agent-a\nagent-b"), { ok: false, error: "invalid_actor" });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseEnvelopeActor("  agent-a  "), { ok: true, actor: "agent-a" });
+});

--- a/packages/remnic-core/src/shared-context/envelope-actor.ts
+++ b/packages/remnic-core/src/shared-context/envelope-actor.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared-item envelope actor parse (issue #1957 leftover).
+ *
+ * Pure. Empty is missing_actor. Newline is invalid_actor.
+ */
+
+export type ParseEnvelopeActorResult =
+  | { ok: true; actor: string }
+  | { ok: false; error: "missing_actor" | "invalid_actor" };
+
+export function parseEnvelopeActor(value: string): ParseEnvelopeActorResult {
+  const actor = value.trim();
+  if (actor.length === 0) return { ok: false, error: "missing_actor" };
+  if (actor.includes("\n")) return { ok: false, error: "invalid_actor" };
+  return { ok: true, actor };
+}


### PR DESCRIPTION
Part of #1957

## Change
parseEnvelopeActor. Empty fails. Newline fails. Trims actor.

## Test
packages/remnic-core/src/shared-context/envelope-actor.test.ts