### PR TITLE
feat(activity): add parseRecapDate helper

### DIFF
--- a/.changeset/recap-date-2051.md
+++ b/.changeset/recap-date-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseRecapDate` to the activity timeline layer: trim, reject empty as `missing_date`, and reject strings outside a bounded `YYYY-MM-DD` class as `invalid_date`. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-date.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-date.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseRecapDate } from "./recap-date.js";
+
+test("accepts a trimmed YYYY-MM-DD date", () => {
+  assert.deepEqual(parseRecapDate("2026-08-19"), { ok: true, date: "2026-08-19" });
+  assert.deepEqual(parseRecapDate("  2026-08-19  "), { ok: true, date: "2026-08-19" });
+});
+
+test("empty and whitespace-only values are missing_date", () => {
+  assert.deepEqual(parseRecapDate(""), { ok: false, error: "missing_date" });
+  assert.deepEqual(parseRecapDate("   "), { ok: false, error: "missing_date" });
+});
+
+test("rejects strings that are not YYYY-MM-DD", () => {
+  assert.deepEqual(parseRecapDate("20260819"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseRecapDate("2026-8-19"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseRecapDate("2026-08-19T00:00:00Z"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseRecapDate("not-a-date"), { ok: false, error: "invalid_date" });
+});

--- a/packages/remnic-core/src/activity/timeline/recap-date.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-date.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse a recap local-day string (issue #2051 leftover).
+ *
+ * Trim first. Empty → missing_date. Bounded YYYY-MM-DD only (no ReDoS).
+ */
+
+export type RecapDateResult =
+  | { ok: true; date: string }
+  | { ok: false; error: "missing_date" | "invalid_date" };
+
+const RECAP_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Trim and accept YYYY-MM-DD, or return a typed error. */
+export function parseRecapDate(value: string): RecapDateResult {
+  const date = value.trim();
+  if (date.length === 0) return { ok: false, error: "missing_date" };
+  if (!RECAP_DATE.test(date)) return { ok: false, error: "invalid_date" };
+  return { ok: true, date };
+}


### PR DESCRIPTION
Part of #2051

## Change
parseRecapDate. YYYY-MM-DD only. Empty or invalid fails.

## Test
packages/remnic-core/src/activity/timeline/recap-date.test.ts