### PR TITLE
feat(activity): add isEmptyObservationSet helper

### DIFF
--- a/.changeset/2050-analysis-empty.md
+++ b/.changeset/2050-analysis-empty.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `isEmptyObservationSet` to the activity timeline layer. `null`, `undefined`, and `[]` are empty. A non-array throws. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-empty.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-empty.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmptyObservationSet } from "./analysis-empty.js";
+
+test("null, undefined, and empty array are empty", () => {
+  assert.equal(isEmptyObservationSet(null), true);
+  assert.equal(isEmptyObservationSet(undefined), true);
+  assert.equal(isEmptyObservationSet([]), true);
+});
+
+test("a non-empty array is not empty", () => {
+  assert.equal(isEmptyObservationSet([{ id: 1 }]), false);
+  assert.equal(isEmptyObservationSet([0]), false);
+});
+
+test("a non-array throws", () => {
+  assert.throws(() => isEmptyObservationSet({}), TypeError);
+  assert.throws(() => isEmptyObservationSet("obs"), TypeError);
+  assert.throws(() => isEmptyObservationSet(1), TypeError);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-empty.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-empty.ts
@@ -1,0 +1,14 @@
+/**
+ * Empty-set guard for timeline analysis observations (issue #2050 leftover).
+ *
+ * null, undefined, and [] are empty. A non-array throws. Any other array is not empty.
+ */
+
+/** True when the observation set is absent or has no items. */
+export function isEmptyObservationSet(items: unknown): boolean {
+  if (items == null) return true;
+  if (!Array.isArray(items)) {
+    throw new TypeError("items must be an array");
+  }
+  return items.length === 0;
+}


### PR DESCRIPTION
Part of #2050

## Change
isEmptyObservationSet. Empty or missing is true. Non-array throws.

## Test
packages/remnic-core/src/activity/timeline/analysis-empty.test.ts