### PR TITLE
fix(mcp): advertise remnic_* tool names for Anthropic clients (#2705)

### DIFF
--- a/.changeset/2705-mcp-tool-names.md
+++ b/.changeset/2705-mcp-tool-names.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Advertise MCP tools as `remnic_*` so names match Anthropic `^[a-zA-Z0-9_-]{1,64}$`.
+`remnic.*` and `engram.*` stay callable. `emitLegacyTools=false` lists `remnic_*` only.
+Fixes #2705.

--- a/docs/RENAME.md
+++ b/docs/RENAME.md
@@ -154,7 +154,7 @@ What is **not** done yet:
 | systemd unit | `engram.service` | `remnic.service` |
 | HTTP port | 4318 | unchanged |
 | Memory store | `~/.openclaw/workspace/memory/local/` | unchanged (OpenClaw-owned path) |
-| MCP tool names | `engram_recall`, `engram_observe`, … | **dual-registered**: both `remnic_*` and `engram_*` work through v1.x, removed in v2.0.0 |
+| MCP tool names | `engram.recall`, `engram.observe`, … | Advertised as `remnic_*` (`^[a-zA-Z0-9_-]{1,64}$`). `remnic.*` and `engram.*` stay callable. `emitLegacyTools` still advertises `engram.*`. |
 
 ---
 
@@ -348,9 +348,9 @@ $ engram recall "typescript preferences"
 
 ## MCP Tool Dual-Registration
 
-All tools registered under both `engram_*` and `remnic_*` names. Same handler,
-same signature. On `engram_*` invocation, the server log emits a one-shot
-warning (not returned to the model — would spam prompts).
+Advertised names are `remnic_*` so Claude Chat accepts the Anthropic tool-name
+pattern. `remnic.*` and `engram.*` stay callable. When `emitLegacyTools` is
+true, `tools/list` also advertises `engram.*`. Same handler, same signature.
 
 ```typescript
 const canonicalTools = [
@@ -360,22 +360,19 @@ const canonicalTools = [
   // … all tools
 ];
 
-// Register canonical
+// Advertise remnic_* (Anthropic-safe). remnic.* still dispatches.
 for (const tool of canonicalTools) server.registerTool(tool);
 
-// Register engram_* aliases (deprecated)
+// Advertise engram.* aliases when emitLegacyTools is true
 for (const tool of canonicalTools) {
   server.registerTool({
-    name: tool.name.replace(/^remnic_/, "engram_"),
-    impl: (args) => {
-      logger.warnOnce(`[remnic] MCP tool ${tool.name.replace(/^remnic_/, "engram_")} is deprecated — use ${tool.name}`);
-      return tool.impl(args);
-    },
+    name: tool.name.replace(/^remnic_/, "engram."),
+    impl: tool.impl,
   });
 }
 ```
 
-`engram_*` aliases removed in v2.0.0 alongside the CLI forwarder and env var fallback.
+`engram.*` aliases are removed from `tools/list` in v2.0.0. Dispatch stays.
 
 ---
 
@@ -510,7 +507,7 @@ conditions are evidence-based, not calendar-based.
 ## Decisions Locked
 
 - ✅ Repo: `joshuaswarren/remnic` (drop "openclaw" from repo name)
-- ✅ MCP tools: dual-register `remnic_*` and `engram_*` through v1.x, removed in v2.0.0
+- ✅ MCP tools: advertise `remnic_*`; keep `remnic.*` and `engram.*` callable through v1.x
 - ✅ Timeline: hours and days, not weeks or months
 - ✅ Four migration surfaces (npm warn, postinstall, runtime, CLI forwarder)
 - ✅ Shim package `@joshuaswarren/openclaw-engram` (9.3.x series) stays on registry forever

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -70,7 +70,7 @@ import { isValidResolutionVerb, executeResolution } from "./contradiction/resolu
 import { RelayMissionStoreError } from "./relay/mission.js";
 import { ReviewDeckAccessHttpBase } from "./review/review-deck-http-base.js";
 import { serializeInlineScriptValue } from "./inline-script.js";
-import type { SupportPassportExternalRequestHandler } from "./support-passport/public-http.js";
+import { toDottedRemnicName } from "./access-mcp-tool-names.js";
 export interface AccessHttpReadinessState {
   ready: boolean;
   warmupAttempts: number;
@@ -3273,7 +3273,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
       params?: Record<string, unknown>;
     };
 
-    const toolName = (typeof request.params?.name === "string" ? request.params.name : "").replace(/^remnic_/, "remnic.");
+    const toolName = toDottedRemnicName(typeof request.params?.name === "string" ? request.params.name : "");
     const toolArgs = request.params?.arguments;
     const dreamsRunDryRun =
       (toolName === "engram.dreams_run" || toolName === "remnic.dreams_run") &&

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -3273,7 +3273,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
       params?: Record<string, unknown>;
     };
 
-    const toolName = typeof request.params?.name === "string" ? request.params.name : "";
+    const toolName = (typeof request.params?.name === "string" ? request.params.name : "").replace(/^remnic_/, "remnic.");
     const toolArgs = request.params?.arguments;
     const dreamsRunDryRun =
       (toolName === "engram.dreams_run" || toolName === "remnic.dreams_run") &&

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -71,6 +71,7 @@ import { RelayMissionStoreError } from "./relay/mission.js";
 import { ReviewDeckAccessHttpBase } from "./review/review-deck-http-base.js";
 import { serializeInlineScriptValue } from "./inline-script.js";
 import { toDottedRemnicName } from "./access-mcp-tool-names.js";
+import type { SupportPassportExternalRequestHandler } from "./support-passport/public-http.js";
 export interface AccessHttpReadinessState {
   ready: boolean;
   warmupAttempts: number;

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -546,7 +546,7 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
 /**
  * Apply outputSchema from the registry to every tool that lacks one.
  * Suffix resolution strips the canonical or legacy prefix so both
- * `remnic.*` and `engram.*` aliases inherit the same schema.
+ * `remnic_*` and `engram.*` aliases inherit the same schema.
  * Tools that already have an explicit outputSchema are skipped.
  */
 export function applyToolOutputSchemas<T extends { name: string; outputSchema?: unknown }>(

--- a/packages/remnic-core/src/access-mcp-tool-names.test.ts
+++ b/packages/remnic-core/src/access-mcp-tool-names.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CANONICAL_MCP_PREFIX,
+  toCanonicalToolName,
+  toLegacyToolName,
+  withToolAliases,
+} from "./access-mcp-tool-names.js";
+
+const ANTHROPIC_TOOL_NAME = /^[a-zA-Z0-9_-]{1,64}$/;
+
+test("toCanonicalToolName maps remnic_ / remnic. / engram. to remnic_suffix", () => {
+  assert.equal(toCanonicalToolName("remnic_recall"), "remnic_recall");
+  assert.equal(toCanonicalToolName("remnic.recall"), "remnic_recall");
+  assert.equal(toCanonicalToolName("engram.recall"), "remnic_recall");
+  assert.equal(toCanonicalToolName("unknown"), "unknown");
+});
+
+test("toLegacyToolName maps remnic_ / remnic. / engram. to engram.suffix", () => {
+  assert.equal(toLegacyToolName("remnic_recall"), "engram.recall");
+  assert.equal(toLegacyToolName("remnic.recall"), "engram.recall");
+  assert.equal(toLegacyToolName("engram.recall"), "engram.recall");
+});
+
+test("withToolAliases advertises remnic_<suffix> and optional engram.*", () => {
+  const tool = { name: "engram.recall" };
+  const both = withToolAliases(tool, true);
+  assert.deepEqual(
+    both.map((entry) => entry.name),
+    ["remnic_recall", "engram.recall"],
+  );
+  const canonicalOnly = withToolAliases(tool, false);
+  assert.deepEqual(
+    canonicalOnly.map((entry) => entry.name),
+    ["remnic_recall"],
+  );
+  assert.ok(canonicalOnly.every((entry) => ANTHROPIC_TOOL_NAME.test(entry.name)));
+  assert.equal(CANONICAL_MCP_PREFIX, "remnic_");
+});

--- a/packages/remnic-core/src/access-mcp-tool-names.test.ts
+++ b/packages/remnic-core/src/access-mcp-tool-names.test.ts
@@ -38,3 +38,19 @@ test("withToolAliases advertises remnic_<suffix> and optional engram.*", () => {
   assert.ok(canonicalOnly.every((entry) => ANTHROPIC_TOOL_NAME.test(entry.name)));
   assert.equal(CANONICAL_MCP_PREFIX, "remnic_");
 });
+
+test("withToolAliases emits the engram.* alias for canonical-named tools too", () => {
+  const tool = { name: "remnic_recall" };
+  assert.deepEqual(
+    withToolAliases(tool, true).map((entry) => entry.name),
+    ["remnic_recall", "engram.recall"],
+  );
+  assert.deepEqual(
+    withToolAliases(tool, false).map((entry) => entry.name),
+    ["remnic_recall"],
+  );
+  assert.deepEqual(
+    withToolAliases({ name: "remnic.recall" }, true).map((entry) => entry.name),
+    ["remnic_recall", "engram.recall"],
+  );
+});

--- a/packages/remnic-core/src/access-mcp-tool-names.ts
+++ b/packages/remnic-core/src/access-mcp-tool-names.ts
@@ -28,9 +28,18 @@ export function toLegacyToolName(name: string): string {
   return suffix === null ? name : `${LEGACY_MCP_PREFIX}${suffix}`;
 }
 
+export function toDottedRemnicName(name: string): string {
+  const suffix = toolNameSuffix(name);
+  return suffix === null ? name : `${DOTTED_REMNIC_PREFIX}${suffix}`;
+}
+
 export function withToolAliases<T extends { name: string }>(tool: T, emitLegacyTools = true): T[] {
-  const canonicalName = toCanonicalToolName(tool.name);
+  const suffix = toolNameSuffix(tool.name);
+  if (suffix === null) return [tool];
+  const canonicalName = `${CANONICAL_MCP_PREFIX}${suffix}`;
   const canonicalTool = canonicalName === tool.name ? tool : { ...tool, name: canonicalName };
-  if (canonicalName === tool.name) return [canonicalTool];
-  return emitLegacyTools ? [canonicalTool, tool] : [canonicalTool];
+  if (!emitLegacyTools) return [canonicalTool];
+  const legacyName = `${LEGACY_MCP_PREFIX}${suffix}`;
+  const legacyTool = legacyName === tool.name ? tool : { ...tool, name: legacyName };
+  return [canonicalTool, legacyTool];
 }

--- a/packages/remnic-core/src/access-mcp-tool-names.ts
+++ b/packages/remnic-core/src/access-mcp-tool-names.ts
@@ -1,0 +1,36 @@
+/**
+ * MCP tool-name prefixes (issue #2705).
+ *
+ * Anthropic tool names must match `^[a-zA-Z0-9_-]{1,64}$`.
+ * Advertised canonical form is `remnic_<suffix>`.
+ * `remnic.` and `engram.` stay callable.
+ */
+export const CANONICAL_MCP_PREFIX = "remnic_";
+export const LEGACY_MCP_PREFIX = "engram.";
+export const DOTTED_REMNIC_PREFIX = "remnic.";
+
+const KNOWN_PREFIXES = [CANONICAL_MCP_PREFIX, DOTTED_REMNIC_PREFIX, LEGACY_MCP_PREFIX] as const;
+
+export function toolNameSuffix(name: string): string | null {
+  for (const prefix of KNOWN_PREFIXES) {
+    if (name.startsWith(prefix)) return name.slice(prefix.length);
+  }
+  return null;
+}
+
+export function toCanonicalToolName(name: string): string {
+  const suffix = toolNameSuffix(name);
+  return suffix === null ? name : `${CANONICAL_MCP_PREFIX}${suffix}`;
+}
+
+export function toLegacyToolName(name: string): string {
+  const suffix = toolNameSuffix(name);
+  return suffix === null ? name : `${LEGACY_MCP_PREFIX}${suffix}`;
+}
+
+export function withToolAliases<T extends { name: string }>(tool: T, emitLegacyTools = true): T[] {
+  const canonicalName = toCanonicalToolName(tool.name);
+  const canonicalTool = canonicalName === tool.name ? tool : { ...tool, name: canonicalName };
+  if (canonicalName === tool.name) return [canonicalTool];
+  return emitLegacyTools ? [canonicalTool, tool] : [canonicalTool];
+}

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -910,9 +910,9 @@ test("MCP tools/list exposes LCM compaction tools under remnic aliases", async (
     (tool) => tool.name,
   );
 
-  assert.ok(listed.includes("remnic.lcm_compaction_flush"));
+  assert.ok(listed.includes("remnic_lcm_compaction_flush"));
   assert.ok(listed.includes("engram.lcm_compaction_flush"));
-  assert.ok(listed.includes("remnic.lcm_compaction_record"));
+  assert.ok(listed.includes("remnic_lcm_compaction_record"));
   assert.ok(listed.includes("engram.lcm_compaction_record"));
 });
 
@@ -977,10 +977,10 @@ function listToolNames(response: unknown): string[] {
 
 const TOOLS_LIST_REQUEST = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
 
-test("tools/list advertises both remnic.* and engram.* by default (back-compat)", async () => {
+test("tools/list advertises remnic_* and engram.* by default (back-compat)", async () => {
   const server = new EngramMcpServer(makeMockService());
   const names = listToolNames(await server.handleRequest(TOOLS_LIST_REQUEST));
-  assert.ok(names.includes("remnic.recall"), "canonical name present");
+  assert.ok(names.includes("remnic_recall"), "canonical name present");
   assert.ok(names.includes("engram.recall"), "legacy alias present by default");
   const legacyCount = names.filter((n) => n.startsWith("engram.")).length;
   assert.ok(legacyCount > 0, "legacy aliases advertised by default");
@@ -989,26 +989,31 @@ test("tools/list advertises both remnic.* and engram.* by default (back-compat)"
 test("tools/list omits engram.* aliases when emitLegacyTools is false", async () => {
   const server = new EngramMcpServer(makeMockService(), { emitLegacyTools: false });
   const names = listToolNames(await server.handleRequest(TOOLS_LIST_REQUEST));
-  assert.ok(names.includes("remnic.recall"), "canonical name still present");
+  assert.ok(names.includes("remnic_recall"), "canonical name still present");
   assert.equal(
     names.filter((n) => n.startsWith("engram.")).length,
     0,
     "no engram.* aliases advertised when opted out",
   );
-  // Every advertised tool uses the canonical prefix; the surface is halved.
-  assert.ok(names.every((n) => n.startsWith("remnic.")), "all advertised tools are canonical");
+  // Every advertised tool uses the Anthropic-safe remnic_* prefix.
+  assert.ok(names.every((n) => n.startsWith("remnic_")), "all advertised tools are canonical");
+  assert.ok(names.every((n) => /^[a-zA-Z0-9_-]{1,64}$/.test(n)), "Anthropic tool-name pattern");
 });
 
 test("emitLegacyTools=false still allows calling tools under BOTH names (advertising-only opt-out)", async () => {
   const server = new EngramMcpServer(makeMockService(), { emitLegacyTools: false });
-  // Canonical call works.
-  const canonical = await server.handleRequest(makeToolRequest("remnic.recall", { query: "hello" }));
+  const advertised = await server.handleRequest(makeToolRequest("remnic_recall", { query: "hello" }));
   assert.notEqual(
-    (canonical as { result?: { isError?: boolean } }).result?.isError,
+    (advertised as { result?: { isError?: boolean } }).result?.isError,
     true,
-    "canonical remnic.recall call succeeds",
+    "advertised remnic_recall call succeeds",
   );
-  // Legacy call still dispatches even though it is no longer advertised.
+  const dotted = await server.handleRequest(makeToolRequest("remnic.recall", { query: "hello" }));
+  assert.notEqual(
+    (dotted as { result?: { isError?: boolean } }).result?.isError,
+    true,
+    "dotted remnic.recall call still dispatches",
+  );
   const legacy = await server.handleRequest(makeToolRequest("engram.recall", { query: "hello" }));
   assert.notEqual(
     (legacy as { result?: { isError?: boolean } }).result?.isError,
@@ -1034,10 +1039,10 @@ test("tools/list: ops-scoped token sees ONLY its permitted tools (issue #1850 fi
   const names = await tokenCapabilityStore.run({ version: 1, ops: ["recall", "memory_get"] }, async () =>
     listToolNames(await server.handleRequest(TOOLS_LIST_REQUEST)),
   );
-  assert.ok(names.includes("remnic.recall"), "permitted recall tool advertised");
-  assert.ok(names.includes("remnic.memory_get"), "permitted memory_get tool advertised");
-  assert.ok(!names.includes("remnic.memory_store"), "non-permitted tool must NOT be advertised");
-  assert.ok(!names.includes("remnic.observe"), "non-permitted tool must NOT be advertised");
+  assert.ok(names.includes("remnic_recall"), "permitted recall tool advertised");
+  assert.ok(names.includes("remnic_memory_get"), "permitted memory_get tool advertised");
+  assert.ok(!names.includes("remnic_memory_store"), "non-permitted tool must NOT be advertised");
+  assert.ok(!names.includes("remnic_observe"), "non-permitted tool must NOT be advertised");
   assert.equal(names.length, 2, "exactly the two permitted tools advertised");
 });
 
@@ -1330,11 +1335,11 @@ test("MCP external_wiki_search exposes aliases and dispatches the stable result"
         ? [tool.name]
         : []
     );
-    assert.ok(toolNames.includes("remnic.external_wiki_search"));
+    assert.ok(toolNames.includes("remnic_external_wiki_search"));
     assert.ok(toolNames.includes("engram.external_wiki_search"));
 
     let canonicalResult: unknown;
-    for (const name of ["remnic.external_wiki_search", "engram.external_wiki_search"]) {
+    for (const name of ["remnic_external_wiki_search", "engram.external_wiki_search", "remnic.external_wiki_search"]) {
       const response = await server.handleRequest(makeToolRequest(name, {
         query: "hybrid retrieval",
         limit: 3,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -42,6 +42,14 @@ import { readEnvVar } from "./runtime/env.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { expandTildePath } from "./utils/path.js";
 import { applyToolOutputSchemas } from "./access-mcp-output-schemas.js";
+import {
+  CANONICAL_MCP_PREFIX,
+  LEGACY_MCP_PREFIX,
+  toCanonicalToolName,
+  toLegacyToolName,
+  toolNameSuffix,
+  withToolAliases,
+} from "./access-mcp-tool-names.js";
 import { MCP_READ_ONLY_TOOL_SUFFIXES } from "./mcp-read-only-tools.js";
 import { MEETINGS_MCP_TOOLS } from "./meetings/mcp-tools.js";
 import { WEARABLES_MCP_TOOLS } from "./wearables/mcp-tools.js";
@@ -119,42 +127,15 @@ type McpResource = {
  */
 export const MCP_SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = ["2025-06-18", "2025-03-26", "2024-11-05"];
 const MCP_DEFAULT_PROTOCOL_VERSION: string = MCP_SUPPORTED_PROTOCOL_VERSIONS[0] ?? "2025-06-18";
-const LEGACY_MCP_PREFIX = "engram.";
-const CANONICAL_MCP_PREFIX = "remnic.";
-
-function toCanonicalToolName(name: string): string {
-  return name.startsWith(LEGACY_MCP_PREFIX) ? `${CANONICAL_MCP_PREFIX}${name.slice(LEGACY_MCP_PREFIX.length)}` : name;
-}
-function toLegacyToolName(name: string): string {
-  return name.startsWith(CANONICAL_MCP_PREFIX)
-    ? `${LEGACY_MCP_PREFIX}${name.slice(CANONICAL_MCP_PREFIX.length)}`
-    : name;
-}
-
 /**
  * Suffix-based allowlist matcher. Returns true for tools whose canonical
- * suffix (after stripping `remnic.` or `engram.`) is in
+ * suffix (after stripping `remnic_`, `remnic.`, or `engram.`) is in
  * {@link MCP_READ_ONLY_TOOL_SUFFIXES}. Unprefixed names are treated as
  * unannotated.
  */
 function isReadOnlyToolName(name: string): boolean {
-  for (const prefix of [CANONICAL_MCP_PREFIX, LEGACY_MCP_PREFIX]) {
-    if (name.startsWith(prefix)) {
-      return MCP_READ_ONLY_TOOL_SUFFIXES[name.slice(prefix.length)] === true;
-    }
-  }
-  return false;
-}
-
-function withToolAliases(tool: McpTool, emitLegacyTools = true): McpTool[] {
-  const canonicalName = toCanonicalToolName(tool.name);
-  const canonicalTool = canonicalName === tool.name ? tool : { ...tool, name: canonicalName };
-  if (canonicalName === tool.name) return [canonicalTool];
-  // Issue #1427: when legacy aliases are opted out, advertise only the
-  // canonical `remnic.*` name and drop the `engram.*` duplicate. Tool *calls*
-  // still accept both names (the dispatch canonicalizes), so suppressing the
-  // alias only trims `tools/list`, not callability.
-  return emitLegacyTools ? [canonicalTool, tool] : [canonicalTool];
+  const suffix = toolNameSuffix(name);
+  return suffix !== null && MCP_READ_ONLY_TOOL_SUFFIXES[suffix] === true;
 }
 
 export const MCP_MIGRATED_OPERATIONS: Readonly<Record<string, OperationName>> = {
@@ -2247,7 +2228,7 @@ export class EngramMcpServer {
     // allowlist. Done as a final pass so every spread (chat, codegraph,
     // coding_*, correction, etc.) inherits the annotation without
     // scattering the same logic across every `withToolAliases` call site.
-    // Suffix-based matching covers both the `remnic.*` and `engram.*`
+    // Suffix-based matching covers both the `remnic_*` and `engram.*`
     // naming forms emitted by `withToolAliases`.
     this.tools = this.tools.map((tool) =>
       isReadOnlyToolName(tool.name) && tool.annotations?.readOnlyHint !== true
@@ -2256,7 +2237,7 @@ export class EngramMcpServer {
     );
     // Apply `outputSchema` declarations from the registry. Like the
     // readOnlyHint pass above, this is a final suffix-based pass so every
-    // tool (including both `remnic.*` and `engram.*` aliases) gets a
+    // tool (including both `remnic_*` and `engram.*` aliases) gets a
     // schema. Tools that already declare an outputSchema (e.g.
     // chatgpt_memory_inspector) are left untouched.
     this.tools = applyToolOutputSchemas(this.tools, CANONICAL_MCP_PREFIX, LEGACY_MCP_PREFIX);
@@ -2589,9 +2570,9 @@ export class EngramMcpServer {
 
   private toolAcceptsArgument(name: string, key: string): boolean {
     // Match by canonical name so argument validation resolves whether the
-    // caller used the `engram.*` or `remnic.*` name and regardless of whether
-    // legacy aliases are advertised (issue #1427) — a tool stays callable under
-    // both names even when only the canonical alias appears in `tools/list`.
+    // caller used `engram.*`, `remnic.*`, or `remnic_*` and regardless of
+    // whether legacy aliases are advertised (issue #1427) — a tool stays
+    // callable under those names even when only remnic_* appears in tools/list.
     const target = toCanonicalToolName(name);
     const tool = this.tools.find((entry) => toCanonicalToolName(entry.name) === target);
     const inputSchema = getObjectProperties(tool?.inputSchema);

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -53,9 +53,9 @@ void getOperation;
 // ---------------------------------------------------------------------------
 
 const LEGACY_PREFIX = "engram.";
-const CANONICAL_PREFIX = "remnic.";
+const CANONICAL_PREFIX = "remnic_";
 
-/** Strip the `engram.`/`remnic.` prefix to get the canonical short name. */
+/** Strip the `engram.`/`remnic_` prefix to get the canonical short name. */
 function shortToolName(advertised: string): string {
   if (advertised.startsWith(LEGACY_PREFIX)) return advertised.slice(LEGACY_PREFIX.length);
   if (advertised.startsWith(CANONICAL_PREFIX)) return advertised.slice(CANONICAL_PREFIX.length);

--- a/packages/remnic-core/src/coding/architecture-surfaces.test.ts
+++ b/packages/remnic-core/src/coding/architecture-surfaces.test.ts
@@ -543,7 +543,7 @@ test("tools/list: engram.coding_architecture absent when gate off (byte-identica
   const response = await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
   const names = extractToolNames(response);
   assert.equal(names.has("engram.coding_architecture"), false, "tool must be absent when gate is off");
-  assert.equal(names.has("remnic.coding_architecture"), false, "alias must be absent when gate is off");
+  assert.equal(names.has("remnic_coding_architecture"), false, "alias must be absent when gate is off");
 });
 
 test("tools/list: engram.coding_architecture present when gate on", async () => {
@@ -552,7 +552,7 @@ test("tools/list: engram.coding_architecture present when gate on", async () => 
   const response = await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
   const names = extractToolNames(response);
   assert.equal(names.has("engram.coding_architecture"), true, "tool must be advertised when gate is on");
-  assert.equal(names.has("remnic.coding_architecture"), true, "alias must be advertised when gate is on");
+  assert.equal(names.has("remnic_coding_architecture"), true, "alias must be advertised when gate is on");
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/codegraph-surfaces.test.ts
+++ b/packages/remnic-core/src/coding/codegraph-surfaces.test.ts
@@ -277,9 +277,9 @@ test("tools/list gate: all 14 codegraph tools absent when codegraphVisible off (
       `engram.codegraph_${suffix} must be absent when gate is off`,
     );
     assert.equal(
-      names.has(`remnic.codegraph_${suffix}`),
+      names.has(`remnic_codegraph_${suffix}`),
       false,
-      `remnic.codegraph_${suffix} must be absent when gate is off`,
+      `remnic_codegraph_${suffix} must be absent when gate is off`,
     );
   }
 });
@@ -296,9 +296,9 @@ test("tools/list gate: all 14 codegraph tools present when codegraphVisible on",
       `engram.codegraph_${suffix} must be present when gate is on`,
     );
     assert.equal(
-      names.has(`remnic.codegraph_${suffix}`),
+      names.has(`remnic_codegraph_${suffix}`),
       true,
-      `remnic.codegraph_${suffix} alias must be present when gate is on`,
+      `remnic_codegraph_${suffix} alias must be present when gate is on`,
     );
   }
 });

--- a/packages/remnic-core/src/coding/decision-surfaces.test.ts
+++ b/packages/remnic-core/src/coding/decision-surfaces.test.ts
@@ -168,7 +168,7 @@ test("tools/list: engram.coding_decision absent when gate off (byte-identical to
   const tools = (response as { result?: { tools?: Array<{ name: string }> } }).result?.tools ?? [];
   const names = new Set(tools.map((t) => t.name));
   assert.equal(names.has("engram.coding_decision"), false, "tool must be absent when gate is off");
-  assert.equal(names.has("remnic.coding_decision"), false, "alias must be absent when gate is off");
+  assert.equal(names.has("remnic_coding_decision"), false, "alias must be absent when gate is off");
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/correction/correction-surfaces.test.ts
+++ b/packages/remnic-core/src/correction/correction-surfaces.test.ts
@@ -114,8 +114,8 @@ test("tools/list gate: correction tools absent when correctionVisible off (byte-
   const names = extractToolNames(response);
   assert.equal(names.has("engram.memory_correct_plan"), false, "plan tool must be absent when gate off");
   assert.equal(names.has("engram.memory_correct_apply"), false, "apply tool must be absent when gate off");
-  assert.equal(names.has("remnic.memory_correct_plan"), false, "plan alias must be absent when gate off");
-  assert.equal(names.has("remnic.memory_correct_apply"), false, "apply alias must be absent when gate off");
+  assert.equal(names.has("remnic_memory_correct_plan"), false, "plan alias must be absent when gate off");
+  assert.equal(names.has("remnic_memory_correct_apply"), false, "apply alias must be absent when gate off");
 });
 
 test("tools/list gate: correction tools present when correctionVisible on (default)", async () => {
@@ -126,8 +126,8 @@ test("tools/list gate: correction tools present when correctionVisible on (defau
   const names = extractToolNames(response);
   assert.equal(names.has("engram.memory_correct_plan"), true, "plan tool must be present by default");
   assert.equal(names.has("engram.memory_correct_apply"), true, "apply tool must be present by default");
-  assert.equal(names.has("remnic.memory_correct_plan"), true, "plan alias must be present");
-  assert.equal(names.has("remnic.memory_correct_apply"), true, "apply alias must be present");
+  assert.equal(names.has("remnic_memory_correct_plan"), true, "plan alias must be present");
+  assert.equal(names.has("remnic_memory_correct_apply"), true, "apply alias must be present");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -7,7 +7,7 @@ import type { RetrievedMemoryProvenance } from "./memory-provenance.js";
 export const REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL =
   "engram.chatgpt_memory_inspector" as const;
 export const REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL =
-  "remnic.chatgpt_memory_inspector" as const;
+  "remnic_chatgpt_memory_inspector" as const;
 export const REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI =
   "ui://remnic/memory-inspector.v1.html" as const;
 export const REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE =

--- a/packages/remnic-core/src/support-passport/mcp-tools.test.ts
+++ b/packages/remnic-core/src/support-passport/mcp-tools.test.ts
@@ -42,10 +42,10 @@ test("support passport MCP tools are hidden until the feature is enabled", async
     false
   );
   assert.equal(enabledNames.filter((name) => name.includes("support_passport")).length, 22);
-  assert.ok(enabledNames.includes("remnic.support_passport_memory_preview"));
-  assert.ok(enabledNames.includes("remnic.support_passport_cards_list"));
+  assert.ok(enabledNames.includes("remnic_support_passport_memory_preview"));
+  assert.ok(enabledNames.includes("remnic_support_passport_cards_list"));
   assert.ok(enabledNames.includes("engram.support_passport_grant_revoke"));
-  for (const name of ["remnic.support_passport_memory_preview", "engram.support_passport_memory_preview"]) {
+  for (const name of ["remnic_support_passport_memory_preview", "engram.support_passport_memory_preview"]) {
     assert.equal(enabledTools.find((tool) => tool.name === name)?.annotations?.readOnlyHint, true);
   }
 });

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -28,7 +28,7 @@
       "packages/remnic-cli/src/bench-args.ts": 1345,
       "packages/remnic-cli/src/index.ts": 13629,
       "packages/remnic-core/src/access-http.ts": 4019,
-      "packages/remnic-core/src/access-mcp.ts": 2772,
+      "packages/remnic-core/src/access-mcp.ts": 2753,
       "packages/remnic-core/src/access-recall-surface.ts": 1412,
       "packages/remnic-core/src/access-service.ts": 5910,
       "packages/remnic-core/src/briefing.ts": 1494,

--- a/scripts/relay/codex-one-shot.ts
+++ b/scripts/relay/codex-one-shot.ts
@@ -124,7 +124,7 @@ export function buildRelayCodexConfigArgs(mcpUrl: string): string[] {
     'shell_environment_policy.set={ PATH="/usr/bin:/bin", HOME="/tmp/relay-model-home", TMPDIR="/tmp", LANG="C.UTF-8", LC_ALL="C.UTF-8" }',
     `mcp_servers.relay.url=${tomlString(mcpUrl)}`,
     'mcp_servers.relay.bearer_token_env_var="REMNIC_RELAY_MCP_TOKEN"',
-    'mcp_servers.relay.enabled_tools=["remnic.recall"]',
+    'mcp_servers.relay.enabled_tools=["remnic_recall"]',
     "mcp_servers.relay.required=true",
     "mcp_servers.relay.startup_timeout_sec=10",
     "mcp_servers.relay.tool_timeout_sec=30",
@@ -166,7 +166,7 @@ function classifyCodexFailure(stdout: string, stderr: string): string[] {
   };
   add("authentication", /\b(?:401|403|authentication|not logged in|unauthori[sz]ed)\b/i);
   add("cli-arguments", /\b(?:unknown|unexpected|invalid) argument\b|\bUsage:/i);
-  add("mcp-startup", /\bMCP\b|mcp_servers|remnic\.recall/i);
+  add("mcp-startup", /\bMCP\b|mcp_servers|remnic[._]recall/i);
   add("model-availability", /\bmodel\b.{0,80}\b(?:not found|unsupported|unavailable|does not exist)\b/i);
   add("network", /\b(?:connection|DNS|network|websocket).{0,80}(?:failed|refused|timed out|unreachable)\b/i);
   add("output-schema", /\b(?:output|json|response).{0,40}schema\b|response_format|structured output/i);
@@ -252,7 +252,7 @@ export function countRecallToolCalls(jsonl: string): number {
       };
       if (event.type !== "item.completed" || event.item?.type !== "mcp_tool_call") continue;
       const tool = event.item.tool ?? event.item.name;
-      if (tool !== "remnic.recall" && tool !== "relay.remnic.recall") continue;
+      if (tool !== "remnic_recall" && tool !== "relay.remnic_recall") continue;
       if (event.item.server !== "relay") continue;
       if (event.item.status !== "completed") continue;
       if (typeof event.item.id === "string") completedIds.add(event.item.id);
@@ -291,7 +291,7 @@ export function parseRelayRecallReceipts(
     }
     if (event.type !== "item.completed" || event.item?.type !== "mcp_tool_call") continue;
     const tool = event.item.tool ?? event.item.name;
-    if (event.item.server !== "relay" || (tool !== "remnic.recall" && tool !== "relay.remnic.recall")) continue;
+    if (event.item.server !== "relay" || (tool !== "remnic_recall" && tool !== "relay.remnic_recall")) continue;
     if (event.item.status !== "completed") continue;
     if (typeof event.item.id === "string") {
       if (completedIds.has(event.item.id)) continue;

--- a/scripts/relay/contracts.ts
+++ b/scripts/relay/contracts.ts
@@ -175,7 +175,9 @@ export const RelayPreflightReceiptSchema = z
       .object({
         accountLinkedAppsDisabled: z.literal(true),
         mcpServers: z.tuple([z.literal("relay")]),
-        mcpTools: z.tuple([z.literal("relay.remnic_recall")]),
+        // #2705: advertised names became remnic_*; recordings made before the
+        // rename still carry the dotted form and stay valid.
+        mcpTools: z.tuple([z.union([z.literal("relay.remnic_recall"), z.literal("relay.remnic.recall")])]),
       })
       .strict(),
     fixtureManifestSha256: z.string().regex(/^[a-f0-9]{64}$/),
@@ -192,7 +194,7 @@ export const RelayPreflightReceiptSchema = z
       .object({
         loopbackOnly: z.literal(true),
         namespace: z.literal(RELAY_NAMESPACE),
-        advertisedTools: z.tuple([z.literal("remnic_recall")]),
+        advertisedTools: z.tuple([z.union([z.literal("remnic_recall"), z.literal("remnic.recall")])]),
         isolatedMemoryDir: z.literal(true),
       })
       .strict(),

--- a/scripts/relay/contracts.ts
+++ b/scripts/relay/contracts.ts
@@ -175,7 +175,7 @@ export const RelayPreflightReceiptSchema = z
       .object({
         accountLinkedAppsDisabled: z.literal(true),
         mcpServers: z.tuple([z.literal("relay")]),
-        mcpTools: z.tuple([z.literal("relay.remnic.recall")]),
+        mcpTools: z.tuple([z.literal("relay.remnic_recall")]),
       })
       .strict(),
     fixtureManifestSha256: z.string().regex(/^[a-f0-9]{64}$/),
@@ -192,7 +192,7 @@ export const RelayPreflightReceiptSchema = z
       .object({
         loopbackOnly: z.literal(true),
         namespace: z.literal(RELAY_NAMESPACE),
-        advertisedTools: z.tuple([z.literal("remnic.recall")]),
+        advertisedTools: z.tuple([z.literal("remnic_recall")]),
         isolatedMemoryDir: z.literal(true),
       })
       .strict(),

--- a/scripts/relay/preflight-lib.ts
+++ b/scripts/relay/preflight-lib.ts
@@ -167,7 +167,7 @@ async function probeChroot(
 interface IsolatedCodexToolSurface {
   accountLinkedAppsDisabled: true;
   mcpServers: ["relay"];
-  mcpTools: ["relay.remnic.recall"];
+  mcpTools: ["relay.remnic_recall"];
 }
 
 async function probeIsolatedCodexToolSurface(
@@ -321,14 +321,14 @@ async function probeIsolatedCodexToolSurface(
     servers.length !== 1 ||
     servers[0]?.name !== "relay" ||
     servers[0].authStatus !== "bearerToken" ||
-    JSON.stringify(Object.keys(servers[0].tools ?? {}).sort()) !== JSON.stringify(["remnic.recall"])
+    JSON.stringify(Object.keys(servers[0].tools ?? {}).sort()) !== JSON.stringify(["remnic_recall"])
   ) {
-    throw new Error("Relay isolated Codex tool surface exposed something other than relay.remnic.recall");
+    throw new Error("Relay isolated Codex tool surface exposed something other than relay.remnic_recall");
   }
   return {
     accountLinkedAppsDisabled: true,
     mcpServers: ["relay"],
-    mcpTools: ["relay.remnic.recall"],
+    mcpTools: ["relay.remnic_recall"],
   };
 }
 
@@ -531,7 +531,7 @@ export async function runRelayPreflight(options: RelayPreflightOptions): Promise
   try {
     harness = await startRelayRemnicHarness(probeMemoryDir);
     const tools = await listRelayMcpTools(harness.mcpUrl, harness.mcpToken);
-    if (JSON.stringify(tools) !== JSON.stringify(["remnic.recall"])) {
+    if (JSON.stringify(tools) !== JSON.stringify(["remnic_recall"])) {
       throw new Error(`Relay capability token advertised unexpected tools: ${tools.join(", ")}`);
     }
     codexToolSurface = await probeIsolatedCodexToolSurface(
@@ -577,7 +577,7 @@ export async function runRelayPreflight(options: RelayPreflightOptions): Promise
     remnic: {
       loopbackOnly: true,
       namespace: RELAY_NAMESPACE,
-      advertisedTools: ["remnic.recall"],
+      advertisedTools: ["remnic_recall"],
       isolatedMemoryDir: true,
     },
     productionDataRead: false,

--- a/scripts/relay/remnic-harness.ts
+++ b/scripts/relay/remnic-harness.ts
@@ -342,7 +342,7 @@ export async function callRelayMcpRecall(
       id: 2,
       method: "tools/call",
       params: {
-        name: "remnic.recall",
+        name: "remnic_recall",
         arguments: {
           query: RELAY_QUERY,
           namespace: RELAY_NAMESPACE,

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -2309,9 +2309,9 @@ test("access HTTP server exposes MCP JSON-RPC endpoint at /mcp", async () => {
       result: { tools: Array<{ name: string }> };
     };
     const toolNames = toolsPayload.result.tools.map((t) => t.name);
-    assert.ok(toolNames.includes("remnic.recall"));
-    assert.ok(toolNames.includes("remnic.memory_store"));
-    assert.ok(toolNames.includes("remnic.entity_get"));
+    assert.ok(toolNames.includes("remnic_recall"));
+    assert.ok(toolNames.includes("remnic_memory_store"));
+    assert.ok(toolNames.includes("remnic_entity_get"));
     assert.ok(toolNames.includes("engram.recall"));
 
     // call remnic.recall tool

--- a/tests/access-mcp-action-confidence.test.ts
+++ b/tests/access-mcp-action-confidence.test.ts
@@ -42,7 +42,7 @@ test("MCP advertises action_confidence under engram and remnic names", async () 
   const names = (tools?.result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
 
   assert.ok(names.includes("engram.action_confidence"));
-  assert.ok(names.includes("remnic.action_confidence"));
+  assert.ok(names.includes("remnic_action_confidence"));
 });
 
 test("MCP action_confidence validates and dispatches to service", async () => {

--- a/tests/access-mcp-recall-xray.test.ts
+++ b/tests/access-mcp-recall-xray.test.ts
@@ -48,7 +48,7 @@ function fakeService(capture: {
   } as unknown as EngramAccessService;
 }
 
-test("MCP advertises both engram.recall_xray and remnic.recall_xray", async () => {
+test("MCP advertises both engram.recall_xray and remnic_recall_xray", async () => {
   const server = new EngramMcpServer(fakeService({ calls: [] }));
   await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   const tools = await server.handleRequest({
@@ -61,7 +61,7 @@ test("MCP advertises both engram.recall_xray and remnic.recall_xray", async () =
     (t) => t.name,
   );
   assert.ok(names.includes("engram.recall_xray"), "legacy engram.* name is advertised");
-  assert.ok(names.includes("remnic.recall_xray"), "canonical remnic.* alias is advertised");
+  assert.ok(names.includes("remnic_recall_xray"), "canonical remnic_* alias is advertised");
 });
 
 test("MCP engram.recall_xray dispatches to recallXray with threaded params", async () => {

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -416,7 +416,7 @@ test("MCP tools/list marks read-only tools with readOnlyHint and leaves write to
   const byName = new Map(result.tools.map((tool) => [tool.name, tool]));
 
   // Pure reads carry the hint in both naming forms.
-  for (const name of ["remnic.recall", "engram.recall", "remnic.memory_get", "engram.memory_search"]) {
+  for (const name of ["remnic_recall", "engram.recall", "remnic_memory_get", "engram.memory_search"]) {
     const tool = byName.get(name);
     assert.ok(tool, `${name} must be listed`);
     assert.equal(tool.annotations?.readOnlyHint, true, `${name} must carry readOnlyHint`);
@@ -424,7 +424,7 @@ test("MCP tools/list marks read-only tools with readOnlyHint and leaves write to
 
   // Mutating tools must NOT carry it — ChatGPT treats unannotated tools as
   // write actions requiring confirmation, which is the safe default.
-  for (const name of ["remnic.memory_store", "engram.memory_store", "remnic.wearables_sync", "engram.observe"]) {
+  for (const name of ["remnic_memory_store", "engram.memory_store", "remnic_wearables_sync", "engram.observe"]) {
     const tool = byName.get(name);
     assert.ok(tool, `${name} must be listed`);
     assert.notEqual(tool.annotations?.readOnlyHint, true, `${name} must not be marked read-only`);
@@ -451,17 +451,17 @@ test("MCP server advertises tools and dispatches recall", async () => {
     params: {},
   });
   const listed = (tools?.result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
-  const remnicNames = listed.filter((name) => name.startsWith("remnic."));
+  const remnicNames = listed.filter((name) => name.startsWith("remnic_"));
   const engramNames = listed.filter((name) => name.startsWith("engram."));
   assert.equal(remnicNames.length, engramNames.length);
   for (const name of remnicNames) {
     assert.ok(
-      listed.includes(name.replace(/^remnic\./, "engram.")),
+      listed.includes(name.replace(/^remnic_/, "engram.")),
       `${name} must have an engram.* alias`,
     );
   }
   assert.ok(listed.includes("engram.recall"));
-  assert.ok(listed.includes("remnic.recall"));
+  assert.ok(listed.includes("remnic_recall"));
 
   const recall = await server.handleRequest({
     jsonrpc: "2.0",
@@ -1354,12 +1354,12 @@ test("MCP tools/list: key tools have outputSchema with declared properties", asy
   const resp = await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
   const tools = fieldOf(fieldOf(resp, "result"), "tools") as unknown as Array<Record<string, unknown>>;
   const keyTools = [
-    "remnic.recall",
-    "remnic.memory_store",
-    "remnic.memory_get",
-    "remnic.briefing",
-    "remnic.action_confidence",
-    "remnic.memory_search",
+    "remnic_recall",
+    "remnic_memory_store",
+    "remnic_memory_get",
+    "remnic_briefing",
+    "remnic_action_confidence",
+    "remnic_memory_search",
   ];
   for (const name of keyTools) {
     const tool = tools.find((t) => fieldOf(t, "name") === name);

--- a/tests/briefing-mcp-tool.test.ts
+++ b/tests/briefing-mcp-tool.test.ts
@@ -40,7 +40,7 @@ function createBriefingOnlyService(captured: CapturedBriefingCall[]): EngramAcce
   return stub as unknown as EngramAccessService;
 }
 
-test("remnic.briefing MCP tool appears in tools/list alongside the engram.* alias", async () => {
+test("remnic_briefing MCP tool appears in tools/list alongside the engram.* alias", async () => {
   const server = new EngramMcpServer(createBriefingOnlyService([]));
   const tools = await server.handleRequest({
     jsonrpc: "2.0",
@@ -50,8 +50,8 @@ test("remnic.briefing MCP tool appears in tools/list alongside the engram.* alia
   });
   const listed = (tools?.result as { tools: Array<{ name: string }> }).tools.map((t) => t.name);
   assert.ok(
-    listed.includes("remnic.briefing"),
-    "tools/list should include the canonical remnic.briefing name",
+    listed.includes("remnic_briefing"),
+    "tools/list should include the canonical remnic_briefing name",
   );
   assert.ok(
     listed.includes("engram.briefing"),
@@ -131,8 +131,8 @@ test("engram.briefing and remnic.briefing are absent from tools/list when briefi
     "engram.briefing must not appear in tools/list when briefing is disabled",
   );
   assert.equal(
-    listed.includes("remnic.briefing"),
+    listed.includes("remnic_briefing"),
     false,
-    "remnic.briefing must not appear in tools/list when briefing is disabled",
+    "remnic_briefing must not appear in tools/list when briefing is disabled",
   );
 });

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -640,8 +640,8 @@ test("MCP graph_snapshot tool is exposed under both prefixes", async () => {
     `expected engram.graph_snapshot in ${listed.join(",")}`,
   );
   assert.ok(
-    listed.includes("remnic.graph_snapshot"),
-    `expected remnic.graph_snapshot in ${listed.join(",")}`,
+    listed.includes("remnic_graph_snapshot"),
+    `expected remnic_graph_snapshot in ${listed.join(",")}`,
   );
 });
 

--- a/tests/relay-codex-jsonl.test.ts
+++ b/tests/relay-codex-jsonl.test.ts
@@ -23,7 +23,7 @@ test("Codex JSONL proof counts only completed Remnic MCP recalls", () => {
     { type: "thread.started", thread_id: "019f62b9-3200-7df1-99fb-cbb35fc28573" },
     {
       type: "item.completed",
-      item: { id: "item-1", type: "mcp_tool_call", server: "relay", tool: "remnic.recall", status: "failed" },
+      item: { id: "item-1", type: "mcp_tool_call", server: "relay", tool: "remnic_recall", status: "failed" },
     },
     {
       type: "item.completed",
@@ -31,7 +31,7 @@ test("Codex JSONL proof counts only completed Remnic MCP recalls", () => {
         id: "item-2",
         type: "mcp_tool_call",
         server: "relay",
-        tool: "remnic.recall",
+        tool: "remnic_recall",
         status: "completed",
         arguments: {
           query: RELAY_QUERY,
@@ -92,7 +92,7 @@ test("Codex JSONL recall proof rejects missing structured MCP evidence", () => {
       id: "item-1",
       type: "mcp_tool_call",
       server: "relay",
-      tool: "remnic.recall",
+      tool: "remnic_recall",
       status: "completed",
       arguments: {
         query: RELAY_QUERY,
@@ -119,7 +119,7 @@ test("Codex JSONL recall proof rejects a missing transcript-free session key bef
       id: "item-1",
       type: "mcp_tool_call",
       server: "relay",
-      tool: "remnic.recall",
+      tool: "remnic_recall",
       status: "completed",
       arguments: {
         query: RELAY_QUERY,

--- a/tests/relay-isolated-runner.test.ts
+++ b/tests/relay-isolated-runner.test.ts
@@ -219,7 +219,7 @@ test("Codex one-shot arguments ignore user state and expose only loopback Remnic
   assert.equal(args.includes("workspace-write"), false);
   assert.ok(args.includes("--ephemeral"));
   assert.ok(args.includes("--output-schema"));
-  assert.ok(args.includes('mcp_servers.relay.enabled_tools=["remnic.recall"]'));
+  assert.ok(args.includes('mcp_servers.relay.enabled_tools=["remnic_recall"]'));
   assert.ok(args.includes('shell_environment_policy.inherit="none"'));
   assert.ok(args.includes('web_search="disabled"'));
   assert.deepEqual(RELAY_DISABLED_CODEX_FEATURES, [
@@ -602,7 +602,7 @@ test("isolated Remnic token lists only recall and the real Correction Contract r
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "relay-remnic-harness-"));
   const harness = await startRelayRemnicHarness(memoryDir);
   try {
-    assert.deepEqual(await listRelayMcpTools(harness.mcpUrl, harness.mcpToken), ["remnic.recall"]);
+    assert.deepEqual(await listRelayMcpTools(harness.mcpUrl, harness.mcpToken), ["remnic_recall"]);
     const staleMemoryId = await harness.seedStaleDecision();
     const staleProof = await harness.proveMcpRecall(staleMemoryId, RELAY_STALE_PROBE_SESSION_KEY);
     assert.deepEqual(staleProof.memoryIds, [staleMemoryId]);

--- a/tests/relay-recording.test.ts
+++ b/tests/relay-recording.test.ts
@@ -462,7 +462,7 @@ test("Relay recording is sanitized, run-scoped, and integrity checked", async ()
     codexToolSurface: {
       accountLinkedAppsDisabled: true,
       mcpServers: ["relay"],
-      mcpTools: ["relay.remnic.recall"],
+      mcpTools: ["relay.remnic_recall"],
     },
     fixtureManifestSha256: fixtureManifest.rootSha256,
     isolation: {
@@ -475,7 +475,7 @@ test("Relay recording is sanitized, run-scoped, and integrity checked", async ()
     remnic: {
       loopbackOnly: true,
       namespace: "relay-build-week",
-      advertisedTools: ["remnic.recall"],
+      advertisedTools: ["remnic_recall"],
       isolatedMemoryDir: true,
     },
     productionDataRead: false,


### PR DESCRIPTION
Advertise MCP tools as `remnic_*` names matching Anthropic's `^[a-zA-Z0-9_-]{1,64}$` pattern.

- Keep `remnic.*` and `engram.*` callable for backward compatibility
- Extract tool-name helpers; do not grow access-mcp.ts
- Fix docs that claimed `remnic_*` was already advertised

Fixes #2705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP tools now advertise Anthropic-compatible `remnic_*` names.
  - Existing `remnic.*` and `engram.*` names remain callable.
  - Legacy `engram.*` names can be included in listings when enabled.

- **Bug Fixes**
  - Tool-name aliases are normalized consistently for dispatch, quotas, and classification.
  - Relay integrations recognize both updated and previously recorded tool names.

- **Documentation**
  - Updated MCP naming guidance and output-schema documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->