### PR TITLE
feat(core): add clipSpan helper for extraction spans

### DIFF
--- a/.changeset/2333-span-clip.md
+++ b/.changeset/2333-span-clip.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span clipper. Offsets clip to `[0, textLength]`. Empty after clip returns `{ok:false,error:"empty"}`. Non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-clip.test.ts
+++ b/packages/remnic-core/src/extraction-span-clip.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { clipSpan } from "./extraction-span-clip.js";
+
+test("clipSpan: in-range span is unchanged", () => {
+  assert.deepEqual(clipSpan({ start: 1, end: 4, textLength: 8 }), {
+    ok: true,
+    start: 1,
+    end: 4,
+  });
+  assert.deepEqual(clipSpan({ start: 0, end: 8, textLength: 8 }), {
+    ok: true,
+    start: 0,
+    end: 8,
+  });
+});
+
+test("clipSpan: clips to [0, textLength]", () => {
+  assert.deepEqual(clipSpan({ start: -3, end: 4, textLength: 10 }), {
+    ok: true,
+    start: 0,
+    end: 4,
+  });
+  assert.deepEqual(clipSpan({ start: 6, end: 20, textLength: 10 }), {
+    ok: true,
+    start: 6,
+    end: 10,
+  });
+  assert.deepEqual(clipSpan({ start: -2, end: 99, textLength: 5 }), {
+    ok: true,
+    start: 0,
+    end: 5,
+  });
+});
+
+test("clipSpan: empty after clip", () => {
+  assert.deepEqual(clipSpan({ start: 3, end: 3, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+  assert.deepEqual(clipSpan({ start: 5, end: 2, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+  assert.deepEqual(clipSpan({ start: -4, end: -1, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+});
+
+test("clipSpan: oob collapses to empty", () => {
+  assert.deepEqual(clipSpan({ start: 10, end: 20, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+  assert.deepEqual(clipSpan({ start: 8, end: 12, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+  assert.deepEqual(clipSpan({ start: -5, end: 0, textLength: 8 }), {
+    ok: false,
+    error: "empty",
+  });
+});
+
+test("clipSpan: non-integers throw", () => {
+  assert.throws(() => clipSpan({ start: 1.5, end: 3, textLength: 8 }), /integers/);
+  assert.throws(() => clipSpan({ start: 0, end: 3.2, textLength: 8 }), /integers/);
+  assert.throws(() => clipSpan({ start: 0, end: 3, textLength: 8.1 }), /integers/);
+  assert.throws(() => clipSpan({ start: Number.NaN, end: 3, textLength: 8 }), /integers/);
+});

--- a/packages/remnic-core/src/extraction-span-clip.ts
+++ b/packages/remnic-core/src/extraction-span-clip.ts
@@ -1,0 +1,26 @@
+/**
+ * Isolated span clipper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export type SpanClipOk = { ok: true; start: number; end: number };
+export type SpanClipErr = { ok: false; error: "empty" };
+export type SpanClipResult = SpanClipOk | SpanClipErr;
+
+export function clipSpan(opts: {
+  start: number;
+  end: number;
+  textLength: number;
+}): SpanClipResult {
+  const { start, end, textLength } = opts;
+  if (!Number.isInteger(start) || !Number.isInteger(end) || !Number.isInteger(textLength)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  const clippedStart = Math.max(0, Math.min(start, textLength));
+  const clippedEnd = Math.max(0, Math.min(end, textLength));
+  if (clippedStart >= clippedEnd) {
+    return { ok: false, error: "empty" };
+  }
+  return { ok: true, start: clippedStart, end: clippedEnd };
+}


### PR DESCRIPTION
Part of #2333

## Change
clipSpan. Clip to text length. Empty after clip fails. Non-integers throw.

## Test
packages/remnic-core/src/extraction-span-clip.test.ts