### PR TITLE
feat(core): parse state-view superseded-at dates

### DIFF
--- a/.changeset/1952-superseded-at.md
+++ b/.changeset/1952-superseded-at.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add parseSupersededAt for state-view superseded dates. Empty after trim is missing_date. An unparseable Date.parse value is invalid_date. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-superseded.test.ts
+++ b/packages/remnic-core/src/recall-state-view-superseded.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSupersededAt } from "./recall-state-view-superseded.js";
+
+test("ok date returns canonical ISO supersededAt", () => {
+  assert.deepEqual(parseSupersededAt("2026-08-19T12:34:56.000Z"), {
+    ok: true,
+    supersededAt: "2026-08-19T12:34:56.000Z",
+  });
+});
+
+test("empty date is missing_date", () => {
+  assert.deepEqual(parseSupersededAt(""), { ok: false, error: "missing_date" });
+  assert.deepEqual(parseSupersededAt("   "), { ok: false, error: "missing_date" });
+});
+
+test("invalid date is invalid_date", () => {
+  assert.deepEqual(parseSupersededAt("not-a-date"), { ok: false, error: "invalid_date" });
+});

--- a/packages/remnic-core/src/recall-state-view-superseded.ts
+++ b/packages/remnic-core/src/recall-state-view-superseded.ts
@@ -1,0 +1,17 @@
+/**
+ * Recall state-view superseded-at parse (issue #1952 leftover).
+ *
+ * Pure. Surfaces wait. Empty is missing_date. Unparseable is invalid_date.
+ */
+
+export type ParseSupersededAtResult =
+  | { ok: true; supersededAt: string }
+  | { ok: false; error: "missing_date" | "invalid_date" };
+
+export function parseSupersededAt(value: string): ParseSupersededAtResult {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return { ok: false, error: "missing_date" };
+  const parsed = Date.parse(trimmed);
+  if (!Number.isFinite(parsed)) return { ok: false, error: "invalid_date" };
+  return { ok: true, supersededAt: new Date(parsed).toISOString() };
+}


### PR DESCRIPTION
Part of #1952

## Change
parseSupersededAt. Empty or invalid date fails. Valid date returns ISO.

## Test
packages/remnic-core/src/recall-state-view-superseded.test.ts