### PR TITLE
feat(core): add isEmptyDeepRecallTrace helper

### DIFF
--- a/packages/remnic-core/src/recall-deep-trace-empty.test.ts
+++ b/packages/remnic-core/src/recall-deep-trace-empty.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isEmptyDeepRecallTrace } from "./recall-deep-trace-empty.js";
+
+test("null, undefined, and empty array are empty", () => {
+  assert.equal(isEmptyDeepRecallTrace(null), true);
+  assert.equal(isEmptyDeepRecallTrace(undefined), true);
+  assert.equal(isEmptyDeepRecallTrace([]), true);
+});
+
+test("a non-empty trace is not empty", () => {
+  assert.equal(
+    isEmptyDeepRecallTrace([
+      {
+        action: "expand",
+        budget: 1,
+        workingSet: [],
+        frontier: [],
+      },
+    ]),
+    false,
+  );
+});
+
+test("non-array throws", () => {
+  assert.throws(() => isEmptyDeepRecallTrace("trace"), /array/);
+});

--- a/packages/remnic-core/src/recall-deep-trace-empty.ts
+++ b/packages/remnic-core/src/recall-deep-trace-empty.ts
@@ -1,0 +1,16 @@
+/**
+ * Empty-trace guard for deep-recall results (issue #2332 leftover).
+ *
+ * null, undefined, and [] are empty. A non-array throws.
+ */
+
+import type { DeepRecallTraceStep } from "./recall-deep.js";
+
+/** True when the trace is absent or has no steps. */
+export function isEmptyDeepRecallTrace(trace: unknown): trace is readonly [] {
+  if (trace == null) return true;
+  if (!Array.isArray(trace)) {
+    throw new TypeError("trace must be an array");
+  }
+  return (trace as DeepRecallTraceStep[]).length === 0;
+}

--- a/packages/remnic-core/src/recall-deep-trace-empty.ts
+++ b/packages/remnic-core/src/recall-deep-trace-empty.ts
@@ -7,7 +7,9 @@
 import type { DeepRecallTraceStep } from "./recall-deep.js";
 
 /** True when the trace is absent or has no steps. */
-export function isEmptyDeepRecallTrace(trace: unknown): trace is readonly [] {
+export function isEmptyDeepRecallTrace(
+  trace: unknown,
+): trace is null | undefined | readonly [] {
   if (trace == null) return true;
   if (!Array.isArray(trace)) {
     throw new TypeError("trace must be an array");


### PR DESCRIPTION
Part of #2332.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to identify empty deep recall traces, including `null`, `undefined`, and empty arrays.
  - Non-empty arrays are correctly recognized as populated traces.
  - Invalid non-array values now produce a clear type error.

- **Tests**
  - Added coverage for empty, populated, nullish, and invalid trace inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->