### PR TITLE
feat(activity): add daysBetweenIso for week span math (#2052)

### DIFF
--- a/.changeset/week-span-2052.md
+++ b/.changeset/week-span-2052.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": minor
+---
+
+Add `daysBetweenIso` for half-open YYYY-MM-DD week spans.
+Inclusive start, exclusive end. Invalid or inverted ranges throw.
+Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/week-span.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-span.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { daysBetweenIso } from "./week-span.js";
+
+test("seven-day week is [start, end)", () => {
+  assert.equal(daysBetweenIso("2026-07-13", "2026-07-20"), 7);
+});
+
+test("same day throws", () => {
+  assert.throws(() => daysBetweenIso("2026-07-13", "2026-07-13"), /end/);
+});
+
+test("inverted range throws", () => {
+  assert.throws(() => daysBetweenIso("2026-07-20", "2026-07-13"), /end/);
+});
+
+test("invalid date throws", () => {
+  assert.throws(() => daysBetweenIso("2026-02-30", "2026-03-02"), /YYYY-MM-DD/);
+  assert.throws(() => daysBetweenIso("2026-07-13", "not-a-date"), /YYYY-MM-DD/);
+});

--- a/packages/remnic-core/src/activity/timeline/week-span.ts
+++ b/packages/remnic-core/src/activity/timeline/week-span.ts
@@ -1,0 +1,18 @@
+/**
+ * Half-open day span between two YYYY-MM-DD dates (issue #2052 leftover).
+ *
+ * Inclusive start, exclusive end. Invalid dates throw. end<=start throws.
+ */
+import { isValidActivityDate } from "../digest.js";
+
+export function daysBetweenIso(startIso: string, endIso: string): number {
+  if (!isValidActivityDate(startIso) || !isValidActivityDate(endIso)) {
+    throw new RangeError(`Invalid date; expected YYYY-MM-DD.`);
+  }
+  const start = Date.parse(`${startIso}T00:00:00Z`);
+  const end = Date.parse(`${endIso}T00:00:00Z`);
+  if (end <= start) {
+    throw new RangeError("end must be after start");
+  }
+  return (end - start) / 86_400_000;
+}


### PR DESCRIPTION
Add `daysBetweenIso(startIso, endIso)` — inclusive start, exclusive end, YYYY-MM-DD.

Part of #2052