### PR TITLE
feat(core): sort timeline analysis observation ids

### DIFF
--- a/.changeset/2050-analysis-order.md
+++ b/.changeset/2050-analysis-order.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `sortObservationIds` to the activity timeline layer: localeCompare-sorted observation ids, no input mutation, empty strings dropped. Empty input returns `[]`. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-order.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-order.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sortObservationIds } from "./analysis-order.js";
+
+test("empty input returns an empty array", () => {
+  assert.deepEqual(sortObservationIds([]), []);
+});
+
+test("sorts ids with localeCompare", () => {
+  assert.deepEqual(sortObservationIds(["obs-c", "obs-a", "obs-b"]), [
+    "obs-a",
+    "obs-b",
+    "obs-c",
+  ]);
+});
+
+test("does not mutate the input array", () => {
+  const input = ["obs-c", "obs-a"];
+  const snapshot = input.slice();
+  const sorted = sortObservationIds(input);
+  assert.deepEqual(input, snapshot);
+  assert.notEqual(sorted, input);
+});
+
+test("drops empty strings", () => {
+  assert.deepEqual(sortObservationIds(["b", "", "a", ""]), ["a", "b"]);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-order.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-order.ts
@@ -1,0 +1,10 @@
+/**
+ * Stable observation-id order for timeline analysis (issue #2050 leftover).
+ *
+ * localeCompare sort. Empty input → []. Does not mutate input. Drops empty strings.
+ */
+
+/** Return a new localeCompare-sorted id list. Empty strings are dropped. */
+export function sortObservationIds(ids: readonly string[]): string[] {
+  return ids.filter((id) => id !== "").sort((a, b) => a.localeCompare(b));
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -18,3 +18,4 @@ export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";
 export * from "./analysis-prompt.js";
 export * from "./analysis-claim.js";
+export * from "./analysis-order.js";


### PR DESCRIPTION
Part of #2050

## Change
sortObservationIds. localeCompare. Drops empty strings. Does not mutate input.

## Test
packages/remnic-core/src/activity/timeline/analysis-order.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent sorting for observation IDs in activity timelines.
  * Empty IDs are excluded automatically, while the original input remains unchanged.
  * Empty inputs now return an empty result. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->