### PR TITLE
feat(activity): summarize vault publish outcomes with a required skip reason

### DIFF
--- a/.changeset/vault-publish-status-1985.md
+++ b/.changeset/vault-publish-status-1985.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+---
+
+Add `summarizeVaultPublish` to aggregate vault publish outcomes (updated/unchanged/skipped/error) with required skip reasons, zero-filled counts, and deterministic ordering.
+Part of #1985.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -25,6 +25,7 @@ export * from "./privacy-status.js";
 export * from "./privacy-window.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";
+export * from "./vault-status.js";
 export * from "./vault-insert.js";
 export * from "./vault-frontmatter.js";
 export * from "./vault-wikilink.js";

--- a/packages/remnic-core/src/activity/vault-status.test.ts
+++ b/packages/remnic-core/src/activity/vault-status.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { VAULT_PUBLISH_OUTCOMES, summarizeVaultPublish } from "./vault-status.js";
+import type { VaultPublishResult } from "./vault-status.js";
+
+test("summarizeVaultPublish counts a mixed list, sorts by path, and flags the error", () => {
+  const status = summarizeVaultPublish([
+    { path: "notes/e.md", outcome: "updated" },
+    { path: "notes/d.md", outcome: "error", reason: "missing_file" },
+    { path: "notes/a.md", outcome: "updated" },
+    { path: "notes/c.md", outcome: "skipped", reason: "no_marker" },
+    { path: "notes/b.md", outcome: "unchanged" },
+  ]);
+  assert.deepEqual(status.counts, { updated: 2, unchanged: 1, skipped: 1, error: 1 });
+  assert.equal(status.hasError, true);
+  assert.deepEqual(status.results, [
+    { path: "notes/a.md", outcome: "updated" },
+    { path: "notes/b.md", outcome: "unchanged" },
+    { path: "notes/c.md", outcome: "skipped", reason: "no_marker" },
+    { path: "notes/d.md", outcome: "error", reason: "missing_file" },
+    { path: "notes/e.md", outcome: "updated" },
+  ]);
+});
+
+test("empty input returns zeroed counts, no results, and hasError false", () => {
+  const status = summarizeVaultPublish([]);
+  assert.deepEqual(status.counts, { updated: 0, unchanged: 0, skipped: 0, error: 0 });
+  for (const outcome of VAULT_PUBLISH_OUTCOMES) {
+    assert.equal(status.counts[outcome], 0, `count key ${outcome} must exist at zero`);
+  }
+  assert.deepEqual(status.results, []);
+  assert.equal(status.hasError, false);
+});
+
+test("unknown outcome throws TypeError listing the allow-list", () => {
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "notes/a.md", outcome: "deleted" }]),
+    (err: unknown) => {
+      assert.ok(err instanceof TypeError);
+      assert.match(err.message, /unknown vault publish outcome/);
+      for (const outcome of VAULT_PUBLISH_OUTCOMES) {
+        assert.ok(err.message.includes(outcome), `message lists ${outcome}`);
+      }
+      return true;
+    },
+  );
+});
+
+test("skipped without a reason throws TypeError", () => {
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "notes/a.md", outcome: "skipped" }]),
+    (err: unknown) => err instanceof TypeError && /reason/.test(err.message),
+  );
+});
+
+test("error with a missing or whitespace-only reason throws TypeError", () => {
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "notes/a.md", outcome: "error" }]),
+    (err: unknown) => err instanceof TypeError && /reason/.test(err.message),
+  );
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "notes/a.md", outcome: "error", reason: "   " }]),
+    (err: unknown) => err instanceof TypeError && /reason/.test(err.message),
+  );
+});
+
+test("updated and unchanged must not carry a reason", () => {
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "notes/a.md", outcome: "updated", reason: "no_marker" }]),
+    (err: unknown) => err instanceof TypeError && /reason/.test(err.message),
+  );
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "notes/a.md", outcome: "unchanged", reason: "x" }]),
+    (err: unknown) => err instanceof TypeError && /reason/.test(err.message),
+  );
+});
+
+test("blank path throws RangeError", () => {
+  assert.throws(
+    () => summarizeVaultPublish([{ path: "", outcome: "updated" }]),
+    (err: unknown) => err instanceof RangeError && /path/.test(err.message),
+  );
+  assert.throws(
+    () => summarizeVaultPublish([{ path: " \t ", outcome: "updated" }]),
+    (err: unknown) => err instanceof RangeError && /path/.test(err.message),
+  );
+});
+
+test("duplicate paths are all preserved, not deduplicated", () => {
+  const status = summarizeVaultPublish([
+    { path: "notes/a.md", outcome: "updated" },
+    { path: "notes/a.md", outcome: "skipped", reason: "no_marker" },
+    { path: "notes/a.md", outcome: "updated" },
+  ]);
+  assert.equal(status.results.length, 3);
+  assert.deepEqual(status.counts, { updated: 2, unchanged: 0, skipped: 1, error: 0 });
+  assert.deepEqual(
+    status.results.map((entry) => entry.outcome),
+    ["updated", "updated", "skipped"],
+  );
+  assert.equal(status.hasError, false);
+});
+
+test("order is deterministic across shuffled input", () => {
+  const base: VaultPublishResult[] = [
+    { path: "days/2026-08-18.md", outcome: "error", reason: "missing_file" },
+    { path: "days/2026-08-18.md", outcome: "updated" },
+    { path: "days/2026-08-18.md", outcome: "skipped", reason: "no_marker" },
+    { path: "days/2026-08-18.md", outcome: "skipped", reason: "duplicate_heading" },
+    { path: "days/2026-08-17.md", outcome: "unchanged" },
+    { path: "places/office.md", outcome: "updated" },
+  ];
+  const forward = summarizeVaultPublish(base);
+  const reversed = summarizeVaultPublish([...base].reverse());
+  assert.deepEqual(forward, reversed);
+  assert.deepEqual(
+    forward.results.map((entry) => `${entry.path}:${entry.outcome}:${entry.reason ?? ""}`),
+    [
+      "days/2026-08-17.md:unchanged:",
+      "days/2026-08-18.md:updated:",
+      "days/2026-08-18.md:skipped:duplicate_heading",
+      "days/2026-08-18.md:skipped:no_marker",
+      "days/2026-08-18.md:error:missing_file",
+      "places/office.md:updated:",
+    ],
+  );
+});
+
+test("input is not mutated", () => {
+  const input: VaultPublishResult[] = [
+    { path: "notes/b.md", outcome: "updated" },
+    { path: "notes/a.md", outcome: "skipped", reason: "no_marker" },
+  ];
+  const snapshot = structuredClone(input);
+  summarizeVaultPublish(input);
+  assert.deepEqual(input, snapshot);
+});

--- a/packages/remnic-core/src/activity/vault-status.ts
+++ b/packages/remnic-core/src/activity/vault-status.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure vault-publish outcome aggregator (issue #1985).
+ *
+ * `summarizeVaultPublish` folds per-file publish results into the status
+ * shape the publish report and the dry-run print: sorted per-file outcomes
+ * plus zero-filled counts. It performs no I/O and never mutates its input.
+ *
+ * Fail-closed contract: an unrecognized outcome is refused, never coerced
+ * into `skipped` or `error`, and `skipped`/`error` must carry a non-blank
+ * reason so every un-actionable row says why.
+ */
+
+export const VAULT_PUBLISH_OUTCOMES = ["updated", "unchanged", "skipped", "error"] as const;
+export type VaultPublishOutcome = (typeof VAULT_PUBLISH_OUTCOMES)[number];
+
+export interface VaultPublishResult {
+  /** Vault-relative note path. */
+  path: string;
+  outcome: string;
+  /** Required for skipped and error, e.g. "no_marker". */
+  reason?: string;
+}
+
+export interface VaultPublishStatus {
+  results: Array<{ path: string; outcome: VaultPublishOutcome; reason?: string }>;
+  counts: Record<VaultPublishOutcome, number>;
+  /** True when at least one entry is an error. */
+  hasError: boolean;
+}
+
+interface ValidatedEntry {
+  path: string;
+  outcome: VaultPublishOutcome;
+  reason?: string;
+}
+
+/** Total order: path asc, then outcome in allow-list order, then reason. */
+function compareEntries(a: ValidatedEntry, b: ValidatedEntry): number {
+  if (a.path !== b.path) return a.path < b.path ? -1 : 1;
+  const rankA = VAULT_PUBLISH_OUTCOMES.indexOf(a.outcome);
+  const rankB = VAULT_PUBLISH_OUTCOMES.indexOf(b.outcome);
+  if (rankA !== rankB) return rankA < rankB ? -1 : 1;
+  const reasonA = a.reason ?? "";
+  const reasonB = b.reason ?? "";
+  if (reasonA !== reasonB) return reasonA < reasonB ? -1 : 1;
+  return 0;
+}
+
+export function summarizeVaultPublish(results: readonly VaultPublishResult[]): VaultPublishStatus {
+  if (!Array.isArray(results)) {
+    throw new TypeError(`summarizeVaultPublish expects an array of results (got ${typeof results})`);
+  }
+
+  const entries: ValidatedEntry[] = [];
+  for (const entry of results) {
+    if (typeof entry !== "object" || entry === null) {
+      throw new TypeError(`vault publish result entries must be objects (got ${typeof entry})`);
+    }
+    if (typeof entry.path !== "string" || entry.path.trim() === "") {
+      throw new RangeError(`vault publish result requires a non-blank path (got ${JSON.stringify(entry.path)})`);
+    }
+    const outcome = VAULT_PUBLISH_OUTCOMES.find((candidate) => candidate === entry.outcome);
+    if (outcome === undefined) {
+      throw new TypeError(
+        `unknown vault publish outcome ${JSON.stringify(entry.outcome)}; expected one of: ${VAULT_PUBLISH_OUTCOMES.join(", ")}`,
+      );
+    }
+    if (outcome === "skipped" || outcome === "error") {
+      if (typeof entry.reason !== "string" || entry.reason.trim() === "") {
+        throw new TypeError(
+          `vault publish outcome "${outcome}" requires a non-blank reason, e.g. "no_marker" (got ${JSON.stringify(entry.reason)})`,
+        );
+      }
+      entries.push({ path: entry.path, outcome, reason: entry.reason });
+    } else {
+      if (entry.reason !== undefined) {
+        throw new TypeError(
+          `vault publish outcome "${outcome}" must not carry a reason (got ${JSON.stringify(entry.reason)})`,
+        );
+      }
+      entries.push({ path: entry.path, outcome });
+    }
+  }
+
+  const sorted = [...entries].sort(compareEntries);
+
+  const counts = {} as Record<VaultPublishOutcome, number>;
+  for (const outcome of VAULT_PUBLISH_OUTCOMES) counts[outcome] = 0;
+  for (const entry of sorted) counts[entry.outcome] += 1;
+
+  return {
+    results: sorted,
+    counts,
+    hasError: counts.error > 0,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the publish-status aggregator #1985 needs for `remnic timeline status` and `--dry-run`: "publish results (per file: updated/unchanged/skipped/error + reason)".

`summarizeVaultPublish` refuses to produce an un-actionable report. A `skipped` or `error` entry without a non-blank reason **throws** — a skip with no reason is exactly the output this slice exists to prevent, and `skipped: no marker` is the issue's own example. Conversely `updated`/`unchanged` must not carry a reason. An unrecognized outcome throws rather than being coerced into `skipped`.

`counts` always contains every outcome key including zeros, so no surface can print "undefined files updated". Results sort by path then allow-list outcome order with a total comparator; duplicate paths are preserved because one note can be published for several artifacts.

Part of #1985 (pure aggregator; CLI/status wiring is PR3 in the issue's own plan, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/vault-status.test.ts` — 10/10
- Covers unknown outcome, reason-required and reason-forbidden cases, blank path, duplicate paths, and deterministic order from shuffled input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vault publish status summaries with counts for updated, unchanged, skipped, and error outcomes.
  * Summaries indicate whether any errors occurred and provide consistently ordered results.
  * Added validation for invalid outcomes, paths, and reasons to prevent incomplete or misleading status data.
  * Duplicate file results are preserved and included in totals.
* **Bug Fixes**
  * Ensured summary generation does not alter the original results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->