### PR TITLE
feat(core): add spansOverlap helper

### DIFF
--- a/.changeset/2333-span-overlap.md
+++ b/.changeset/2333-span-overlap.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-overlap helper. Half-open `[start, end)` ranges that only touch at an endpoint do not overlap. Inverted spans and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-overlap.test.ts
+++ b/packages/remnic-core/src/extraction-span-overlap.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spansOverlap } from "./extraction-span-overlap.js";
+
+test("spansOverlap: interior overlap is true", () => {
+  assert.equal(spansOverlap({ start: 0, end: 4 }, { start: 2, end: 6 }), true);
+  assert.equal(spansOverlap({ start: 2, end: 6 }, { start: 0, end: 4 }), true);
+  assert.equal(spansOverlap({ start: 1, end: 5 }, { start: 2, end: 3 }), true);
+});
+
+test("spansOverlap: touching at an endpoint is false", () => {
+  assert.equal(spansOverlap({ start: 0, end: 3 }, { start: 3, end: 5 }), false);
+  assert.equal(spansOverlap({ start: 3, end: 5 }, { start: 0, end: 3 }), false);
+  assert.equal(spansOverlap({ start: 1, end: 1 }, { start: 1, end: 4 }), false);
+});
+
+test("spansOverlap: disjoint spans are false", () => {
+  assert.equal(spansOverlap({ start: 0, end: 2 }, { start: 4, end: 6 }), false);
+  assert.equal(spansOverlap({ start: 4, end: 6 }, { start: 0, end: 2 }), false);
+});
+
+test("spansOverlap: inverted span throws", () => {
+  assert.throws(() => spansOverlap({ start: 3, end: 2 }, { start: 0, end: 1 }), /inverted/i);
+  assert.throws(() => spansOverlap({ start: 0, end: 1 }, { start: 5, end: 4 }), /inverted/i);
+});
+
+test("spansOverlap: non-integers throw", () => {
+  assert.throws(() => spansOverlap({ start: 1.5, end: 3 }, { start: 0, end: 1 }), /integers/);
+  assert.throws(() => spansOverlap({ start: 0, end: 3 }, { start: 1, end: 2.2 }), /integers/);
+  assert.throws(
+    () => spansOverlap({ start: Number.NaN, end: 3 }, { start: 0, end: 1 }),
+    /integers/,
+  );
+});

--- a/packages/remnic-core/src/extraction-span-overlap.ts
+++ b/packages/remnic-core/src/extraction-span-overlap.ts
@@ -1,0 +1,23 @@
+/**
+ * Isolated span-overlap helper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export function spansOverlap(
+  a: { start: number; end: number },
+  b: { start: number; end: number },
+): boolean {
+  if (
+    !Number.isInteger(a.start) ||
+    !Number.isInteger(a.end) ||
+    !Number.isInteger(b.start) ||
+    !Number.isInteger(b.end)
+  ) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (a.end < a.start || b.end < b.start) {
+    throw new RangeError("span offsets inverted");
+  }
+  return a.start < b.end && b.start < a.end;
+}


### PR DESCRIPTION
Part of #2333

## Change
spansOverlap. Half-open. Endpoint touch is false. Inverted throws.

## Test
packages/remnic-core/src/extraction-span-overlap.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added span-overlap detection using half-open range semantics, so ranges that only touch at an endpoint are treated as non-overlapping.
  * Invalid spans now provide clear validation errors when offsets are inverted or non-integer.
* **Bug Fixes**
  * Improved reliability of span comparisons across interior overlaps, disjoint ranges, and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->