### PR TITLE
feat(activity): add recapSortKey helper

### DIFF
--- a/.changeset/recap-sort-key-2051.md
+++ b/.changeset/recap-sort-key-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `recapSortKey` to the activity timeline layer. Returns `card.id`. Missing or empty id throws. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-sort-key.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-sort-key.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { recapSortKey } from "./recap-sort-key.js";
+
+test("ok card id is the sort key", () => {
+  assert.equal(recapSortKey({ id: "card-1" }), "card-1");
+});
+
+test("missing id throws", () => {
+  assert.throws(() => recapSortKey({}), /missing recap card id/);
+  assert.throws(() => recapSortKey({ id: undefined }), /missing recap card id/);
+  assert.throws(() => recapSortKey({ id: null }), /missing recap card id/);
+});
+
+test("empty id throws", () => {
+  assert.throws(() => recapSortKey({ id: "" }), /empty recap card id/);
+});

--- a/packages/remnic-core/src/activity/timeline/recap-sort-key.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-sort-key.ts
@@ -1,0 +1,14 @@
+/**
+ * Recap card sort key (issue #2051 leftover).
+ *
+ * Returns card.id. Missing or empty id throws.
+ */
+export function recapSortKey(card: { id?: string | null }): string {
+  if (card.id == null) {
+    throw new Error("missing recap card id");
+  }
+  if (card.id === "") {
+    throw new Error("empty recap card id");
+  }
+  return card.id;
+}


### PR DESCRIPTION
Part of #2051

## Change
recapSortKey. Returns card.id. Missing or empty id throws.

## Test
packages/remnic-core/src/activity/timeline/recap-sort-key.test.ts