### PR TITLE
feat(activity): add countRecapCards for recap card dedup (#2051)

### DIFF
--- a/.changeset/recap-card-count-2051.md
+++ b/.changeset/recap-card-count-2051.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `countRecapCards` for unique recap card ids.
+Empty strings are dropped. The input list is not mutated.
+Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/recap-card-count.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-card-count.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { countRecapCards } from "./recap-card-count.js";
+
+test("empty list is 0", () => {
+  assert.equal(countRecapCards([]), 0);
+});
+
+test("counts unique ids", () => {
+  assert.equal(countRecapCards(["card-a", "card-b", "card-a"]), 2);
+  assert.equal(countRecapCards(["card-a", "card-b", "card-c"]), 3);
+});
+
+test("drops empty strings and does not mutate", () => {
+  const cards = ["card-a", "", "card-b", "", "card-a"];
+  assert.equal(countRecapCards(cards), 2);
+  assert.deepEqual(cards, ["card-a", "", "card-b", "", "card-a"]);
+});

--- a/packages/remnic-core/src/activity/timeline/recap-card-count.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-card-count.ts
@@ -1,0 +1,13 @@
+/**
+ * Recap card counter (issue #2051 leftover).
+ *
+ * Unique ids after dropping empty strings. Does not mutate input.
+ */
+
+export function countRecapCards(cards: readonly string[]): number {
+  const unique = new Set<string>();
+  for (const id of cards) {
+    if (id !== "") unique.add(id);
+  }
+  return unique.size;
+}


### PR DESCRIPTION
Add `countRecapCards(cards)` — unique non-empty recap card ids.

Part of #2051