### PR TITLE
feat(dedup): add decideMergeOnWrite create/update/skip decision

### DIFF
--- a/.changeset/2330-merge-decision.md
+++ b/.changeset/2330-merge-decision.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `decideMergeOnWrite`, a pure create/update/skip decision over merge candidates. Best candidate by similarity desc, then `updatedAt` desc, then id asc (total order). At or above `duplicateThreshold` skips as duplicate; at or above `updateThreshold` updates the best id; otherwise creates. Invalid thresholds throw `RangeError`; malformed candidates are ignored. Part of #2330.

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -460,3 +460,10 @@ function walkMdFiles(
     }
   }
 }
+
+export {
+  decideMergeOnWrite,
+  type MergeCandidate,
+  type MergeDecision,
+  type MergeDecisionOptions,
+} from "./merge-decision.js";

--- a/packages/remnic-core/src/dedup/merge-decision.test.ts
+++ b/packages/remnic-core/src/dedup/merge-decision.test.ts
@@ -126,3 +126,32 @@ test("unparseable updatedAt sorts last", () => {
     { action: "update", targetId: "newer" },
   );
 });
+
+// Two unparseable timestamps must not make the comparator asymmetric: testing
+// each side against NaN independently returned 1 for both orderings, so the
+// winner depended on array order.
+test("two unparseable updatedAt values break the tie by id, whatever the order", () => {
+  const options = { updateThreshold: 0.5, duplicateThreshold: 0.95 };
+  const alpha = { id: "alpha", similarity: 0.7, updatedAt: "not-a-date" };
+  const beta = { id: "beta", similarity: 0.7, updatedAt: "also-not-a-date" };
+
+  for (const candidates of [[alpha, beta], [beta, alpha]]) {
+    assert.deepEqual(decideMergeOnWrite(candidates, options), {
+      action: "update",
+      targetId: "alpha",
+    });
+  }
+});
+
+test("a parseable updatedAt still outranks an unparseable one in both orders", () => {
+  const options = { updateThreshold: 0.5, duplicateThreshold: 0.95 };
+  const dated = { id: "zeta", similarity: 0.7, updatedAt: "2026-08-19T00:00:00.000Z" };
+  const undated = { id: "alpha", similarity: 0.7, updatedAt: "nope" };
+
+  for (const candidates of [[dated, undated], [undated, dated]]) {
+    assert.deepEqual(decideMergeOnWrite(candidates, options), {
+      action: "update",
+      targetId: "zeta",
+    });
+  }
+});

--- a/packages/remnic-core/src/dedup/merge-decision.test.ts
+++ b/packages/remnic-core/src/dedup/merge-decision.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decideMergeOnWrite,
+  type MergeCandidate,
+  type MergeDecisionOptions,
+} from "./merge-decision.js";
+
+const OPTS: MergeDecisionOptions = { updateThreshold: 0.8, duplicateThreshold: 0.92 };
+
+function candidate(overrides: Partial<MergeCandidate> = {}): MergeCandidate {
+  return {
+    id: "fact-1",
+    similarity: 0.85,
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("no candidates creates", () => {
+  assert.deepEqual(decideMergeOnWrite([], OPTS), { action: "create" });
+});
+
+test("best similarity at or above duplicateThreshold skips as duplicate", () => {
+  assert.deepEqual(
+    decideMergeOnWrite(
+      [candidate({ id: "low", similarity: 0.5 }), candidate({ id: "dup", similarity: 0.92 })],
+      OPTS,
+    ),
+    { action: "skip", reason: "duplicate" },
+  );
+});
+
+test("best similarity between thresholds updates the best candidate", () => {
+  assert.deepEqual(
+    decideMergeOnWrite(
+      [candidate({ id: "best", similarity: 0.9 }), candidate({ id: "worst", similarity: 0.81 })],
+      OPTS,
+    ),
+    { action: "update", targetId: "best" },
+  );
+});
+
+test("best similarity below updateThreshold creates", () => {
+  assert.deepEqual(
+    decideMergeOnWrite([candidate({ similarity: 0.79 })], OPTS),
+    { action: "create" },
+  );
+});
+
+test("invalid thresholds throw RangeError", () => {
+  const bad: MergeDecisionOptions[] = [
+    { updateThreshold: Number.NaN, duplicateThreshold: 0.9 },
+    { updateThreshold: 0.8, duplicateThreshold: Number.POSITIVE_INFINITY },
+    { updateThreshold: -0.1, duplicateThreshold: 0.9 },
+    { updateThreshold: 0.8, duplicateThreshold: 1.1 },
+    { updateThreshold: 0.92, duplicateThreshold: 0.8 }, // duplicate < update
+  ];
+  for (const options of bad) {
+    assert.throws(() => decideMergeOnWrite([], options), RangeError);
+  }
+});
+
+test("updateThreshold 0 is honored, never coerced up", () => {
+  const zero = { updateThreshold: 0, duplicateThreshold: 0.92 };
+  // similarity 0 is >= 0 -> update, not create and not default-band behavior
+  assert.deepEqual(
+    decideMergeOnWrite([candidate({ similarity: 0 })], zero),
+    { action: "update", targetId: "fact-1" },
+  );
+  // no candidates still creates
+  assert.deepEqual(decideMergeOnWrite([], zero), { action: "create" });
+});
+
+test("malformed candidates are ignored, never thrown on", () => {
+  assert.deepEqual(
+    decideMergeOnWrite(
+      [
+        { id: "", similarity: 0.99, updatedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "  ", similarity: 0.99, updatedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "nan", similarity: Number.NaN, updatedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "inf", similarity: Number.POSITIVE_INFINITY, updatedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "high", similarity: 1.5, updatedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "neg", similarity: -0.2, updatedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "good", similarity: 0.85, updatedAt: "2026-01-02T00:00:00.000Z" },
+      ],
+      OPTS,
+    ),
+    { action: "update", targetId: "good" },
+  );
+  // all-malformed behaves like no candidates
+  assert.deepEqual(
+    decideMergeOnWrite([{ id: "nan", similarity: Number.NaN, updatedAt: "x" }], OPTS),
+    { action: "create" },
+  );
+});
+
+test("identical similarity and updatedAt tie-breaks on id ascending, deterministically", () => {
+  const candidates = [
+    candidate({ id: "b", similarity: 0.9, updatedAt: "2026-03-01T00:00:00.000Z" }),
+    candidate({ id: "a", similarity: 0.9, updatedAt: "2026-03-01T00:00:00.000Z" }),
+    candidate({ id: "c", similarity: 0.9, updatedAt: "2026-03-01T00:00:00.000Z" }),
+  ];
+  const first = decideMergeOnWrite(candidates, OPTS);
+  const second = decideMergeOnWrite([...candidates].reverse(), OPTS);
+  assert.deepEqual(first, second);
+  assert.deepEqual(first, { action: "update", targetId: "a" });
+});
+
+test("unparseable updatedAt sorts last", () => {
+  const candidates = [
+    candidate({ id: "bad-date", similarity: 0.9, updatedAt: "not-a-timestamp" }),
+    candidate({ id: "good-date", similarity: 0.9, updatedAt: "2026-03-01T00:00:00.000Z" }),
+  ];
+  assert.deepEqual(decideMergeOnWrite(candidates, OPTS), { action: "update", targetId: "good-date" });
+  // newer timestamp wins when both parse
+  assert.deepEqual(
+    decideMergeOnWrite(
+      [
+        candidate({ id: "older", updatedAt: "2026-01-01T00:00:00.000Z" }),
+        candidate({ id: "newer", updatedAt: "2026-06-01T00:00:00.000Z" }),
+      ],
+      OPTS,
+    ),
+    { action: "update", targetId: "newer" },
+  );
+});

--- a/packages/remnic-core/src/dedup/merge-decision.ts
+++ b/packages/remnic-core/src/dedup/merge-decision.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure create/update/skip decision for merge-on-write (issue #2330 slice).
+ *
+ * No I/O, no LLM. Invalid thresholds throw RangeError; bad candidates are
+ * ignored, never thrown on. `below_threshold` is reserved for a later slice.
+ */
+
+export type MergeDecision =
+  | { action: "create" }
+  | { action: "update"; targetId: string }
+  | { action: "skip"; reason: "duplicate" | "below_threshold" };
+
+export interface MergeCandidate {
+  id: string;
+  similarity: number; // 0..1
+  updatedAt: string; // ISO
+}
+
+export interface MergeDecisionOptions {
+  updateThreshold: number; // >= this similarity -> update
+  duplicateThreshold: number; // >= this similarity -> skip as duplicate
+}
+
+function assertThreshold(value: number, name: string): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError(`invalid ${name}: ${value}`);
+  }
+}
+
+/** Total order: similarity desc, then updatedAt desc, then id asc. NaN times sort last. */
+function compareCandidates(a: MergeCandidate, b: MergeCandidate): number {
+  if (a.similarity !== b.similarity) return b.similarity - a.similarity;
+  // Date.parse never throws; unparseable timestamps yield NaN and sort last.
+  const aTime = Date.parse(a.updatedAt);
+  const bTime = Date.parse(b.updatedAt);
+  if (aTime !== bTime) {
+    if (Number.isNaN(aTime)) return 1;
+    if (Number.isNaN(bTime)) return -1;
+    return bTime - aTime;
+  }
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+export function decideMergeOnWrite(
+  candidates: readonly MergeCandidate[],
+  options: MergeDecisionOptions,
+): MergeDecision {
+  assertThreshold(options.updateThreshold, "updateThreshold");
+  assertThreshold(options.duplicateThreshold, "duplicateThreshold");
+  if (options.duplicateThreshold < options.updateThreshold) {
+    throw new RangeError(
+      `duplicateThreshold ${options.duplicateThreshold} < updateThreshold ${options.updateThreshold}`,
+    );
+  }
+
+  const valid = candidates.filter(
+    (c) =>
+      typeof c.id === "string" &&
+      c.id.trim() !== "" &&
+      typeof c.similarity === "number" &&
+      Number.isFinite(c.similarity) &&
+      c.similarity >= 0 &&
+      c.similarity <= 1,
+  );
+  if (valid.length === 0) return { action: "create" };
+
+  const best = valid.reduce((acc, c) => (compareCandidates(c, acc) < 0 ? c : acc));
+
+  if (best.similarity >= options.duplicateThreshold) {
+    return { action: "skip", reason: "duplicate" };
+  }
+  if (best.similarity >= options.updateThreshold) {
+    return { action: "update", targetId: best.id };
+  }
+  return { action: "create" };
+}

--- a/packages/remnic-core/src/dedup/merge-decision.ts
+++ b/packages/remnic-core/src/dedup/merge-decision.ts
@@ -31,13 +31,15 @@ function assertThreshold(value: number, name: string): void {
 function compareCandidates(a: MergeCandidate, b: MergeCandidate): number {
   if (a.similarity !== b.similarity) return b.similarity - a.similarity;
   // Date.parse never throws; unparseable timestamps yield NaN and sort last.
+  // NaN !== NaN, so the two sides must be classified as a pair: testing each
+  // independently returned 1 for BOTH orderings when both were unparseable,
+  // which breaks antisymmetry and made the winner depend on array order.
   const aTime = Date.parse(a.updatedAt);
   const bTime = Date.parse(b.updatedAt);
-  if (aTime !== bTime) {
-    if (Number.isNaN(aTime)) return 1;
-    if (Number.isNaN(bTime)) return -1;
-    return bTime - aTime;
-  }
+  const aUnparseable = Number.isNaN(aTime);
+  const bUnparseable = Number.isNaN(bTime);
+  if (aUnparseable !== bUnparseable) return aUnparseable ? 1 : -1;
+  if (!aUnparseable && aTime !== bTime) return bTime - aTime;
   return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
 }
 


### PR DESCRIPTION
## Summary

Pure decision function for judge-mediated merge-on-write: given similarity-scored candidates, return `create`, `update` with a target, or `skip`.

- validates thresholds up front — finite, in `[0,1]`, and `duplicateThreshold >= updateThreshold`, else `RangeError`. `updateThreshold: 0` is honored verbatim as an operator value rather than coerced up (config zero-value contract).
- malformed candidates (non-finite or out-of-range similarity, blank id) are filtered, never thrown on, so one bad row cannot fail a write.
- total comparator: similarity desc, then `updatedAt` desc, then `id` asc; an unparseable `updatedAt` sorts last. Repeated calls on equal keys return the same target.
- `skip`/`below_threshold` stays in the union so callers can switch exhaustively, but this slice never emits it — the below-threshold path is `create`.

No LLM call, no I/O. `extraction-persist.ts`, the orchestrator, and storage are untouched.

Part of #2330 — decision function only, so the issue stays open for the extraction/persist wiring.

## Test

`NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/dedup/merge-decision.test.ts` — 9/9 pass.

Covers: empty candidates; duplicate above the duplicate threshold; update between thresholds; create below both; invalid thresholds including `duplicateThreshold < updateThreshold`; `updateThreshold: 0` honored; malformed candidates ignored; deterministic tie-break across two calls; unparseable `updatedAt` sorted last.