### PR TITLE
feat(core): add parseStepCount helper

### DIFF
--- a/.changeset/2332-deep-step-count.md
+++ b/.changeset/2332-deep-step-count.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall step-count parser. 0 is allowed. Negative or non-integer values throw. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-step-count.test.ts
+++ b/packages/remnic-core/src/recall-deep-step-count.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseStepCount } from "./recall-deep-step-count.js";
+
+test("step count 0 is allowed", () => {
+  assert.equal(parseStepCount(0), 0);
+});
+
+test("step count 5 is returned", () => {
+  assert.equal(parseStepCount(5), 5);
+});
+
+test("negative step count throws", () => {
+  assert.throws(() => parseStepCount(-1), /non-negative integer/);
+});
+
+test("float step count throws", () => {
+  assert.throws(() => parseStepCount(1.5), /non-negative integer/);
+});

--- a/packages/remnic-core/src/recall-deep-step-count.ts
+++ b/packages/remnic-core/src/recall-deep-step-count.ts
@@ -1,0 +1,13 @@
+/**
+ * Deep-recall step-count parse (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. 0 is allowed. Negative or non-integer throws.
+ */
+export function parseStepCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `deep recall step count must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
Part of #2332

## Change
parseStepCount. 0 allowed. Negative or non-integer throws.

## Test
packages/remnic-core/src/recall-deep-step-count.test.ts