### PR TITLE
feat(activity): classify timeline analysis failures with a typed, fail-closed status

### DIFF
--- a/.changeset/analysis-failure-2050.md
+++ b/.changeset/analysis-failure-2050.md
@@ -1,0 +1,9 @@
+---
+"@remnic/core": patch
+---
+
+Add `classifyAnalysisFailure` to the activity timeline layer: a pure,
+fail-closed classifier for timeline analysis failures. Unknown kinds throw a
+`TypeError` listing the allowed kinds, only `provider_unavailable`,
+`timeout`, and `rate_limited` are retryable, and every failure kind
+preserves the deterministic cards unchanged. Part of #2050

--- a/packages/remnic-core/src/activity/timeline/analysis-failure.test.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-failure.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ANALYSIS_FAILURE_KINDS,
+  classifyAnalysisFailure,
+  isAnalysisFailureKind,
+  type AnalysisFailureKind,
+} from "./analysis-failure.js";
+
+test("every known kind classifies with the explicit retryable split", () => {
+  const retryableKinds: readonly AnalysisFailureKind[] = [
+    "provider_unavailable",
+    "timeout",
+    "rate_limited",
+  ];
+  const nonRetryableKinds: readonly AnalysisFailureKind[] = [
+    "aborted",
+    "malformed_json",
+    "invalid_schema",
+    "partial_output",
+    "invalid_config",
+  ];
+  for (const kind of ANALYSIS_FAILURE_KINDS) {
+    const failure = classifyAnalysisFailure(kind);
+    assert.equal(failure.kind, kind);
+    assert.equal(failure.preservesDeterministic, true);
+    const expectedRetryable = retryableKinds.includes(kind);
+    assert.ok(
+      expectedRetryable || nonRetryableKinds.includes(kind),
+      `${kind} missing from the explicit retryable split`,
+    );
+    assert.equal(
+      failure.retryable,
+      expectedRetryable,
+      `${kind} retryable must be ${expectedRetryable}`,
+    );
+  }
+});
+
+test("the explicit retryable split covers all kinds exactly once", () => {
+  const split: readonly string[] = [
+    "provider_unavailable",
+    "timeout",
+    "rate_limited",
+    "aborted",
+    "malformed_json",
+    "invalid_schema",
+    "partial_output",
+    "invalid_config",
+  ];
+  assert.equal(new Set(split).size, split.length);
+  assert.deepEqual(
+    [...ANALYSIS_FAILURE_KINDS].sort(),
+    [...split].sort(),
+  );
+});
+
+test("unknown string kind throws TypeError naming the allowed kinds", () => {
+  assert.throws(
+    () => classifyAnalysisFailure("provider_on_fire"),
+    (err: unknown) => {
+      assert.ok(err instanceof TypeError);
+      assert.match((err as Error).message, /unknown analysis failure/);
+      for (const kind of ANALYSIS_FAILURE_KINDS) {
+        assert.ok((err as Error).message.includes(kind));
+      }
+      return true;
+    },
+  );
+});
+
+test("empty, null, undefined, and non-string kinds throw", () => {
+  for (const bad of ["", undefined, null, 42]) {
+    assert.throws(
+      () => classifyAnalysisFailure(bad as string),
+      TypeError,
+      `expected throw for ${String(bad)}`,
+    );
+  }
+});
+
+test("isAnalysisFailureKind is false for non-strings, empty, and unknown", () => {
+  assert.equal(isAnalysisFailureKind(undefined), false);
+  assert.equal(isAnalysisFailureKind(null), false);
+  assert.equal(isAnalysisFailureKind(42), false);
+  assert.equal(isAnalysisFailureKind({ kind: "timeout" }), false);
+  assert.equal(isAnalysisFailureKind(""), false);
+  assert.equal(isAnalysisFailureKind("timeout "), false);
+  assert.equal(isAnalysisFailureKind("TIMEOUT"), false);
+  assert.equal(isAnalysisFailureKind("provider_on_fire"), false);
+  for (const kind of ANALYSIS_FAILURE_KINDS) {
+    assert.equal(isAnalysisFailureKind(kind), true);
+  }
+});
+
+test("preservesDeterministic is true for every kind", () => {
+  for (const kind of ANALYSIS_FAILURE_KINDS) {
+    assert.deepEqual(
+      classifyAnalysisFailure(kind).preservesDeterministic,
+      true,
+    );
+  }
+});

--- a/packages/remnic-core/src/activity/timeline/analysis-failure.ts
+++ b/packages/remnic-core/src/activity/timeline/analysis-failure.ts
@@ -1,0 +1,60 @@
+/**
+ * Typed failure classification for timeline analysis (issue #2050).
+ *
+ * Unknown kinds fail closed with a TypeError. Pure: no I/O, no clock, no randomness.
+ */
+
+export const ANALYSIS_FAILURE_KINDS = [
+  "provider_unavailable",
+  "timeout",
+  "aborted",
+  "rate_limited",
+  "malformed_json",
+  "invalid_schema",
+  "partial_output",
+  "invalid_config",
+] as const;
+export type AnalysisFailureKind = (typeof ANALYSIS_FAILURE_KINDS)[number];
+
+export interface AnalysisFailure {
+  kind: AnalysisFailureKind;
+  /** True only when retrying the same request could plausibly succeed. */
+  retryable: boolean;
+  /** True when the deterministic cards must be preserved unchanged. */
+  preservesDeterministic: true;
+}
+
+const RETRYABLE_BY_KIND: Readonly<Record<AnalysisFailureKind, boolean>> = {
+  provider_unavailable: true,
+  timeout: true,
+  rate_limited: true,
+  aborted: false,
+  malformed_json: false,
+  invalid_schema: false,
+  partial_output: false,
+  invalid_config: false,
+};
+
+/** True when the value is one of the known failure kinds. */
+export function isAnalysisFailureKind(
+  value: unknown,
+): value is AnalysisFailureKind {
+  return (
+    typeof value === "string" &&
+    (ANALYSIS_FAILURE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/** Classify a failure kind. Unknown kinds throw; there is no permissive default. */
+export function classifyAnalysisFailure(kind: string): AnalysisFailure {
+  if (!isAnalysisFailureKind(kind)) {
+    throw new TypeError(
+      `unknown analysis failure kind: ${String(kind)}; allowed kinds: ${ANALYSIS_FAILURE_KINDS.join(", ")}`,
+    );
+  }
+  return {
+    kind,
+    retryable: RETRYABLE_BY_KIND[kind],
+    preservesDeterministic: true,
+  };
+}

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -21,3 +21,4 @@ export * from "./analysis-prompt.js";
 export * from "./analysis-claim.js";
 export * from "./analysis-order.js";
 export * from "./recap-window.js";
+export * from "./analysis-failure.js";


### PR DESCRIPTION
## Summary
Adds `classifyAnalysisFailure`, the typed failure status the #2050 analysis contract requires. Eight failure kinds (provider unavailable, timeout, aborted, rate limited, malformed JSON, invalid schema, partial output, invalid config) classify into a retryable flag plus an invariant `preservesDeterministic: true`. Unknown kinds throw — an explicitly invalid value never falls back to a permissive default.

Pure and standalone: no provider call, no parseConfig wiring. Surfaces consume the type later.

Part of #2050.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/timeline/analysis-failure.test.ts` — 6/6
- Covers the retryable split asserted explicitly per kind, unknown/empty/non-string throws, and `preservesDeterministic` for every kind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured classification for timeline analysis failures.
  * Identified provider availability, timeout, and rate-limit errors as retryable.
  * Preserved deterministic timeline cards across all supported failure types.
  * Invalid or unknown failure types are rejected explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->