### PR TITLE
feat(core): parse shared-context claim key

### DIFF
--- a/.changeset/1957-claim-key.md
+++ b/.changeset/1957-claim-key.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add shared-context claim key parse (issue #1957). `parseClaimKey` trims the value, rejects empty as `missing_key`, rejects an embedded newline as `invalid_key`, and otherwise returns the key. Part of #1957.

--- a/packages/remnic-core/src/shared-context/claim-key.test.ts
+++ b/packages/remnic-core/src/shared-context/claim-key.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseClaimKey } from "./claim-key.js";
+
+test("ok key returns trimmed key", () => {
+  assert.deepEqual(parseClaimKey("claim-a"), { ok: true, key: "claim-a" });
+});
+
+test("empty key is missing_key", () => {
+  assert.deepEqual(parseClaimKey(""), { ok: false, error: "missing_key" });
+  assert.deepEqual(parseClaimKey("   "), { ok: false, error: "missing_key" });
+});
+
+test("newline in key is invalid_key", () => {
+  assert.deepEqual(parseClaimKey("claim-a\nclaim-b"), { ok: false, error: "invalid_key" });
+});
+
+test("trims surrounding whitespace", () => {
+  assert.deepEqual(parseClaimKey("  claim-a  "), { ok: true, key: "claim-a" });
+});

--- a/packages/remnic-core/src/shared-context/claim-key.ts
+++ b/packages/remnic-core/src/shared-context/claim-key.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared-context claim key parse (issue #1957 leftover).
+ *
+ * Pure. Empty is missing_key. Newline is invalid_key.
+ */
+
+export type ParseClaimKeyResult =
+  | { ok: true; key: string }
+  | { ok: false; error: "missing_key" | "invalid_key" };
+
+export function parseClaimKey(value: string): ParseClaimKeyResult {
+  const key = value.trim();
+  if (key.length === 0) return { ok: false, error: "missing_key" };
+  if (key.includes("\n")) return { ok: false, error: "invalid_key" };
+  return { ok: true, key };
+}


### PR DESCRIPTION
Part of #1957

## Change
parseClaimKey. Empty or newline fails. Trims key.

## Test
packages/remnic-core/src/shared-context/claim-key.test.ts