### PR TITLE
fix(ci): skip neutralizer stamp when ai-reviewers success is latest

### DIFF
--- a/.github/workflows/ai-review-gate-neutralizer.yml
+++ b/.github/workflows/ai-review-gate-neutralizer.yml
@@ -138,6 +138,47 @@ jobs:
               core.notice(`No older cancelled ai-reviewers suites to clear on head ${headSha.slice(0, 7)}.`);
               return;
             }
+            // Rulesets take the newest ai-reviewers check-run. Posting a neutral
+            // stamp after the gate's success verdict makes merge block forever
+            // (#2711). When success is already the latest completed check, the
+            // dead workflow cancellations do not need a newer neutral overlay.
+            let existingChecks;
+            try {
+              existingChecks = await github.paginate(github.rest.checks.listForRef, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: headSha,
+                filter: 'name',
+                name: 'ai-reviewers',
+                per_page: 100,
+              });
+            } catch (error) {
+              core.notice(
+                `Could not list ai-reviewers check runs for ${headSha.slice(0, 7)} (${error && error.message ? error.message : error}); not neutralizing.`,
+              );
+              return;
+            }
+            const completedChecks = existingChecks
+              .filter((check) => check.status === 'completed' && check.completed_at)
+              .sort((a, b) => Date.parse(b.completed_at) - Date.parse(a.completed_at));
+            const latestCheck = completedChecks[0];
+            if (latestCheck?.conclusion === 'success') {
+              const latestAt = Date.parse(latestCheck.completed_at);
+              const hasNewerBlockingCheck = completedChecks.some(
+                (check) =>
+                  check.id !== latestCheck.id &&
+                  Date.parse(check.completed_at) > latestAt &&
+                  (check.conclusion === 'cancelled' ||
+                    check.conclusion === 'failure' ||
+                    check.conclusion === 'neutral'),
+              );
+              if (!hasNewerBlockingCheck) {
+                core.notice(
+                  `Latest ai-reviewers check on ${headSha.slice(0, 7)} is already success; skipping neutral stamp (#2711).`,
+                );
+                return;
+              }
+            }
             // Post ONE neutral ai-reviewers check-run for the head. A newer,
             // FINAL positive verdict (run ${run.id}) already evaluated this head,
             // so this only clears dead cancelled suites - it never substitutes for

--- a/.github/workflows/ai-review-gate-neutralizer.yml
+++ b/.github/workflows/ai-review-gate-neutralizer.yml
@@ -148,8 +148,8 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: headSha,
-                filter: 'name',
-                name: 'ai-reviewers',
+                filter: 'all',
+                check_name: 'ai-reviewers',
                 per_page: 100,
               });
             } catch (error) {

--- a/tests/ai-review-gate.test.mjs
+++ b/tests/ai-review-gate.test.mjs
@@ -153,6 +153,22 @@ test("AI review gate neutralizer clears only OLDER same-PR cancellations, never 
   assert.match(guard, /return;/);
 });
 
+test("AI review gate neutralizer skips neutral stamp when ai-reviewers success is already latest (#2711)", () => {
+  const neutralizer = readFileSync(
+    ".github/workflows/ai-review-gate-neutralizer.yml",
+    "utf8",
+  );
+  assert.match(neutralizer, /github\.rest\.checks\.listForRef/);
+  assert.match(neutralizer, /filter:\s*'name'/);
+  assert.match(neutralizer, /name:\s*'ai-reviewers'/);
+  assert.match(neutralizer, /latestCheck\?\.conclusion === 'success'/);
+  assert.match(neutralizer, /skipping neutral stamp \(#2711\)/);
+  assert.ok(
+    neutralizer.indexOf("listForRef") < neutralizer.indexOf("github.rest.checks.create("),
+    "existing check lookup must precede neutral checks.create",
+  );
+});
+
 test("AI review gate workflow limits the Dependabot exception to manifest-only missing Cursor activity", () => {
   const workflow = readFileSync(".github/workflows/ai-review-gate.yml", "utf8");
 

--- a/tests/ai-review-gate.test.mjs
+++ b/tests/ai-review-gate.test.mjs
@@ -159,8 +159,8 @@ test("AI review gate neutralizer skips neutral stamp when ai-reviewers success i
     "utf8",
   );
   assert.match(neutralizer, /github\.rest\.checks\.listForRef/);
-  assert.match(neutralizer, /filter:\s*'name'/);
-  assert.match(neutralizer, /name:\s*'ai-reviewers'/);
+  assert.match(neutralizer, /filter:\s*'all'/);
+  assert.match(neutralizer, /check_name:\s*'ai-reviewers'/);
   assert.match(neutralizer, /latestCheck\?\.conclusion === 'success'/);
   assert.match(neutralizer, /skipping neutral stamp \(#2711\)/);
   assert.ok(


### PR DESCRIPTION
Fixes #2711.

When the AI Review Gate completes with success, the neutralizer was posting a newer neutral ai-reviewers check-run that rulesets treated as the latest required context, blocking merge forever.

Skip posting the neutral stamp when the head already has a completed success ai-reviewers check and no newer blocking check exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary neutral review checks when the latest AI review has already completed successfully.
  - Improved handling of check-status lookup failures by stopping without posting an incorrect neutral result.

- **Tests**
  - Added regression coverage to verify successful completed reviews are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->