### PR TITLE
feat(activity): add parseAtxHeadingLevel helper

### DIFF
--- a/.changeset/1987-heading-level.md
+++ b/.changeset/1987-heading-level.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseAtxHeadingLevel` to count ATX heading hashes 1-6. No hashes is not_heading. Seven or more is invalid_level. Part of #1987.

--- a/packages/remnic-core/src/activity/heading-level.test.ts
+++ b/packages/remnic-core/src/activity/heading-level.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAtxHeadingLevel } from "./heading-level.js";
+
+test("h1 is level 1", () => {
+  assert.deepEqual(parseAtxHeadingLevel("# Title"), { ok: true, level: 1 });
+});
+
+test("h6 is level 6", () => {
+  assert.deepEqual(parseAtxHeadingLevel("###### Title"), { ok: true, level: 6 });
+});
+
+test("no hashes is not_heading", () => {
+  assert.deepEqual(parseAtxHeadingLevel("Title"), { ok: false, error: "not_heading" });
+});
+
+test("seven hashes is invalid_level", () => {
+  assert.deepEqual(parseAtxHeadingLevel("####### Title"), {
+    ok: false,
+    error: "invalid_level",
+  });
+});

--- a/packages/remnic-core/src/activity/heading-level.ts
+++ b/packages/remnic-core/src/activity/heading-level.ts
@@ -1,0 +1,21 @@
+/**
+ * Parse an ATX heading level (issue #1987 leftover).
+ *
+ * Trim, then walk leading `#` chars. 1-6 is a heading. No hashes is
+ * not_heading. Seven or more is invalid_level. No regex.
+ */
+
+export type ParseAtxHeadingLevelResult =
+  | { ok: true; level: number }
+  | { ok: false; error: "not_heading" | "invalid_level" };
+
+export function parseAtxHeadingLevel(line: string): ParseAtxHeadingLevelResult {
+  const trimmed = line.trim();
+  let level = 0;
+  while (level < trimmed.length && trimmed[level] === "#") {
+    level++;
+  }
+  if (level === 0) return { ok: false, error: "not_heading" };
+  if (level > 6) return { ok: false, error: "invalid_level" };
+  return { ok: true, level };
+}


### PR DESCRIPTION
Part of #1987

## Change
parseAtxHeadingLevel. Walk leading hashes. Level 1-6 only.

## Test
packages/remnic-core/src/activity/heading-level.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ATX heading recognition for Markdown lines.
  * Correctly identifies heading levels 1 through 6, including lines with surrounding whitespace.
  * Distinguishes plain text from invalid headings containing seven or more hash characters.
  * Provides clear parsing results for valid headings, non-headings, and invalid heading levels.

* **Tests**
  * Added coverage for level 1 and level 6 headings, plain text, and excessive hash characters.

* **Release**
  * Scheduled a minor release for the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->