### PR TITLE
feat(extraction): evaluate the span-mode Phase B gate per condition

### DIFF
--- a/.changeset/span-phase-gate-2333.md
+++ b/.changeset/span-phase-gate-2333.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add the pure span-mode Phase B gate evaluator (wall-clock reduction, judge-score drop, fallback rate) with per-condition verdicts and strict boundary semantics. Part of #2333

--- a/packages/remnic-core/src/extraction-span-gate.test.ts
+++ b/packages/remnic-core/src/extraction-span-gate.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  evaluateSpanPhaseGate,
+  SPAN_GATE_MAX_FALLBACK_RATE_PCT,
+  SPAN_GATE_MAX_JUDGE_DROP_POINTS,
+  SPAN_GATE_MIN_WALLCLOCK_REDUCTION_PCT,
+} from "./extraction-span-gate.js";
+
+function assertRangeError(fn: () => unknown, field: string): void {
+  assert.throws(fn, (err: unknown) => {
+    assert.ok(err instanceof RangeError, `expected RangeError, got ${String(err)}`);
+    assert.match((err as RangeError).message, new RegExp(field));
+    return true;
+  });
+}
+
+describe("evaluateSpanPhaseGate", () => {
+  it("passes the Phase A bench numbers from the issue", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: 0.3,
+      fallbackRatePct: 4,
+    });
+    assert.deepEqual(verdict, {
+      pass: true,
+      conditions: { wallClockReduction: true, judgeQuality: true, fallbackRate: true },
+      failed: [],
+    });
+  });
+
+  it("treats the wall-clock boundary 20.0 as a pass (>= 20)", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: SPAN_GATE_MIN_WALLCLOCK_REDUCTION_PCT,
+      judgeScoreDropPoints: 0,
+      fallbackRatePct: 0,
+    });
+    assert.equal(verdict.conditions.wallClockReduction, true);
+  });
+
+  it("treats a judge drop of exactly 2.0 as a failure (< 2)", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: SPAN_GATE_MAX_JUDGE_DROP_POINTS,
+      fallbackRatePct: 4,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.failed, ["judgeQuality"]);
+  });
+
+  it("treats a fallback rate of exactly 15.0 as a failure (< 15)", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: 0.3,
+      fallbackRatePct: SPAN_GATE_MAX_FALLBACK_RATE_PCT,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.failed, ["fallbackRate"]);
+  });
+
+  it("fails on wall-clock reduction alone", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 19.9,
+      judgeScoreDropPoints: 0.3,
+      fallbackRatePct: 4,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.failed, ["wallClockReduction"]);
+  });
+
+  it("fails on judge quality alone", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: 2.5,
+      fallbackRatePct: 4,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.failed, ["judgeQuality"]);
+  });
+
+  it("fails on fallback rate alone", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: 0.3,
+      fallbackRatePct: 15.1,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.failed, ["fallbackRate"]);
+  });
+
+  it("lists all three failures in declaration order", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 10,
+      judgeScoreDropPoints: 3,
+      fallbackRatePct: 20,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.conditions, {
+      wallClockReduction: false,
+      judgeQuality: false,
+      fallbackRate: false,
+    });
+    assert.deepEqual(verdict.failed, ["wallClockReduction", "judgeQuality", "fallbackRate"]);
+  });
+
+  it("fails a negative wall-clock reduction without throwing", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: -5,
+      judgeScoreDropPoints: 0.3,
+      fallbackRatePct: 4,
+    });
+    assert.equal(verdict.pass, false);
+    assert.deepEqual(verdict.failed, ["wallClockReduction"]);
+  });
+
+  it("passes a negative judge drop (quality improved)", () => {
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: -0.5,
+      fallbackRatePct: 4,
+    });
+    assert.equal(verdict.conditions.judgeQuality, true);
+    assert.equal(verdict.pass, true);
+  });
+
+  it("throws RangeError naming the field on non-finite wall-clock reduction", () => {
+    assertRangeError(
+      () =>
+        evaluateSpanPhaseGate({
+          wallClockReductionPct: Number.NaN,
+          judgeScoreDropPoints: 0.3,
+          fallbackRatePct: 4,
+        }),
+      "wallClockReductionPct",
+    );
+  });
+
+  it("throws RangeError naming the field on non-finite judge drop", () => {
+    assertRangeError(
+      () =>
+        evaluateSpanPhaseGate({
+          wallClockReductionPct: 45,
+          judgeScoreDropPoints: Number.POSITIVE_INFINITY,
+          fallbackRatePct: 4,
+        }),
+      "judgeScoreDropPoints",
+    );
+  });
+
+  it("throws RangeError naming the field on non-finite fallback rate", () => {
+    assertRangeError(
+      () =>
+        evaluateSpanPhaseGate({
+          wallClockReductionPct: 45,
+          judgeScoreDropPoints: 0.3,
+          fallbackRatePct: Number.NEGATIVE_INFINITY,
+        }),
+      "fallbackRatePct",
+    );
+  });
+
+  it("throws RangeError on a fallback rate of 101", () => {
+    assertRangeError(
+      () =>
+        evaluateSpanPhaseGate({
+          wallClockReductionPct: 45,
+          judgeScoreDropPoints: 0.3,
+          fallbackRatePct: 101,
+        }),
+      "fallbackRatePct",
+    );
+  });
+
+  it("throws RangeError on a fallback rate of -1", () => {
+    assertRangeError(
+      () =>
+        evaluateSpanPhaseGate({
+          wallClockReductionPct: 45,
+          judgeScoreDropPoints: 0.3,
+          fallbackRatePct: -1,
+        }),
+      "fallbackRatePct",
+    );
+  });
+
+  it("accepts the fallback-rate endpoints 0 and 100 as measurements", () => {
+    assert.doesNotThrow(() =>
+      evaluateSpanPhaseGate({
+        wallClockReductionPct: 45,
+        judgeScoreDropPoints: 0.3,
+        fallbackRatePct: 0,
+      }),
+    );
+    const verdict = evaluateSpanPhaseGate({
+      wallClockReductionPct: 45,
+      judgeScoreDropPoints: 0.3,
+      fallbackRatePct: 100,
+    });
+    assert.deepEqual(verdict.failed, ["fallbackRate"]);
+  });
+});

--- a/packages/remnic-core/src/extraction-span-gate.ts
+++ b/packages/remnic-core/src/extraction-span-gate.ts
@@ -1,0 +1,58 @@
+/**
+ * Span-mode Phase B gate (issue #2333).
+ *
+ * Phase A must earn >= 20% extraction wall-clock reduction, keep the LLM-judge
+ * score drop under 2 points, and keep the span fallback rate under 15% before
+ * Phase B wiring starts. A failed gate is reported, never rounded into a pass.
+ *
+ * Pure. No I/O, no clock, no randomness.
+ */
+
+export const SPAN_GATE_MIN_WALLCLOCK_REDUCTION_PCT = 20;
+export const SPAN_GATE_MAX_JUDGE_DROP_POINTS = 2;
+export const SPAN_GATE_MAX_FALLBACK_RATE_PCT = 15;
+
+export interface SpanGateConditions {
+  wallClockReduction: boolean;
+  judgeQuality: boolean;
+  fallbackRate: boolean;
+}
+
+export interface SpanGateVerdict {
+  /** True only when every condition passes. */
+  pass: boolean;
+  conditions: SpanGateConditions;
+  /** Condition names that failed, in declaration order. Empty when pass. */
+  failed: string[];
+}
+
+function requireFinite(value: number, field: string): void {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new RangeError(`span gate input ${field} must be a finite number, got ${value}`);
+  }
+}
+
+export function evaluateSpanPhaseGate(input: {
+  wallClockReductionPct: number;
+  judgeScoreDropPoints: number;
+  fallbackRatePct: number;
+}): SpanGateVerdict {
+  requireFinite(input.wallClockReductionPct, "wallClockReductionPct");
+  requireFinite(input.judgeScoreDropPoints, "judgeScoreDropPoints");
+  requireFinite(input.fallbackRatePct, "fallbackRatePct");
+  if (input.fallbackRatePct < 0 || input.fallbackRatePct > 100) {
+    throw new RangeError(
+      `span gate input fallbackRatePct must be within [0, 100], got ${input.fallbackRatePct}`,
+    );
+  }
+
+  const conditions: SpanGateConditions = {
+    wallClockReduction: input.wallClockReductionPct >= SPAN_GATE_MIN_WALLCLOCK_REDUCTION_PCT,
+    judgeQuality: input.judgeScoreDropPoints < SPAN_GATE_MAX_JUDGE_DROP_POINTS,
+    fallbackRate: input.fallbackRatePct < SPAN_GATE_MAX_FALLBACK_RATE_PCT,
+  };
+  const failed = (Object.keys(conditions) as (keyof SpanGateConditions)[]).filter(
+    (name) => !conditions[name],
+  );
+  return { pass: failed.length === 0, conditions, failed };
+}


### PR DESCRIPTION
## Summary
Encodes #2333's Phase A→B gate exactly as the issue states it: **>= 20% extraction wall-clock reduction AND LLM-judge score drop < 2 points AND span fallback rate < 15%.**

`evaluateSpanPhaseGate` reports each condition separately and lists the failures in declaration order, so a failed gate is recorded honestly instead of being averaged or rounded into a pass — the issue is explicit that a measured "no" is a valid, complete Phase A outcome and must not be relabelled as shipped.

Boundary semantics match the issue's operators, which is the whole point of the module: 20.0 reduction **passes**, a drop of exactly 2.0 **fails**, a fallback rate of exactly 15.0 **fails**. A negative reduction (span mode was slower) is a real measurement and fails the condition rather than throwing; a negative judge drop (quality improved) passes. Non-finite inputs throw naming the field — a missing measurement is never a pass — and a fallback rate outside `[0, 100]` throws.

No Phase B wiring: `extraction.ts` is untouched.

Part of #2333 (Phase A gate helper; the bench run and any Phase B work are separate, so the issue stays open).

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/extraction-span-gate.test.ts` — 16/16
- Covers the paper's own numbers, all three boundary values individually, each single-condition failure in isolation, all-three failure ordering, and the throw cases.