### PR TITLE
feat(core): add parseDeepQuery helper

### DIFF
--- a/.changeset/2332-deep-query.md
+++ b/.changeset/2332-deep-query.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall query parser. Trim. Empty values return empty_query. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-query.test.ts
+++ b/packages/remnic-core/src/recall-deep-query.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDeepQuery } from "./recall-deep-query.js";
+
+test("query is returned", () => {
+  assert.deepEqual(parseDeepQuery("what happened"), {
+    ok: true,
+    query: "what happened",
+  });
+});
+
+test("empty query is empty_query", () => {
+  assert.deepEqual(parseDeepQuery(""), { ok: false, error: "empty_query" });
+  assert.deepEqual(parseDeepQuery("   "), { ok: false, error: "empty_query" });
+});
+
+test("query is trimmed", () => {
+  assert.deepEqual(parseDeepQuery("  what happened  "), {
+    ok: true,
+    query: "what happened",
+  });
+});

--- a/packages/remnic-core/src/recall-deep-query.ts
+++ b/packages/remnic-core/src/recall-deep-query.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse a deep-recall query (issue #2332 leftover).
+ *
+ * Pure. Surfaces wait. Trim. Empty is empty_query.
+ */
+
+export type ParseDeepQueryResult =
+  | { ok: true; query: string }
+  | { ok: false; error: "empty_query" };
+
+export function parseDeepQuery(value: string): ParseDeepQueryResult {
+  const query = value.trim();
+  if (query.length === 0) return { ok: false, error: "empty_query" };
+  return { ok: true, query };
+}


### PR DESCRIPTION
Part of #2332

## Change
parseDeepQuery. Empty after trim fails.

## Test
packages/remnic-core/src/recall-deep-query.test.ts