### PR TITLE
feat(recall): gate navigation to ids served in the session window

### DIFF
--- a/.changeset/recall-navigate-window-1956.md
+++ b/.changeset/recall-navigate-window-1956.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Gate recall navigation authority to ids served within the session's last N recall snapshots. Part of #1956

--- a/packages/remnic-core/src/recall-navigate-window.test.ts
+++ b/packages/remnic-core/src/recall-navigate-window.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_NAVIGATION_WINDOW_SNAPSHOTS,
+  assertIdInNavigationWindow,
+  type NavigationSnapshot,
+} from "./recall-navigate-window.js";
+
+const snap = (...servedIds: string[]): NavigationSnapshot => ({ servedIds });
+const malformed = (value: unknown): NavigationSnapshot => value as NavigationSnapshot;
+
+test("default window is 3 snapshots", () => {
+  assert.equal(DEFAULT_NAVIGATION_WINDOW_SNAPSHOTS, 3);
+});
+
+test("id in the newest snapshot is ok", () => {
+  assert.deepEqual(
+    assertIdInNavigationWindow({ snapshots: [snap("fact-1"), snap("fact-2")], memoryId: "fact-1" }),
+    { ok: true, memoryId: "fact-1" },
+  );
+});
+
+test("id in the 3rd snapshot is ok at the default window", () => {
+  const snapshots = [snap("fact-a"), snap("fact-b"), snap("fact-c"), snap("fact-d")];
+  assert.deepEqual(assertIdInNavigationWindow({ snapshots, memoryId: "fact-c" }), {
+    ok: true,
+    memoryId: "fact-c",
+  });
+});
+
+test("id only in a 4th snapshot is not_served", () => {
+  const snapshots = [snap("fact-a"), snap("fact-b"), snap("fact-c"), snap("fact-d")];
+  assert.deepEqual(assertIdInNavigationWindow({ snapshots, memoryId: "fact-d" }), {
+    ok: false,
+    error: "not_served",
+  });
+});
+
+test("windowSnapshots 1 rejects an id from the 2nd snapshot", () => {
+  const snapshots = [snap("fact-a"), snap("fact-b")];
+  assert.deepEqual(
+    assertIdInNavigationWindow({ snapshots, memoryId: "fact-b", windowSnapshots: 1 }),
+    { ok: false, error: "not_served" },
+  );
+});
+
+test("windowSnapshots 0, negative, fractional, NaN, Infinity throw", () => {
+  const snapshots = [snap("fact-a")];
+  for (const windowSnapshots of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => assertIdInNavigationWindow({ snapshots, memoryId: "fact-a", windowSnapshots }),
+      { name: "RangeError", message: /windowSnapshots/ },
+    );
+  }
+});
+
+test("non-string and whitespace ids are empty_id, never not_served", () => {
+  const snapshots = [snap("fact-a")];
+  for (const memoryId of [null, undefined, 42, {}, "", "   ", "\t\n"]) {
+    assert.deepEqual(assertIdInNavigationWindow({ snapshots, memoryId }), {
+      ok: false,
+      error: "empty_id",
+    });
+  }
+});
+
+test("padded id matches after trim", () => {
+  const snapshots = [snap("fact-1")];
+  assert.deepEqual(assertIdInNavigationWindow({ snapshots, memoryId: "  fact-1 \t" }), {
+    ok: true,
+    memoryId: "fact-1",
+  });
+});
+
+test("case-different id is not_served", () => {
+  const snapshots = [snap("Fact-1")];
+  assert.deepEqual(assertIdInNavigationWindow({ snapshots, memoryId: "fact-1" }), {
+    ok: false,
+    error: "not_served",
+  });
+});
+
+test("empty snapshots list is not_served", () => {
+  assert.deepEqual(assertIdInNavigationWindow({ snapshots: [], memoryId: "fact-1" }), {
+    ok: false,
+    error: "not_served",
+  });
+});
+
+test("malformed snapshot consumes its window slot without throwing", () => {
+  // Missing servedIds on the newest snapshot: it still burns the only
+  // window slot, so the id served by the 2nd snapshot stays not_served.
+  assert.doesNotThrow(() => {
+    assert.deepEqual(
+      assertIdInNavigationWindow({
+        snapshots: [malformed({}), malformed({ servedIds: "fact-1" })],
+        memoryId: "fact-1",
+        windowSnapshots: 1,
+      }),
+      { ok: false, error: "not_served" },
+    );
+  });
+});

--- a/packages/remnic-core/src/recall-navigate-window.ts
+++ b/packages/remnic-core/src/recall-navigate-window.ts
@@ -1,0 +1,48 @@
+/**
+ * Recall navigation window authority (issue #1956).
+ *
+ * Pure. An expandable id must have been served by one of the session's
+ * last `windowSnapshots` recall snapshots, ordered newest first. Unknown
+ * or foreign ids are rejected, not reinterpreted (pattern 39).
+ */
+
+export const DEFAULT_NAVIGATION_WINDOW_SNAPSHOTS = 3;
+
+/** Ids served by one recall snapshot, newest snapshot first when passed in. */
+export interface NavigationSnapshot {
+  servedIds: readonly string[];
+}
+
+export type NavigationAuthorityResult =
+  | { ok: true; memoryId: string }
+  | { ok: false; error: "empty_id" | "not_served" };
+
+export function assertIdInNavigationWindow(input: {
+  snapshots: readonly NavigationSnapshot[];
+  memoryId: unknown;
+  windowSnapshots?: number;
+}): NavigationAuthorityResult {
+  const windowSnapshots = input.windowSnapshots ?? DEFAULT_NAVIGATION_WINDOW_SNAPSHOTS;
+  if (!Number.isInteger(windowSnapshots) || windowSnapshots < 1) {
+    throw new RangeError(
+      `windowSnapshots must be a positive integer; got ${JSON.stringify(windowSnapshots)}`,
+    );
+  }
+  if (typeof input.memoryId !== "string" || input.memoryId.trim() === "") {
+    return { ok: false, error: "empty_id" };
+  }
+  const wanted = input.memoryId.trim();
+  for (const snapshot of input.snapshots.slice(0, windowSnapshots)) {
+    // A malformed entry (missing or non-array servedIds) was still a real
+    // recall turn: it consumes a window slot but contributes no ids.
+    if (!snapshot || !Array.isArray(snapshot.servedIds)) {
+      continue;
+    }
+    for (const served of snapshot.servedIds) {
+      if (typeof served === "string" && served.trim() === wanted) {
+        return { ok: true, memoryId: wanted };
+      }
+    }
+  }
+  return { ok: false, error: "not_served" };
+}


### PR DESCRIPTION
## Summary
Adds the session-scoped navigation authority #1956 requires: "only ids from the session's last N recall snapshots are expandable (config `navigationWindowSnapshots`, default 3). Unknown/foreign id → explicit error."

`recall-navigate-access.ts` already gates action, budget, and node resolution — it does **not** check whether the caller was ever served the id, which is the check that stops arbitrary-id fishing. `assertIdInNavigationWindow` closes that gap: snapshots are newest-first, only the first N are consulted, and an id served solely by an out-of-window snapshot is `not_served`.

Fail-closed details: `windowSnapshots` of 0 or negative **throws** rather than being read as "allow all" or "allow none"; `empty_id` and `not_served` stay distinct failures; comparison is trimmed but case-sensitive because memory ids are; a malformed snapshot entry consumes its window slot (it was a real recall turn) without throwing.

Part of #1956 — authority helper only; the MCP/CLI/HTTP expand and traverse tools are a later slice, so the issue stays open.

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/recall-navigate-window.test.ts` — 11/11
- Covers in-window vs 4th-snapshot expiry, custom window of 1, invalid window values, case-different id rejection, and the malformed-entry slot.