### PR TITLE
feat(activity): report weekly recurring patterns only above a deterministic threshold

### DIFF
--- a/.changeset/week-recurring-2052.md
+++ b/.changeset/week-recurring-2052.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": patch
+---
+
+Add `findRecurringPatterns`: weekly recurring category/application patterns
+reported only when a key appears on at least a configurable number of distinct
+days (default 3), so one-off blips are never labeled patterns. Pure gate with
+strict input validation and deterministic total ordering. Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -15,6 +15,7 @@ export * from "./recap-markdown.js";
 export * from "./week-export.js";
 export * from "./week-snapshot.js";
 export * from "./week-previous.js";
+export * from "./week-recurring.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";
 export * from "./analysis-prompt.js";

--- a/packages/remnic-core/src/activity/timeline/week-recurring.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-recurring.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   DEFAULT_RECURRENCE_MIN_DAYS,
+  MIN_RECURRENCE_MIN_DAYS,
   findRecurringPatterns,
   type WeekDayOccurrence,
 } from "./week-recurring.js";
@@ -70,8 +71,8 @@ test("keys are compared trimmed and case-sensitively", () => {
   assert.deepEqual(result, [{ key: "code", dayCount: 3, totalDurationMs: 300 }]);
 });
 
-test("minDays must be an integer >= 1", () => {
-  for (const bad of [0, -3, 1.5]) {
+test("minDays must be an integer >= MIN_RECURRENCE_MIN_DAYS", () => {
+  for (const bad of [0, 1, -3, 1.5]) {
     assert.throws(
       () => findRecurringPatterns({ occurrences: [], minDays: bad }),
       rangeErrorMatching(/minDays/),
@@ -80,17 +81,23 @@ test("minDays must be an integer >= 1", () => {
   assert.doesNotThrow(() =>
     findRecurringPatterns({
       occurrences: [{ date: "2026-08-10", key: "code", durationMs: 1 }],
-      minDays: 1,
+      minDays: MIN_RECURRENCE_MIN_DAYS,
     }),
   );
 });
 
-test("minDays 1 reports every non-blank key", () => {
-  const result = findRecurringPatterns({
-    occurrences: [{ date: "2026-08-10", key: "code", durationMs: 5 }],
-    minDays: 1,
-  });
-  assert.deepEqual(result, [{ key: "code", dayCount: 1, totalDurationMs: 5 }]);
+// minDays 1 would make a single-day key "recurring", which is the invariant
+// this helper exists to enforce — configuration must not be able to disable it.
+test("minDays 1 is refused rather than reporting one-off keys", () => {
+  assert.throws(
+    () =>
+      findRecurringPatterns({
+        occurrences: [{ date: "2026-08-10", key: "code", durationMs: 5 }],
+        minDays: 1,
+      }),
+    rangeErrorMatching(/minDays/),
+  );
+  assert.equal(MIN_RECURRENCE_MIN_DAYS, 2);
 });
 
 test("durationMs must be a finite number >= 0", () => {

--- a/packages/remnic-core/src/activity/timeline/week-recurring.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-recurring.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_RECURRENCE_MIN_DAYS,
+  findRecurringPatterns,
+  type WeekDayOccurrence,
+} from "./week-recurring.js";
+
+function rangeErrorMatching(pattern: RegExp): (err: unknown) => boolean {
+  return (err: unknown) => err instanceof RangeError && pattern.test((err as Error).message);
+}
+
+test("default minDays is 3; a key on exactly minDays distinct dates qualifies", () => {
+  assert.equal(DEFAULT_RECURRENCE_MIN_DAYS, 3);
+  const result = findRecurringPatterns({
+    occurrences: [
+      { date: "2026-08-10", key: "code", durationMs: 100 },
+      { date: "2026-08-11", key: "code", durationMs: 100 },
+      { date: "2026-08-12", key: "code", durationMs: 100 },
+    ],
+  });
+  assert.deepEqual(result, [{ key: "code", dayCount: 3, totalDurationMs: 300 }]);
+});
+
+test("a key on minDays - 1 distinct dates does not qualify", () => {
+  const result = findRecurringPatterns({
+    occurrences: [
+      { date: "2026-08-10", key: "code", durationMs: 999_999 },
+      { date: "2026-08-11", key: "code", durationMs: 999_999 },
+    ],
+  });
+  assert.deepEqual(result, []);
+});
+
+test("same-date occurrences count as one day but all durations sum", () => {
+  const result = findRecurringPatterns({
+    occurrences: [
+      { date: "2026-08-10", key: "code", durationMs: 100 },
+      { date: "2026-08-10", key: "code", durationMs: 40 },
+      { date: "2026-08-11", key: "code", durationMs: 100 },
+      { date: "2026-08-12", key: "code", durationMs: 100 },
+    ],
+  });
+  assert.deepEqual(result, [{ key: "code", dayCount: 3, totalDurationMs: 340 }]);
+});
+
+test("blank keys are ignored", () => {
+  const result = findRecurringPatterns({
+    occurrences: [
+      { date: "2026-08-10", key: "", durationMs: 100 },
+      { date: "2026-08-11", key: "   ", durationMs: 100 },
+      { date: "2026-08-12", key: "\t", durationMs: 100 },
+    ],
+  });
+  assert.deepEqual(result, []);
+});
+
+test("keys are compared trimmed and case-sensitively", () => {
+  const result = findRecurringPatterns({
+    occurrences: [
+      { date: "2026-08-10", key: "code", durationMs: 100 },
+      { date: "2026-08-11", key: " code ", durationMs: 100 },
+      { date: "2026-08-12", key: "code", durationMs: 100 },
+      { date: "2026-08-10", key: "Code", durationMs: 100 },
+      { date: "2026-08-11", key: "Code", durationMs: 100 },
+    ],
+  });
+  // " code " folds into "code" (3 distinct days); "Code" stays separate at 2 days.
+  assert.deepEqual(result, [{ key: "code", dayCount: 3, totalDurationMs: 300 }]);
+});
+
+test("minDays must be an integer >= 1", () => {
+  for (const bad of [0, -3, 1.5]) {
+    assert.throws(
+      () => findRecurringPatterns({ occurrences: [], minDays: bad }),
+      rangeErrorMatching(/minDays/),
+    );
+  }
+  assert.doesNotThrow(() =>
+    findRecurringPatterns({
+      occurrences: [{ date: "2026-08-10", key: "code", durationMs: 1 }],
+      minDays: 1,
+    }),
+  );
+});
+
+test("minDays 1 reports every non-blank key", () => {
+  const result = findRecurringPatterns({
+    occurrences: [{ date: "2026-08-10", key: "code", durationMs: 5 }],
+    minDays: 1,
+  });
+  assert.deepEqual(result, [{ key: "code", dayCount: 1, totalDurationMs: 5 }]);
+});
+
+test("durationMs must be a finite number >= 0", () => {
+  for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+    assert.throws(
+      () =>
+        findRecurringPatterns({
+          occurrences: [{ date: "2026-08-10", key: "code", durationMs: bad }],
+        }),
+      rangeErrorMatching(/durationMs/),
+    );
+  }
+});
+
+test("date must be a valid YYYY-MM-DD calendar date", () => {
+  for (const bad of ["", "not-a-date", "2026-8-10", "2026-02-30"]) {
+    assert.throws(
+      () =>
+        findRecurringPatterns({
+          occurrences: [{ date: bad, key: "code", durationMs: 0 }],
+        }),
+      rangeErrorMatching(/date/),
+    );
+  }
+});
+
+test("ordering: dayCount desc, then totalDurationMs desc, then key asc", () => {
+  const result = findRecurringPatterns({
+    minDays: 2,
+    occurrences: [
+      // alpha: 2 days, biggest total — dayCount still ranks it last.
+      { date: "2026-08-10", key: "alpha", durationMs: 999_999 },
+      { date: "2026-08-11", key: "alpha", durationMs: 999_999 },
+      // beta: 3 days, 10 total — wins the dayCount tie on duration.
+      { date: "2026-08-10", key: "beta", durationMs: 4 },
+      { date: "2026-08-11", key: "beta", durationMs: 4 },
+      { date: "2026-08-12", key: "beta", durationMs: 2 },
+      // gamma: 3 days, 8 total — ties delta on both, loses on key ascending.
+      { date: "2026-08-10", key: "gamma", durationMs: 8 },
+      { date: "2026-08-11", key: "gamma", durationMs: 0 },
+      { date: "2026-08-12", key: "gamma", durationMs: 0 },
+      // delta: 3 days, 8 total.
+      { date: "2026-08-10", key: "delta", durationMs: 8 },
+      { date: "2026-08-11", key: "delta", durationMs: 0 },
+      { date: "2026-08-12", key: "delta", durationMs: 0 },
+    ],
+  });
+  assert.deepEqual(result.map((p) => p.key), ["beta", "delta", "gamma", "alpha"]);
+  assert.deepEqual(result[0], { key: "beta", dayCount: 3, totalDurationMs: 10 });
+  assert.deepEqual(result[3], { key: "alpha", dayCount: 2, totalDurationMs: 1_999_998 });
+});
+
+test("empty input and no-qualifier input return []", () => {
+  assert.deepEqual(findRecurringPatterns({ occurrences: [] }), []);
+  assert.deepEqual(
+    findRecurringPatterns({
+      occurrences: [{ date: "2026-08-10", key: "code", durationMs: 5000 }],
+    }),
+    [],
+  );
+});
+
+test("pure: two calls deep-equal and the input is not mutated", () => {
+  const occurrences: WeekDayOccurrence[] = [
+    { date: "2026-08-10", key: "code", durationMs: 100 },
+    { date: "2026-08-10", key: "code", durationMs: 50 },
+    { date: "2026-08-11", key: "mail", durationMs: 10 },
+    { date: "2026-08-11", key: "code", durationMs: 100 },
+    { date: "2026-08-12", key: "code", durationMs: 100 },
+  ];
+  const snapshot = structuredClone(occurrences);
+  const first = findRecurringPatterns({ occurrences });
+  const second = findRecurringPatterns({ occurrences });
+  assert.deepEqual(first, second);
+  assert.deepEqual(first, [{ key: "code", dayCount: 3, totalDurationMs: 350 }]);
+  assert.deepEqual(occurrences, snapshot);
+});

--- a/packages/remnic-core/src/activity/timeline/week-recurring.ts
+++ b/packages/remnic-core/src/activity/timeline/week-recurring.ts
@@ -12,6 +12,9 @@ import { isValidActivityDate } from "../digest.js";
 
 export const DEFAULT_RECURRENCE_MIN_DAYS = 3;
 
+/** Lowest threshold that still means "recurring": two distinct days. */
+export const MIN_RECURRENCE_MIN_DAYS = 2;
+
 export interface WeekDayOccurrence {
   /** YYYY-MM-DD inside the analyzed week. */
   date: string;
@@ -32,8 +35,14 @@ export function findRecurringPatterns(input: {
   minDays?: number;
 }): RecurringPattern[] {
   const minDays = input.minDays ?? DEFAULT_RECURRENCE_MIN_DAYS;
-  if (!Number.isInteger(minDays) || minDays < 1) {
-    throw new RangeError(`Invalid minDays ${minDays}; expected an integer >= 1.`);
+  // A floor of 2 is the module's defining invariant, not a preference: at
+  // minDays 1 every key that appeared once is "recurring", which is exactly
+  // the one-off blip this helper exists to exclude. Configuration must not be
+  // able to switch the invariant off.
+  if (!Number.isInteger(minDays) || minDays < MIN_RECURRENCE_MIN_DAYS) {
+    throw new RangeError(
+      `Invalid minDays ${minDays}; expected an integer >= ${MIN_RECURRENCE_MIN_DAYS}.`,
+    );
   }
 
   const daysByKey = new Map<string, Set<string>>();

--- a/packages/remnic-core/src/activity/timeline/week-recurring.ts
+++ b/packages/remnic-core/src/activity/timeline/week-recurring.ts
@@ -1,0 +1,79 @@
+/**
+ * Recurring weekly pattern gate (issue #2052).
+ *
+ * A category/application key counts as recurring only when it appeared on at
+ * least `minDays` DISTINCT days of the analyzed week, so a one-off blip is
+ * never reported as a pattern. Pure: no I/O, no clock, no input mutation.
+ * Validation happens on the exact occurrence values before any key trimming
+ * (AGENTS.md: validate before normalizing; reject non-finite numbers
+ * explicitly instead of letting NaN fall through a comparison).
+ */
+import { isValidActivityDate } from "../digest.js";
+
+export const DEFAULT_RECURRENCE_MIN_DAYS = 3;
+
+export interface WeekDayOccurrence {
+  /** YYYY-MM-DD inside the analyzed week. */
+  date: string;
+  /** Category id or application/domain label. */
+  key: string;
+  durationMs: number;
+}
+
+export interface RecurringPattern {
+  key: string;
+  /** Count of DISTINCT days the key appeared on. */
+  dayCount: number;
+  totalDurationMs: number;
+}
+
+export function findRecurringPatterns(input: {
+  occurrences: readonly WeekDayOccurrence[];
+  minDays?: number;
+}): RecurringPattern[] {
+  const minDays = input.minDays ?? DEFAULT_RECURRENCE_MIN_DAYS;
+  if (!Number.isInteger(minDays) || minDays < 1) {
+    throw new RangeError(`Invalid minDays ${minDays}; expected an integer >= 1.`);
+  }
+
+  const daysByKey = new Map<string, Set<string>>();
+  const totalsByKey = new Map<string, number>();
+
+  for (const occurrence of input.occurrences) {
+    if (!isValidActivityDate(occurrence.date)) {
+      throw new RangeError(`Invalid date "${occurrence.date}"; expected YYYY-MM-DD.`);
+    }
+    if (
+      typeof occurrence.durationMs !== "number" ||
+      !Number.isFinite(occurrence.durationMs) ||
+      occurrence.durationMs < 0
+    ) {
+      throw new RangeError(`Invalid durationMs ${occurrence.durationMs}; expected a finite number >= 0.`);
+    }
+    const key = occurrence.key.trim();
+    if (key === "") continue;
+    let days = daysByKey.get(key);
+    if (!days) {
+      days = new Set<string>();
+      daysByKey.set(key, days);
+      totalsByKey.set(key, 0);
+    }
+    days.add(occurrence.date);
+    totalsByKey.set(key, totalsByKey.get(key)! + occurrence.durationMs);
+  }
+
+  const patterns: RecurringPattern[] = [];
+  for (const [key, days] of daysByKey) {
+    if (days.size < minDays) continue;
+    patterns.push({ key, dayCount: days.size, totalDurationMs: totalsByKey.get(key)! });
+  }
+
+  patterns.sort((a, b) => {
+    if (a.dayCount !== b.dayCount) return b.dayCount - a.dayCount;
+    if (a.totalDurationMs !== b.totalDurationMs) return b.totalDurationMs - a.totalDurationMs;
+    if (a.key < b.key) return -1;
+    if (a.key > b.key) return 1;
+    return 0;
+  });
+  return patterns;
+}


### PR DESCRIPTION
## Summary
Implements #2052's rule that "recurring category/application patterns [appear] only when a deterministic threshold is met", so a one-off blip is never reported as a pattern.

`findRecurringPatterns` counts DISTINCT days a key appears on (repeat occurrences on one date count once toward `dayCount` but all durations still sum), and qualifies a key only at `minDays` or more. `minDays: 0` throws rather than being clamped — it would make everything a "pattern". Non-finite and negative durations throw instead of poisoning a sum; malformed dates throw. Ordering is a total comparator (`dayCount` desc, duration desc, key asc) so two calls are byte-identical.

No productivity, mood, or intent inference — the issue forbids it, and this only counts days and sums durations.

Part of #2052 (helper only; the weekly snapshot wiring is a later slice, so the issue stays open).

## Test plan
- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/timeline/week-recurring.test.ts` — 12/12
- Includes the `minDays` boundary (exactly-threshold qualifies, one-below does not) and the same-date double-occurrence case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly recurring-pattern detection for activity timelines.
  * Supports configurable minimum day thresholds, distinct-date counting, and duration totals.
  * Results are consistently ordered and invalid or empty entries are safely handled.

* **Bug Fixes**
  * Added strict validation for thresholds, dates, and durations.
  * Preserves input data without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->