### PR TITLE
feat(activity): parse activity.timeline.journal source and heading

### DIFF
--- a/.changeset/journal-source-config-1987.md
+++ b/.changeset/journal-source-config-1987.md
@@ -1,0 +1,9 @@
+---
+"@remnic/core": patch
+---
+
+Parse `activity.timeline.journal.source` (`"file"` default, `"vault"` opt-in)
+and `heading` (required non-empty string in vault mode, trimmed; ignored in
+file mode). Unknown sources and empty vault headings throw instead of
+silently defaulting. Config parsing only; no runtime read path yet.
+Part of #1987.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -55,6 +55,8 @@ The activity subsystem is off by default. It synchronizes redacted text snapshot
 | `activity.sources.token` | `(unset)` | Literal bearer token sent to a trusted local capture daemon over loopback. This parser does not resolve secret references or `${ENV_VAR}` placeholders; omit the field when the daemon needs no auth. |
 | `activity.timeline.enabled` | `false` | Master gate for timeline-card derivation (issue #2049). When false, no timeline cards are built or exposed. |
 | `activity.timeline.journal.enabled` | `false` | Master gate for daily journal seed/show (issue #1984). Journal files live at `journal/<YYYY-MM-DD>.md` and are excluded from generic recall. |
+| `activity.timeline.journal.source` | `"file"` | Where journal text is read from (issue #1987): `"file"` reads `journal/<YYYY-MM-DD>.md`; `"vault"` reads a section of the daily vault note named by `heading`. |
+| `activity.timeline.journal.heading` | `(unset)` | Vault section heading required when `source` is `"vault"`; trimmed on parse, rejected when empty or whitespace-only. Ignored (not stored) in `"file"` mode. |
 | `activity.timeline.qa.enabled` | `false` | Gate for `remnic timeline range|search` (issue #1983). |
 | `activity.timeline.qa.maxRangeDays` | `31` | Maximum `timeline_range` span in days. Integer 1..366. |
 
@@ -2089,6 +2091,8 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `activity.maxMemoriesPerDay` | `0` | `0` (no count cap) |
 | `activity.timeline.enabled` | `false` | `false` |
 | `activity.timeline.journal.enabled` | `false` | `false` |
+| `activity.timeline.journal.source` | `"file"` | `"file"`; `"vault"` only once vault-section journals are deliberately adopted |
+| `activity.timeline.journal.heading` | `(unset)` | `(unset)`; required non-empty when `source` is `"vault"` |
 | `activity.timeline.qa.enabled` | `false` | `false` |
 | `activity.timeline.qa.maxRangeDays` | `31` | `31` |
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -6293,6 +6293,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Master gate for remnic journal seed/show. Default false."
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": ["file", "vault"],
+                    "default": "file",
+                    "description": "Where a day's journal body is read from (issue #1987). 'file' uses journal/<date>.md under the memory dir; 'vault' reads a designated heading in the vault daily note. An unrecognized value is rejected at config load."
+                  },
+                  "heading": {
+                    "type": "string",
+                    "description": "Heading whose section holds the journal body when source is 'vault' (issue #1987). Required and non-blank in vault mode, trimmed before use, ignored in file mode."
                   }
                 }
               },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -6293,6 +6293,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Master gate for remnic journal seed/show. Default false."
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": ["file", "vault"],
+                    "default": "file",
+                    "description": "Where a day's journal body is read from (issue #1987). 'file' uses journal/<date>.md under the memory dir; 'vault' reads a designated heading in the vault daily note. An unrecognized value is rejected at config load."
+                  },
+                  "heading": {
+                    "type": "string",
+                    "description": "Heading whose section holds the journal body when source is 'vault' (issue #1987). Required and non-blank in vault mode, trimmed before use, ignored in file mode."
                   }
                 }
               },

--- a/packages/remnic-core/src/activity/config.test.ts
+++ b/packages/remnic-core/src/activity/config.test.ts
@@ -17,7 +17,7 @@ test("parseActivityConfig defaults to an inert, search-only configuration", () =
     minConfidence: 0.7,
     minImportance: "normal",
     maxMemoriesPerDay: 0,
-    timeline: { enabled: false, journal: { enabled: false }, qa: { enabled: false, maxRangeDays: 31 } },
+    timeline: { enabled: false, journal: { enabled: false, source: "file" }, qa: { enabled: false, maxRangeDays: 31 } },
   });
   assert.deepEqual(parseActivityConfig(undefined), defaultActivityConfig());
 });

--- a/packages/remnic-core/src/activity/config.ts
+++ b/packages/remnic-core/src/activity/config.ts
@@ -1,5 +1,6 @@
 import { coerceBooleanLike, coerceNumber } from "../connectors/coerce.js";
 import { assertValidTimezone } from "./digest.js";
+import { resolveJournalSource } from "./journal-source.js";
 import type { ImportanceLevel } from "../types.js";
 import type {
   ActivityConfig,
@@ -29,7 +30,7 @@ export function defaultActivityConfig(): ActivityConfig {
     minConfidence: 0.7,
     minImportance: "normal",
     maxMemoriesPerDay: 0,
-    timeline: { enabled: false, journal: { enabled: false }, qa: { enabled: false, maxRangeDays: 31 } },
+    timeline: { enabled: false, journal: { enabled: false, source: "file" }, qa: { enabled: false, maxRangeDays: 31 } },
   };
 }
 
@@ -200,7 +201,7 @@ export function parseActivityConfig(raw: unknown): ActivityConfig {
  * is malformed and must fail rather than silently disabling the layer.
  */
 function parseTimelineConfig(raw: unknown): ActivityTimelineConfig {
-  if (raw === undefined) return { enabled: false, journal: { enabled: false }, qa: parseTimelineQaConfig(undefined) };
+  if (raw === undefined) return { enabled: false, journal: { enabled: false, source: "file" }, qa: parseTimelineQaConfig(undefined) };
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     throw new TypeError("activity.timeline must be an object");
   }
@@ -217,7 +218,7 @@ function parseTimelineConfig(raw: unknown): ActivityTimelineConfig {
 }
 
 function parseTimelineJournalConfig(raw: unknown): ActivityTimelineJournalConfig {
-  if (raw === undefined) return { enabled: false };
+  if (raw === undefined) return { enabled: false, source: "file" };
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     throw new TypeError("activity.timeline.journal must be an object");
   }
@@ -226,7 +227,22 @@ function parseTimelineJournalConfig(raw: unknown): ActivityTimelineJournalConfig
   if (journal.enabled !== undefined && enabledValue === undefined) {
     throw new TypeError("activity.timeline.journal.enabled must be a boolean");
   }
-  return { enabled: enabledValue ?? false };
+  const heading = journal.heading;
+  if (heading !== undefined && typeof heading !== "string") {
+    throw new TypeError("activity.timeline.journal.heading must be a string");
+  }
+  const source = journal.source === undefined ? "file" : typeof journal.source === "string" ? journal.source : "";
+  const resolved = resolveJournalSource({ source, heading: heading ?? "" });
+  if (!resolved.ok) {
+    if (resolved.error === "unknown_source") {
+      throw new RangeError('activity.timeline.journal.source must be one of "file", "vault"');
+    }
+    throw new RangeError('activity.timeline.journal.heading must be a non-empty string when source is "vault"');
+  }
+  if (resolved.mode === "vault") {
+    return { enabled: enabledValue ?? false, source: "vault", heading: resolved.heading };
+  }
+  return { enabled: enabledValue ?? false, source: "file" };
 }
 
 function parseTimelineQaConfig(raw: unknown): ActivityTimelineQaConfig {

--- a/packages/remnic-core/src/activity/journal.test.ts
+++ b/packages/remnic-core/src/activity/journal.test.ts
@@ -32,6 +32,46 @@ test("activity.timeline.journal.enabled defaults off", () => {
   );
 });
 
+test("activity.timeline.journal source defaults to file with no heading", () => {
+  const journal = parseActivityConfig(undefined).timeline.journal;
+  assert.equal(journal.source, "file");
+  assert.equal(journal.heading, undefined);
+});
+
+test("activity.timeline.journal vault mode trims and stores the heading", () => {
+  const journal = parseActivityConfig({ timeline: { journal: { enabled: true, source: "vault", heading: " Journal " } } }).timeline.journal;
+  assert.deepEqual(journal, { enabled: true, source: "vault", heading: "Journal" });
+});
+
+test("activity.timeline.journal vault mode requires a non-empty heading", () => {
+  for (const heading of [undefined, "", "   "]) {
+    assert.throws(
+      () => parseActivityConfig({ timeline: { journal: { source: "vault", heading } } }),
+      RangeError,
+    );
+  }
+});
+
+test("activity.timeline.journal rejects an unknown source", () => {
+  assert.throws(
+    () => parseActivityConfig({ timeline: { journal: { source: "memoryDir" } } }),
+    /activity\.timeline\.journal\.source must be one of "file", "vault"/,
+  );
+});
+
+test("activity.timeline.journal rejects a non-string heading", () => {
+  assert.throws(
+    () => parseActivityConfig({ timeline: { journal: { heading: 5 } } }),
+    /activity\.timeline\.journal\.heading must be a string/,
+  );
+});
+
+test("activity.timeline.journal file mode ignores a provided heading", () => {
+  const journal = parseActivityConfig({ timeline: { journal: { source: "file", heading: "Ignored" } } }).timeline.journal;
+  assert.deepEqual(journal, { enabled: false, source: "file" });
+  assert.equal("heading" in journal, false);
+});
+
 test("seed is a hard no-op without force", () => {
   withMemoryDir((memoryDir) => {
     const first = seedJournal({

--- a/packages/remnic-core/src/activity/types.ts
+++ b/packages/remnic-core/src/activity/types.ts
@@ -99,6 +99,10 @@ export interface ActivitySourceConfig {
 /** Opt-in daily journal settings (issue #1984). Default off. */
 export interface ActivityTimelineJournalConfig {
   enabled: boolean;
+  /** Where the journal text is read from (issue #1987). */
+  source: "file" | "vault";
+  /** Vault section heading, trimmed. Required when `source` is `"vault"`; not stored in `"file"` mode. */
+  heading?: string;
 }
 
 /** Opt-in timeline Q&A range/search settings (issue #1983 PR1). Default off. */

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2569,7 +2569,7 @@ test("parseConfig forwards activity source settings", () => {
     minConfidence: 0.7,
     minImportance: "normal",
     maxMemoriesPerDay: 0,
-    timeline: { enabled: false, journal: { enabled: false }, qa: { enabled: false, maxRangeDays: 31 } },
+    timeline: { enabled: false, journal: { enabled: false, source: "file" }, qa: { enabled: false, maxRangeDays: 31 } },
   });
 });
 

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -6293,6 +6293,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Master gate for remnic journal seed/show. Default false."
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": ["file", "vault"],
+                    "default": "file",
+                    "description": "Where a day's journal body is read from (issue #1987). 'file' uses journal/<date>.md under the memory dir; 'vault' reads a designated heading in the vault daily note. An unrecognized value is rejected at config load."
+                  },
+                  "heading": {
+                    "type": "string",
+                    "description": "Heading whose section holds the journal body when source is 'vault' (issue #1987). Required and non-blank in vault mode, trimmed before use, ignored in file mode."
                   }
                 }
               },

--- a/scripts/config-contract/grandfathered.json
+++ b/scripts/config-contract/grandfathered.json
@@ -116,11 +116,6 @@
   },
   {
     "kind": "undocumented-key",
-    "key": "agentAccessHttp.authToken.source",
-    "issue": "#1990"
-  },
-  {
-    "kind": "undocumented-key",
     "key": "briefing",
     "issue": "#1990"
   },

--- a/scripts/config-contract/parsed-keys.snapshot.json
+++ b/scripts/config-contract/parsed-keys.snapshot.json
@@ -61,6 +61,8 @@
     "activity.timeline.enabled",
     "activity.timeline.journal",
     "activity.timeline.journal.enabled",
+    "activity.timeline.journal.heading",
+    "activity.timeline.journal.source",
     "activity.timeline.qa",
     "activity.timeline.qa.enabled",
     "activity.timeline.qa.maxRangeDays",


### PR DESCRIPTION
## Summary

Config parsing for the vault-sourced journal mode. The pure reader (`readVaultJournal`) and resolver (`resolveJournalSource`) already landed; this teaches `parseActivityConfig` to accept the operator-facing settings.

`activity.timeline.journal` gains:

| Setting | Default | Behavior |
|---|---|---|
| `source` | `"file"` | `"file"` or `"vault"`; an unrecognized value throws a `RangeError` naming the allowed values rather than silently defaulting |
| `heading` | unset | required and non-blank when `source: "vault"` (else `RangeError`); trimmed before storage; a non-string throws a `TypeError`; ignored and not stored in `file` mode |

The source/heading branch delegates to the already-exported `resolveJournalSource` instead of re-implementing it, so the enum lives in exactly one place. `enabled` and its boolean-like coercion are untouched, and `defaultActivityConfig()` now reports `{ enabled: false, source: "file" }`.

No runtime read path, CLI, MCP, or HTTP surface is wired — parsing only.

Part of #1987 — the read-back wiring is the next slice, so the issue stays open.

## Test

`NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/journal.test.ts` — 10/10 pass.

Six new cases: default `source`; vault mode trimming ` Journal `; vault mode with missing/empty/whitespace heading throwing; unknown source naming allowed values; non-string heading; and `file` mode discarding a supplied heading. The two default-shape deep-equals in `activity/config.test.ts` and `src/config.test.ts` were updated for the new field (177/177 pass there).

`docs/config-reference.md` documents both settings.