### PR TITLE
feat(core): add merge-id empty-set guard

### DIFF
--- a/.changeset/2330-merge-empty.md
+++ b/.changeset/2330-merge-empty.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-id empty-set guard. Empty list is empty_set. Any empty string is empty_id. Otherwise the same ids stay in order. The input list is not mutated. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-empty.test.ts
+++ b/packages/remnic-core/src/dedup/merge-empty.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rejectEmptyMergeIds } from "./merge-empty.js";
+
+test("empty set is empty_set", () => {
+  assert.deepEqual(rejectEmptyMergeIds([]), { ok: false, error: "empty_set" });
+});
+
+test("empty id is empty_id", () => {
+  assert.deepEqual(rejectEmptyMergeIds([""]), { ok: false, error: "empty_id" });
+  assert.deepEqual(rejectEmptyMergeIds(["alpha", ""]), { ok: false, error: "empty_id" });
+  assert.deepEqual(rejectEmptyMergeIds(["", "alpha"]), { ok: false, error: "empty_id" });
+});
+
+test("ok returns the same ids in order and does not mutate", () => {
+  const ids = ["zeta", "alpha", "beta"];
+  const result = rejectEmptyMergeIds(ids);
+  assert.deepEqual(result, { ok: true, ids: ["zeta", "alpha", "beta"] });
+  assert.equal(result.ok && result.ids, ids);
+  assert.deepEqual(ids, ["zeta", "alpha", "beta"]);
+});

--- a/packages/remnic-core/src/dedup/merge-empty.ts
+++ b/packages/remnic-core/src/dedup/merge-empty.ts
@@ -1,0 +1,18 @@
+/**
+ * Merge-id empty-set guard (issue #2330 leftover).
+ *
+ * Empty list → empty_set. Any empty string → empty_id.
+ * Otherwise returns the same ids in order. Does not mutate input.
+ */
+
+export type RejectEmptyMergeIdsResult =
+  | { ok: true; ids: readonly string[] }
+  | { ok: false; error: "empty_set" | "empty_id" };
+
+export function rejectEmptyMergeIds(ids: readonly string[]): RejectEmptyMergeIdsResult {
+  if (ids.length === 0) return { ok: false, error: "empty_set" };
+  for (const id of ids) {
+    if (id === "") return { ok: false, error: "empty_id" };
+  }
+  return { ok: true, ids };
+}


### PR DESCRIPTION
Part of #2330

## Change
rejectEmptyMergeIds. Empty set or empty id fails. Does not mutate input.

## Test
packages/remnic-core/src/dedup/merge-empty.test.ts