### PR TITLE
feat(activity): insert vault managed-region markers under a heading when absent

### DIFF
--- a/.changeset/1985-vault-insert.md
+++ b/.changeset/1985-vault-insert.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Insert vault managed-region markers under a unique heading when they are absent. Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -22,6 +22,7 @@ export * from "./privacy.js";
 export * from "./privacy-window.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";
+export * from "./vault-insert.js";
 export * from "./vault-frontmatter.js";
 export * from "./vault-wikilink.js";
 export * from "./vault-region.js";

--- a/packages/remnic-core/src/activity/vault-insert.test.ts
+++ b/packages/remnic-core/src/activity/vault-insert.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { insertMarkersUnderHeading } from "./vault-insert.js";
+
+const START = "<!-- remnic:daily:start -->";
+const END = "<!-- remnic:daily:end -->";
+
+test("inserts markers under a unique heading before existing body", () => {
+  const fileText = ["# Notes", "", "## Journal", "", "Existing entry.", ""].join("\n");
+  const result = insertMarkersUnderHeading(fileText, {
+    heading: "Journal",
+    name: "daily",
+    content: "Line one.\nLine two.",
+  });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(
+    result.text,
+    ["# Notes", "", "## Journal", START, "Line one.", "Line two.", END, "", "Existing entry.", ""].join("\n"),
+  );
+});
+
+test("returns text unchanged when both markers already exist", () => {
+  const fileText = ["## Journal", START, "old", END, "tail", ""].join("\n");
+  const result = insertMarkersUnderHeading(fileText, { heading: "Journal", name: "daily", content: "new" });
+  assert.deepEqual(result, { ok: true, text: fileText, inserted: false });
+});
+
+test("fails with no_heading when no heading matches exactly", () => {
+  const fileText = ["## Journal entry", "body", ""].join("\n");
+  const result = insertMarkersUnderHeading(fileText, { heading: "Journal", name: "daily", content: "new" });
+  assert.deepEqual(result, { ok: false, reason: "no_heading", text: fileText });
+});
+
+test("fails with duplicate_heading and both 1-based line numbers", () => {
+  const fileText = ["# Top", "## Journal", "a", "## Journal", "b", ""].join("\n");
+  const result = insertMarkersUnderHeading(fileText, { heading: "Journal", name: "daily", content: "new" });
+  assert.ok(!result.ok && result.reason === "duplicate_heading");
+  assert.deepEqual(result.lines, [2, 4]);
+  assert.equal(result.text, fileText);
+});
+
+test("inserts before a later same-level heading and leaves that section intact", () => {
+  const fileText = ["## Journal", "existing", "## Other", "other body", ""].join("\n");
+  const result = insertMarkersUnderHeading(fileText, { heading: "Journal", name: "daily", content: "cards" });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(
+    result.text,
+    ["## Journal", START, "cards", END, "existing", "## Other", "other body", ""].join("\n"),
+  );
+});
+
+test("deeper headings do not end the section", () => {
+  const fileText = ["## Journal", "### Nested", "nested body", "## Other", ""].join("\n");
+  const result = insertMarkersUnderHeading(fileText, { heading: "Journal", name: "daily", content: "cards" });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(
+    result.text,
+    ["## Journal", START, "cards", END, "### Nested", "nested body", "## Other", ""].join("\n"),
+  );
+});
+
+test("inserts under a heading at EOF without trailing newline", () => {
+  const result = insertMarkersUnderHeading("## Journal", { heading: "Journal", name: "daily", content: "cards" });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(result.text, `## Journal\n${START}\ncards\n${END}\n`);
+});
+
+test("keeps content ending in a newline without doubling it", () => {
+  const result = insertMarkersUnderHeading("## Journal\nbody\n", {
+    heading: "Journal",
+    name: "daily",
+    content: "cards\n",
+  });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(result.text, `## Journal\n${START}\ncards\n${END}\nbody\n`);
+});
+
+test("empty content inserts adjacent markers", () => {
+  const result = insertMarkersUnderHeading("## Journal\n", { heading: "Journal", name: "daily", content: "" });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(result.text, `## Journal\n${START}\n${END}\n`);
+});
+
+test("preserves CRLF as the dominant EOL", () => {
+  const fileText = ["## Journal", "body", ""].join("\r\n");
+  const result = insertMarkersUnderHeading(fileText, {
+    heading: "Journal",
+    name: "daily",
+    content: "line a\r\nline b",
+  });
+  assert.ok(result.ok && result.inserted);
+  assert.equal(result.text, `## Journal\r\n${START}\r\nline a\r\nline b\r\n${END}\r\nbody\r\n`);
+});
+
+test("empty heading or name throws RangeError", () => {
+  assert.throws(
+    () => insertMarkersUnderHeading("## Journal\n", { heading: "", name: "daily", content: "" }),
+    (err) => err instanceof RangeError && /empty/i.test(err.message),
+  );
+  assert.throws(
+    () => insertMarkersUnderHeading("## Journal\n", { heading: "Journal", name: "", content: "" }),
+    (err) => err instanceof RangeError && /empty/i.test(err.message),
+  );
+});

--- a/packages/remnic-core/src/activity/vault-insert.ts
+++ b/packages/remnic-core/src/activity/vault-insert.ts
@@ -1,0 +1,86 @@
+/**
+ * Managed-region marker insertion (issue #1985).
+ *
+ * Inserts a `<!-- remnic:<name>:start/end -->` pair under a unique ATX
+ * heading when the region is absent. This helper never replaces (see
+ * `vault-publish.ts`), never creates files, and never invents a heading.
+ * Pure string-in/string-out.
+ */
+
+export type InsertVaultRegionResult =
+  | { ok: true; text: string; inserted: true }
+  | { ok: true; text: string; inserted: false }
+  | { ok: false; reason: "no_heading"; text: string }
+  | { ok: false; reason: "duplicate_heading"; lines: readonly number[]; text: string };
+
+export function insertMarkersUnderHeading(
+  fileText: string,
+  opts: { heading: string; name: string; content: string },
+): InsertVaultRegionResult {
+  if (typeof opts.heading !== "string" || opts.heading.length === 0) {
+    throw new RangeError("Heading must be non-empty.");
+  }
+  if (typeof opts.name !== "string" || opts.name.length === 0) {
+    throw new RangeError("Region name must be non-empty.");
+  }
+
+  const startMarker = `<!-- remnic:${opts.name}:start -->`;
+  const endMarker = `<!-- remnic:${opts.name}:end -->`;
+  if (fileText.includes(startMarker) && fileText.includes(endMarker)) {
+    return { ok: true, text: fileText, inserted: false };
+  }
+
+  const rows = fileLines(fileText);
+  const hits: Array<{ row: (typeof rows)[number]; level: number }> = [];
+  for (const row of rows) {
+    const heading = parseAtxHeading(row.line);
+    if (heading && heading.text === opts.heading) {
+      hits.push({ row, level: heading.level });
+    }
+  }
+  if (hits.length === 0) return { ok: false, reason: "no_heading", text: fileText };
+  if (hits.length > 1) {
+    return { ok: false, reason: "duplicate_heading", lines: hits.map((hit) => hit.row.number), text: fileText };
+  }
+
+  const hit = hits[0]!;
+
+  const eol = fileText.includes("\r\n") ? "\r\n" : "\n";
+  const prefix =
+    hit.row.next === fileText.length && !fileText.endsWith("\n") && !fileText.endsWith("\r")
+      ? `${fileText}${eol}`
+      : fileText.slice(0, hit.row.next);
+  let content = opts.content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (eol === "\r\n") content = content.replace(/\n/g, "\r\n");
+  if (content.length > 0 && !content.endsWith(eol)) content += eol;
+
+  const text = `${prefix}${startMarker}${eol}${content}${endMarker}${eol}${fileText.slice(hit.row.next)}`;
+  return { ok: true, text, inserted: true };
+}
+
+type FileLine = { line: string; start: number; next: number; number: number };
+
+function fileLines(fileText: string): FileLine[] {
+  const rows: FileLine[] = [];
+  let start = 0;
+  let number = 1;
+  while (start < fileText.length) {
+    let i = start;
+    while (i < fileText.length && fileText[i] !== "\n" && fileText[i] !== "\r") i++;
+    let next = i;
+    if (fileText[i] === "\r" && fileText[i + 1] === "\n") next = i + 2;
+    else if (fileText[i] === "\n" || fileText[i] === "\r") next = i + 1;
+    else next = fileText.length;
+    rows.push({ line: fileText.slice(start, i), start, next, number });
+    number += 1;
+    start = next;
+  }
+  return rows;
+}
+
+function parseAtxHeading(line: string): { level: number; text: string } | null {
+  let level = 0;
+  while (level < line.length && level < 6 && line[level] === "#") level++;
+  if (level === 0 || line[level] !== " ") return null;
+  return { level, text: line.slice(level + 1) };
+}


### PR DESCRIPTION
## Summary
Adds `insertMarkersUnderHeading`, the #1985 insert-under-heading path: when a managed-region marker pair is missing, insert it under a unique ATX heading (before the next same-or-higher heading). Missing heading skips; duplicate headings refuse with line numbers. Does not replace existing regions (that stays in `vault-publish.ts`).

Part of #1985.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/vault-insert.test.ts`