### PR TITLE
feat(activity): add parseAtxHeadingTitle helper

### DIFF
--- a/.changeset/1987-heading-title.md
+++ b/.changeset/1987-heading-title.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `parseAtxHeadingTitle` to take the text after 1-6 ATX hashes. Empty title is empty_title. Not a heading is not_heading. Part of #1987.

--- a/packages/remnic-core/src/activity/heading-title.test.ts
+++ b/packages/remnic-core/src/activity/heading-title.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAtxHeadingTitle } from "./heading-title.js";
+
+test("parseAtxHeadingTitle returns the title", () => {
+  assert.deepEqual(parseAtxHeadingTitle("## Journal"), { ok: true, title: "Journal" });
+  assert.deepEqual(parseAtxHeadingTitle("  # Title  "), { ok: true, title: "Title" });
+  assert.deepEqual(parseAtxHeadingTitle("###### Deep"), { ok: true, title: "Deep" });
+});
+
+test("parseAtxHeadingTitle rejects an empty title", () => {
+  assert.deepEqual(parseAtxHeadingTitle("#"), { ok: false, error: "empty_title" });
+  assert.deepEqual(parseAtxHeadingTitle("##   "), { ok: false, error: "empty_title" });
+});
+
+test("parseAtxHeadingTitle rejects a non-heading", () => {
+  assert.deepEqual(parseAtxHeadingTitle("Journal"), { ok: false, error: "not_heading" });
+  assert.deepEqual(parseAtxHeadingTitle("#Title"), { ok: false, error: "not_heading" });
+  assert.deepEqual(parseAtxHeadingTitle("####### Too many"), { ok: false, error: "not_heading" });
+});

--- a/packages/remnic-core/src/activity/heading-title.ts
+++ b/packages/remnic-core/src/activity/heading-title.ts
@@ -1,0 +1,26 @@
+/**
+ * Parse an ATX heading title (issue #1987 leftover).
+ *
+ * Trim, then walk 1-6 leading `#` plus one space. Empty title is
+ * empty_title. Anything else is not_heading. Walk chars. No regex.
+ */
+
+export type ParseAtxHeadingTitleResult =
+  | { ok: true; title: string }
+  | { ok: false; error: "empty_title" | "not_heading" };
+
+export function parseAtxHeadingTitle(line: string): ParseAtxHeadingTitleResult {
+  const trimmed = line.trim();
+  let i = 0;
+  while (i < trimmed.length && trimmed[i] === "#") {
+    i++;
+  }
+  if (i < 1 || i > 6) return { ok: false, error: "not_heading" };
+  if (i < trimmed.length && trimmed[i] !== " ") {
+    return { ok: false, error: "not_heading" };
+  }
+  if (i < trimmed.length) i++;
+  const title = trimmed.slice(i);
+  if (title.length === 0) return { ok: false, error: "empty_title" };
+  return { ok: true, title };
+}


### PR DESCRIPTION
Part of #1987

## Change
parseAtxHeadingTitle. Strip 1-6 hashes. Empty title fails.

## Test
packages/remnic-core/src/activity/heading-title.test.ts