### PR TITLE
fix(okf): resolve --namespace safely and make forced publish re-runnable

### DIFF
--- a/.changeset/okf-publish-safety.md
+++ b/.changeset/okf-publish-safety.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Harden the OKF export publish path: `--namespace` resolves through the shared containment guard instead of a raw path join, each forced publish uses its own backup directory, a non-directory `--out` is refused with a clear message, and staging happens beside `--out` so the publish rename is never cross-device. Part of #2548.

--- a/packages/remnic-cli/src/commands/export-okf.ts
+++ b/packages/remnic-cli/src/commands/export-okf.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import path from "node:path";
 import { Orchestrator, parseConfig, resolveRemnicConfigRecord } from "@remnic/core";
 import { exportOkfBundle, parseIncludeStatus } from "@remnic/core/export-okf";
 import { resolveConfigPath } from "../index.js";
@@ -36,11 +35,9 @@ export async function runExportOkfBinaryCommand(rest: string[]): Promise<void> {
     orchestrator = new Orchestrator(config);
     await orchestrator.initialize();
     await orchestrator.deferredReady;
-    const memoryDir = namespace
-      ? path.join(orchestrator.config.memoryDir, "namespaces", namespace)
-      : orchestrator.config.memoryDir;
     const result = await exportOkfBundle({
-      memoryDir,
+      memoryDir: orchestrator.config.memoryDir,
+      namespace,
       outDir: out,
       includeStatus: parseIncludeStatus(takeFlag(args, "--include-status")),
       includeCategories: takeFlag(args, "--include-categories")?.split(","),

--- a/packages/remnic-core/src/cli/okf-commands.ts
+++ b/packages/remnic-core/src/cli/okf-commands.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { Orchestrator } from "../orchestrator.js";
 import type { CliCommand } from "../cli.js";
 import { runOkfCliCommand } from "../okf/cli.js";
@@ -44,11 +43,9 @@ export function registerExportOkfCommand(exportCmd: CliCommand, orchestrator: Or
       if (!out) throw new Error("Missing --out");
       const includeStatus = parseIncludeStatus(options.includeStatus);
       const namespace = options.namespace ? String(options.namespace) : "";
-      const memoryDir = namespace
-        ? path.join(orchestrator.config.memoryDir, "namespaces", namespace)
-        : orchestrator.config.memoryDir;
       const result = await exportOkfBundle({
-        memoryDir,
+        memoryDir: orchestrator.config.memoryDir,
+        namespace,
         outDir: out,
         includeStatus,
         includeCategories: options.includeCategories ? String(options.includeCategories).split(",") : undefined,

--- a/packages/remnic-core/src/okf/render.ts
+++ b/packages/remnic-core/src/okf/render.ts
@@ -9,6 +9,7 @@
  * bundles are byte-compatible in convention (rule 38 — deterministic
  * rendering discipline; rule 9 — stable seam over shared mechanics).
  */
+import { randomUUID } from "node:crypto";
 import { lstatSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
@@ -76,6 +77,7 @@ export function publishBundle(staging: string, outDir: string, force: boolean): 
   try {
     const stat = lstatSync(outDir);
     if (stat.isSymbolicLink()) throw new Error(`--out must not be a symlink: ${outDir}`);
+    if (!stat.isDirectory()) throw new Error(`--out exists and is not a directory: ${outDir}`);
     exists = true;
     const entries = readdirSync(outDir).filter((name) => name !== "." && name !== "..");
     if (entries.length > 0 && !force) {
@@ -87,7 +89,12 @@ export function publishBundle(staging: string, outDir: string, force: boolean): 
   }
   mkdirSync(path.dirname(outDir), { recursive: true });
   if (exists && force) {
-    const backup = `${outDir}.okf-prev`;
+    // A fixed backup name is not reusable: an earlier crash between the two
+    // renames, or an unrelated directory a user created, leaves the path
+    // occupied and every later --force export fails on the rename. Each
+    // attempt takes its own name and removes it on both the success and the
+    // rollback path.
+    const backup = `${outDir}.okf-prev-${randomUUID().slice(0, 8)}`;
     try {
       renameSync(outDir, backup);
     } catch {
@@ -100,8 +107,10 @@ export function publishBundle(staging: string, outDir: string, force: boolean): 
     } catch (err) {
       try {
         renameSync(backup, outDir);
+        rmSync(staging, { recursive: true, force: true });
       } catch {
-        // Keep backup if restore fails.
+        // Keep the backup when the restore itself fails: it is the only
+        // surviving copy of the operator's previous bundle.
       }
       throw err;
     }

--- a/packages/remnic-core/src/transfer/export-okf.test.ts
+++ b/packages/remnic-core/src/transfer/export-okf.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile, symlink } from "node:fs/promises";
 import { existsSync, lstatSync, readdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -162,3 +162,79 @@ function collectFiles(root: string): string[] {
   walk(root);
   return out.sort();
 }
+
+test("--namespace cannot escape the namespace root", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-ns-"));
+  const outDir = path.join(await mkdtemp(path.join(os.tmpdir(), "remnic-okf-nsout-")), "bundle");
+  try {
+    await seedStore(memoryDir);
+    // A raw path.join on the operator value used to resolve outside
+    // <memoryDir>/namespaces and export an arbitrary tree.
+    for (const namespace of ["../../..", "../sibling", path.resolve(memoryDir)]) {
+      await assert.rejects(
+        () => exportOkfBundle({ memoryDir, namespace, outDir }),
+        /invalid --namespace/,
+        `namespace ${namespace} must be rejected`,
+      );
+    }
+    assert.equal(existsSync(outDir), false, "a rejected namespace must not create the bundle");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a plain --namespace still exports from the namespace subtree", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-nsok-"));
+  const outDir = path.join(root, "bundle");
+  try {
+    await seedStore(path.join(root, "namespaces", "team-a"));
+    const result = await exportOkfBundle({ memoryDir: root, namespace: "team-a", outDir });
+    assert.ok(result.exported > 0, "namespaced export must find its own memories");
+    assert.ok(existsSync(path.join(outDir, "index.md")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a leftover backup directory does not block a forced export", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-bk-"));
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-bkout-"));
+  const outDir = path.join(root, "bundle");
+  try {
+    await seedStore(memoryDir);
+    await exportOkfBundle({ memoryDir, outDir });
+    // Simulate a crash between the two publish renames, or any directory a
+    // user happens to own at the old fixed backup path.
+    const stale = `${outDir}.okf-prev`;
+    await mkdir(stale, { recursive: true });
+    await writeFile(path.join(stale, "keep.md"), "stale\n", "utf8");
+
+    const again = await exportOkfBundle({ memoryDir, outDir, force: true });
+    assert.ok(again.exported > 0);
+    assert.ok(existsSync(path.join(outDir, "index.md")), "forced export must republish");
+    assert.equal(existsSync(path.join(stale, "keep.md")), true, "an unrelated directory is left alone");
+    const leftovers = readdirSync(root).filter((name) => name.startsWith("bundle.okf-prev-"));
+    assert.deepEqual(leftovers, [], "each attempt removes its own backup");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("--out that is a file is rejected before anything is written", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-file-"));
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-fileout-"));
+  const outDir = path.join(root, "bundle");
+  try {
+    await seedStore(memoryDir);
+    await writeFile(outDir, "not a directory\n", "utf8");
+    await assert.rejects(
+      () => exportOkfBundle({ memoryDir, outDir, force: true }),
+      /--out exists and is not a directory/,
+    );
+    assert.equal(await readFile(outDir, "utf8"), "not a directory\n", "the file is left untouched");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/transfer/export-okf.ts
+++ b/packages/remnic-core/src/transfer/export-okf.ts
@@ -1,6 +1,5 @@
-import { rmSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 
 import { parseOaiMemCitation } from "../citations.js";
@@ -8,6 +7,7 @@ import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { normalizeProjectionPreview } from "../memory-projection-format.js";
 import { lintOkfDir } from "../okf/lint.js";
 import { okfTypeForMemory, OKF_PROFILE_TYPE } from "../okf/type-mapping.js";
+import { resolveNamespaceChildRoot } from "../namespaces/path.js";
 import {
   OKF_EXPORT_VERSION,
   publishBundle,
@@ -38,6 +38,14 @@ const MEMORY_STATUSES: readonly MemoryStatus[] = [
 
 export interface ExportOkfOptions {
   memoryDir: string;
+  /**
+   * Optional namespace segment. Resolved here, once, through the shared
+   * containment guard: both CLI entry points used to join the raw operator
+   * value onto `memoryDir/namespaces`, so `--namespace ../../..` escaped the
+   * namespace root and exported an arbitrary tree (rule 9 — one resolver, not
+   * a per-caller guard).
+   */
+  namespace?: string;
   outDir: string;
   includeStatus?: readonly string[];
   includeCategories?: readonly string[];
@@ -71,15 +79,19 @@ export function parseIncludeStatus(raw: unknown): MemoryStatus[] {
 export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkfResult> {
   const outDir = path.resolve(opts.outDir);
   rejectSymlinkPath(outDir);
+  const namespace = (opts.namespace ?? "").trim();
+  const memoryDir = namespace
+    ? resolveNamespaceChildRoot(opts.memoryDir, namespace, "--namespace")
+    : opts.memoryDir;
   const includeStatus = new Set(parseIncludeStatus(opts.includeStatus));
   const includeCategories = opts.includeCategories?.length ? new Set(opts.includeCategories) : null;
   const excludeTags = new Set(opts.excludeTags ?? []);
-  const storage = new StorageManager(opts.memoryDir);
+  const storage = new StorageManager(memoryDir);
   const memories = await storage.readAllMemories();
   const included: MemoryFile[] = [];
   let excluded = 0;
   for (const memory of memories) {
-    const rel = toRel(memory.path, opts.memoryDir);
+    const rel = toRel(memory.path, memoryDir);
     if (!opts.includeWearables && rel.startsWith("wearables/")) {
       excluded += 1;
       continue;
@@ -99,17 +111,21 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
     }
     included.push(memory);
   }
-  included.sort((a, b) => toRel(a.path, opts.memoryDir).localeCompare(toRel(b.path, opts.memoryDir)));
+  included.sort((a, b) => toRel(a.path, memoryDir).localeCompare(toRel(b.path, memoryDir)));
 
-  const staging = await mkdtemp(path.join(os.tmpdir(), "remnic-okf-export-"));
+  // Stage inside the destination's parent, not the OS temp dir: publishBundle
+  // finishes with a rename, and a rename across filesystems fails with EXDEV
+  // whenever --out lives on a different mount than /tmp.
+  mkdirSync(path.dirname(outDir), { recursive: true });
+  const staging = await mkdtemp(path.join(path.dirname(outDir), ".remnic-okf-export-"));
   const byCategory: Record<string, number> = {};
   const idToRel = new Map<string, string>();
   for (const memory of included) {
-    const rel = toRel(memory.path, opts.memoryDir);
+    const rel = toRel(memory.path, memoryDir);
     idToRel.set(memory.frontmatter.id, rel);
   }
   for (const memory of included) {
-    const rel = toRel(memory.path, opts.memoryDir);
+    const rel = toRel(memory.path, memoryDir);
     const rendered = renderMemory(memory, rel, idToRel);
     writeBundleFile(staging, rel, rendered);
     const category = memory.frontmatter.category;
@@ -140,7 +156,7 @@ export async function exportOkfBundle(opts: ExportOkfOptions): Promise<ExportOkf
     writeBundleFile(staging, "log.md", renderLog(events, idToRel, opts.logMaxEntries ?? DEFAULT_OKF_LOG_MAX_ENTRIES));
   }
 
-  writeIndexes(staging, included, opts.memoryDir);
+  writeIndexes(staging, included, memoryDir);
   const lint = lintOkfDir(staging);
   const blocking = lint.findings.filter((f) => f.code !== "skipped_encrypted" && f.code !== "reserved_basename");
   if (blocking.length > 0) {


### PR DESCRIPTION
## Summary

Replaces #2553, which sat unmerged for a day and went stale. In the meantime the OKF bundle mechanics were extracted into `okf/render.ts`, which absorbed most of that PR (symlink guard, non-empty check, backup-and-swap). This lands only the four defects that are **still present on `main`**, against current `main`, in one subsystem.

### Security
- Both CLI entry points joined the raw `--namespace` value onto `<memoryDir>/namespaces`, so `--namespace ../../..` escaped the namespace root and exported an arbitrary tree. The namespace is now resolved **once** inside `exportOkfBundle` through the existing `resolveNamespaceChildRoot` guard, so neither caller carries its own path logic (AGENTS.md pattern 9 — one resolver, not a per-caller guard).

### Publish safety
- The forced-publish backup used a fixed `<out>.okf-prev` path. A crash between the two renames, or any directory a user owned at that name, left it occupied and every later `--force` export failed on the rename. Each attempt now takes its own backup name and removes it on both the success and the rollback path. (CodeRabbit finding from #2553, still valid.)
- A non-directory `--out` surfaced a raw `ENOTDIR` from `readdir`; it is now refused up front with the same message shape as the symlink guard. The rollback path also cleans up its staging directory.
- Staging moved from the OS temp dir to a hidden sibling of `--out`, so the publish rename cannot fail with `EXDEV` when `--out` lives on another filesystem.

Part of #2548.

## Test plan

`packages/remnic-core/src/transfer/export-okf.test.ts` — 9/9 pass. The four new tests were verified to **fail without the fixes** (4 fail / 5 pass on the pre-fix tree) so none of them is vacuous:

- \`--namespace\` traversal rejected for \`../../..\`, \`../sibling\`, and an absolute path, with no bundle created
- a plain \`--namespace\` still exports from its own subtree
- a leftover \`<out>.okf-prev\` directory no longer blocks a forced export, is left untouched, and no per-attempt backup is leaked
- a file at \`--out\` is refused before any write, with the file left intact

One candidate test was **dropped rather than kept green**: asserting the staging location after a successful publish passes with and without the fix, because the rename consumes the directory either way. Observing it would need a DI seam this change does not justify; the staging move is a three-line, inspection-verifiable change.

\`packages/remnic-core\` \`tsc --noEmit\` clean. \`preflight:quick\` fails in this fresh worktree on \`@remnic/connector-droid\` (\`resolveFactoryMcpPath\` missing from \`@remnic/core/connectors\`) — that worktree has no \`node_modules\`, the symbol is present at \`packages/remnic-core/src/connectors/index.ts:32\`, and this diff touches no connector code.