### PR TITLE
feat(core): guard current state-view against successors

### DIFF
--- a/.changeset/1952-current-guard.md
+++ b/.changeset/1952-current-guard.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add assertCurrentHasNoSuccessor for state-view current facts. Current plus a successor is current_has_successor. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-current.test.ts
+++ b/packages/remnic-core/src/recall-state-view-current.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertCurrentHasNoSuccessor } from "./recall-state-view-current.js";
+
+test("current plus successor id is current_has_successor", () => {
+  assert.deepEqual(assertCurrentHasNoSuccessor({ kind: "current", successorId: "mem-2" }), {
+    ok: false,
+    error: "current_has_successor",
+  });
+});
+
+test("current plus empty successor id is ok", () => {
+  assert.deepEqual(assertCurrentHasNoSuccessor({ kind: "current", successorId: "" }), { ok: true });
+  assert.deepEqual(assertCurrentHasNoSuccessor({ kind: "current", successorId: "   " }), { ok: true });
+  assert.deepEqual(assertCurrentHasNoSuccessor({ kind: "current" }), { ok: true });
+});
+
+test("historical plus successor id is ok", () => {
+  assert.deepEqual(assertCurrentHasNoSuccessor({ kind: "historical", successorId: "mem-2" }), {
+    ok: true,
+  });
+});

--- a/packages/remnic-core/src/recall-state-view-current.ts
+++ b/packages/remnic-core/src/recall-state-view-current.ts
@@ -1,0 +1,24 @@
+/**
+ * Recall state-view current-has-no-successor guard (issue #1952 leftover).
+ *
+ * Pure. Surfaces wait. Current plus a successor is current_has_successor.
+ */
+
+export type AssertCurrentHasNoSuccessorInput = {
+  kind: string;
+  successorId?: string;
+};
+
+export type AssertCurrentHasNoSuccessorResult =
+  | { ok: true }
+  | { ok: false; error: "current_has_successor" };
+
+export function assertCurrentHasNoSuccessor(
+  input: AssertCurrentHasNoSuccessorInput,
+): AssertCurrentHasNoSuccessorResult {
+  const successorId = input.successorId?.trim() ?? "";
+  if (input.kind === "current" && successorId.length > 0) {
+    return { ok: false, error: "current_has_successor" };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #1952

## Change
assertCurrentHasNoSuccessor. Current plus successor id fails.

## Test
packages/remnic-core/src/recall-state-view-current.test.ts