### PR TITLE
feat(activity): add joinVaultSegments helper

### DIFF
--- a/.changeset/1985-vault-join.md
+++ b/.changeset/1985-vault-join.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `joinVaultSegments` to join vault-relative path parts on `/`. Empty lists, empty parts, `..`, absolute parts, backslash, and newline throw. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -26,3 +26,4 @@ export * from "./vault-frontmatter.js";
 export * from "./vault-wikilink.js";
 export * from "./vault-region.js";
 export * from "./vault-suffix.js";
+export * from "./vault-join.js";

--- a/packages/remnic-core/src/activity/vault-join.test.ts
+++ b/packages/remnic-core/src/activity/vault-join.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { joinVaultSegments } from "./vault-join.js";
+
+test("joinVaultSegments joins relative parts with /", () => {
+  assert.equal(
+    joinVaultSegments(["Daily Notes", "2026", "08", "2026-08-18.md"]),
+    "Daily Notes/2026/08/2026-08-18.md",
+  );
+});
+
+test("joinVaultSegments rejects ..", () => {
+  assert.throws(() => joinVaultSegments(["Daily Notes", "..", "secret"]), /\.\./);
+  assert.throws(() => joinVaultSegments(["foo/../bar"]), /\.\./);
+});
+
+test("joinVaultSegments rejects empty", () => {
+  assert.throws(() => joinVaultSegments([]), /empty/i);
+  assert.throws(() => joinVaultSegments(["Daily Notes", ""]), /empty/i);
+});

--- a/packages/remnic-core/src/activity/vault-join.ts
+++ b/packages/remnic-core/src/activity/vault-join.ts
@@ -1,0 +1,31 @@
+/**
+ * Join vault-relative path segments (issue #1985).
+ *
+ * Joins with `/`. Rejects an empty list, empty parts, `..`, absolute
+ * parts, backslash, and newline.
+ */
+import path from "node:path";
+
+export function joinVaultSegments(parts: readonly string[]): string {
+  if (parts.length === 0) {
+    throw new RangeError("Vault path parts must be a non-empty list.");
+  }
+  for (const part of parts) {
+    if (typeof part !== "string" || part.length === 0) {
+      throw new RangeError("Vault path part must be non-empty.");
+    }
+    if (part.includes("\\")) {
+      throw new RangeError("Vault path part must not contain a backslash.");
+    }
+    if (part.includes("\n") || part.includes("\r")) {
+      throw new RangeError("Vault path part must not contain a newline.");
+    }
+    if (path.posix.isAbsolute(part) || path.win32.isAbsolute(part)) {
+      throw new RangeError("Vault path part must be relative.");
+    }
+    if (part.split("/").includes("..")) {
+      throw new RangeError("Vault path part must not contain `..`.");
+    }
+  }
+  return parts.join("/");
+}


### PR DESCRIPTION
Part of #1985

## Change
joinVaultSegments. Join with slash. Rejects empty, .., absolute, backslash, newline.

## Test
packages/remnic-core/src/activity/vault-join.test.ts