### PR TITLE
feat(activity): add dedupeObservationIds helper

### DIFF
--- a/.changeset/2050-analysis-dup.md
+++ b/.changeset/2050-analysis-dup.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `dedupeObservationIds` to the activity timeline layer: first-seen observation ids, no input mutation, empty strings dropped. Empty input returns `[]`. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-dup.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-dup.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dedupeObservationIds } from "./analysis-dup.js";
+
+test("empty input returns an empty array", () => {
+  assert.deepEqual(dedupeObservationIds([]), []);
+});
+
+test("keeps first-seen order and drops later duplicates", () => {
+  assert.deepEqual(dedupeObservationIds(["obs-b", "obs-a", "obs-b", "obs-c", "obs-a"]), [
+    "obs-b",
+    "obs-a",
+    "obs-c",
+  ]);
+});
+
+test("does not mutate the input array", () => {
+  const input = ["obs-b", "obs-a", "obs-b"];
+  const snapshot = input.slice();
+  const deduped = dedupeObservationIds(input);
+  assert.deepEqual(input, snapshot);
+  assert.notEqual(deduped, input);
+});
+
+test("drops empty strings", () => {
+  assert.deepEqual(dedupeObservationIds(["b", "", "a", "", "b"]), ["b", "a"]);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-dup.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-dup.ts
@@ -1,0 +1,10 @@
+/**
+ * First-seen observation-id dedupe for timeline analysis (issue #2050 leftover).
+ *
+ * Insertion order. Empty input → []. Does not mutate input. Drops empty strings.
+ */
+
+/** Return a new first-seen id list. Empty strings are dropped. */
+export function dedupeObservationIds(ids: readonly string[]): string[] {
+  return [...new Set(ids.filter((id) => id !== ""))];
+}


### PR DESCRIPTION
Part of #2050

## Change
dedupeObservationIds. First-seen order. Drops empty strings. Does not mutate input.

## Test
packages/remnic-core/src/activity/timeline/analysis-dup.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Observation ID lists are now cleaned automatically by removing duplicate entries and empty values.
  - The original order of valid IDs is preserved, ensuring consistent results.
  - Input data remains unchanged during processing, improving reliability when the same data is reused.

- **Tests**
  - Added coverage for empty inputs, duplicate IDs, ordering, empty-value filtering, and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->