### PR TITLE
feat(core): add assertTransitionHasSuccessor helper

### DIFF
--- a/.changeset/1952-transition-guard.md
+++ b/.changeset/1952-transition-guard.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add assertTransitionHasSuccessor for state-view transition facts. Transition without a successor is transition_missing_successor. Part of #1952.

--- a/packages/remnic-core/src/recall-state-view-transition.test.ts
+++ b/packages/remnic-core/src/recall-state-view-transition.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertTransitionHasSuccessor } from "./recall-state-view-transition.js";
+
+test("transition plus empty successor id is transition_missing_successor", () => {
+  assert.deepEqual(assertTransitionHasSuccessor({ kind: "transition", successorId: "" }), {
+    ok: false,
+    error: "transition_missing_successor",
+  });
+  assert.deepEqual(assertTransitionHasSuccessor({ kind: "transition", successorId: "   " }), {
+    ok: false,
+    error: "transition_missing_successor",
+  });
+  assert.deepEqual(assertTransitionHasSuccessor({ kind: "transition" }), {
+    ok: false,
+    error: "transition_missing_successor",
+  });
+});
+
+test("transition plus successor id is ok", () => {
+  assert.deepEqual(assertTransitionHasSuccessor({ kind: "transition", successorId: "mem-2" }), {
+    ok: true,
+  });
+});
+
+test("current plus empty successor id is ok", () => {
+  assert.deepEqual(assertTransitionHasSuccessor({ kind: "current", successorId: "" }), { ok: true });
+  assert.deepEqual(assertTransitionHasSuccessor({ kind: "current" }), { ok: true });
+});

--- a/packages/remnic-core/src/recall-state-view-transition.ts
+++ b/packages/remnic-core/src/recall-state-view-transition.ts
@@ -1,0 +1,24 @@
+/**
+ * Recall state-view transition-has-successor guard (issue #1952 leftover).
+ *
+ * Pure. Surfaces wait. Transition without a successor is transition_missing_successor.
+ */
+
+export type AssertTransitionHasSuccessorInput = {
+  kind: string;
+  successorId?: string;
+};
+
+export type AssertTransitionHasSuccessorResult =
+  | { ok: true }
+  | { ok: false; error: "transition_missing_successor" };
+
+export function assertTransitionHasSuccessor(
+  input: AssertTransitionHasSuccessorInput,
+): AssertTransitionHasSuccessorResult {
+  const successorId = input.successorId?.trim() ?? "";
+  if (input.kind === "transition" && successorId.length === 0) {
+    return { ok: false, error: "transition_missing_successor" };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #1952

## Change
assertTransitionHasSuccessor. Transition without successor id fails.

## Test
packages/remnic-core/src/recall-state-view-transition.test.ts