### PR TITLE
feat(activity): compare weekly previous-period totals without treating missing as zero

### DIFF
--- a/.changeset/week-previous-2052.md
+++ b/.changeset/week-previous-2052.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": patch
+---
+
+Add `compareWeeklyPreviousPeriod` to compare weekly duration totals against
+the previous week. Missing or timestamp-less previous periods return
+`{ available: false }` instead of zero deltas. Non-finite durations throw.
+Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -14,6 +14,7 @@ export * from "./recap-export.js";
 export * from "./recap-markdown.js";
 export * from "./week-export.js";
 export * from "./week-snapshot.js";
+export * from "./week-previous.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";
 export * from "./analysis-prompt.js";

--- a/packages/remnic-core/src/activity/timeline/week-previous.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-previous.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { compareWeeklyPreviousPeriod } from "./week-previous.js";
+
+const CURRENT = {
+  activeMs: 3_600_000,
+  idleMs: 600_000,
+  pauseMs: 120_000,
+  gapMs: 300_000,
+  unclassifiedMs: 60_000,
+};
+
+const PREVIOUS = {
+  activeMs: 1_800_000,
+  idleMs: 900_000,
+  pauseMs: 120_000,
+  gapMs: 100_000,
+  unclassifiedMs: 0,
+};
+
+test("null previous is unavailable, not zero", () => {
+  const result = compareWeeklyPreviousPeriod({
+    previous: null,
+    current: CURRENT,
+    previousStartUtc: "2026-07-06T00:00:00Z",
+    previousEndUtc: "2026-07-13T00:00:00Z",
+  });
+  assert.deepEqual(result, { available: false });
+  assert.equal("deltaActiveMs" in result, false);
+});
+
+test("undefined previous is unavailable", () => {
+  const result = compareWeeklyPreviousPeriod({
+    previous: undefined,
+    current: CURRENT,
+  });
+  assert.deepEqual(result, { available: false });
+});
+
+test("previous without timestamps is unavailable", () => {
+  const result = compareWeeklyPreviousPeriod({ previous: PREVIOUS, current: CURRENT });
+  assert.deepEqual(result, { available: false });
+});
+
+test("previous with blank timestamps is unavailable", () => {
+  const result = compareWeeklyPreviousPeriod({
+    previous: PREVIOUS,
+    current: CURRENT,
+    previousStartUtc: "   ",
+    previousEndUtc: "\t",
+  });
+  assert.deepEqual(result, { available: false });
+});
+
+test("mixed deltas keep sign and trim timestamps", () => {
+  const result = compareWeeklyPreviousPeriod({
+    previous: PREVIOUS,
+    current: CURRENT,
+    previousStartUtc: " 2026-07-06T00:00:00Z ",
+    previousEndUtc: " 2026-07-13T00:00:00Z ",
+  });
+  assert.equal(result.available, true);
+  if (!result.available) return;
+  assert.equal(result.previousStartUtc, "2026-07-06T00:00:00Z");
+  assert.equal(result.previousEndUtc, "2026-07-13T00:00:00Z");
+  assert.equal(result.deltaActiveMs, 1_800_000);
+  assert.equal(result.deltaIdleMs, -300_000);
+  assert.equal(result.deltaPauseMs, 0);
+  assert.equal(result.deltaGapMs, 200_000);
+  assert.equal(result.deltaUnclassifiedMs, 60_000);
+});
+
+test("NaN duration on previous throws TypeError", () => {
+  assert.throws(
+    () =>
+      compareWeeklyPreviousPeriod({
+        previous: { ...PREVIOUS, gapMs: Number.NaN },
+        current: CURRENT,
+        previousStartUtc: "2026-07-06T00:00:00Z",
+        previousEndUtc: "2026-07-13T00:00:00Z",
+      }),
+    TypeError,
+  );
+});
+
+test("Infinity duration on current throws TypeError", () => {
+  assert.throws(
+    () =>
+      compareWeeklyPreviousPeriod({
+        previous: PREVIOUS,
+        current: { ...CURRENT, activeMs: Number.POSITIVE_INFINITY },
+      }),
+    /current\.activeMs/,
+  );
+});
+
+test("all-zero current with present previous is available with negative deltas", () => {
+  const zeros = {
+    activeMs: 0,
+    idleMs: 0,
+    pauseMs: 0,
+    gapMs: 0,
+    unclassifiedMs: 0,
+  };
+  const result = compareWeeklyPreviousPeriod({
+    previous: PREVIOUS,
+    current: zeros,
+    previousStartUtc: "2026-07-06T00:00:00Z",
+    previousEndUtc: "2026-07-13T00:00:00Z",
+  });
+  assert.equal(result.available, true);
+  if (!result.available) return;
+  assert.equal(result.deltaActiveMs, -PREVIOUS.activeMs);
+  assert.equal(result.deltaIdleMs, -PREVIOUS.idleMs);
+  assert.equal(result.deltaPauseMs, -PREVIOUS.pauseMs);
+  assert.equal(result.deltaGapMs, -PREVIOUS.gapMs);
+  assert.equal(result.deltaUnclassifiedMs, 0);
+});

--- a/packages/remnic-core/src/activity/timeline/week-previous.ts
+++ b/packages/remnic-core/src/activity/timeline/week-previous.ts
@@ -1,0 +1,83 @@
+/**
+ * Previous-week duration comparison (issue #2052).
+ *
+ * The prior week is explicit when unavailable. It is never silently treated
+ * as zero.
+ */
+
+export interface WeeklyDurationTotals {
+  activeMs: number;
+  idleMs: number;
+  pauseMs: number;
+  gapMs: number;
+  unclassifiedMs: number;
+}
+
+export type WeeklyPreviousPeriod =
+  | { available: false }
+  | {
+      available: true;
+      previousStartUtc: string;
+      previousEndUtc: string;
+      deltaActiveMs: number;
+      deltaIdleMs: number;
+      deltaPauseMs: number;
+      deltaGapMs: number;
+      deltaUnclassifiedMs: number;
+    };
+
+const DURATION_FIELDS = [
+  "activeMs",
+  "idleMs",
+  "pauseMs",
+  "gapMs",
+  "unclassifiedMs",
+] as const;
+
+function assertFiniteTotals(totals: WeeklyDurationTotals, label: string): void {
+  for (const field of DURATION_FIELDS) {
+    const value = totals[field];
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new TypeError(`${label}.${field} must be a finite number; got ${String(value)}.`);
+    }
+  }
+}
+
+/**
+ * Compare this week's duration totals against the previous week's.
+ *
+ * `previous` absent (null/undefined) or lacking trimmed start/end timestamps
+ * returns `{ available: false }` — never zero deltas. Otherwise returns the
+ * per-field deltas (`current - previous`, may be negative). Pure.
+ */
+export function compareWeeklyPreviousPeriod(input: {
+  previous: WeeklyDurationTotals | null | undefined;
+  current: WeeklyDurationTotals;
+  previousStartUtc?: string;
+  previousEndUtc?: string;
+}): WeeklyPreviousPeriod {
+  const { previous, current, previousStartUtc, previousEndUtc } = input;
+  assertFiniteTotals(current, "current");
+
+  if (previous === null || previous === undefined) {
+    return { available: false };
+  }
+  assertFiniteTotals(previous, "previous");
+
+  const start = previousStartUtc?.trim() ?? "";
+  const end = previousEndUtc?.trim() ?? "";
+  if (start === "" || end === "") {
+    return { available: false };
+  }
+
+  return {
+    available: true,
+    previousStartUtc: start,
+    previousEndUtc: end,
+    deltaActiveMs: current.activeMs - previous.activeMs,
+    deltaIdleMs: current.idleMs - previous.idleMs,
+    deltaPauseMs: current.pauseMs - previous.pauseMs,
+    deltaGapMs: current.gapMs - previous.gapMs,
+    deltaUnclassifiedMs: current.unclassifiedMs - previous.unclassifiedMs,
+  };
+}


### PR DESCRIPTION
## Summary
Adds `compareWeeklyPreviousPeriod`, a pure helper for the #2052 weekly analytics snapshot. Missing previous-week data returns `{ available: false }` and never silently becomes zero deltas.

Part of #2052.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/timeline/week-previous.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly comparison functionality to show duration changes from the previous week.
  * Reports whether previous-period data is available.
  * Includes changes for active, idle, pause, gap, and unclassified durations.
  * Normalizes period timestamps and validates duration values.

* **Tests**
  * Added coverage for missing data, timestamp handling, duration changes, zero values, and invalid durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->