### PR TITLE
feat(activity): preserve user recap edits across regeneration

### DIFF
--- a/.changeset/2051-recap-merge-edits.md
+++ b/.changeset/2051-recap-merge-edits.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a pure `mergeRecapUserEdits` helper (plus `RecapSection` / `MergeRecapEditsResult` types) in the activity timeline layer that merges user hand-edited recap sections with a regenerated recap: edited bodies win over regenerated bodies, edited-only sections are kept, whitespace-only edits fall back to the generated body, and `reset: true` is the only path that discards edits. Not yet wired into the regeneration flow. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -22,3 +22,4 @@ export * from "./analysis-claim.js";
 export * from "./analysis-order.js";
 export * from "./recap-window.js";
 export * from "./analysis-failure.js";
+export * from "./recap-merge-edits.js";

--- a/packages/remnic-core/src/activity/timeline/recap-merge-edits.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-merge-edits.test.ts
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  mergeRecapUserEdits,
+  type RecapSection,
+} from "./recap-merge-edits.js";
+
+test("edited section survives regeneration", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "new body" }],
+    edited: [{ key: "highlights", body: "hand edit" }],
+  });
+  assert.deepEqual(result.sections, [{ key: "highlights", body: "hand edit" }]);
+  assert.deepEqual(result.preserved, ["highlights"]);
+  assert.deepEqual(result.regenerated, []);
+});
+
+test("reset discards every edit", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "new body" }],
+    edited: [{ key: "highlights", body: "hand edit" }],
+    reset: true,
+  });
+  assert.deepEqual(result.sections, [{ key: "highlights", body: "new body" }]);
+  assert.deepEqual(result.preserved, []);
+  assert.deepEqual(result.regenerated, ["highlights"]);
+});
+
+test("edited-only section is kept and counted preserved", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "new body" }],
+    edited: [
+      { key: "highlights", body: "hand edit" },
+      { key: "zeta", body: "user section" },
+      { key: "alpha", body: "another user section" },
+    ],
+  });
+  assert.deepEqual(
+    result.sections.map((s) => s.key),
+    ["highlights", "alpha", "zeta"],
+  );
+  assert.deepEqual(result.preserved, ["highlights", "alpha", "zeta"]);
+  assert.deepEqual(result.regenerated, []);
+  const alpha = result.sections.find((s) => s.key === "alpha");
+  assert.equal(alpha?.body, "another user section");
+});
+
+test("edited-only section is dropped on reset", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "new body" }],
+    edited: [{ key: "zeta", body: "user section" }],
+    reset: true,
+  });
+  assert.deepEqual(
+    result.sections.map((s) => s.key),
+    ["highlights"],
+  );
+  assert.deepEqual(result.preserved, []);
+});
+
+test("generated-only section is included and counted regenerated", () => {
+  const result = mergeRecapUserEdits({
+    generated: [
+      { key: "highlights", body: "new body" },
+      { key: "notes", body: "generated notes" },
+    ],
+    edited: [{ key: "highlights", body: "hand edit" }],
+  });
+  const notes = result.sections.find((s) => s.key === "notes");
+  assert.equal(notes?.body, "generated notes");
+  assert.deepEqual(result.regenerated, ["notes"]);
+});
+
+test("whitespace-only edit falls back to generated body", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "new body" }],
+    edited: [{ key: "highlights", body: "  \n\t " }],
+  });
+  assert.deepEqual(result.sections, [{ key: "highlights", body: "new body" }]);
+  assert.deepEqual(result.preserved, []);
+  assert.deepEqual(result.regenerated, ["highlights"]);
+});
+
+test("whitespace-only edited-only key is dropped entirely", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "new body" }],
+    edited: [{ key: "zeta", body: "   " }],
+  });
+  assert.deepEqual(
+    result.sections.map((s) => s.key),
+    ["highlights"],
+  );
+  assert.deepEqual(result.preserved, []);
+});
+
+test("duplicate keys keep the first occurrence", () => {
+  const result = mergeRecapUserEdits({
+    generated: [
+      { key: "highlights", body: "first generated" },
+      { key: "highlights", body: "second generated" },
+    ],
+    edited: [
+      { key: "highlights", body: "first edit" },
+      { key: "highlights", body: "second edit" },
+    ],
+  });
+  assert.deepEqual(result.sections, [
+    { key: "highlights", body: "first edit" },
+  ]);
+});
+
+test("duplicate edited-only keys keep the first occurrence", () => {
+  const result = mergeRecapUserEdits({
+    generated: [{ key: "highlights", body: "gen" }],
+    edited: [
+      { key: "zeta", body: "first user section" },
+      { key: "zeta", body: "second user section" },
+    ],
+  });
+  const zeta = result.sections.find((s) => s.key === "zeta");
+  assert.equal(zeta?.body, "first user section");
+  assert.equal(result.sections.filter((s) => s.key === "zeta").length, 1);
+});
+
+test("output is deterministic across two calls on the same input", () => {
+  const input = {
+    generated: [
+      { key: "notes", body: "generated notes" },
+      { key: "highlights", body: "new body" },
+    ],
+    edited: [
+      { key: "zeta", body: "user section" },
+      { key: "highlights", body: "hand edit" },
+      { key: "alpha", body: "another user section" },
+    ],
+  };
+  const first = mergeRecapUserEdits(input);
+  const second = mergeRecapUserEdits(input);
+  assert.deepEqual(first, second);
+  assert.deepEqual(
+    first.sections.map((s) => s.key),
+    ["notes", "highlights", "alpha", "zeta"],
+  );
+});
+
+test("preserved and regenerated are disjoint and cover every output key", () => {
+  const result = mergeRecapUserEdits({
+    generated: [
+      { key: "highlights", body: "new body" },
+      { key: "notes", body: "generated notes" },
+    ],
+    edited: [
+      { key: "highlights", body: "hand edit" },
+      { key: "zeta", body: "user section" },
+    ],
+  });
+  const outputKeys = result.sections.map((s) => s.key).sort();
+  const accounted = [...result.preserved, ...result.regenerated].sort();
+  assert.deepEqual(accounted, outputKeys);
+  for (const key of result.preserved) {
+    assert.equal(result.regenerated.includes(key), false);
+  }
+});
+
+test("inputs are not mutated", () => {
+  const generated: RecapSection[] = [
+    { key: "highlights", body: "new body" },
+    { key: "notes", body: "generated notes" },
+  ];
+  const edited: RecapSection[] = [
+    { key: "highlights", body: "hand edit" },
+    { key: "zeta", body: "user section" },
+  ];
+  const generatedSnapshot = structuredClone(generated);
+  const editedSnapshot = structuredClone(edited);
+  mergeRecapUserEdits({ generated, edited, reset: false });
+  mergeRecapUserEdits({ generated, edited, reset: true });
+  assert.deepEqual(generated, generatedSnapshot);
+  assert.deepEqual(edited, editedSnapshot);
+});

--- a/packages/remnic-core/src/activity/timeline/recap-merge-edits.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-merge-edits.ts
@@ -1,0 +1,70 @@
+/**
+ * Merge user hand-edits into a regenerated journal recap (issue #2051).
+ *
+ * Rule: user edits survive regeneration; an explicit reset is the only
+ * way to discard them. Pure — no I/O, no clock, no randomness.
+ */
+
+export interface RecapSection {
+  /** Stable section key, e.g. "highlights". */
+  key: string;
+  body: string;
+}
+
+export type MergeRecapEditsResult = {
+  sections: RecapSection[];
+  /** Section keys whose user edit was kept over the regenerated body. */
+  preserved: string[];
+  /** Section keys taken from the regenerated recap. */
+  regenerated: string[];
+};
+
+function dedupeByFirst(list: readonly RecapSection[]): RecapSection[] {
+  const seen = new Set<string>();
+  const out: RecapSection[] = [];
+  for (const section of list) {
+    if (seen.has(section.key)) continue;
+    seen.add(section.key);
+    out.push(section);
+  }
+  return out;
+}
+
+export function mergeRecapUserEdits(input: {
+  generated: readonly RecapSection[];
+  edited?: readonly RecapSection[];
+  reset?: boolean;
+}): MergeRecapEditsResult {
+  const generated = dedupeByFirst(input.generated);
+  const edited = dedupeByFirst(input.edited ?? []);
+  const editedByKey = new Map(edited.map((s) => [s.key, s]));
+
+  const sections: RecapSection[] = [];
+  const preserved: string[] = [];
+  const regenerated: string[] = [];
+
+  for (const gen of generated) {
+    const edit = editedByKey.get(gen.key);
+    if (!input.reset && edit !== undefined && edit.body.trim() !== "") {
+      sections.push({ key: gen.key, body: edit.body });
+      preserved.push(gen.key);
+    } else {
+      sections.push({ key: gen.key, body: gen.body });
+      regenerated.push(gen.key);
+    }
+  }
+
+  if (!input.reset) {
+    const generatedKeys = new Set(generated.map((s) => s.key));
+    const editedOnly = edited
+      .filter((s) => !generatedKeys.has(s.key))
+      .filter((s) => s.body.trim() !== "")
+      .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+    for (const edit of editedOnly) {
+      sections.push({ key: edit.key, body: edit.body });
+      preserved.push(edit.key);
+    }
+  }
+
+  return { sections, preserved, regenerated };
+}


### PR DESCRIPTION
## Summary
Implements the #2051 merge rule: "User edits survive regeneration; explicit reset is the only way to discard them."

`mergeRecapUserEdits` keeps a hand-edited section body over the regenerated one, keeps user-authored sections the generator no longer emits, and reports which keys were `preserved` vs `regenerated` (disjoint, covering). `reset: true` is the only path that discards edits. A whitespace-only "edit" is not treated as an edit — it falls back to generated, and an edited-only key that is blank is dropped rather than persisted as an empty section.

Deterministic order (generated order, then edited-only keys sorted); inputs never mutated.

Part of #2051 — this is the merge helper only, not the regeneration wiring, so the issue stays open.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/timeline/recap-merge-edits.test.ts` — 12/12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for merging regenerated recap sections with user edits.
  * Meaningful edits are preserved, while whitespace-only edits fall back to regenerated content.
  * Edited-only sections are retained and can be reset when requested.
  * Merge results identify preserved and regenerated sections with consistent ordering.

* **Tests**
  * Added comprehensive coverage for edit handling, reset behavior, duplicate sections, ordering, and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->