### PR TITLE
feat(core): add joinAdjacentSpans helper

### DIFF
--- a/.changeset/2333-span-join.md
+++ b/.changeset/2333-span-join.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-join helper. Adjacent half-open `[start, end)` spans merge. A gap or overlap returns `not_adjacent`. Inverted spans and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-join.test.ts
+++ b/packages/remnic-core/src/extraction-span-join.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { joinAdjacentSpans } from "./extraction-span-join.js";
+
+test("joinAdjacentSpans: adjacent half-open spans join", () => {
+  assert.deepEqual(joinAdjacentSpans({ start: 0, end: 3 }, { start: 3, end: 5 }), {
+    start: 0,
+    end: 5,
+  });
+  assert.deepEqual(joinAdjacentSpans({ start: 1, end: 1 }, { start: 1, end: 4 }), {
+    start: 1,
+    end: 4,
+  });
+});
+
+test("joinAdjacentSpans: gap is not_adjacent", () => {
+  assert.deepEqual(joinAdjacentSpans({ start: 0, end: 2 }, { start: 4, end: 6 }), {
+    ok: false,
+    error: "not_adjacent",
+  });
+  assert.deepEqual(joinAdjacentSpans({ start: 4, end: 6 }, { start: 0, end: 2 }), {
+    ok: false,
+    error: "not_adjacent",
+  });
+});
+
+test("joinAdjacentSpans: overlap is not_adjacent", () => {
+  assert.deepEqual(joinAdjacentSpans({ start: 0, end: 4 }, { start: 2, end: 6 }), {
+    ok: false,
+    error: "not_adjacent",
+  });
+  assert.deepEqual(joinAdjacentSpans({ start: 1, end: 5 }, { start: 2, end: 3 }), {
+    ok: false,
+    error: "not_adjacent",
+  });
+});
+
+test("joinAdjacentSpans: inverted span throws", () => {
+  assert.throws(() => joinAdjacentSpans({ start: 3, end: 2 }, { start: 0, end: 1 }), /inverted/i);
+  assert.throws(() => joinAdjacentSpans({ start: 0, end: 1 }, { start: 5, end: 4 }), /inverted/i);
+});
+
+test("joinAdjacentSpans: non-integers throw", () => {
+  assert.throws(() => joinAdjacentSpans({ start: 1.5, end: 3 }, { start: 3, end: 5 }), /integers/);
+  assert.throws(() => joinAdjacentSpans({ start: 0, end: 3 }, { start: 3, end: 5.2 }), /integers/);
+  assert.throws(
+    () => joinAdjacentSpans({ start: Number.NaN, end: 3 }, { start: 3, end: 5 }),
+    /integers/,
+  );
+});

--- a/packages/remnic-core/src/extraction-span-join.ts
+++ b/packages/remnic-core/src/extraction-span-join.ts
@@ -1,0 +1,30 @@
+/**
+ * Isolated span-join helper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export type SpanJoinOk = { start: number; end: number };
+export type SpanJoinErr = { ok: false; error: "not_adjacent" };
+export type SpanJoinResult = SpanJoinOk | SpanJoinErr;
+
+export function joinAdjacentSpans(
+  a: { start: number; end: number },
+  b: { start: number; end: number },
+): SpanJoinResult {
+  if (
+    !Number.isInteger(a.start) ||
+    !Number.isInteger(a.end) ||
+    !Number.isInteger(b.start) ||
+    !Number.isInteger(b.end)
+  ) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (a.end < a.start || b.end < b.start) {
+    throw new RangeError("span offsets inverted");
+  }
+  if (a.end !== b.start) {
+    return { ok: false, error: "not_adjacent" };
+  }
+  return { start: a.start, end: b.end };
+}


### PR DESCRIPTION
Part of #2333

## Change
joinAdjacentSpans. Adjacent half-open spans join. Gap or overlap fails.

## Test
packages/remnic-core/src/extraction-span-join.test.ts