### PR TITLE
feat(core): parse activity privacy enabled flag

### DIFF
--- a/.changeset/2053-privacy-enabled.md
+++ b/.changeset/2053-privacy-enabled.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": minor
+---
+
+Add `parsePrivacyEnabled` for the activity privacy flag.
+Boolean passthrough. Known string tokens map to true or false.
+Unknown values return `invalid_enabled`.
+Part of #2053.

--- a/packages/remnic-core/src/activity/privacy-enabled.test.ts
+++ b/packages/remnic-core/src/activity/privacy-enabled.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parsePrivacyEnabled } from "./privacy-enabled.js";
+
+test("boolean passthrough returns enabled", () => {
+  assert.deepEqual(parsePrivacyEnabled(true), { ok: true, enabled: true });
+  assert.deepEqual(parsePrivacyEnabled(false), { ok: true, enabled: false });
+});
+
+test("string false tokens return enabled false", () => {
+  assert.deepEqual(parsePrivacyEnabled("false"), { ok: true, enabled: false });
+  assert.deepEqual(parsePrivacyEnabled("0"), { ok: true, enabled: false });
+  assert.deepEqual(parsePrivacyEnabled("no"), { ok: true, enabled: false });
+  assert.deepEqual(parsePrivacyEnabled("off"), { ok: true, enabled: false });
+});
+
+test("string true tokens return enabled true", () => {
+  assert.deepEqual(parsePrivacyEnabled("true"), { ok: true, enabled: true });
+  assert.deepEqual(parsePrivacyEnabled("1"), { ok: true, enabled: true });
+  assert.deepEqual(parsePrivacyEnabled("yes"), { ok: true, enabled: true });
+  assert.deepEqual(parsePrivacyEnabled("on"), { ok: true, enabled: true });
+});
+
+test("unknown values are invalid_enabled", () => {
+  assert.deepEqual(parsePrivacyEnabled("maybe"), { ok: false, error: "invalid_enabled" });
+  assert.deepEqual(parsePrivacyEnabled(2), { ok: false, error: "invalid_enabled" });
+  assert.deepEqual(parsePrivacyEnabled(null), { ok: false, error: "invalid_enabled" });
+  assert.deepEqual(parsePrivacyEnabled({}), { ok: false, error: "invalid_enabled" });
+});

--- a/packages/remnic-core/src/activity/privacy-enabled.ts
+++ b/packages/remnic-core/src/activity/privacy-enabled.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse the activity privacy enabled flag (issue #2053 leftover).
+ *
+ * Boolean passthrough. String tokens true/1/yes/on and false/0/no/off.
+ * Unknown values fail closed as invalid_enabled.
+ */
+
+export type ParsePrivacyEnabledResult =
+  | { ok: true; enabled: boolean }
+  | { ok: false; error: "invalid_enabled" };
+
+const ENABLED_TOKENS: Record<string, boolean> = {
+  true: true,
+  "1": true,
+  yes: true,
+  on: true,
+  false: false,
+  "0": false,
+  no: false,
+  off: false,
+};
+
+/** Accept a boolean or known token. Unknown values are invalid_enabled. */
+export function parsePrivacyEnabled(value: unknown): ParsePrivacyEnabledResult {
+  if (typeof value === "boolean") return { ok: true, enabled: value };
+  if (typeof value === "string") {
+    const token = value.trim().toLowerCase();
+    if (Object.hasOwn(ENABLED_TOKENS, token)) {
+      return { ok: true, enabled: ENABLED_TOKENS[token] };
+    }
+  }
+  return { ok: false, error: "invalid_enabled" };
+}


### PR DESCRIPTION
Part of #2053

## Change
parsePrivacyEnabled. Coerces false/0/no/off. Unknown fails.

## Test
packages/remnic-core/src/activity/privacy-enabled.test.ts