### PR TITLE
feat(core): detect duplicate merge ids

### DIFF
--- a/.changeset/2330-merge-dup.md
+++ b/.changeset/2330-merge-dup.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-id duplicate detector. True if any non-empty id appears twice. Empty strings are ignored. The input list is not mutated. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-dup.test.ts
+++ b/packages/remnic-core/src/dedup/merge-dup.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasDuplicateMergeIds } from "./merge-dup.js";
+
+test("none is false", () => {
+  assert.equal(hasDuplicateMergeIds([]), false);
+  assert.equal(hasDuplicateMergeIds(["alpha"]), false);
+  assert.equal(hasDuplicateMergeIds(["alpha", "beta"]), false);
+});
+
+test("duplicate non-empty id is true", () => {
+  assert.equal(hasDuplicateMergeIds(["alpha", "beta", "alpha"]), true);
+});
+
+test("empty strings are ignored and input is not mutated", () => {
+  const ids = ["alpha", "", "", "beta"];
+  assert.equal(hasDuplicateMergeIds(ids), false);
+  assert.equal(hasDuplicateMergeIds(["", "", "alpha", "", "alpha"]), true);
+  assert.deepEqual(ids, ["alpha", "", "", "beta"]);
+});

--- a/packages/remnic-core/src/dedup/merge-dup.ts
+++ b/packages/remnic-core/src/dedup/merge-dup.ts
@@ -1,0 +1,16 @@
+/**
+ * Merge-id duplicate detector (issue #2330 leftover).
+ *
+ * True if any non-empty id appears twice. Empty strings are ignored.
+ * Does not mutate the input list.
+ */
+
+export function hasDuplicateMergeIds(ids: readonly string[]): boolean {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (id === "") continue;
+    if (seen.has(id)) return true;
+    seen.add(id);
+  }
+  return false;
+}


### PR DESCRIPTION
Part of #2330

## Change
hasDuplicateMergeIds. Empty strings ignored. Does not mutate input.

## Test
packages/remnic-core/src/dedup/merge-dup.test.ts