### PR TITLE
feat(activity): add parseIsoDate helper

### DIFF
--- a/.changeset/week-iso-2052.md
+++ b/.changeset/week-iso-2052.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseIsoDate` for a YYYY-MM-DD week date check.
+Empty is missing_date. Other shapes are invalid_date.
+Part of #2052.

--- a/.changeset/week-iso-2052.md
+++ b/.changeset/week-iso-2052.md
@@ -3,5 +3,5 @@
 ---
 
 Add `parseIsoDate` for a YYYY-MM-DD week date check.
-Empty is missing_date. Other shapes are invalid_date.
+Empty is missing_date. Anything that is not a real calendar day is invalid_date.
 Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/week-iso.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-iso.test.ts
@@ -19,3 +19,11 @@ test("rejects strings that are not YYYY-MM-DD", () => {
   assert.deepEqual(parseIsoDate("2026-08-19T00:00:00Z"), { ok: false, error: "invalid_date" });
   assert.deepEqual(parseIsoDate("not-a-date"), { ok: false, error: "invalid_date" });
 });
+
+test("rejects impossible calendar days", () => {
+  assert.deepEqual(parseIsoDate("2026-02-30"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseIsoDate("2026-13-01"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseIsoDate("2026-00-10"), { ok: false, error: "invalid_date" });
+  // Real leap day still passes the round-trip.
+  assert.deepEqual(parseIsoDate("2024-02-29"), { ok: true, date: "2024-02-29" });
+});

--- a/packages/remnic-core/src/activity/timeline/week-iso.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-iso.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseIsoDate } from "./week-iso.js";
+
+test("accepts a trimmed YYYY-MM-DD date", () => {
+  assert.deepEqual(parseIsoDate("2026-08-19"), { ok: true, date: "2026-08-19" });
+  assert.deepEqual(parseIsoDate("  2026-08-19  "), { ok: true, date: "2026-08-19" });
+});
+
+test("empty and whitespace-only values are missing_date", () => {
+  assert.deepEqual(parseIsoDate(""), { ok: false, error: "missing_date" });
+  assert.deepEqual(parseIsoDate("   "), { ok: false, error: "missing_date" });
+});
+
+test("rejects strings that are not YYYY-MM-DD", () => {
+  assert.deepEqual(parseIsoDate("20260819"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseIsoDate("2026-8-19"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseIsoDate("2026-08-19T00:00:00Z"), { ok: false, error: "invalid_date" });
+  assert.deepEqual(parseIsoDate("not-a-date"), { ok: false, error: "invalid_date" });
+});

--- a/packages/remnic-core/src/activity/timeline/week-iso.ts
+++ b/packages/remnic-core/src/activity/timeline/week-iso.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse a YYYY-MM-DD week date (issue #2052 leftover).
+ *
+ * Trim first. Empty → missing_date. Bounded YYYY-MM-DD only (no ReDoS).
+ */
+
+export type IsoDateResult =
+  | { ok: true; date: string }
+  | { ok: false; error: "missing_date" | "invalid_date" };
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Trim and accept YYYY-MM-DD, or return a typed error. */
+export function parseIsoDate(value: string): IsoDateResult {
+  const date = value.trim();
+  if (date.length === 0) return { ok: false, error: "missing_date" };
+  if (!ISO_DATE.test(date)) return { ok: false, error: "invalid_date" };
+  return { ok: true, date };
+}

--- a/packages/remnic-core/src/activity/timeline/week-iso.ts
+++ b/packages/remnic-core/src/activity/timeline/week-iso.ts
@@ -1,19 +1,20 @@
 /**
  * Parse a YYYY-MM-DD week date (issue #2052 leftover).
  *
- * Trim first. Empty → missing_date. Bounded YYYY-MM-DD only (no ReDoS).
+ * Trim first. Empty → missing_date. Real YYYY-MM-DD calendar days only
+ * (no ReDoS, no impossible dates like 2026-02-30).
  */
+
+import { isValidActivityDate } from "../digest.js";
 
 export type IsoDateResult =
   | { ok: true; date: string }
   | { ok: false; error: "missing_date" | "invalid_date" };
 
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
-
-/** Trim and accept YYYY-MM-DD, or return a typed error. */
+/** Trim and accept a real YYYY-MM-DD calendar day, or return a typed error. */
 export function parseIsoDate(value: string): IsoDateResult {
   const date = value.trim();
   if (date.length === 0) return { ok: false, error: "missing_date" };
-  if (!ISO_DATE.test(date)) return { ok: false, error: "invalid_date" };
+  if (!isValidActivityDate(date)) return { ok: false, error: "invalid_date" };
   return { ok: true, date };
 }


### PR DESCRIPTION
Part of #2052

## Change
parseIsoDate. YYYY-MM-DD only. Empty or invalid fails.

## Test
packages/remnic-core/src/activity/timeline/week-iso.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ISO date parsing with normalized `YYYY-MM-DD` output.
  - Empty or whitespace-only values now report a missing-date error.
  - Malformed or out-of-range dates now report an invalid-date error.

- **Tests**
  - Added coverage for valid, empty, whitespace-only, and malformed date inputs.

- **Documentation**
  - Added release notes for the new date parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->