### PR TITLE
feat(core): add isEmptyNavigatePath helper

### DIFF
--- a/.changeset/1956-navigate-path.md
+++ b/.changeset/1956-navigate-path.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate empty-path guard. null, undefined, and [] are empty. A non-array throws. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-path.test.ts
+++ b/packages/remnic-core/src/recall-navigate-path.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmptyNavigatePath } from "./recall-navigate-path.js";
+
+test("null, undefined, and empty array are empty", () => {
+  assert.equal(isEmptyNavigatePath(null), true);
+  assert.equal(isEmptyNavigatePath(undefined), true);
+  assert.equal(isEmptyNavigatePath([]), true);
+});
+
+test("a non-empty array is not empty", () => {
+  assert.equal(isEmptyNavigatePath([{ id: 1 }]), false);
+  assert.equal(isEmptyNavigatePath([0]), false);
+});
+
+test("a non-array throws", () => {
+  assert.throws(() => isEmptyNavigatePath({}), TypeError);
+  assert.throws(() => isEmptyNavigatePath("nodes"), TypeError);
+  assert.throws(() => isEmptyNavigatePath(1), TypeError);
+});

--- a/packages/remnic-core/src/recall-navigate-path.ts
+++ b/packages/remnic-core/src/recall-navigate-path.ts
@@ -1,0 +1,14 @@
+/**
+ * Empty-set guard for a recall-navigate path (issue #1956 leftover).
+ *
+ * null, undefined, and [] are empty. A non-array throws. Any other array is not empty.
+ */
+
+/** True when the navigate path is absent or has no nodes. */
+export function isEmptyNavigatePath(nodes: unknown): boolean {
+  if (nodes == null) return true;
+  if (!Array.isArray(nodes)) {
+    throw new TypeError("nodes must be an array");
+  }
+  return nodes.length === 0;
+}


### PR DESCRIPTION
Part of #1956

## Change
isEmptyNavigatePath. Empty or missing is true. Non-array throws.

## Test
packages/remnic-core/src/recall-navigate-path.test.ts