### PR TITLE
feat(core): parse deep-recall policy names

### DIFF
--- a/.changeset/2332-deep-policy-name.md
+++ b/.changeset/2332-deep-policy-name.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure deep-recall policy-name parser. Allow-list is `stop` and `expand-once`. Unknown or empty names fail closed. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-policy.test.ts
+++ b/packages/remnic-core/src/recall-deep-policy.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDeepPolicyName } from "./recall-deep-policy.js";
+
+test("stop is allowed", () => {
+  assert.deepEqual(parseDeepPolicyName("stop"), {
+    ok: true,
+    policy: "stop",
+  });
+});
+
+test("expand-once is allowed", () => {
+  assert.deepEqual(parseDeepPolicyName("expand-once"), {
+    ok: true,
+    policy: "expand-once",
+  });
+});
+
+test("unknown policy is unknown_policy", () => {
+  assert.deepEqual(parseDeepPolicyName("refine-twice"), {
+    ok: false,
+    error: "unknown_policy",
+  });
+});
+
+test("empty policy is unknown_policy", () => {
+  assert.deepEqual(parseDeepPolicyName(""), {
+    ok: false,
+    error: "unknown_policy",
+  });
+});

--- a/packages/remnic-core/src/recall-deep-policy.ts
+++ b/packages/remnic-core/src/recall-deep-policy.ts
@@ -1,0 +1,22 @@
+/**
+ * Parse a deep-recall policy name (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. Unknown or empty values fail closed.
+ */
+export const DEEP_POLICY_NAMES = ["stop", "expand-once"] as const;
+
+export type DeepPolicyName = (typeof DEEP_POLICY_NAMES)[number];
+
+export type ParseDeepPolicyNameResult =
+  | { ok: true; policy: DeepPolicyName }
+  | { ok: false; error: "unknown_policy" };
+
+export function parseDeepPolicyName(value: unknown): ParseDeepPolicyNameResult {
+  if (typeof value !== "string" || value.length === 0) {
+    return { ok: false, error: "unknown_policy" };
+  }
+  if (!(DEEP_POLICY_NAMES as readonly string[]).includes(value)) {
+    return { ok: false, error: "unknown_policy" };
+  }
+  return { ok: true, policy: value as DeepPolicyName };
+}


### PR DESCRIPTION
Part of #2332

## Change
parseDeepPolicyName. Allow stop or expand-once. Unknown or empty fails.

## Test
packages/remnic-core/src/recall-deep-policy.test.ts