### PR TITLE
feat(activity): add parseOverlap for timeline batch overlap (#2050)

### DIFF
--- a/.changeset/2050-analysis-overlap.md
+++ b/.changeset/2050-analysis-overlap.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `parseOverlap` to the activity timeline layer. `0` is allowed. Negative or non-integer values throw. When `maxBatch > 0`, overlap must be less than `maxBatch`. Part of #2050.

--- a/packages/remnic-core/src/activity/timeline/analysis-overlap.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-overlap.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseOverlap } from "./analysis-overlap.js";
+
+test("overlap 0 is allowed", () => {
+  assert.equal(parseOverlap(0, 8), 0);
+  assert.equal(parseOverlap(0, 0), 0);
+});
+
+test("overlap 3 with maxBatch 8 is returned", () => {
+  assert.equal(parseOverlap(3, 8), 3);
+});
+
+test("overlap >= maxBatch throws when maxBatch > 0", () => {
+  assert.throws(() => parseOverlap(8, 8), /less than maxBatch/);
+  assert.throws(() => parseOverlap(5, 4), /less than maxBatch/);
+});
+
+test("negative overlap throws", () => {
+  assert.throws(() => parseOverlap(-1, 8), /non-negative integer/);
+});
+
+test("float overlap throws", () => {
+  assert.throws(() => parseOverlap(1.5, 8), /non-negative integer/);
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-overlap.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-overlap.ts
@@ -1,0 +1,17 @@
+/**
+ * Timeline analysis overlap parse (issue #2050 leftover).
+ *
+ * Pure. 0 is allowed. Negative or non-integer throws.
+ * When maxBatch > 0, overlap must be less than maxBatch.
+ */
+export function parseOverlap(value: unknown, maxBatch: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new RangeError(
+      `analysis overlap must be a non-negative integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  if (maxBatch > 0 && value >= maxBatch) {
+    throw new RangeError(`analysis overlap must be less than maxBatch; got ${value} >= ${maxBatch}`);
+  }
+  return value;
+}


### PR DESCRIPTION
Add `parseOverlap(value, maxBatch)` for timeline analysis overlap validation.

- 0 allowed
- Negative and out-of-range throw

Part of #2050