### PR TITLE
feat(activity): add isRegionBeginLine helper

### DIFF
--- a/.changeset/1985-vault-begin.md
+++ b/.changeset/1985-vault-begin.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `isRegionBeginLine` to match a trimmed `<!-- remnic:begin NAME -->` line. Empty name throws. Part of #1985.

--- a/packages/remnic-core/src/activity/vault-begin.test.ts
+++ b/packages/remnic-core/src/activity/vault-begin.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isRegionBeginLine } from "./vault-begin.js";
+
+test("isRegionBeginLine matches a trimmed begin comment", () => {
+  assert.equal(isRegionBeginLine("<!-- remnic:begin timeline -->", "timeline"), true);
+  assert.equal(isRegionBeginLine("  <!-- remnic:begin timeline -->\t", "timeline"), true);
+});
+
+test("isRegionBeginLine rejects a mismatch", () => {
+  assert.equal(isRegionBeginLine("<!-- remnic:end timeline -->", "timeline"), false);
+  assert.equal(isRegionBeginLine("<!-- remnic:begin weekly -->", "timeline"), false);
+  assert.equal(isRegionBeginLine("<!-- remnic:timeline:start -->", "timeline"), false);
+  assert.equal(isRegionBeginLine("<!-- remnic:begin timeline --> extra", "timeline"), false);
+});
+
+test("isRegionBeginLine throws on an empty name", () => {
+  assert.throws(() => isRegionBeginLine("<!-- remnic:begin  -->", ""), /empty/i);
+});

--- a/packages/remnic-core/src/activity/vault-begin.ts
+++ b/packages/remnic-core/src/activity/vault-begin.ts
@@ -1,0 +1,13 @@
+/**
+ * Match a managed-region begin marker line (issue #1985).
+ *
+ * True iff the trimmed line equals `<!-- remnic:begin NAME -->`.
+ * Empty name throws.
+ */
+
+export function isRegionBeginLine(line: string, name: string): boolean {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new RangeError("Region name must be non-empty.");
+  }
+  return line.trim() === `<!-- remnic:begin ${name} -->`;
+}


### PR DESCRIPTION
Part of #1985

## Change
isRegionBeginLine. Match trimmed begin marker. Empty name throws.

## Test
packages/remnic-core/src/activity/vault-begin.test.ts