### PR TITLE
feat(core): add isEmptyWorkingSet helper

### DIFF
--- a/.changeset/2332-deep-working-set.md
+++ b/.changeset/2332-deep-working-set.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a deep-recall working-set empty guard. null, undefined, and [] are empty. A non-array throws. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-working-set.test.ts
+++ b/packages/remnic-core/src/recall-deep-working-set.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmptyWorkingSet } from "./recall-deep-working-set.js";
+
+test("null, undefined, and empty array are empty", () => {
+  assert.equal(isEmptyWorkingSet(null), true);
+  assert.equal(isEmptyWorkingSet(undefined), true);
+  assert.equal(isEmptyWorkingSet([]), true);
+});
+
+test("a non-empty array is not empty", () => {
+  assert.equal(isEmptyWorkingSet([{ id: 1 }]), false);
+  assert.equal(isEmptyWorkingSet([0]), false);
+});
+
+test("a non-array throws", () => {
+  assert.throws(() => isEmptyWorkingSet({}), TypeError);
+  assert.throws(() => isEmptyWorkingSet("items"), TypeError);
+  assert.throws(() => isEmptyWorkingSet(1), TypeError);
+});

--- a/packages/remnic-core/src/recall-deep-working-set.ts
+++ b/packages/remnic-core/src/recall-deep-working-set.ts
@@ -1,0 +1,14 @@
+/**
+ * Empty-set guard for a deep-recall working set (issue #2332 leftover).
+ *
+ * null, undefined, and [] are empty. A non-array throws. Any other array is not empty.
+ */
+
+/** True when the working set is absent or has no items. */
+export function isEmptyWorkingSet(items: unknown): boolean {
+  if (items == null) return true;
+  if (!Array.isArray(items)) {
+    throw new TypeError("items must be an array");
+  }
+  return items.length === 0;
+}


### PR DESCRIPTION
Part of #2332

## Change
isEmptyWorkingSet. Empty or missing is true. Non-array throws.

## Test
packages/remnic-core/src/recall-deep-working-set.test.ts