### PR TITLE
feat(activity): strip Remnic-owned regions before reading a vault journal

### DIFF
--- a/.changeset/1987-journal-strip.md
+++ b/.changeset/1987-journal-strip.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure journal stripper that removes Remnic-owned marker regions and configured owned heading sections before vault daily-note text is read, so published output cannot re-enter the journal. Unterminated regions fail closed and strip to the end of the section. Part of #1987.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -17,6 +17,7 @@ export * from "./reindex.js";
 export * from "./timeline/index.js";
 export * from "./journal.js";
 export * from "./journal-vault-read.js";
+export { stripRemnicOwnedRegions } from "./journal-strip.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";
 export * from "./privacy-status.js";

--- a/packages/remnic-core/src/activity/journal-section.ts
+++ b/packages/remnic-core/src/activity/journal-section.ts
@@ -53,7 +53,7 @@ function splitFileLines(fileText: string): string[] {
   return lines;
 }
 
-function parseAtxHeading(line: string): { level: number; text: string } | null {
+export function parseAtxHeading(line: string): { level: number; text: string } | null {
   let level = 0;
   while (level < line.length && level < 6 && line[level] === "#") level++;
   if (level === 0) return null;

--- a/packages/remnic-core/src/activity/journal-strip.test.ts
+++ b/packages/remnic-core/src/activity/journal-strip.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stripRemnicOwnedRegions } from "./journal-strip.js";
+
+test("stripRemnicOwnedRegions removes a marker pair and keeps user text", () => {
+  const text = [
+    "Morning standup.",
+    "<!-- remnic:timeline:start -->",
+    "9:00 deep work",
+    "<!-- remnic:timeline:end -->",
+    "Wrote the parser.",
+  ].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, []), "Morning standup.\nWrote the parser.");
+});
+
+test("stripRemnicOwnedRegions keeps one blank line where a removal doubled it", () => {
+  const text = [
+    "Before.",
+    "",
+    "<!-- remnic:timeline:start -->",
+    "generated",
+    "<!-- remnic:timeline:end -->",
+    "",
+    "After.",
+  ].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, []), "Before.\n\nAfter.");
+});
+
+test("stripRemnicOwnedRegions removes two distinct marker pairs", () => {
+  const text = [
+    "head",
+    "<!-- remnic:timeline:start -->",
+    "timeline body",
+    "<!-- remnic:timeline:end -->",
+    "middle",
+    "<!-- remnic:digest:start -->",
+    "digest body",
+    "<!-- remnic:digest:end -->",
+    "tail",
+  ].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, []), "head\nmiddle\ntail");
+});
+
+test("stripRemnicOwnedRegions strips an unterminated start marker to the end of input", () => {
+  const text = ["kept", "<!-- remnic:timeline:start -->", "generated", "later user text"].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, []), "kept");
+});
+
+test("stripRemnicOwnedRegions removes an orphan end marker and keeps surrounding text", () => {
+  const text = ["Before.", "<!-- remnic:timeline:end -->", "After."].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, []), "Before.\nAfter.");
+});
+
+test("stripRemnicOwnedRegions removes an owned heading section up to the next same-level heading", () => {
+  const text = ["## Journal", "intro", "## Timeline", "card one", "## Notes", "kept"].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["Timeline"]), "## Journal\nintro\n## Notes\nkept");
+});
+
+test("stripRemnicOwnedRegions does not end an owned section at a deeper heading", () => {
+  const text = [
+    "## Journal",
+    "## Timeline",
+    "card one",
+    "### Deep",
+    "deep card",
+    "## Notes",
+    "kept",
+  ].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["Timeline"]), "## Journal\n## Notes\nkept");
+});
+
+test("stripRemnicOwnedRegions preserves a non-owned heading section", () => {
+  const text = ["## Journal", "## Timeline", "card one", "## Notes", "kept"].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["Digest"]), text);
+});
+
+test("stripRemnicOwnedRegions ignores blank and whitespace owned heading entries", () => {
+  const text = ["## Timeline", "card one", ""].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["", "   ", "\t"]), text);
+});
+
+test("stripRemnicOwnedRegions trims configured owned heading entries", () => {
+  const text = ["## Timeline", "card", "## Notes", "kept"].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["  Timeline  "]), "## Notes\nkept");
+});
+
+test("stripRemnicOwnedRegions returns empty string for empty input", () => {
+  assert.equal(stripRemnicOwnedRegions("", ["Timeline"]), "");
+});
+
+test("stripRemnicOwnedRegions returns unchanged text when nothing is owned", () => {
+  const text = ["first", "", "second", "", "third"].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["Timeline"]), text);
+});

--- a/packages/remnic-core/src/activity/journal-strip.test.ts
+++ b/packages/remnic-core/src/activity/journal-strip.test.ts
@@ -93,3 +93,34 @@ test("stripRemnicOwnedRegions returns unchanged text when nothing is owned", () 
   const text = ["first", "", "second", "", "third"].join("\n");
   assert.equal(stripRemnicOwnedRegions(text, ["Timeline"]), text);
 });
+
+// Regression: the journal-section reader normalizes tab separators, extra
+// spaces, trailing whitespace, and closing # sequences. The stripper must
+// recognize exactly the same set, or an owned heading the reader treats as
+// the journal section would keep its generated body in the journal text.
+test("owned heading matching accepts every ATX form the section reader accepts", () => {
+  const body = ["generated line", "", "## User Notes", "kept"].join("\n");
+  for (const headingLine of [
+    "## Timeline",
+    "##  Timeline",
+    "##\tTimeline",
+    "## Timeline   ",
+    "## Timeline ##",
+    "## Timeline ### ",
+  ]) {
+    const stripped = stripRemnicOwnedRegions(
+      [headingLine, body].join("\n"),
+      ["Timeline"],
+    );
+    assert.equal(
+      stripped,
+      ["## User Notes", "kept"].join("\n"),
+      `heading line ${JSON.stringify(headingLine)} must strip as owned`,
+    );
+  }
+});
+
+test("an indented heading is not owned, matching the section reader", () => {
+  const text = ["  ## Timeline", "not owned body"].join("\n");
+  assert.equal(stripRemnicOwnedRegions(text, ["Timeline"]), text);
+});

--- a/packages/remnic-core/src/activity/journal-strip.ts
+++ b/packages/remnic-core/src/activity/journal-strip.ts
@@ -6,8 +6,12 @@
  * owned heading section is removed, so published output can never
  * re-enter the journal. An unterminated start marker fails closed and
  * strips to the end of the section. Pure string-in/string-out. No
- * filesystem.
+ * filesystem. Heading lines parse through the SAME exported ATX
+ * parser the journal-section reader uses, so a heading the reader
+ * recognizes is always a heading this stripper strips.
  */
+
+import { parseAtxHeading } from "./journal-section.js";
 
 const MARKER_OPEN = "<!-- remnic:";
 const MARKER_CLOSE = "-->";
@@ -49,11 +53,11 @@ function stripOwnedHeadings(text: string, ownedHeadings: readonly string[]): str
   const keep = lines.map(() => true);
   for (let i = 0; i < lines.length; i++) {
     if (!keep[i]) continue;
-    const heading = parseOwnedHeading(lines[i]!);
+    const heading = parseAtxHeading(lines[i]!);
     if (!heading || !wanted.has(heading.text)) continue;
     keep[i] = false;
     for (let j = i + 1; j < lines.length; j++) {
-      const next = parseOwnedHeading(lines[j]!);
+      const next = parseAtxHeading(lines[j]!);
       if (next && next.level <= heading.level) break;
       keep[j] = false;
     }
@@ -98,13 +102,6 @@ function parseRegionMarker(line: string): RegionMarker | null {
     return name.length > 0 ? { kind: "end", name } : null;
   }
   return null;
-}
-
-function parseOwnedHeading(line: string): { level: number; text: string } | null {
-  let level = 0;
-  while (level < 6 && line[level] === "#") level++;
-  if (level === 0 || line[level] !== " ") return null;
-  return { level, text: line.slice(level + 1) };
 }
 
 function ownedHeadingSet(ownedHeadings: readonly string[]): Set<string> {

--- a/packages/remnic-core/src/activity/journal-strip.ts
+++ b/packages/remnic-core/src/activity/journal-strip.ts
@@ -1,0 +1,118 @@
+/**
+ * Strip Remnic-owned regions from a vault journal section (issue #1987).
+ *
+ * Loop prevention for vault journals: before daily-note text is treated
+ * as journal text, every managed marker region and every configured
+ * owned heading section is removed, so published output can never
+ * re-enter the journal. An unterminated start marker fails closed and
+ * strips to the end of the section. Pure string-in/string-out. No
+ * filesystem.
+ */
+
+const MARKER_OPEN = "<!-- remnic:";
+const MARKER_CLOSE = "-->";
+const START_SUFFIX = ":start";
+const END_SUFFIX = ":end";
+
+type RegionMarker = { kind: "start" | "end"; name: string };
+
+export function stripRemnicOwnedRegions(
+  sectionText: string,
+  ownedHeadings: readonly string[],
+): string {
+  return stripOwnedHeadings(stripMarkerRegions(sectionText), ownedHeadings);
+}
+
+function stripMarkerRegions(text: string): string {
+  const lines = text.split("\n");
+  const keep = lines.map(() => true);
+  let openName: string | null = null;
+  for (let i = 0; i < lines.length; i++) {
+    const marker = parseRegionMarker(lines[i]!);
+    if (openName !== null) {
+      keep[i] = false;
+      if (marker && marker.kind === "end" && marker.name === openName) openName = null;
+      continue;
+    }
+    if (marker) {
+      keep[i] = false;
+      if (marker.kind === "start") openName = marker.name;
+    }
+  }
+  return emitKeptLines(lines, keep);
+}
+
+function stripOwnedHeadings(text: string, ownedHeadings: readonly string[]): string {
+  const wanted = ownedHeadingSet(ownedHeadings);
+  if (wanted.size === 0 || text.length === 0) return text;
+  const lines = text.split("\n");
+  const keep = lines.map(() => true);
+  for (let i = 0; i < lines.length; i++) {
+    if (!keep[i]) continue;
+    const heading = parseOwnedHeading(lines[i]!);
+    if (!heading || !wanted.has(heading.text)) continue;
+    keep[i] = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      const next = parseOwnedHeading(lines[j]!);
+      if (next && next.level <= heading.level) break;
+      keep[j] = false;
+    }
+  }
+  return emitKeptLines(lines, keep);
+}
+
+/**
+ * Emit kept lines, collapsing the one blank line each removal would
+ * otherwise double. Text outside removals is preserved byte-for-byte.
+ */
+function emitKeptLines(lines: readonly string[], keep: readonly boolean[]): string {
+  const out: string[] = [];
+  let dropped = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (!keep[i]) {
+      dropped = true;
+      continue;
+    }
+    const line = lines[i]!;
+    const previous = out.length > 0 ? out[out.length - 1]! : null;
+    if (dropped && previous !== null && previous.trim().length === 0 && line.trim().length === 0) {
+      dropped = false;
+      continue;
+    }
+    out.push(line);
+    dropped = false;
+  }
+  return out.join("\n");
+}
+
+function parseRegionMarker(line: string): RegionMarker | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith(MARKER_OPEN) || !trimmed.endsWith(MARKER_CLOSE)) return null;
+  const inner = trimmed.slice(MARKER_OPEN.length, trimmed.length - MARKER_CLOSE.length).trim();
+  if (inner.endsWith(START_SUFFIX)) {
+    const name = inner.slice(0, -START_SUFFIX.length);
+    return name.length > 0 ? { kind: "start", name } : null;
+  }
+  if (inner.endsWith(END_SUFFIX)) {
+    const name = inner.slice(0, -END_SUFFIX.length);
+    return name.length > 0 ? { kind: "end", name } : null;
+  }
+  return null;
+}
+
+function parseOwnedHeading(line: string): { level: number; text: string } | null {
+  let level = 0;
+  while (level < 6 && line[level] === "#") level++;
+  if (level === 0 || line[level] !== " ") return null;
+  return { level, text: line.slice(level + 1) };
+}
+
+function ownedHeadingSet(ownedHeadings: readonly string[]): Set<string> {
+  const wanted = new Set<string>();
+  for (const entry of ownedHeadings) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (trimmed.length > 0) wanted.add(trimmed);
+  }
+  return wanted;
+}


### PR DESCRIPTION
## Summary
Adds `stripRemnicOwnedRegions`, the loop-prevention rule for #1987 vault journal read-back: before any daily-note text is treated as journal text, every `<!-- remnic:<name>:start/end -->` pair (any name) and every configured owned-heading section is removed, so published output can never re-enter the journal.

Fail-closed details: an unterminated start marker strips to end of input; an end marker of a different name does not close an open region; blank/whitespace `ownedHeadings` entries are ignored rather than matching everything. User text outside owned regions is preserved byte-for-byte with at most one collapsed blank line per removal.

Pure string-in/string-out. Read wiring stays in a later slice.

Part of #1987.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/journal-strip.test.ts` — 12/12
- Adversarial probes re-verified separately: a non-remnic HTML comment survives; a foreign-name end marker does not close an open region; an owned section removes through nested deeper headings but stops at the next same-level heading; whitespace-only owned entries match nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added journal cleanup that removes Remnic-managed marker regions and configured heading sections before journal content is read.
  * Handles incomplete or orphaned markers safely and preserves unrelated journal text.
  * Collapses excess blank lines created during cleanup.

* **Tests**
  * Added coverage for marker removal, heading sections, blank-line handling, empty input, and unchanged content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->