### PR TITLE
feat(core): parse deep-recall remaining budget

### DIFF
--- a/.changeset/2332-deep-budget-left.md
+++ b/.changeset/2332-deep-budget-left.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall remaining-budget parser. 0 is allowed. Negative or non-integer values throw. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-budget-left.test.ts
+++ b/packages/remnic-core/src/recall-deep-budget-left.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseBudgetLeft } from "./recall-deep-budget-left.js";
+
+test("budget left 0 is allowed", () => {
+  assert.equal(parseBudgetLeft(0), 0);
+});
+
+test("budget left 4 is returned", () => {
+  assert.equal(parseBudgetLeft(4), 4);
+});
+
+test("negative budget left throws", () => {
+  assert.throws(() => parseBudgetLeft(-1), /non-negative integer/);
+});
+
+test("float budget left throws", () => {
+  assert.throws(() => parseBudgetLeft(1.5), /non-negative integer/);
+});

--- a/packages/remnic-core/src/recall-deep-budget-left.ts
+++ b/packages/remnic-core/src/recall-deep-budget-left.ts
@@ -1,0 +1,13 @@
+/**
+ * Deep-recall remaining-budget parse (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. 0 is allowed. Negative or non-integer throws.
+ */
+export function parseBudgetLeft(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `deep recall budget left must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
Part of #2332

## Change
parseBudgetLeft. 0 allowed. Negative or non-integer throws.

## Test
packages/remnic-core/src/recall-deep-budget-left.test.ts