### PR TITLE
feat(core): add merge-candidate counter

### DIFF
--- a/.changeset/2330-merge-count.md
+++ b/.changeset/2330-merge-count.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-candidate counter. Unique ids after dropping empty strings. The input list is not mutated. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-count.test.ts
+++ b/packages/remnic-core/src/dedup/merge-count.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { countMergeCandidates } from "./merge-count.js";
+
+test("empty list is 0", () => {
+  assert.equal(countMergeCandidates([]), 0);
+});
+
+test("counts unique ids", () => {
+  assert.equal(countMergeCandidates(["alpha", "beta", "alpha"]), 2);
+  assert.equal(countMergeCandidates(["alpha", "beta", "gamma"]), 3);
+});
+
+test("drops empty strings and does not mutate", () => {
+  const ids = ["alpha", "", "beta", "", "alpha"];
+  assert.equal(countMergeCandidates(ids), 2);
+  assert.deepEqual(ids, ["alpha", "", "beta", "", "alpha"]);
+});

--- a/packages/remnic-core/src/dedup/merge-count.ts
+++ b/packages/remnic-core/src/dedup/merge-count.ts
@@ -1,0 +1,13 @@
+/**
+ * Merge-candidate counter (issue #2330 leftover).
+ *
+ * Unique ids after dropping empty strings. Does not mutate input.
+ */
+
+export function countMergeCandidates(ids: readonly string[]): number {
+  const unique = new Set<string>();
+  for (const id of ids) {
+    if (id !== "") unique.add(id);
+  }
+  return unique.size;
+}


### PR DESCRIPTION
Part of #2330

## Change
countMergeCandidates. Unique ids. Drops empty strings. Does not mutate input.

## Test
packages/remnic-core/src/dedup/merge-count.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge-candidate counting that reports the number of unique, non-empty IDs.
  * Input lists remain unchanged when counting candidates.

* **Bug Fixes**
  * Duplicate and empty IDs are now excluded from merge-candidate totals.

* **Tests**
  * Added coverage for empty inputs, duplicates, empty values, unique IDs, and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->