### PR TITLE
feat(activity): plan activity retention deletion without touching unrelated memories

### DIFF
--- a/.changeset/activity-privacy-delete-plan-2053.md
+++ b/.changeset/activity-privacy-delete-plan-2053.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": patch
+---
+
+Add `planActivityDeletion`: a pure planner that selects expired activity
+artifacts for deletion, refuses non-activity-owned paths (facts, profile,
+entities) so unrelated memories survive, and skips out-of-scope scopes.
+Part of #2053.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -20,6 +20,7 @@ export * from "./journal-vault-read.js";
 export { stripRemnicOwnedRegions } from "./journal-strip.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";
+export * from "./privacy-delete-plan.js";
 export * from "./privacy-status.js";
 export * from "./privacy-window.js";
 export * from "./vault-path.js";

--- a/packages/remnic-core/src/activity/privacy-delete-plan.test.ts
+++ b/packages/remnic-core/src/activity/privacy-delete-plan.test.ts
@@ -176,3 +176,40 @@ test("input candidates are not mutated", () => {
   plan(candidates);
   assert.deepEqual(candidates, snapshot);
 });
+
+// Review round 1: the planner trimmed relPath before validating it, so
+// " activity/x.md" validated as owned and the plan then targeted
+// "activity/x.md" — a path the caller never supplied.
+test("a path with surrounding whitespace is refused, not normalized into a delete", () => {
+  const expired = 0;
+  for (const relPath of [" activity/day.md", "activity/day.md ", "\tactivity/day.md"]) {
+    const plan = planActivityDeletion({
+      candidates: [{ scope: "cards", relPath, capturedAtMs: expired }],
+      scopes: ["cards"],
+      retentionDays: 1,
+      nowMs: 10 * 86_400_000,
+    });
+    assert.deepEqual(plan.deletePaths, [], `${JSON.stringify(relPath)} must not be planned`);
+    assert.deepEqual(plan.refused, [relPath], "the exact candidate path is reported as refused");
+  }
+});
+
+// Review round 1: every comparison against NaN is false, so shouldRetain
+// reported "not retained" and a corrupt timestamp resolved toward deletion.
+test("a non-finite capturedAtMs is refused instead of deleted", () => {
+  for (const capturedAtMs of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    const plan = planActivityDeletion({
+      candidates: [{ scope: "cards", relPath: "activity/corrupt.md", capturedAtMs }],
+      scopes: ["cards"],
+      retentionDays: 1,
+      nowMs: 10 * 86_400_000,
+    });
+    assert.deepEqual(
+      plan.deletePaths,
+      [],
+      `capturedAtMs ${String(capturedAtMs)} must never resolve toward deletion`,
+    );
+    assert.deepEqual(plan.refused, ["activity/corrupt.md"]);
+    assert.equal(plan.keptCount, 0);
+  }
+});

--- a/packages/remnic-core/src/activity/privacy-delete-plan.test.ts
+++ b/packages/remnic-core/src/activity/privacy-delete-plan.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MS_PER_DAY } from "./privacy.js";
+import {
+  ACTIVITY_DELETE_SCOPES,
+  planActivityDeletion,
+  type ActivityDeleteCandidate,
+} from "./privacy-delete-plan.js";
+
+const NOW = 100 * MS_PER_DAY;
+
+function cand(
+  scope: string,
+  relPath: string,
+  capturedAtMs: number,
+): ActivityDeleteCandidate {
+  return { scope, relPath, capturedAtMs };
+}
+
+function plan(
+  candidates: readonly ActivityDeleteCandidate[],
+  overrides: Partial<Parameters<typeof planActivityDeletion>[0]> = {},
+) {
+  return planActivityDeletion({
+    candidates,
+    scopes: ACTIVITY_DELETE_SCOPES,
+    retentionDays: 30,
+    nowMs: NOW,
+    ...overrides,
+  });
+}
+
+test("expired in-scope activity paths are planned across every owned root", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([
+    cand("observations", "activity/2026-01-01.md", expired),
+    cand("cards", "wearables/limitless/2026-01-01.md", expired),
+    cand("journal", "meetings/2026-01-01/mtg-x.md", expired),
+  ]);
+  assert.deepEqual(result.deletePaths, [
+    "activity/2026-01-01.md",
+    "meetings/2026-01-01/mtg-x.md",
+    "wearables/limitless/2026-01-01.md",
+  ]);
+  assert.equal(result.keptCount, 0);
+  assert.deepEqual(result.refused, []);
+});
+
+test("fresh in-scope candidates are kept, not deleted", () => {
+  const result = plan([cand("observations", "activity/2026-08-19.md", NOW - MS_PER_DAY)]);
+  assert.deepEqual(result.deletePaths, []);
+  assert.equal(result.keptCount, 1);
+  assert.deepEqual(result.refused, []);
+});
+
+test("retentionDays 0 deletes nothing but counts kept", () => {
+  const ancient = NOW - 4000 * MS_PER_DAY;
+  const result = plan([cand("weekly", "activity/2015-01-01.md", ancient)], {
+    retentionDays: 0,
+  });
+  assert.deepEqual(result.deletePaths, []);
+  assert.equal(result.keptCount, 1);
+});
+
+test("facts paths are refused even when expired and in scope", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([cand("observations", "facts/2026-01-01/fact-1.md", expired)]);
+  assert.deepEqual(result.deletePaths, []);
+  assert.deepEqual(result.refused, ["facts/2026-01-01/fact-1.md"]);
+  assert.equal(result.keptCount, 0);
+});
+
+test("profile.md, entities, and state files are refused", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([
+    cand("journal", "profile.md", expired),
+    cand("journal", "entities/person-a.md", expired),
+    cand("providerCache", "state/buffer.json", expired),
+  ]);
+  assert.deepEqual(result.deletePaths, []);
+  assert.deepEqual(result.refused, ["entities/person-a.md", "profile.md", "state/buffer.json"]);
+});
+
+test("absolute, traversal, and blank paths are refused", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([
+    cand("observations", "/etc/passwd", expired),
+    cand("observations", "activity/../../facts/fact-1.md", expired),
+    cand("observations", "   ", expired),
+  ]);
+  assert.deepEqual(result.deletePaths, []);
+  assert.deepEqual(result.refused, [
+    "   ",
+    "/etc/passwd",
+    "activity/../../facts/fact-1.md",
+  ]);
+});
+
+test("unknown candidate scope is refused", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([cand("bogus", "activity/2026-01-01.md", expired)]);
+  assert.deepEqual(result.deletePaths, []);
+  assert.deepEqual(result.refused, ["activity/2026-01-01.md"]);
+  assert.equal(result.keptCount, 0);
+});
+
+test("scope absent from scopes is skipped entirely", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([cand("cards", "activity/2026-01-01.md", expired)], {
+    scopes: ["observations"],
+  });
+  assert.deepEqual(result.deletePaths, []);
+  assert.deepEqual(result.refused, []);
+  assert.equal(result.keptCount, 0);
+});
+
+test("unknown value in scopes throws RangeError", () => {
+  assert.throws(
+    () => plan([], { scopes: ["observations", "everything"] }),
+    (error: unknown) => error instanceof RangeError && /scope/.test(error.message),
+  );
+});
+
+test("negative or float retentionDays throws RangeError", () => {
+  assert.throws(
+    () => plan([], { retentionDays: -1 }),
+    (error: unknown) => error instanceof RangeError && /retentionDays/.test(error.message),
+  );
+  assert.throws(
+    () => plan([], { retentionDays: 2.5 }),
+    (error: unknown) => error instanceof RangeError && /retentionDays/.test(error.message),
+  );
+});
+
+test("non-finite nowMs throws RangeError", () => {
+  assert.throws(
+    () => plan([], { nowMs: Number.POSITIVE_INFINITY }),
+    (error: unknown) => error instanceof RangeError && /nowMs/.test(error.message),
+  );
+  assert.throws(
+    () => plan([], { nowMs: Number.NaN }),
+    (error: unknown) => error instanceof RangeError && /nowMs/.test(error.message),
+  );
+});
+
+test("deletePaths and refused are sorted and deduplicated", () => {
+  const expired = NOW - 40 * MS_PER_DAY;
+  const result = plan([
+    cand("observations", "activity/b.md", expired),
+    cand("cards", "activity/a.md", expired),
+    cand("journal", "activity/b.md", expired),
+    cand("observations", "facts/z.md", expired),
+    cand("cards", "facts/z.md", expired),
+  ]);
+  assert.deepEqual(result.deletePaths, ["activity/a.md", "activity/b.md"]);
+  assert.deepEqual(result.refused, ["facts/z.md"]);
+});
+
+test("half-open boundary: age exactly retentionDays * MS_PER_DAY is deleted", () => {
+  const boundary = NOW - 30 * MS_PER_DAY;
+  const result = plan([
+    cand("observations", "activity/boundary.md", boundary),
+    cand("observations", "activity/inside.md", boundary + 1),
+  ]);
+  assert.deepEqual(result.deletePaths, ["activity/boundary.md"]);
+  assert.equal(result.keptCount, 1);
+});
+
+test("input candidates are not mutated", () => {
+  const candidates = [
+    cand("observations", "activity/2026-01-01.md", NOW - 40 * MS_PER_DAY),
+    cand("observations", "facts/2026-01-01/fact-1.md", NOW - 40 * MS_PER_DAY),
+  ];
+  const snapshot = structuredClone(candidates);
+  plan(candidates);
+  assert.deepEqual(candidates, snapshot);
+});

--- a/packages/remnic-core/src/activity/privacy-delete-plan.ts
+++ b/packages/remnic-core/src/activity/privacy-delete-plan.ts
@@ -36,10 +36,16 @@ export interface ActivityDeletePlan {
   refused: string[];
 }
 
-function isRefusablePath(relPath: string): boolean {
-  const trimmed = relPath.trim();
-  if (trimmed === "" || trimmed.startsWith("/")) return true;
-  const segments = trimmed.split("/");
+function isRefusablePath(relPath: unknown): boolean {
+  if (typeof relPath !== "string") return true;
+  if (relPath.trim() === "") return true;
+  // Validate the EXACT candidate path. Trimming first would let
+  // " activity/x.md" validate as owned and then plan a delete for
+  // "activity/x.md" — a path the caller never supplied. Surrounding
+  // whitespace means this is not a clean owned path: refuse it.
+  if (relPath !== relPath.trim()) return true;
+  if (relPath.startsWith("/")) return true;
+  const segments = relPath.split("/");
   if (segments.includes("..")) return true;
   const [root = "", ...rest] = segments;
   return (
@@ -80,11 +86,18 @@ export function planActivityDeletion(input: {
 
   for (const candidate of candidates) {
     if (!KNOWN_SCOPES.includes(candidate.scope)) {
-      refused.push(candidate.relPath);
+      refused.push(String(candidate.relPath));
       continue;
     }
     if (!selectedScopes.has(candidate.scope)) continue;
     if (isRefusablePath(candidate.relPath)) {
+      refused.push(String(candidate.relPath));
+      continue;
+    }
+    // A corrupt timestamp must never resolve toward deletion: every
+    // comparison against NaN is false, which shouldRetain reads as
+    // "not retained". Refuse the candidate instead.
+    if (typeof candidate.capturedAtMs !== "number" || !Number.isFinite(candidate.capturedAtMs)) {
       refused.push(candidate.relPath);
       continue;
     }
@@ -92,7 +105,7 @@ export function planActivityDeletion(input: {
       keptCount += 1;
       continue;
     }
-    deletePaths.push(candidate.relPath.trim());
+    deletePaths.push(candidate.relPath);
   }
 
   return {

--- a/packages/remnic-core/src/activity/privacy-delete-plan.ts
+++ b/packages/remnic-core/src/activity/privacy-delete-plan.ts
@@ -1,0 +1,103 @@
+/**
+ * Activity retention deletion planner (issue #2053).
+ *
+ * Pure: decides what a retention pass may delete. Never performs I/O.
+ * Safety rule: a path outside the activity-owned roots is refused, never
+ * planned for deletion, so unrelated Remnic memories survive.
+ */
+import { shouldRetain } from "./privacy.js";
+
+export const ACTIVITY_DELETE_SCOPES = [
+  "observations",
+  "cards",
+  "journal",
+  "weekly",
+  "providerCache",
+] as const;
+export type ActivityDeleteScope = (typeof ACTIVITY_DELETE_SCOPES)[number];
+
+const KNOWN_SCOPES: readonly string[] = ACTIVITY_DELETE_SCOPES;
+
+/** Deletion only ever touches these memory-dir-relative roots. */
+const OWNED_ROOTS: readonly string[] = ["activity", "wearables", "meetings"];
+
+export interface ActivityDeleteCandidate {
+  /** Which activity artifact family this item belongs to. */
+  scope: string;
+  /** Memory-dir-relative path, POSIX separators. */
+  relPath: string;
+  capturedAtMs: number;
+}
+
+export interface ActivityDeletePlan {
+  deletePaths: string[];
+  keptCount: number;
+  /** Candidates refused because they are not activity-owned paths. */
+  refused: string[];
+}
+
+function isRefusablePath(relPath: string): boolean {
+  const trimmed = relPath.trim();
+  if (trimmed === "" || trimmed.startsWith("/")) return true;
+  const segments = trimmed.split("/");
+  if (segments.includes("..")) return true;
+  const [root = "", ...rest] = segments;
+  return (
+    rest.length === 0 ||
+    !OWNED_ROOTS.includes(root) ||
+    rest.some((segment) => segment.length === 0)
+  );
+}
+
+function sortedUnique(paths: Iterable<string>): string[] {
+  return [...new Set(paths)].sort();
+}
+
+export function planActivityDeletion(input: {
+  candidates: readonly ActivityDeleteCandidate[];
+  scopes: readonly string[];
+  retentionDays: number;
+  nowMs: number;
+}): ActivityDeletePlan {
+  const { candidates, scopes, retentionDays, nowMs } = input;
+
+  for (const scope of scopes) {
+    if (!KNOWN_SCOPES.includes(scope)) {
+      throw new RangeError(`unknown activity delete scope: ${scope}`);
+    }
+  }
+  if (!Number.isInteger(retentionDays) || retentionDays < 0) {
+    throw new RangeError("retentionDays must be a non-negative integer");
+  }
+  if (!Number.isFinite(nowMs)) {
+    throw new RangeError("nowMs must be a finite number");
+  }
+
+  const selectedScopes = new Set(scopes);
+  const deletePaths: string[] = [];
+  const refused: string[] = [];
+  let keptCount = 0;
+
+  for (const candidate of candidates) {
+    if (!KNOWN_SCOPES.includes(candidate.scope)) {
+      refused.push(candidate.relPath);
+      continue;
+    }
+    if (!selectedScopes.has(candidate.scope)) continue;
+    if (isRefusablePath(candidate.relPath)) {
+      refused.push(candidate.relPath);
+      continue;
+    }
+    if (shouldRetain(candidate.capturedAtMs, nowMs, retentionDays, true)) {
+      keptCount += 1;
+      continue;
+    }
+    deletePaths.push(candidate.relPath.trim());
+  }
+
+  return {
+    deletePaths: sortedUnique(deletePaths),
+    keptCount,
+    refused: sortedUnique(refused),
+  };
+}


### PR DESCRIPTION
## Summary
Implements the planner behind #2053's deletion/retention requirement, with its hard safety rule as the module's whole point: "Deletion must not remove unrelated Remnic memories."

`planActivityDeletion` only ever plans paths under the activity-owned roots (`activity/`, `wearables/`, `meetings/`). A `facts/...`, `profile.md`, `entities/...`, absolute, or `..`-traversing path is **refused**, never normalized into something deletable. An unknown candidate scope is refused; an unknown value in the requested `scopes` argument throws rather than silently narrowing the request.

Retention reuses the existing `shouldRetain` rather than re-deriving the window, so `retentionDays: 0` keeps forever and plans nothing while still counting kept items. `deletePaths` and `refused` are deduplicated and sorted for a deterministic plan.

Plans only — this slice performs no I/O.

Part of #2053 (surface wiring not included, so the issue stays open).

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/privacy-delete-plan.test.ts` — 14/14
- Includes the half-open retention boundary at exactly `retentionDays * MS_PER_DAY`, and refusal cases for `facts/`, `profile.md`, absolute, and `..` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activity privacy deletion planning based on expiration and retention rules.
  * Supports safe handling of eligible activity artifacts while protecting non-activity and unsupported paths.
  * Provides sorted, deduplicated deletion and refused-path results without performing deletions directly.

* **Bug Fixes**
  * Added validation for retention inputs and supported deletion scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->