### PR TITLE
feat(core): parse shared-context required actor

### DIFF
--- a/.changeset/1957-envelope-required.md
+++ b/.changeset/1957-envelope-required.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context envelope required-actor parse (issue #1957). `parseRequiredActor` trims the value, treats empty as no requirement, rejects an embedded newline as `invalid_required`, and otherwise returns the required actor. Part of #1957.

--- a/packages/remnic-core/src/shared-context/envelope-required.test.ts
+++ b/packages/remnic-core/src/shared-context/envelope-required.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseRequiredActor } from "./envelope-required.js";
+
+test("empty required actor is allowed", () => {
+  assert.deepEqual(parseRequiredActor(""), { ok: true, required: "" });
+  assert.deepEqual(parseRequiredActor("   "), { ok: true, required: "" });
+});
+
+test("ok required actor returns trimmed value", () => {
+  assert.deepEqual(parseRequiredActor("agent-a"), { ok: true, required: "agent-a" });
+});
+
+test("newline in required actor is invalid_required", () => {
+  assert.deepEqual(parseRequiredActor("agent-a\nagent-b"), {
+    ok: false,
+    error: "invalid_required",
+  });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseRequiredActor("  agent-a  "), { ok: true, required: "agent-a" });
+});

--- a/packages/remnic-core/src/shared-context/envelope-required.ts
+++ b/packages/remnic-core/src/shared-context/envelope-required.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared-item envelope required-actor parse (issue #1957 leftover).
+ *
+ * Pure. Empty is allowed (no requirement). Newline is invalid_required.
+ */
+
+export type ParseRequiredActorResult =
+  | { ok: true; required: string }
+  | { ok: false; error: "invalid_required" };
+
+export function parseRequiredActor(value: string): ParseRequiredActorResult {
+  const required = value.trim();
+  if (required.includes("\n")) return { ok: false, error: "invalid_required" };
+  return { ok: true, required };
+}


### PR DESCRIPTION
Part of #1957

## Change
parseRequiredActor. Empty means no requirement. Newline fails.

## Test
packages/remnic-core/src/shared-context/envelope-required.test.ts