### PR TITLE
feat(activity): add parseJournalFilePath helper

### DIFF
--- a/.changeset/1987-journal-path.md
+++ b/.changeset/1987-journal-path.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseJournalFilePath` to accept relative journal paths. Empty is missing_path. Absolute, `..`, backslash, or newline is invalid_path. Part of #1987.

--- a/packages/remnic-core/src/activity/journal-path.test.ts
+++ b/packages/remnic-core/src/activity/journal-path.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseJournalFilePath } from "./journal-path.js";
+
+test("parseJournalFilePath accepts a relative path", () => {
+  assert.deepEqual(parseJournalFilePath("journal/2026-08-19.md"), {
+    ok: true,
+    path: "journal/2026-08-19.md",
+  });
+  assert.deepEqual(parseJournalFilePath("  notes/today.md  "), {
+    ok: true,
+    path: "notes/today.md",
+  });
+});
+
+test("parseJournalFilePath rejects an empty path", () => {
+  assert.deepEqual(parseJournalFilePath(""), { ok: false, error: "missing_path" });
+  assert.deepEqual(parseJournalFilePath("   "), { ok: false, error: "missing_path" });
+});
+
+test("parseJournalFilePath rejects ..", () => {
+  assert.deepEqual(parseJournalFilePath("../secret"), { ok: false, error: "invalid_path" });
+  assert.deepEqual(parseJournalFilePath("foo/../bar"), { ok: false, error: "invalid_path" });
+});

--- a/packages/remnic-core/src/activity/journal-path.ts
+++ b/packages/remnic-core/src/activity/journal-path.ts
@@ -1,0 +1,27 @@
+/**
+ * Parse a journal file path (issue #1987 leftover).
+ *
+ * Trim. Empty is missing_path. Absolute, `..`, backslash, or newline
+ * is invalid_path.
+ */
+import { posix, win32 } from "node:path";
+
+export type ParseJournalFilePathResult =
+  | { ok: true; path: string }
+  | { ok: false; error: "missing_path" | "invalid_path" };
+
+export function parseJournalFilePath(value: string): ParseJournalFilePathResult {
+  const journalPath = value.trim();
+  if (journalPath.length === 0) return { ok: false, error: "missing_path" };
+  if (
+    journalPath.includes("\\") ||
+    journalPath.includes("\n") ||
+    journalPath.includes("\r") ||
+    posix.isAbsolute(journalPath) ||
+    win32.isAbsolute(journalPath) ||
+    journalPath.split("/").includes("..")
+  ) {
+    return { ok: false, error: "invalid_path" };
+  }
+  return { ok: true, path: journalPath };
+}


### PR DESCRIPTION
Part of #1987

## Change
parseJournalFilePath. Rejects empty, absolute, .., backslash, newline.

## Test
packages/remnic-core/src/activity/journal-path.test.ts