### PR TITLE
feat(extraction): build verified span provenance from offsets

### DIFF
--- a/.changeset/2333-span-provenance.md
+++ b/.changeset/2333-span-provenance.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span provenance builder. Verified offsets produce the quote/charStart/charEnd triple; empty spans, out-of-range offsets, and non-matching quotes return `{ok:false}`. Non-integers throw. No on-disk format change. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-provenance.test.ts
+++ b/packages/remnic-core/src/extraction-span-provenance.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spanToProvenance } from "./extraction-span-provenance.js";
+
+const TEXT = "The quick brown fox jumps over the lazy dog";
+
+test("spanToProvenance: mid-text span yields exact slice with echoed offsets", () => {
+  const result = spanToProvenance({ text: TEXT, start: 4, end: 19 });
+  assert.deepEqual(result, {
+    ok: true,
+    provenance: { quote: "quick brown fox", charStart: 4, charEnd: 19 },
+  });
+  if (result.ok) {
+    assert.ok(result.provenance.charEnd >= result.provenance.charStart);
+  }
+});
+
+test("spanToProvenance: full-text span succeeds", () => {
+  const result = spanToProvenance({ text: TEXT, start: 0, end: TEXT.length });
+  assert.deepEqual(result, {
+    ok: true,
+    provenance: { quote: TEXT, charStart: 0, charEnd: TEXT.length },
+  });
+});
+
+test("spanToProvenance: matching supplied quote succeeds", () => {
+  const result = spanToProvenance({ text: TEXT, start: 4, end: 9, quote: "quick" });
+  assert.deepEqual(result, {
+    ok: true,
+    provenance: { quote: "quick", charStart: 4, charEnd: 9 },
+  });
+});
+
+test("spanToProvenance: whitespace-differing quote is quote_mismatch", () => {
+  const result = spanToProvenance({ text: TEXT, start: 4, end: 15, quote: "quick  brown" });
+  assert.deepEqual(result, { ok: false, error: "quote_mismatch" });
+});
+
+test("spanToProvenance: paraphrase is quote_mismatch", () => {
+  const result = spanToProvenance({ text: TEXT, start: 4, end: 19, quote: "a fast fox" });
+  assert.deepEqual(result, { ok: false, error: "quote_mismatch" });
+});
+
+test("spanToProvenance: empty span", () => {
+  assert.deepEqual(spanToProvenance({ text: TEXT, start: 3, end: 3 }), {
+    ok: false,
+    error: "empty_span",
+  });
+  assert.deepEqual(spanToProvenance({ text: "", start: 0, end: 0 }), {
+    ok: false,
+    error: "empty_span",
+  });
+});
+
+test("spanToProvenance: out of range", () => {
+  assert.deepEqual(spanToProvenance({ text: TEXT, start: -1, end: 4 }), {
+    ok: false,
+    error: "out_of_range",
+  });
+  assert.deepEqual(spanToProvenance({ text: TEXT, start: 0, end: TEXT.length + 1 }), {
+    ok: false,
+    error: "out_of_range",
+  });
+  assert.deepEqual(spanToProvenance({ text: TEXT, start: 10, end: 4 }), {
+    ok: false,
+    error: "out_of_range",
+  });
+});
+
+test("spanToProvenance: non-integers and non-finite offsets throw", () => {
+  assert.throws(() => spanToProvenance({ text: TEXT, start: 1.5, end: 4 }), /integers/);
+  assert.throws(() => spanToProvenance({ text: TEXT, start: 0, end: 3.2 }), /integers/);
+  assert.throws(() => spanToProvenance({ text: TEXT, start: Number.NaN, end: 4 }), /integers/);
+  assert.throws(
+    () => spanToProvenance({ text: TEXT, start: 0, end: Number.POSITIVE_INFINITY }),
+    /integers/,
+  );
+});
+
+test("spanToProvenance: does not mutate the input object", () => {
+  const input = { text: TEXT, start: 4, end: 19, quote: "quick brown fox" };
+  const snapshot = { ...input };
+  spanToProvenance(input);
+  assert.deepEqual(input, snapshot);
+});

--- a/packages/remnic-core/src/extraction-span-provenance.ts
+++ b/packages/remnic-core/src/extraction-span-provenance.ts
@@ -1,0 +1,41 @@
+/**
+ * Isolated span-provenance builder (issue #2333).
+ *
+ * Pure. Builds the ProvenanceSource quote/charStart/charEnd triple from
+ * offsets and verifies a model-supplied quote equals the sliced text, so a
+ * bad offset pair can never persist a quote absent from the source.
+ */
+
+export interface SpanProvenance {
+  quote: string;
+  charStart: number;
+  charEnd: number;
+}
+
+export type SpanProvenanceResult =
+  | { ok: true; provenance: SpanProvenance }
+  | { ok: false; error: "empty_span" | "out_of_range" | "quote_mismatch" };
+
+export function spanToProvenance(input: {
+  text: string;
+  start: number;
+  end: number;
+  /** Optional model-supplied quote to verify against the slice. */
+  quote?: string;
+}): SpanProvenanceResult {
+  const { text, start, end, quote } = input;
+  if (!Number.isInteger(start) || !Number.isInteger(end)) {
+    throw new TypeError("span offsets must be integers");
+  }
+  if (start < 0 || end > text.length || end < start) {
+    return { ok: false, error: "out_of_range" };
+  }
+  if (start === end) {
+    return { ok: false, error: "empty_span" };
+  }
+  const sliced = text.slice(start, end);
+  if (quote !== undefined && quote !== sliced) {
+    return { ok: false, error: "quote_mismatch" };
+  }
+  return { ok: true, provenance: { quote: sliced, charStart: start, charEnd: end } };
+}


### PR DESCRIPTION
## Summary
Adds `spanToProvenance` for #2333 Phase A: builds the `ProvenanceSource`-shaped `quote`/`charStart`/`charEnd` triple from offsets, and — the load-bearing part — verifies a model-supplied quote equals the sliced text EXACTLY before it can become provenance. A bad offset pair or a hallucinated paraphrase returns a typed error instead of persisting a quote that does not appear in the source.

This is the design point that lets span mode ship without any on-disk format change: `ProvenanceSource` already carries these three fields. The module is structurally compatible but deliberately standalone (no import from `provenance.ts`, no barrel — matching the sibling `extraction-span-*` slices).

Half-open `[start, end)`; `start === end` is `empty_span` because `provenance.ts` requires a non-empty quote; out-of-range is typed, non-integer offsets throw like the sibling helpers.

Part of #2333.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/extraction-span-provenance.test.ts` — 9/9
- Covers exact-slice echo, matching-quote success, whitespace-differing and paraphrase quotes rejected, boundary spans, and integer-guards.