### PR TITLE
feat(recall): stop deep recall on an empty, identical, or over-budget rewrite

### DIFF
--- a/.changeset/2332-refine-rewrite-guard.md
+++ b/.changeset/2332-refine-rewrite-guard.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `validateRefineRewrite` (new `recall-deep-rewrite.ts`) for deep-recall REFINE policy: reject a rewrite that is empty, identical to the current query after case/whitespace normalization, or submitted once the per-invocation refine budget (`MAX_REFINES_PER_INVOCATION`) is spent; every rejection carries `stop: true` and a machine-readable reason. Part of #2332

--- a/packages/remnic-core/src/recall-deep-rewrite.test.ts
+++ b/packages/remnic-core/src/recall-deep-rewrite.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAX_REFINES_PER_INVOCATION,
+  validateRefineRewrite,
+} from "./recall-deep-rewrite.js";
+
+const base = {
+  currentQuery: "who met at the cafe",
+  refinesUsed: 0,
+};
+
+test("genuine rewrite succeeds and is trimmed", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      ...base,
+      refinedQuery: "  which people met at the cafe on friday  ",
+    }),
+    { ok: true, refinedQuery: "which people met at the cafe on friday" },
+  );
+});
+
+test("success keeps internal whitespace as written", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      ...base,
+      refinedQuery: "which  people  met at the cafe",
+    }),
+    { ok: true, refinedQuery: "which  people  met at the cafe" },
+  );
+});
+
+test("refinesUsed 0 is allowed", () => {
+  assert.equal(
+    validateRefineRewrite({
+      ...base,
+      refinesUsed: 0,
+      refinedQuery: "which people met at the cafe",
+    }).ok,
+    true,
+  );
+});
+
+test("refinesUsed 1 is allowed", () => {
+  assert.equal(
+    validateRefineRewrite({
+      ...base,
+      refinesUsed: 1,
+      refinedQuery: "which people met at the cafe",
+    }).ok,
+    true,
+  );
+});
+
+test("refinesUsed 2 gives refine_budget_spent", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      ...base,
+      refinesUsed: 2,
+      refinedQuery: "which people met at the cafe",
+    }),
+    { ok: false, stop: true, reason: "refine_budget_spent" },
+  );
+});
+
+test("refinesUsed 3 gives refine_budget_spent", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      ...base,
+      refinesUsed: 3,
+      refinedQuery: "which people met at the cafe",
+    }),
+    { ok: false, stop: true, reason: "refine_budget_spent" },
+  );
+});
+
+test("budget check wins over a valid rewrite", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      currentQuery: "who met at the cafe",
+      refinedQuery: "completely different and clearly better query",
+      refinesUsed: MAX_REFINES_PER_INVOCATION,
+    }),
+    { ok: false, stop: true, reason: "refine_budget_spent" },
+  );
+});
+
+test("negative refinesUsed throws", () => {
+  assert.throws(
+    () => validateRefineRewrite({ ...base, refinedQuery: "new query", refinesUsed: -1 }),
+    RangeError,
+  );
+  assert.throws(
+    () => validateRefineRewrite({ ...base, refinedQuery: "new query", refinesUsed: -1 }),
+    /refinesUsed/,
+  );
+});
+
+test("float refinesUsed throws", () => {
+  assert.throws(
+    () => validateRefineRewrite({ ...base, refinedQuery: "new query", refinesUsed: 1.5 }),
+    /refinesUsed/,
+  );
+});
+
+test("NaN refinesUsed throws", () => {
+  assert.throws(
+    () => validateRefineRewrite({ ...base, refinedQuery: "new query", refinesUsed: Number.NaN }),
+    /refinesUsed/,
+  );
+});
+
+test("empty string rewrite gives empty_rewrite", () => {
+  assert.deepEqual(validateRefineRewrite({ ...base, refinedQuery: "" }), {
+    ok: false,
+    stop: true,
+    reason: "empty_rewrite",
+  });
+});
+
+test("whitespace-only rewrite gives empty_rewrite", () => {
+  assert.deepEqual(validateRefineRewrite({ ...base, refinedQuery: "   " }), {
+    ok: false,
+    stop: true,
+    reason: "empty_rewrite",
+  });
+});
+
+test("null rewrite gives empty_rewrite", () => {
+  assert.deepEqual(validateRefineRewrite({ ...base, refinedQuery: null }), {
+    ok: false,
+    stop: true,
+    reason: "empty_rewrite",
+  });
+});
+
+test("undefined rewrite gives empty_rewrite", () => {
+  assert.deepEqual(validateRefineRewrite({ ...base, refinedQuery: undefined }), {
+    ok: false,
+    stop: true,
+    reason: "empty_rewrite",
+  });
+});
+
+test("number rewrite gives empty_rewrite", () => {
+  assert.deepEqual(validateRefineRewrite({ ...base, refinedQuery: 42 }), {
+    ok: false,
+    stop: true,
+    reason: "empty_rewrite",
+  });
+});
+
+test("exact duplicate gives identical_rewrite", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      ...base,
+      refinedQuery: "who met at the cafe",
+    }),
+    { ok: false, stop: true, reason: "identical_rewrite" },
+  );
+});
+
+test("case-different duplicate gives identical_rewrite", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      ...base,
+      refinedQuery: "  Who Met At The Cafe  ",
+    }),
+    { ok: false, stop: true, reason: "identical_rewrite" },
+  );
+});
+
+test("extra internal whitespace duplicate gives identical_rewrite", () => {
+  assert.deepEqual(
+    validateRefineRewrite({
+      currentQuery: "who met",
+      refinedQuery: "who  met",
+      refinesUsed: 0,
+    }),
+    { ok: false, stop: true, reason: "identical_rewrite" },
+  );
+});
+
+test("every failure carries stop true", () => {
+  const failures = [
+    validateRefineRewrite({
+      ...base,
+      refinedQuery: "fine",
+      refinesUsed: 2,
+    }),
+    validateRefineRewrite({ ...base, refinedQuery: "   " }),
+    validateRefineRewrite({ ...base, refinedQuery: "who met at the cafe" }),
+  ];
+  for (const failure of failures) {
+    assert.equal(failure.ok, false);
+    assert.equal(failure.stop, true);
+  }
+});

--- a/packages/remnic-core/src/recall-deep-rewrite.ts
+++ b/packages/remnic-core/src/recall-deep-rewrite.ts
@@ -1,0 +1,50 @@
+/**
+ * Validate a deep-recall REFINE rewrite (issue #2332).
+ *
+ * Pure. The budget check runs before the rewrite is inspected, so an
+ * exhausted budget cannot be bypassed by a valid-looking query. An empty
+ * or no-progress rewrite is rejected and treated as STOP.
+ */
+export const MAX_REFINES_PER_INVOCATION = 2;
+
+export type RefineRewriteResult =
+  | { ok: true; refinedQuery: string }
+  | {
+      ok: false;
+      stop: true;
+      reason: "empty_rewrite" | "identical_rewrite" | "refine_budget_spent";
+    };
+
+export function validateRefineRewrite(input: {
+  currentQuery: string;
+  refinedQuery: unknown;
+  refinesUsed: number;
+}): RefineRewriteResult {
+  if (!Number.isInteger(input.refinesUsed) || input.refinesUsed < 0) {
+    throw new RangeError(
+      `refinesUsed must be a non-negative integer; got ${JSON.stringify(input.refinesUsed)}`,
+    );
+  }
+  if (input.refinesUsed >= MAX_REFINES_PER_INVOCATION) {
+    return { ok: false, stop: true, reason: "refine_budget_spent" };
+  }
+  if (
+    typeof input.refinedQuery !== "string" ||
+    input.refinedQuery.trim() === ""
+  ) {
+    return { ok: false, stop: true, reason: "empty_rewrite" };
+  }
+  const trimmed = input.refinedQuery.trim();
+  // Comparison key: case-folded with internal whitespace runs collapsed, so
+  // pure case/spacing drift is not progress. The returned rewrite keeps
+  // internal whitespace as the model wrote it.
+  const currentKey = input.currentQuery
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+  const refinedKey = trimmed.toLowerCase().replace(/\s+/g, " ");
+  if (refinedKey === currentKey) {
+    return { ok: false, stop: true, reason: "identical_rewrite" };
+  }
+  return { ok: true, refinedQuery: trimmed };
+}


### PR DESCRIPTION
## Summary
Adds `validateRefineRewrite`, the REFINE-loop guard for #2332's policy validation: a rewritten query that is empty, makes no progress, or arrives after the refine budget is spent is rejected and treated as STOP. Every failure carries `stop: true` so a caller that checks only `ok` still halts.

Details: the budget check (`MAX_REFINES_PER_INVOCATION = 2`) runs before the rewrite is inspected, so an exhausted budget cannot be bypassed by a valid-looking query. Progress is compared case-folded with internal whitespace runs collapsed — `"Who Met At The Cafe"` over `"who met at the cafe"` is no progress — while the returned rewrite preserves the model's internal whitespace. `refinesUsed` itself must be a non-negative integer; that one throws, because it is a caller bug rather than a model answer.

Pure, standalone, no barrel export (siblings have none).

Part of #2332.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/recall-deep-rewrite.test.ts` — 19/19
- Covers budget precedence over a valid rewrite, all three no-progress duplicate forms, non-string rewrites, and invalid `refinesUsed` throws.