### PR TITLE
feat(activity): add parseMaxBatch helper

### DIFF
--- a/.changeset/2050-analysis-max.md
+++ b/.changeset/2050-analysis-max.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `parseMaxBatch` to the activity timeline layer. `0` is allowed (empty batches). Negative or non-integer values throw. Finite integer ≥ 0 is returned. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-max.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-max.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseMaxBatch } from "./analysis-max.js";
+
+test("maxBatch 0 is allowed", () => {
+  assert.equal(parseMaxBatch(0), 0);
+});
+
+test("maxBatch 8 is returned", () => {
+  assert.equal(parseMaxBatch(8), 8);
+});
+
+test("negative maxBatch throws", () => {
+  assert.throws(() => parseMaxBatch(-1), /non-negative integer/);
+});
+
+test("float maxBatch throws", () => {
+  assert.throws(() => parseMaxBatch(1.5), /non-negative integer/);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-max.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-max.test.ts
@@ -18,3 +18,9 @@ test("negative maxBatch throws", () => {
 test("float maxBatch throws", () => {
   assert.throws(() => parseMaxBatch(1.5), /non-negative integer/);
 });
+
+test("non-number maxBatch throws RangeError", () => {
+  for (const bad of ["8", undefined, Number.NaN, null]) {
+    assert.throws(() => parseMaxBatch(bad), RangeError);
+  }
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-max.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-max.ts
@@ -1,0 +1,14 @@
+/**
+ * Timeline analysis max-batch parse (issue #2050 leftover).
+ *
+ * Pure. 0 is allowed (empty batches). Negative or non-integer throws.
+ * Finite integer ≥ 0 is returned.
+ */
+export function parseMaxBatch(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `analysis maxBatch must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}

--- a/packages/remnic-core/src/activity/timeline/analysis-max.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-max.ts
@@ -6,7 +6,7 @@
  */
 export function parseMaxBatch(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
-    throw new Error(
+    throw new RangeError(
       `analysis maxBatch must be a non-negative integer; got ${JSON.stringify(value)}`,
     );
   }


### PR DESCRIPTION
Part of #2050

## Change
parseMaxBatch. 0 allowed. Negative or non-integer throws.

## Test
packages/remnic-core/src/activity/timeline/analysis-max.test.ts