### PR TITLE
feat(extraction): estimate span-mode token savings for the Phase A bench

### DIFF
--- a/.changeset/2333-span-tokens.md
+++ b/.changeset/2333-span-tokens.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add pure span-mode token-cost estimators: `estimateGeneratedTokens`, `estimateOffsetTokens`, and `spanModeSavesTokens`. Phase A helper for the bench that compares offset prediction against generating the memory value. Extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-tokens.test.ts
+++ b/packages/remnic-core/src/extraction-span-tokens.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  estimateGeneratedTokens,
+  estimateOffsetTokens,
+  spanModeSavesTokens,
+} from "./extraction-span-tokens.js";
+
+test("estimateGeneratedTokens: 0 chars -> 0 tokens", () => {
+  assert.equal(estimateGeneratedTokens(0), 0);
+});
+
+test("estimateGeneratedTokens: 1..4 chars -> 1 token", () => {
+  for (const chars of [1, 2, 3, 4]) {
+    assert.equal(estimateGeneratedTokens(chars), 1);
+  }
+});
+
+test("estimateGeneratedTokens: 5 chars -> 2 tokens", () => {
+  assert.equal(estimateGeneratedTokens(5), 2);
+});
+
+test("estimateGeneratedTokens: invalid charCount throws", () => {
+  assert.throws(() => estimateGeneratedTokens(-1), /charCount/);
+  assert.throws(() => estimateGeneratedTokens(Number.NaN), /charCount/);
+  assert.throws(() => estimateGeneratedTokens(3.7), /charCount/);
+  assert.throws(() => estimateGeneratedTokens(-1), RangeError);
+  assert.throws(() => estimateGeneratedTokens(Number.NaN), RangeError);
+});
+
+test("estimateOffsetTokens: (0, 12) cost is a positive integer", () => {
+  const cost = estimateOffsetTokens(0, 12);
+  assert.equal(Number.isInteger(cost), true);
+  assert.ok(cost > 0);
+});
+
+test("estimateOffsetTokens: offset 0 costs one character (one token)", () => {
+  assert.equal(estimateOffsetTokens(0, 0), 2);
+});
+
+test("estimateOffsetTokens: reversed span throws", () => {
+  assert.throws(() => estimateOffsetTokens(13, 12), RangeError);
+  assert.throws(() => estimateOffsetTokens(13, 12), /reversed/);
+});
+
+test("estimateOffsetTokens: non-finite or non-integer offsets throw", () => {
+  assert.throws(() => estimateOffsetTokens(Number.NaN, 12), RangeError);
+  assert.throws(() => estimateOffsetTokens(0, Number.POSITIVE_INFINITY), RangeError);
+  assert.throws(() => estimateOffsetTokens(0.5, 12), RangeError);
+});
+
+test("spanModeSavesTokens: long generated value beats small offsets", () => {
+  assert.equal(
+    spanModeSavesTokens({ generatedCharCount: 1000, start: 0, end: 12 }),
+    true,
+  );
+});
+
+test("spanModeSavesTokens: equal costs return false", () => {
+  // (0, 12) costs 2 tokens; 5..8 generated chars also cost 2 tokens.
+  assert.equal(
+    spanModeSavesTokens({ generatedCharCount: 8, start: 0, end: 12 }),
+    false,
+  );
+  assert.equal(
+    spanModeSavesTokens({ generatedCharCount: 5, start: 0, end: 0 }),
+    false,
+  );
+});

--- a/packages/remnic-core/src/extraction-span-tokens.ts
+++ b/packages/remnic-core/src/extraction-span-tokens.ts
@@ -1,0 +1,44 @@
+/**
+ * Isolated span token-cost estimator (issue #2333, Phase A).
+ *
+ * Pure. Estimates the output-token cost of emitting span offsets versus
+ * generating the memory value, so the Phase A bench can compare both sides
+ * without touching the extraction engine.
+ */
+
+const CHARS_PER_TOKEN = 4;
+
+export function estimateGeneratedTokens(charCount: number): number {
+  if (!Number.isInteger(charCount) || charCount < 0) {
+    throw new RangeError(`charCount must be a non-negative integer, got ${charCount}`);
+  }
+  return Math.ceil(charCount / CHARS_PER_TOKEN);
+}
+
+export function estimateOffsetTokens(start: number, end: number): number {
+  if (!Number.isInteger(start)) {
+    throw new RangeError(`start must be a finite integer, got ${start}`);
+  }
+  if (!Number.isInteger(end)) {
+    throw new RangeError(`end must be a finite integer, got ${end}`);
+  }
+  if (start > end) {
+    throw new RangeError(`reversed span: start ${start} > end ${end}`);
+  }
+  return offsetTokens(start) + offsetTokens(end);
+}
+
+export function spanModeSavesTokens(input: {
+  generatedCharCount: number;
+  start: number;
+  end: number;
+}): boolean {
+  return (
+    estimateOffsetTokens(input.start, input.end) <
+    estimateGeneratedTokens(input.generatedCharCount)
+  );
+}
+
+function offsetTokens(offset: number): number {
+  return Math.ceil(String(offset).length / CHARS_PER_TOKEN);
+}


### PR DESCRIPTION
## Summary
Adds a pure Phase A token-cost estimator for #2333 span-mode extraction. Offset pairs are cheaper than generating the memory value (`Math.ceil(chars / 4)`); equal costs do not count as savings. Not wired into `extraction.ts`.

Part of #2333.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/extraction-span-tokens.test.ts`