### PR TITLE
feat(dedup): parse merge-judge verdicts strictly and fail closed to create

### DIFF
--- a/.changeset/2330-merge-verdict.md
+++ b/.changeset/2330-merge-verdict.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `parseMergeJudgeVerdict`: a strict, throw-free parser for free-form merge-judge verdicts that distinguishes unparseable answers from deliberate "create" verdicts while failing closed — every non-"merge" outcome carries `decision: "create"`. Part of #2330

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -467,3 +467,10 @@ export {
   type MergeDecision,
   type MergeDecisionOptions,
 } from "./merge-decision.js";
+
+export {
+  MERGE_JUDGE_VERDICTS,
+  parseMergeJudgeVerdict,
+  type MergeJudgeVerdictName,
+  type ParseMergeVerdictResult,
+} from "./merge-verdict.js";

--- a/packages/remnic-core/src/dedup/merge-verdict.test.ts
+++ b/packages/remnic-core/src/dedup/merge-verdict.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MERGE_JUDGE_VERDICTS, parseMergeJudgeVerdict } from "./merge-verdict.js";
+
+test("every allow-list name parses (loops the constant)", () => {
+  for (const name of MERGE_JUDGE_VERDICTS) {
+    const result = parseMergeJudgeVerdict(name);
+    assert.equal(result.ok, true);
+    assert.ok(result.ok);
+    assert.equal(result.verdict, name);
+    assert.equal(result.decision, name === "merge" ? "merge" : "create");
+  }
+});
+
+test("accepts mixed case and surrounding whitespace", () => {
+  for (const raw of ["MERGE", " merge ", "Create", "\tcreate\n", "UnCertain", "  uncertain  "]) {
+    const result = parseMergeJudgeVerdict(raw);
+    assert.ok(result.ok, `expected "${raw}" to parse`);
+    assert.equal(result.verdict, raw.trim().toLowerCase());
+  }
+});
+
+test("only merge yields decision merge", () => {
+  const merged = parseMergeJudgeVerdict("merge");
+  assert.ok(merged.ok);
+  assert.equal(merged.decision, "merge");
+});
+
+test("uncertain yields decision create", () => {
+  const result = parseMergeJudgeVerdict("uncertain");
+  assert.ok(result.ok);
+  assert.equal(result.verdict, "uncertain");
+  assert.equal(result.decision, "create");
+});
+
+test("empty and non-string inputs give empty_verdict with decision create", () => {
+  const empties: unknown[] = ["", "   ", null, undefined, 42, { verdict: "merge" }, ["merge"]];
+  for (const raw of empties) {
+    const result = parseMergeJudgeVerdict(raw);
+    assert.ok(!result.ok, `expected ${JSON.stringify(raw)} to fail`);
+    assert.equal(result.error, "empty_verdict");
+    assert.equal(result.decision, "create");
+  }
+});
+
+test("unrecognized strings give unknown_verdict with decision create", () => {
+  for (const raw of ["I think merge", "maybe", "merge them", "merg", "MERGE!"]) {
+    const result = parseMergeJudgeVerdict(raw);
+    assert.ok(!result.ok, `expected "${raw}" to fail`);
+    assert.equal(result.error, "unknown_verdict");
+    assert.equal(result.decision, "create");
+  }
+});
+
+test("no input throws", () => {
+  const hostile: unknown[] = [
+    "",
+    "   ",
+    null,
+    undefined,
+    0,
+    NaN,
+    {},
+    [],
+    () => "merge",
+    Symbol("merge"),
+    "I think merge",
+    "merge",
+  ];
+  for (const raw of hostile) {
+    assert.doesNotThrow(() => parseMergeJudgeVerdict(raw));
+  }
+});

--- a/packages/remnic-core/src/dedup/merge-verdict.ts
+++ b/packages/remnic-core/src/dedup/merge-verdict.ts
@@ -1,0 +1,31 @@
+/**
+ * Strict parser for free-form merge-judge verdicts (issue #2330 slice).
+ *
+ * Keeps "unparseable answer" distinguishable from a deliberate "create"
+ * while still failing closed: every failure carries decision "create".
+ */
+
+export const MERGE_JUDGE_VERDICTS = ["merge", "create", "uncertain"] as const;
+export type MergeJudgeVerdictName = (typeof MERGE_JUDGE_VERDICTS)[number];
+
+export type ParseMergeVerdictResult =
+  | { ok: true; verdict: MergeJudgeVerdictName; decision: "merge" | "create" }
+  | { ok: false; error: "empty_verdict" | "unknown_verdict"; decision: "create" };
+
+export function parseMergeJudgeVerdict(raw: unknown): ParseMergeVerdictResult {
+  if (typeof raw !== "string") {
+    return { ok: false, error: "empty_verdict", decision: "create" };
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "") {
+    return { ok: false, error: "empty_verdict", decision: "create" };
+  }
+  if (!(MERGE_JUDGE_VERDICTS as readonly string[]).includes(normalized)) {
+    return { ok: false, error: "unknown_verdict", decision: "create" };
+  }
+  return {
+    ok: true,
+    verdict: normalized as MergeJudgeVerdictName,
+    decision: normalized === "merge" ? "merge" : "create",
+  };
+}


### PR DESCRIPTION
## Summary
Adds `parseMergeJudgeVerdict` for #2330: a strict parser for free-form LLM judge answers. Today `judgeMergeDecision` coerces any non-"merge" verdict straight to "create", so an unparseable answer is indistinguishable from a deliberate "these are different facts". This keeps the distinction typed — `empty_verdict` vs `unknown_verdict` vs a parsed name — while every failure path still carries `decision: "create"`, so a caller reading only `decision` is safe and the write path never merges on an ambiguous answer.

Accepts only the three allow-list names, case-insensitive, after trim. Sentences and substrings ("I think merge") are `unknown_verdict`. Never throws.

Not yet wired into `judgeMergeDecision` — that changes a write-path signature and belongs with its own tests.

Part of #2330.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/dedup/merge-verdict.test.ts` — 7/7
- Covers mixed-case and padded accepts, `uncertain` → create, every non-string shape, sentence-form rejection, and no-throw on any input.