### PR TITLE
feat(core): parse shared-context envelope at

### DIFF
--- a/.changeset/1957-envelope-at.md
+++ b/.changeset/1957-envelope-at.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context envelope at parse (issue #1957). `parseEnvelopeAt` trims the value, rejects empty as `missing_at`, rejects an unparsable timestamp as `invalid_at`, and otherwise returns the ISO instant. Part of #1957.

--- a/packages/remnic-core/src/shared-context/envelope-at.test.ts
+++ b/packages/remnic-core/src/shared-context/envelope-at.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseEnvelopeAt } from "./envelope-at.js";
+
+const AT = "2026-08-18T12:00:00.000Z";
+
+test("ok at returns ISO string", () => {
+  assert.deepEqual(parseEnvelopeAt(AT), { ok: true, at: AT });
+});
+
+test("empty at is missing_at", () => {
+  assert.deepEqual(parseEnvelopeAt(""), { ok: false, error: "missing_at" });
+  assert.deepEqual(parseEnvelopeAt("   "), { ok: false, error: "missing_at" });
+});
+
+test("invalid at is invalid_at", () => {
+  assert.deepEqual(parseEnvelopeAt("not-a-date"), { ok: false, error: "invalid_at" });
+});

--- a/packages/remnic-core/src/shared-context/envelope-at.ts
+++ b/packages/remnic-core/src/shared-context/envelope-at.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared-item envelope at parse (issue #1957 leftover).
+ *
+ * Pure. Empty is missing_at. Invalid Date.parse is invalid_at.
+ */
+
+export type ParseEnvelopeAtResult =
+  | { ok: true; at: string }
+  | { ok: false; error: "missing_at" | "invalid_at" };
+
+export function parseEnvelopeAt(value: string): ParseEnvelopeAtResult {
+  const raw = value.trim();
+  if (raw.length === 0) return { ok: false, error: "missing_at" };
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) return { ok: false, error: "invalid_at" };
+  return { ok: true, at: new Date(ms).toISOString() };
+}


### PR DESCRIPTION
Part of #1957

## Change
parseEnvelopeAt. Empty or invalid date fails. Valid date returns ISO.

## Test
packages/remnic-core/src/shared-context/envelope-at.test.ts