### PR TITLE
feat(extraction): add spanGap helper for half-open ranges (#2333)

### DIFF
--- a/.changeset/2333-span-gap.md
+++ b/.changeset/2333-span-gap.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span-gap helper. Half-open `[start, end)` ranges return the distance between them. Overlap is 0. Inverted spans and non-integers throw. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-gap.test.ts
+++ b/packages/remnic-core/src/extraction-span-gap.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spanGap } from "./extraction-span-gap.js";
+
+test("spanGap: disjoint half-open gap is b.start - a.end", () => {
+  assert.equal(spanGap({ start: 0, end: 2 }, { start: 4, end: 6 }), 2);
+  assert.equal(spanGap({ start: 0, end: 3 }, { start: 3, end: 5 }), 0);
+  assert.equal(spanGap({ start: 4, end: 6 }, { start: 0, end: 2 }), 2);
+});
+
+test("spanGap: overlap is 0", () => {
+  assert.equal(spanGap({ start: 0, end: 4 }, { start: 2, end: 6 }), 0);
+  assert.equal(spanGap({ start: 1, end: 5 }, { start: 2, end: 3 }), 0);
+});
+
+test("spanGap: inverted span throws", () => {
+  assert.throws(() => spanGap({ start: 3, end: 2 }, { start: 0, end: 1 }), /inverted/i);
+  assert.throws(() => spanGap({ start: 0, end: 1 }, { start: 5, end: 4 }), /inverted/i);
+});
+
+test("spanGap: non-integers throw", () => {
+  assert.throws(() => spanGap({ start: 1.5, end: 3 }, { start: 3, end: 5 }), /integers/);
+  assert.throws(() => spanGap({ start: 0, end: 3 }, { start: 3, end: 5.2 }), /integers/);
+  assert.throws(
+    () => spanGap({ start: Number.NaN, end: 3 }, { start: 3, end: 5 }),
+    /integers/,
+  );
+});
+

--- a/packages/remnic-core/src/extraction-span-gap.ts
+++ b/packages/remnic-core/src/extraction-span-gap.ts
@@ -1,0 +1,25 @@
+/**
+ * Isolated span-gap helper (issue #2333 leftover).
+ *
+ * Pure. Extraction wiring waits on the Phase A bench gate.
+ */
+
+export function spanGap(
+  a: { start: number; end: number },
+  b: { start: number; end: number },
+): number {
+  if (
+    !Number.isInteger(a.start) ||
+    !Number.isInteger(a.end) ||
+    !Number.isInteger(b.start) ||
+    !Number.isInteger(b.end)
+  ) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (a.end < a.start || b.end < b.start) {
+    throw new RangeError("span offsets inverted");
+  }
+  if (a.end <= b.start) return b.start - a.end;
+  if (b.end <= a.start) return a.start - b.end;
+  return 0;
+}


### PR DESCRIPTION
Add `spanGap(a, b)` for half-open span gap/overlap math.

- Gap when `a.end <= b.start`
- Overlap returns 0
- Inverted ranges throw

Part of #2333