### PR TITLE
feat(activity): add isRegionEndLine helper

### DIFF
--- a/.changeset/1985-vault-end.md
+++ b/.changeset/1985-vault-end.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `isRegionEndLine` to match a trimmed `<!-- remnic:end NAME -->` line. Empty name throws. Part of #1985.

--- a/packages/remnic-core/src/activity/vault-end.test.ts
+++ b/packages/remnic-core/src/activity/vault-end.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isRegionEndLine } from "./vault-end.js";
+
+test("isRegionEndLine matches a trimmed end comment", () => {
+  assert.equal(isRegionEndLine("<!-- remnic:end timeline -->", "timeline"), true);
+  assert.equal(isRegionEndLine("  <!-- remnic:end timeline -->\t", "timeline"), true);
+});
+
+test("isRegionEndLine rejects a mismatch", () => {
+  assert.equal(isRegionEndLine("<!-- remnic:begin timeline -->", "timeline"), false);
+  assert.equal(isRegionEndLine("<!-- remnic:end weekly -->", "timeline"), false);
+  assert.equal(isRegionEndLine("<!-- remnic:timeline:end -->", "timeline"), false);
+  assert.equal(isRegionEndLine("<!-- remnic:end timeline --> extra", "timeline"), false);
+});
+
+test("isRegionEndLine throws on an empty name", () => {
+  assert.throws(() => isRegionEndLine("<!-- remnic:end  -->", ""), /empty/i);
+});

--- a/packages/remnic-core/src/activity/vault-end.ts
+++ b/packages/remnic-core/src/activity/vault-end.ts
@@ -1,0 +1,13 @@
+/**
+ * Match a managed-region end marker line (issue #1985).
+ *
+ * True iff the trimmed line equals `<!-- remnic:end NAME -->`.
+ * Empty name throws.
+ */
+
+export function isRegionEndLine(line: string, name: string): boolean {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new RangeError("Region name must be non-empty.");
+  }
+  return line.trim() === `<!-- remnic:end ${name} -->`;
+}


### PR DESCRIPTION
Part of #1985

## Change
isRegionEndLine. Match trimmed end marker. Empty name throws.

## Test
packages/remnic-core/src/activity/vault-end.test.ts