### PR TITLE
feat(core): add rejectSelfMerge helper

### DIFF
--- a/.changeset/2330-merge-self.md
+++ b/.changeset/2330-merge-self.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-self guard. Same id is self_merge. Empty id throws. Otherwise the pair is ok. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-self.test.ts
+++ b/packages/remnic-core/src/dedup/merge-self.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rejectSelfMerge } from "./merge-self.js";
+
+test("same id is self_merge", () => {
+  assert.deepEqual(rejectSelfMerge("alpha", "alpha"), { ok: false, error: "self_merge" });
+});
+
+test("different ids are ok", () => {
+  assert.deepEqual(rejectSelfMerge("alpha", "beta"), { ok: true });
+  assert.deepEqual(rejectSelfMerge("beta", "alpha"), { ok: true });
+});
+
+test("empty id throws", () => {
+  assert.throws(() => rejectSelfMerge("", "alpha"), /empty merge id/);
+  assert.throws(() => rejectSelfMerge("alpha", ""), /empty merge id/);
+  assert.throws(() => rejectSelfMerge("", ""), /empty merge id/);
+});

--- a/packages/remnic-core/src/dedup/merge-self.ts
+++ b/packages/remnic-core/src/dedup/merge-self.ts
@@ -1,0 +1,17 @@
+/**
+ * Merge-self guard (issue #2330 leftover).
+ *
+ * Same id → self_merge. Empty id throws. Otherwise ok.
+ */
+
+export type RejectSelfMergeResult =
+  | { ok: true }
+  | { ok: false; error: "self_merge" };
+
+export function rejectSelfMerge(aId: string, bId: string): RejectSelfMergeResult {
+  if (aId === "" || bId === "") {
+    throw new Error("empty merge id");
+  }
+  if (aId === bId) return { ok: false, error: "self_merge" };
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #2330

## Change
rejectSelfMerge. Same id fails. Empty id throws.

## Test
packages/remnic-core/src/dedup/merge-self.test.ts