### PR TITLE
feat(activity): add isEmptyRecapCards helper

### DIFF
--- a/.changeset/recap-empty-2051.md
+++ b/.changeset/recap-empty-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `isEmptyRecapCards` to the activity timeline layer. `null`, `undefined`, and `[]` are empty. A non-array throws. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-empty.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-empty.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmptyRecapCards } from "./recap-empty.js";
+
+test("null, undefined, and empty array are empty", () => {
+  assert.equal(isEmptyRecapCards(null), true);
+  assert.equal(isEmptyRecapCards(undefined), true);
+  assert.equal(isEmptyRecapCards([]), true);
+});
+
+test("a non-empty array is not empty", () => {
+  assert.equal(isEmptyRecapCards([{ id: 1 }]), false);
+  assert.equal(isEmptyRecapCards([0]), false);
+});
+
+test("a non-array throws", () => {
+  assert.throws(() => isEmptyRecapCards({}), TypeError);
+  assert.throws(() => isEmptyRecapCards("cards"), TypeError);
+  assert.throws(() => isEmptyRecapCards(1), TypeError);
+});

--- a/packages/remnic-core/src/activity/timeline/recap-empty.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-empty.ts
@@ -1,0 +1,14 @@
+/**
+ * Empty-set guard for timeline recap cards (issue #2051 leftover).
+ *
+ * null, undefined, and [] are empty. A non-array throws. Any other array is not empty.
+ */
+
+/** True when the recap card list is absent or has no items. */
+export function isEmptyRecapCards(cards: unknown): boolean {
+  if (cards == null) return true;
+  if (!Array.isArray(cards)) {
+    throw new TypeError("cards must be an array");
+  }
+  return cards.length === 0;
+}


### PR DESCRIPTION
Part of #2051

## Change
isEmptyRecapCards. Empty or missing is true. Non-array throws.

## Test
packages/remnic-core/src/activity/timeline/recap-empty.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility to determine whether recap cards are empty.
  * Supports `null`, `undefined`, and empty arrays as empty values.
  * Returns `false` for non-empty arrays and reports invalid non-array inputs with a type error.

* **Tests**
  * Added coverage for empty, non-empty, and invalid recap card values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->