### PR TITLE
feat(activity): add parseRecapCardId helper

### DIFF
--- a/.changeset/recap-card-id-2051.md
+++ b/.changeset/recap-card-id-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseRecapCardId` to the activity timeline layer: trim, reject empty as `missing_id`, and reject an embedded newline as `invalid_id`. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-card-id.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-card-id.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseRecapCardId } from "./recap-card-id.js";
+
+test("ok card id returns trimmed id", () => {
+  assert.deepEqual(parseRecapCardId("card-1"), { ok: true, id: "card-1" });
+});
+
+test("empty card id is missing_id", () => {
+  assert.deepEqual(parseRecapCardId(""), { ok: false, error: "missing_id" });
+  assert.deepEqual(parseRecapCardId("   "), { ok: false, error: "missing_id" });
+});
+
+test("newline in card id is invalid_id", () => {
+  assert.deepEqual(parseRecapCardId("card-1\ncard-2"), { ok: false, error: "invalid_id" });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseRecapCardId("  card-1  "), { ok: true, id: "card-1" });
+});

--- a/packages/remnic-core/src/activity/timeline/recap-card-id.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-card-id.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse a recap card id (issue #2051 leftover).
+ *
+ * Pure. Empty is missing_id. Newline is invalid_id.
+ */
+
+export type ParseRecapCardIdResult =
+  | { ok: true; id: string }
+  | { ok: false; error: "missing_id" | "invalid_id" };
+
+export function parseRecapCardId(value: string): ParseRecapCardIdResult {
+  const id = value.trim();
+  if (id.length === 0) return { ok: false, error: "missing_id" };
+  if (id.includes("\n")) return { ok: false, error: "invalid_id" };
+  return { ok: true, id };
+}


### PR DESCRIPTION
Part of #2051

## Change
parseRecapCardId. Empty or newline fails. Trims id.

## Test
packages/remnic-core/src/activity/timeline/recap-card-id.test.ts