### PR TITLE
feat(activity): add content-free activity health snapshot

### DIFF
--- a/.changeset/activity-privacy-status-2053.md
+++ b/.changeset/activity-privacy-status-2053.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+---
+
+Add `buildActivityHealth` for a content-free activity health snapshot.
+Part of #2053.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -19,6 +19,7 @@ export * from "./journal.js";
 export * from "./journal-vault-read.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";
+export * from "./privacy-status.js";
 export * from "./privacy-window.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";

--- a/packages/remnic-core/src/activity/privacy-status.test.ts
+++ b/packages/remnic-core/src/activity/privacy-status.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ACTIVITY_ANALYSIS_STATUSES, buildActivityHealth } from "./privacy-status.js";
+
+const base = {
+  enabled: true,
+  retentionDays: 30,
+  sourceRevision: "rev-42",
+  lastAnalysisStatus: "ok",
+  observationCount: 7,
+  cardCount: 3,
+} as const;
+
+test("enabled true returns full snapshot with trimmed revision", () => {
+  const snapshot = buildActivityHealth({ ...base, sourceRevision: "  rev-42  " });
+  assert.deepEqual(snapshot, {
+    enabled: true,
+    retentionDays: 30,
+    sourceRevision: "rev-42",
+    lastAnalysisStatus: "ok",
+    observationCount: 7,
+    cardCount: 3,
+  });
+});
+
+test("snapshot keys equal the documented set", () => {
+  const snapshot = buildActivityHealth({ ...base });
+  assert.deepEqual(Object.keys(snapshot), [
+    "enabled",
+    "retentionDays",
+    "sourceRevision",
+    "lastAnalysisStatus",
+    "observationCount",
+    "cardCount",
+  ]);
+});
+
+test("enabled false still returns snapshot with counts as given", () => {
+  const snapshot = buildActivityHealth({
+    ...base,
+    enabled: false,
+    observationCount: 9,
+    cardCount: 0,
+  });
+  assert.equal(snapshot.enabled, false);
+  assert.equal(snapshot.retentionDays, 30);
+  assert.equal(snapshot.observationCount, 9);
+  assert.equal(snapshot.cardCount, 0);
+});
+
+test("retentionDays 0 (keep forever) is preserved", () => {
+  assert.equal(buildActivityHealth({ ...base, retentionDays: 0 }).retentionDays, 0);
+});
+
+test("retentionDays must be a non-negative integer", () => {
+  assert.throws(
+    () => buildActivityHealth({ ...base, retentionDays: -1 }),
+    { name: "RangeError", message: /retentionDays/ },
+  );
+  assert.throws(() => buildActivityHealth({ ...base, retentionDays: 1.5 }), /retentionDays/);
+});
+
+test("null or missing sourceRevision maps to null", () => {
+  const nulled = buildActivityHealth({ ...base, sourceRevision: null });
+  const missing = buildActivityHealth({ ...base, sourceRevision: undefined });
+  assert.equal(nulled.sourceRevision, null);
+  assert.equal(missing.sourceRevision, null);
+});
+
+test("trimmed-blank sourceRevision maps to null", () => {
+  const blank = buildActivityHealth({ ...base, sourceRevision: "   \t " });
+  const empty = buildActivityHealth({ ...base, sourceRevision: "" });
+  assert.equal(blank.sourceRevision, null);
+  assert.equal(empty.sourceRevision, null);
+});
+
+test("missing lastAnalysisStatus defaults to never", () => {
+  const missing = buildActivityHealth({ ...base, lastAnalysisStatus: undefined });
+  const nulled = buildActivityHealth({ ...base, lastAnalysisStatus: null });
+  assert.equal(missing.lastAnalysisStatus, "never");
+  assert.equal(nulled.lastAnalysisStatus, "never");
+});
+
+test("each allow-list status round-trips", () => {
+  for (const status of ACTIVITY_ANALYSIS_STATUSES) {
+    const snapshot = buildActivityHealth({ ...base, lastAnalysisStatus: status });
+    assert.equal(snapshot.lastAnalysisStatus, status);
+  }
+});
+
+test("unknown analysis status throws listing the allow-list", () => {
+  assert.throws(
+    () => buildActivityHealth({ ...base, lastAnalysisStatus: "pending" }),
+    (err: unknown) => {
+      assert.ok(err instanceof TypeError);
+      assert.match(err.message, /analysis status/);
+      for (const status of ACTIVITY_ANALYSIS_STATUSES) {
+        assert.ok(err.message.includes(status), `message lists ${status}`);
+      }
+      return true;
+    },
+  );
+});
+
+test("negative or non-integer counts throw", () => {
+  assert.throws(
+    () => buildActivityHealth({ ...base, observationCount: -1 }),
+    { name: "RangeError", message: /count/ },
+  );
+  assert.throws(
+    () => buildActivityHealth({ ...base, cardCount: -2 }),
+    { name: "RangeError", message: /count/ },
+  );
+  assert.throws(() => buildActivityHealth({ ...base, observationCount: 1.5 }), /count/);
+  assert.throws(() => buildActivityHealth({ ...base, cardCount: Number.NaN }), /count/);
+});

--- a/packages/remnic-core/src/activity/privacy-status.ts
+++ b/packages/remnic-core/src/activity/privacy-status.ts
@@ -1,0 +1,65 @@
+/**
+ * Content-free activity health snapshot (issue #2053 slice).
+ *
+ * Pure status builder. Surfaces report gate state, retention policy, source
+ * revision, last analysis outcome, and counts only — never observation or
+ * card content, prompts, or media.
+ */
+
+export const ACTIVITY_ANALYSIS_STATUSES = ["ok", "failed", "skipped", "never"] as const;
+export type ActivityAnalysisStatus = (typeof ACTIVITY_ANALYSIS_STATUSES)[number];
+
+export interface ActivityHealthSnapshot {
+  enabled: boolean;
+  retentionDays: number;
+  sourceRevision: string | null;
+  lastAnalysisStatus: ActivityAnalysisStatus;
+  observationCount: number;
+  cardCount: number;
+}
+
+const STATUS_ALLOW_LIST = ACTIVITY_ANALYSIS_STATUSES.join(", ");
+
+/**
+ * Build the health snapshot. Master `enabled: false` still returns a snapshot
+ * (surfaces must report the gate); counts stay as given and are never redacted.
+ */
+export function buildActivityHealth(input: {
+  enabled: boolean;
+  retentionDays: number;
+  sourceRevision?: string | null;
+  lastAnalysisStatus?: string | null;
+  observationCount: number;
+  cardCount: number;
+}): ActivityHealthSnapshot {
+  const { enabled, retentionDays, observationCount, cardCount } = input;
+  if (!Number.isInteger(retentionDays) || retentionDays < 0) {
+    throw new RangeError("retentionDays must be a non-negative integer");
+  }
+  if (!Number.isInteger(observationCount) || observationCount < 0) {
+    throw new RangeError("invalid count: observationCount must be a non-negative integer");
+  }
+  if (!Number.isInteger(cardCount) || cardCount < 0) {
+    throw new RangeError("invalid count: cardCount must be a non-negative integer");
+  }
+  const rawRevision = input.sourceRevision;
+  const trimmedRevision = typeof rawRevision === "string" ? rawRevision.trim() : "";
+  const rawStatus = input.lastAnalysisStatus;
+  let lastAnalysisStatus: ActivityAnalysisStatus = "never";
+  if (rawStatus !== undefined && rawStatus !== null) {
+    if (!(ACTIVITY_ANALYSIS_STATUSES as readonly string[]).includes(rawStatus)) {
+      throw new TypeError(
+        `unknown analysis status ${JSON.stringify(rawStatus)}; expected one of: ${STATUS_ALLOW_LIST}`,
+      );
+    }
+    lastAnalysisStatus = rawStatus as ActivityAnalysisStatus;
+  }
+  return {
+    enabled,
+    retentionDays,
+    sourceRevision: trimmedRevision === "" ? null : trimmedRevision,
+    lastAnalysisStatus,
+    observationCount,
+    cardCount,
+  };
+}


### PR DESCRIPTION
## Summary
Adds `buildActivityHealth`, a content-free status snapshot for the #2053 activity privacy/health surface. It reports enabled state, retention, source revision, last analysis status, and counts — never prompts, card bodies, or media.

Part of #2053.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/privacy-status.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a content-free activity health snapshot with gate status, retention settings, source revision, analysis status, and activity counts.
  * Added validation for supported analysis statuses, non-negative retention values, and count inputs.
  * Blank source revisions are normalized, and missing analysis status defaults to “never.”

* **Bug Fixes**
  * Invalid statuses and negative or non-integer values are now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->