### PR TITLE
feat(activity): add parseFromMs helper

### DIFF
--- a/.changeset/2053-from-ms.md
+++ b/.changeset/2053-from-ms.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseFromMs` for activity window bounds. Finite number ≥ 0 is returned.
+Negative, NaN, and non-number values throw.
+Part of #2053.

--- a/packages/remnic-core/src/activity/from-ms.test.ts
+++ b/packages/remnic-core/src/activity/from-ms.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseFromMs } from "./from-ms.js";
+
+test("fromMs 0 is accepted", () => {
+  assert.equal(parseFromMs(0), 0);
+});
+
+test("epoch fromMs is accepted", () => {
+  const epoch = 1_700_000_000_000;
+  assert.equal(parseFromMs(epoch), epoch);
+});
+
+test("negative fromMs throws", () => {
+  assert.throws(() => parseFromMs(-1), /non-negative/);
+});
+
+test("NaN fromMs throws", () => {
+  assert.throws(() => parseFromMs(Number.NaN), /finite/);
+});
+
+test("non-number fromMs throws", () => {
+  assert.throws(() => parseFromMs("0"), /finite/);
+});

--- a/packages/remnic-core/src/activity/from-ms.ts
+++ b/packages/remnic-core/src/activity/from-ms.ts
@@ -1,0 +1,13 @@
+/**
+ * Parse activity window fromMs (issue #2053 leftover).
+ *
+ * Finite number ≥ 0 is returned. Negative, NaN, and non-number values throw.
+ */
+export function parseFromMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new RangeError(
+      `activity.fromMs must be a finite non-negative number; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
Part of #2053

## Change
parseFromMs. Finite number at least 0. Negative or NaN throws.

## Test
packages/remnic-core/src/activity/from-ms.test.ts