### PR TITLE
feat(activity): add trimRegionName helper

### DIFF
--- a/.changeset/1985-vault-name-trim.md
+++ b/.changeset/1985-vault-name-trim.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `trimRegionName` to trim a managed-region name. Empty after trim throws. Newline throws. Part of #1985.

--- a/packages/remnic-core/src/activity/vault-name-trim.test.ts
+++ b/packages/remnic-core/src/activity/vault-name-trim.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { trimRegionName } from "./vault-name-trim.js";
+
+test("trimRegionName accepts a name", () => {
+  assert.equal(trimRegionName("timeline"), "timeline");
+});
+
+test("trimRegionName rejects an empty name", () => {
+  assert.throws(() => trimRegionName(""), /empty/i);
+  assert.throws(() => trimRegionName("   "), /empty/i);
+});
+
+test("trimRegionName rejects a newline in the name", () => {
+  assert.throws(() => trimRegionName("time\nline"), /newline/i);
+  assert.throws(() => trimRegionName("time\rline"), /newline/i);
+});
+
+test("trimRegionName trims surrounding whitespace", () => {
+  assert.equal(trimRegionName("  timeline  "), "timeline");
+});

--- a/packages/remnic-core/src/activity/vault-name-trim.ts
+++ b/packages/remnic-core/src/activity/vault-name-trim.ts
@@ -1,0 +1,16 @@
+/**
+ * Trim a managed-region name (issue #1985).
+ *
+ * Empty after trim throws. Newline throws. Else the trimmed string.
+ */
+
+export function trimRegionName(value: string): string {
+  const name = value.trim();
+  if (name.length === 0) {
+    throw new RangeError("Region name must be non-empty.");
+  }
+  if (name.includes("\n") || name.includes("\r")) {
+    throw new RangeError("Region name must not contain a newline.");
+  }
+  return name;
+}


### PR DESCRIPTION
Part of #1985

## Change
trimRegionName. Empty after trim throws. Newline throws.

## Test
packages/remnic-core/src/activity/vault-name-trim.test.ts