### PR TITLE
feat(recall): rank and cap the deep-recall frontier at 20

### DIFF
--- a/.changeset/2332-deep-frontier.md
+++ b/.changeset/2332-deep-frontier.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure deep-recall frontier ranker. Drops blank ids and invalid counts, dedups by node, sorts by shared anchors then id, and caps at 20. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-frontier.test.ts
+++ b/packages/remnic-core/src/recall-deep-frontier.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DEEP_RECALL_FRONTIER_CAP, rankDeepRecallFrontier } from "./recall-deep-frontier.js";
+
+test("empty input returns empty", () => {
+  assert.deepEqual(rankDeepRecallFrontier([]), []);
+});
+
+test("blank nodeIds and counts below 1 are dropped", () => {
+  const result = rankDeepRecallFrontier([
+    { nodeId: "", sharedAnchorCount: 3 },
+    { nodeId: "   ", sharedAnchorCount: 3 },
+    { nodeId: "a", sharedAnchorCount: 0 },
+    { nodeId: "b", sharedAnchorCount: -2 },
+    { nodeId: "c", sharedAnchorCount: 1 },
+  ]);
+  assert.deepEqual(result, [{ nodeId: "c", sharedAnchorCount: 1 }]);
+});
+
+test("NaN and infinite counts are dropped", () => {
+  const result = rankDeepRecallFrontier([
+    { nodeId: "a", sharedAnchorCount: Number.NaN },
+    { nodeId: "b", sharedAnchorCount: Number.POSITIVE_INFINITY },
+    { nodeId: "c", sharedAnchorCount: 2 },
+  ]);
+  assert.deepEqual(result, [{ nodeId: "c", sharedAnchorCount: 2 }]);
+});
+
+test("dedup by nodeId keeps the higher count, first on tie", () => {
+  const result = rankDeepRecallFrontier([
+    { nodeId: "a", sharedAnchorCount: 2 },
+    { nodeId: "a", sharedAnchorCount: 5 },
+    { nodeId: "b", sharedAnchorCount: 4 },
+    { nodeId: "b", sharedAnchorCount: 4 },
+  ]);
+  assert.deepEqual(result, [
+    { nodeId: "a", sharedAnchorCount: 5 },
+    { nodeId: "b", sharedAnchorCount: 4 },
+  ]);
+});
+
+test("sorts by count desc then nodeId asc", () => {
+  const result = rankDeepRecallFrontier([
+    { nodeId: "c", sharedAnchorCount: 3 },
+    { nodeId: "a", sharedAnchorCount: 3 },
+    { nodeId: "b", sharedAnchorCount: 9 },
+    { nodeId: "d", sharedAnchorCount: 1 },
+  ]);
+  assert.deepEqual(
+    result.map((candidate) => candidate.nodeId),
+    ["b", "a", "c", "d"],
+  );
+});
+
+test("caps at 20 keeping the top 20 of 21", () => {
+  const candidates = Array.from({ length: 21 }, (_, i) => ({
+    nodeId: `n${String(i).padStart(2, "0")}`,
+    sharedAnchorCount: i + 1,
+  }));
+  const result = rankDeepRecallFrontier(candidates);
+  assert.equal(result.length, DEEP_RECALL_FRONTIER_CAP);
+  assert.equal(result[0]?.nodeId, "n20");
+  assert.equal(result.at(-1)?.nodeId, "n01");
+  assert.ok(!result.some((candidate) => candidate.nodeId === "n00"));
+});
+
+test("does not mutate the input array or its objects", () => {
+  const input = [
+    { nodeId: " b ", sharedAnchorCount: 2 },
+    { nodeId: "a", sharedAnchorCount: 1 },
+  ];
+  const snapshot = structuredClone(input);
+  rankDeepRecallFrontier(input);
+  assert.deepEqual(input, snapshot);
+});
+
+test("two calls on the same input are deep-equal", () => {
+  const input = [
+    { nodeId: "a", sharedAnchorCount: 2 },
+    { nodeId: "b", sharedAnchorCount: 2 },
+    { nodeId: "a", sharedAnchorCount: 7 },
+  ];
+  assert.deepEqual(rankDeepRecallFrontier(input), rankDeepRecallFrontier(input));
+});

--- a/packages/remnic-core/src/recall-deep-frontier.ts
+++ b/packages/remnic-core/src/recall-deep-frontier.ts
@@ -1,0 +1,39 @@
+/**
+ * Deep-recall frontier ranker (issue #2332).
+ *
+ * Pure. After every working-set change the frontier is capped at
+ * DEEP_RECALL_FRONTIER_CAP items ordered by shared-anchor count
+ * descending, then nodeId ascending — a total comparator.
+ */
+
+export const DEEP_RECALL_FRONTIER_CAP = 20;
+
+export interface DeepRecallFrontierCandidate {
+  nodeId: string;
+  sharedAnchorCount: number;
+}
+
+export function rankDeepRecallFrontier(
+  candidates: readonly DeepRecallFrontierCandidate[],
+): DeepRecallFrontierCandidate[] {
+  const byNodeId = new Map<string, DeepRecallFrontierCandidate>();
+  for (const candidate of candidates) {
+    const nodeId = typeof candidate.nodeId === "string" ? candidate.nodeId.trim() : "";
+    if (nodeId === "") continue;
+    const count = candidate.sharedAnchorCount;
+    if (typeof count !== "number" || !Number.isFinite(count) || count < 1) continue;
+    const kept = byNodeId.get(nodeId);
+    if (kept === undefined || count > kept.sharedAnchorCount) {
+      byNodeId.set(nodeId, { nodeId, sharedAnchorCount: count });
+    }
+  }
+  return [...byNodeId.values()]
+    .sort((a, b) => {
+      if (a.sharedAnchorCount !== b.sharedAnchorCount) {
+        return b.sharedAnchorCount - a.sharedAnchorCount;
+      }
+      if (a.nodeId !== b.nodeId) return a.nodeId < b.nodeId ? -1 : 1;
+      return 0;
+    })
+    .slice(0, DEEP_RECALL_FRONTIER_CAP);
+}


### PR DESCRIPTION
## Summary
Adds `rankDeepRecallFrontier`, a pure cap-20 ranker for the #2332 deep-recall stepper. Candidates sort by shared-anchor count descending, then nodeId ascending. Blank ids and zero-overlap nodes are dropped; duplicates keep the higher count.

Part of #2332.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/recall-deep-frontier.test.ts`