### PR TITLE
feat(core): add parseMinMergeScore helper

### DIFF
--- a/.changeset/2330-merge-min-score.md
+++ b/.changeset/2330-merge-min-score.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merge-on-write min-score parser. Finite numbers in [0, 1] are accepted. Outside range or non-finite values throw. Part of #2330.

--- a/packages/remnic-core/src/dedup/merge-min-score.test.ts
+++ b/packages/remnic-core/src/dedup/merge-min-score.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseMinMergeScore } from "./merge-min-score.js";
+
+test("minScore 0 is accepted", () => {
+  assert.equal(parseMinMergeScore(0), 0);
+});
+
+test("minScore 1 is accepted", () => {
+  assert.equal(parseMinMergeScore(1), 1);
+});
+
+test("minScore 0.5 is accepted", () => {
+  assert.equal(parseMinMergeScore(0.5), 0.5);
+});
+
+test("out of range minScore throws", () => {
+  assert.throws(() => parseMinMergeScore(-0.1), /\[0, 1\]/);
+  assert.throws(() => parseMinMergeScore(1.1), /\[0, 1\]/);
+});
+
+test("non-finite minScore throws", () => {
+  assert.throws(() => parseMinMergeScore(Number.NaN), RangeError);
+  assert.throws(() => parseMinMergeScore(Number.POSITIVE_INFINITY), RangeError);
+  assert.throws(() => parseMinMergeScore("0.5"), RangeError);
+});

--- a/packages/remnic-core/src/dedup/merge-min-score.test.ts
+++ b/packages/remnic-core/src/dedup/merge-min-score.test.ts
@@ -25,3 +25,13 @@ test("non-finite minScore throws", () => {
   assert.throws(() => parseMinMergeScore(Number.POSITIVE_INFINITY), RangeError);
   assert.throws(() => parseMinMergeScore("0.5"), RangeError);
 });
+
+test("bigint minScore throws RangeError, not TypeError", () => {
+  assert.throws(() => parseMinMergeScore(10n), RangeError);
+});
+
+test("cyclic object minScore throws RangeError, not TypeError", () => {
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  assert.throws(() => parseMinMergeScore(cyclic), RangeError);
+});

--- a/packages/remnic-core/src/dedup/merge-min-score.ts
+++ b/packages/remnic-core/src/dedup/merge-min-score.ts
@@ -1,0 +1,13 @@
+/**
+ * Parse merge-on-write min score (issue #2330 leftover).
+ *
+ * Finite number in [0, 1] is returned. Outside range or non-finite throws.
+ */
+export function parseMinMergeScore(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError(
+      `merge minScore must be a finite number in [0, 1]; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}

--- a/packages/remnic-core/src/dedup/merge-min-score.ts
+++ b/packages/remnic-core/src/dedup/merge-min-score.ts
@@ -3,10 +3,19 @@
  *
  * Finite number in [0, 1] is returned. Outside range or non-finite throws.
  */
+function describeValue(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}
+
 export function parseMinMergeScore(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
     throw new RangeError(
-      `merge minScore must be a finite number in [0, 1]; got ${JSON.stringify(value)}`,
+      `merge minScore must be a finite number in [0, 1]; got ${describeValue(value)}`,
     );
   }
   return value;


### PR DESCRIPTION
Part of #2330

## Change
parseMinMergeScore. Finite number in [0,1]. Outside range throws.

## Test
packages/remnic-core/src/dedup/merge-min-score.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for merge-on-write minimum scores.
  * Accepts finite numeric values from 0 through 1, including boundary values.

* **Bug Fixes**
  * Invalid, non-numeric, out-of-range, or non-finite score values now produce clear validation errors.

* **Release**
  * Included a patch release update for the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->