### PR TITLE
feat(core): add parseNavigateCost helper

### DIFF
--- a/.changeset/1956-navigate-cost.md
+++ b/.changeset/1956-navigate-cost.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate cost parser. 0 is allowed. Negative or non-integer values throw. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-cost.test.ts
+++ b/packages/remnic-core/src/recall-navigate-cost.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseNavigateCost } from "./recall-navigate-cost.js";
+
+test("cost 0 is allowed", () => {
+  assert.equal(parseNavigateCost(0), 0);
+});
+
+test("cost 2 is returned", () => {
+  assert.equal(parseNavigateCost(2), 2);
+});
+
+test("negative cost throws", () => {
+  assert.throws(() => parseNavigateCost(-1), /non-negative integer/);
+});
+
+test("float cost throws", () => {
+  assert.throws(() => parseNavigateCost(1.5), /non-negative integer/);
+});

--- a/packages/remnic-core/src/recall-navigate-cost.ts
+++ b/packages/remnic-core/src/recall-navigate-cost.ts
@@ -1,0 +1,13 @@
+/**
+ * Recall navigation cost parse (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. 0 is allowed. Negative or non-integer throws.
+ */
+export function parseNavigateCost(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `navigate cost must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
Part of #1956

## Change
parseNavigateCost. 0 allowed. Negative or non-integer throws.

## Test
packages/remnic-core/src/recall-navigate-cost.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for recall navigation costs.
  * Accepts zero and other non-negative integer values.
  * Rejects negative, fractional, non-numeric, and non-finite values.

* **Bug Fixes**
  * Prevents invalid navigation cost values from being accepted.

* **Tests**
  * Added coverage for valid and invalid cost inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->