### PR TITLE
feat(core): add shiftSpan helper for extraction spans

### DIFF
--- a/.changeset/2333-span-shift.md
+++ b/.changeset/2333-span-shift.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-shift helper. Offsets move by `delta`. Inverted spans and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-shift.test.ts
+++ b/packages/remnic-core/src/extraction-span-shift.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { shiftSpan } from "./extraction-span-shift.js";
+
+test("shiftSpan: +delta", () => {
+  assert.deepEqual(shiftSpan({ start: 1, end: 4, delta: 3 }), { start: 4, end: 7 });
+  assert.deepEqual(shiftSpan({ start: 0, end: 0, delta: 5 }), { start: 5, end: 5 });
+});
+
+test("shiftSpan: -delta", () => {
+  assert.deepEqual(shiftSpan({ start: 5, end: 8, delta: -2 }), { start: 3, end: 6 });
+  assert.deepEqual(shiftSpan({ start: 2, end: 2, delta: -2 }), { start: 0, end: 0 });
+});
+
+test("shiftSpan: inverted span throws", () => {
+  assert.throws(() => shiftSpan({ start: 3, end: 2, delta: 1 }), /inverted/i);
+  assert.throws(() => shiftSpan({ start: 1, end: 0, delta: 0 }), /inverted/i);
+});
+
+test("shiftSpan: non-integers throw", () => {
+  assert.throws(() => shiftSpan({ start: 1.5, end: 3, delta: 1 }), /integers/);
+  assert.throws(() => shiftSpan({ start: 0, end: 3.2, delta: 1 }), /integers/);
+  assert.throws(() => shiftSpan({ start: 0, end: 3, delta: 1.5 }), /integers/);
+  assert.throws(() => shiftSpan({ start: Number.NaN, end: 3, delta: 0 }), /integers/);
+});

--- a/packages/remnic-core/src/extraction-span-shift.ts
+++ b/packages/remnic-core/src/extraction-span-shift.ts
@@ -1,0 +1,20 @@
+/**
+ * Isolated span-shift helper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export function shiftSpan(opts: {
+  start: number;
+  end: number;
+  delta: number;
+}): { start: number; end: number } {
+  const { start, end, delta } = opts;
+  if (!Number.isInteger(start) || !Number.isInteger(end) || !Number.isInteger(delta)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (end < start) {
+    throw new RangeError("span offsets inverted");
+  }
+  return { start: start + delta, end: end + delta };
+}


### PR DESCRIPTION
Part of #2333

## Change
shiftSpan. Add delta to start and end. Inverted range throws.

## Test
packages/remnic-core/src/extraction-span-shift.test.ts