### PR TITLE
feat(core): parse recall navigate depth

### DIFF
--- a/.changeset/1956-navigate-depth.md
+++ b/.changeset/1956-navigate-depth.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate depth parser. 0 is allowed. Negative or non-integer values throw. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-depth.test.ts
+++ b/packages/remnic-core/src/recall-navigate-depth.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseNavigateDepth } from "./recall-navigate-depth.js";
+
+test("depth 0 is allowed", () => {
+  assert.equal(parseNavigateDepth(0), 0);
+});
+
+test("depth 3 is returned", () => {
+  assert.equal(parseNavigateDepth(3), 3);
+});
+
+test("negative depth throws", () => {
+  assert.throws(() => parseNavigateDepth(-1), /non-negative integer/);
+});
+
+test("float depth throws", () => {
+  assert.throws(() => parseNavigateDepth(1.5), /non-negative integer/);
+});

--- a/packages/remnic-core/src/recall-navigate-depth.ts
+++ b/packages/remnic-core/src/recall-navigate-depth.ts
@@ -1,0 +1,13 @@
+/**
+ * Recall navigation depth parse (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. 0 is allowed. Negative or non-integer throws.
+ */
+export function parseNavigateDepth(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `navigate depth must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
Part of #1956

## Change
parseNavigateDepth. 0 allowed. Negative or non-integer throws.

## Test
packages/remnic-core/src/recall-navigate-depth.test.ts