### PR TITLE
feat(activity): add assertHalfOpenWindow helper

### DIFF
--- a/.changeset/2053-window-order.md
+++ b/.changeset/2053-window-order.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `assertHalfOpenWindow` for activity range bounds. `toMs <= fromMs` is
+empty_window. Non-finite values throw.
+Part of #2053.

--- a/packages/remnic-core/src/activity/window-order.test.ts
+++ b/packages/remnic-core/src/activity/window-order.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertHalfOpenWindow } from "./window-order.js";
+
+test("ordered window is ok", () => {
+  assert.deepEqual(assertHalfOpenWindow({ fromMs: 0, toMs: 1 }), { ok: true });
+});
+
+test("equal bounds are empty_window", () => {
+  assert.deepEqual(assertHalfOpenWindow({ fromMs: 10, toMs: 10 }), {
+    ok: false,
+    error: "empty_window",
+  });
+});
+
+test("inverted bounds are empty_window", () => {
+  assert.deepEqual(assertHalfOpenWindow({ fromMs: 20, toMs: 10 }), {
+    ok: false,
+    error: "empty_window",
+  });
+});
+
+test("NaN bounds throw", () => {
+  assert.throws(() => assertHalfOpenWindow({ fromMs: Number.NaN, toMs: 1 }), /finite/);
+  assert.throws(() => assertHalfOpenWindow({ fromMs: 0, toMs: Number.NaN }), /finite/);
+});

--- a/packages/remnic-core/src/activity/window-order.ts
+++ b/packages/remnic-core/src/activity/window-order.ts
@@ -1,0 +1,24 @@
+/**
+ * Assert a half-open activity window [fromMs, toMs) (issue #2053 leftover).
+ *
+ * Non-finite bounds throw. `toMs <= fromMs` is empty_window.
+ */
+
+export type AssertHalfOpenWindowResult =
+  | { ok: true }
+  | { ok: false; error: "empty_window" };
+
+/** Validate `[fromMs, toMs)`. Empty or inverted windows fail closed. */
+export function assertHalfOpenWindow(window: {
+  fromMs: number;
+  toMs: number;
+}): AssertHalfOpenWindowResult {
+  const { fromMs, toMs } = window;
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) {
+    throw new RangeError(
+      `activity window bounds must be finite; got fromMs=${fromMs} toMs=${toMs}`,
+    );
+  }
+  if (toMs <= fromMs) return { ok: false, error: "empty_window" };
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #2053

## Change
assertHalfOpenWindow. toMs <= fromMs is empty_window. Non-finite throws.

## Test
packages/remnic-core/src/activity/window-order.test.ts