### PR TITLE
feat(activity): add parseJournalMode helper

### DIFF
--- a/.changeset/1987-journal-mode.md
+++ b/.changeset/1987-journal-mode.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseJournalMode` to allow only file or vault journal modes. Unknown or empty is unknown_mode. Part of #1987.

--- a/packages/remnic-core/src/activity/journal-mode.test.ts
+++ b/packages/remnic-core/src/activity/journal-mode.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseJournalMode } from "./journal-mode.js";
+
+test("file is allowed", () => {
+  assert.deepEqual(parseJournalMode("file"), {
+    ok: true,
+    mode: "file",
+  });
+});
+
+test("vault is allowed", () => {
+  assert.deepEqual(parseJournalMode("vault"), {
+    ok: true,
+    mode: "vault",
+  });
+});
+
+test("unknown mode is unknown_mode", () => {
+  assert.deepEqual(parseJournalMode("memoryDir"), {
+    ok: false,
+    error: "unknown_mode",
+  });
+});
+
+test("empty mode is unknown_mode", () => {
+  assert.deepEqual(parseJournalMode(""), {
+    ok: false,
+    error: "unknown_mode",
+  });
+});

--- a/packages/remnic-core/src/activity/journal-mode.ts
+++ b/packages/remnic-core/src/activity/journal-mode.ts
@@ -1,0 +1,20 @@
+/**
+ * Parse journal mode (issue #1987 leftover).
+ *
+ * Pure. Surfaces wait. Allow file or vault. Unknown or empty is unknown_mode.
+ */
+
+const JOURNAL_MODES = ["file", "vault"] as const;
+
+export type JournalMode = (typeof JOURNAL_MODES)[number];
+
+export type ParseJournalModeResult =
+  | { ok: true; mode: JournalMode }
+  | { ok: false; error: "unknown_mode" };
+
+export function parseJournalMode(value: string): ParseJournalModeResult {
+  if ((JOURNAL_MODES as readonly string[]).includes(value)) {
+    return { ok: true, mode: value as JournalMode };
+  }
+  return { ok: false, error: "unknown_mode" };
+}


### PR DESCRIPTION
Part of #1987

## Change
parseJournalMode. Allow file or vault. Unknown or empty fails.

## Test
packages/remnic-core/src/activity/journal-mode.test.ts