### PR TITLE
feat(core): parse shared-context envelope id

### DIFF
--- a/.changeset/1957-envelope-id.md
+++ b/.changeset/1957-envelope-id.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context envelope id parse (issue #1957). `parseEnvelopeId` trims the value, rejects empty as `missing_id`, rejects an embedded newline as `invalid_id`, and otherwise returns the id. Part of #1957.

--- a/packages/remnic-core/src/shared-context/envelope-id.test.ts
+++ b/packages/remnic-core/src/shared-context/envelope-id.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseEnvelopeId } from "./envelope-id.js";
+
+test("ok id returns trimmed id", () => {
+  assert.deepEqual(parseEnvelopeId("item-a"), { ok: true, id: "item-a" });
+});
+
+test("empty id is missing_id", () => {
+  assert.deepEqual(parseEnvelopeId(""), { ok: false, error: "missing_id" });
+  assert.deepEqual(parseEnvelopeId("   "), { ok: false, error: "missing_id" });
+});
+
+test("newline in id is invalid_id", () => {
+  assert.deepEqual(parseEnvelopeId("item-a\nitem-b"), { ok: false, error: "invalid_id" });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseEnvelopeId("  item-a  "), { ok: true, id: "item-a" });
+});

--- a/packages/remnic-core/src/shared-context/envelope-id.ts
+++ b/packages/remnic-core/src/shared-context/envelope-id.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared-item envelope id parse (issue #1957 leftover).
+ *
+ * Pure. Empty is missing_id. Newline is invalid_id.
+ */
+
+export type ParseEnvelopeIdResult =
+  | { ok: true; id: string }
+  | { ok: false; error: "missing_id" | "invalid_id" };
+
+export function parseEnvelopeId(value: string): ParseEnvelopeIdResult {
+  const id = value.trim();
+  if (id.length === 0) return { ok: false, error: "missing_id" };
+  if (id.includes("\n")) return { ok: false, error: "invalid_id" };
+  return { ok: true, id };
+}


### PR DESCRIPTION
Part of #1957

## Change
parseEnvelopeId. Empty or newline fails. Trims id.

## Test
packages/remnic-core/src/shared-context/envelope-id.test.ts