### PR TITLE
feat(core): add parseMaxChildren helper

### DIFF
--- a/.changeset/1956-navigate-max-children.md
+++ b/.changeset/1956-navigate-max-children.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a recall-navigate max-children parser. 0 is allowed. Negative or non-integer values throw. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-max-children.test.ts
+++ b/packages/remnic-core/src/recall-navigate-max-children.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseMaxChildren } from "./recall-navigate-max-children.js";
+
+test("max children 0 is allowed", () => {
+  assert.equal(parseMaxChildren(0), 0);
+});
+
+test("max children 10 is returned", () => {
+  assert.equal(parseMaxChildren(10), 10);
+});
+
+test("negative max children throws", () => {
+  assert.throws(() => parseMaxChildren(-1), /non-negative integer/);
+});
+
+test("float max children throws", () => {
+  assert.throws(() => parseMaxChildren(1.5), /non-negative integer/);
+});

--- a/packages/remnic-core/src/recall-navigate-max-children.ts
+++ b/packages/remnic-core/src/recall-navigate-max-children.ts
@@ -1,0 +1,13 @@
+/**
+ * Recall navigation max-children parse (issue #1956 leftover).
+ *
+ * Pure. Surfaces wait. 0 is allowed. Negative or non-integer throws.
+ */
+export function parseMaxChildren(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `max children must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
Part of #1956

## Change
parseMaxChildren. 0 allowed. Negative or non-integer throws.

## Test
packages/remnic-core/src/recall-navigate-max-children.test.ts