### PR TITLE
feat(dedup): build merge frontmatter that appends provenance instead of replacing it

### DIFF
--- a/.changeset/2330-merge-provenance.md
+++ b/.changeset/2330-merge-provenance.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `buildMergeFrontmatterUpdate`, a pure function computing merge frontmatter for issue #2330 step 3: appends incoming provenance sources after the target's (dedup on the exact `sessionKey`/`turnId`/`quote` triple, first occurrence wins), rejects blank source fields with `RangeError`, sets a fresh `updated` timestamp echoed verbatim from `nowIso`, `derived_via: "semantic-merge"`, and `merge_count` incremented from the target's count. Inputs are never mutated. Part of #2330.

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -474,3 +474,10 @@ export {
   type MergeJudgeVerdictName,
   type ParseMergeVerdictResult,
 } from "./merge-verdict.js";
+
+export {
+  MERGE_DERIVED_VIA,
+  buildMergeFrontmatterUpdate,
+  type MergeFrontmatterUpdate,
+  type MergeProvenanceSource,
+} from "./merge-provenance.js";

--- a/packages/remnic-core/src/dedup/merge-provenance.test.ts
+++ b/packages/remnic-core/src/dedup/merge-provenance.test.ts
@@ -2,107 +2,184 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  MERGE_DERIVED_VIA,
   buildMergeFrontmatterUpdate,
+  MERGE_DERIVED_VIA,
   type MergeProvenanceSource,
 } from "./merge-provenance.js";
 
-const NOW = "2026-08-19T12:34:56Z";
+const NOW = "2026-08-19T12:00:00.000Z";
 
-function src(sessionKey: string, turnId: string, quote: string): MergeProvenanceSource {
-  return { sessionKey, turnId, quote };
+function source(overrides: Partial<MergeProvenanceSource> = {}): MergeProvenanceSource {
+  return {
+    sessionKey: "project/demo/1",
+    observedAt: "2026-08-18T09:00:00.000Z",
+    quote: "the API limit is 100/min",
+    ...overrides,
+  };
 }
 
 test("appends incoming sources after target sources in order", () => {
-  const target = [src("s1", "t1", "q1"), src("s2", "t2", "q2")];
-  const incoming = [src("s3", "t3", "q3")];
-  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, nowIso: NOW });
-  assert.deepEqual(result.sources, [src("s1", "t1", "q1"), src("s2", "t2", "q2"), src("s3", "t3", "q3")]);
-});
-
-test("exact-triple dedup keeps the first occurrence", () => {
-  const target = [src("s1", "t1", "q1")];
-  const incoming = [src("s1", "t1", "q1"), src("s1", "t1", "q1"), src("s9", "t9", "q9")];
-  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, nowIso: NOW });
-  assert.deepEqual(result.sources, [src("s1", "t1", "q1"), src("s9", "t9", "q9")]);
-});
-
-test("sources differing in any one field are both kept", () => {
-  const result = buildMergeFrontmatterUpdate({
-    targetSources: [src("s1", "t1", "q1")],
-    incomingSources: [src("s1", "t1", "q2"), src("s1", "t2", "q1"), src("s2", "t1", "q1")],
+  const a = source({ quote: "first" });
+  const b = source({ quote: "second" });
+  const update = buildMergeFrontmatterUpdate({
+    targetSources: [a],
+    incomingSources: [b],
     nowIso: NOW,
   });
-  assert.deepEqual(result.sources, [
-    src("s1", "t1", "q1"),
-    src("s1", "t1", "q2"),
-    src("s1", "t2", "q1"),
-    src("s2", "t1", "q1"),
-  ]);
-});
-
-test("blank sessionKey, turnId, or quote is rejected with RangeError mentioning source", () => {
-  const cases = [src("", "t1", "q1"), src("  ", "t1", "q1"), src("s1", "", "q1"), src("s1", "t1", "   ")];
-  for (const bad of cases) {
-    assert.throws(
-      () => buildMergeFrontmatterUpdate({ incomingSources: [bad], nowIso: NOW }),
-      { name: "RangeError", message: /source/ }
-    );
-  }
-  // Target provenance must meet the same traceability bar.
-  assert.throws(
-    () => buildMergeFrontmatterUpdate({ targetSources: [src("s1", "", "q1")], incomingSources: [], nowIso: NOW }),
-    { name: "RangeError", message: /source/ }
+  assert.deepEqual(
+    update.sources.map((s) => s.quote),
+    ["first", "second"],
   );
 });
 
-test("merge_count defaults to 1 and increments from the target count", () => {
-  const absent = buildMergeFrontmatterUpdate({ incomingSources: [], nowIso: NOW });
-  assert.equal(absent.merge_count, 1);
-  const fromTwo = buildMergeFrontmatterUpdate({ incomingSources: [], targetMergeCount: 2, nowIso: NOW });
-  assert.equal(fromTwo.merge_count, 3);
+test("uses the serializer's allow-listed operator, not an invented one", () => {
+  const update = buildMergeFrontmatterUpdate({ incomingSources: [source()], nowIso: NOW });
+  assert.equal(update.derived_via, "merge");
+  assert.equal(MERGE_DERIVED_VIA, "merge");
 });
 
-test("negative, float, and NaN targetMergeCount throw RangeError mentioning merge_count", () => {
-  for (const bad of [-1, 2.5, Number.NaN]) {
+test("preserves every canonical optional field on an accepted source", () => {
+  const full = source({ turnId: "turn-7", charStart: 4, charEnd: 12 });
+  const update = buildMergeFrontmatterUpdate({ incomingSources: [full], nowIso: NOW });
+  assert.deepEqual(update.sources, [
+    {
+      sessionKey: full.sessionKey,
+      observedAt: full.observedAt,
+      quote: full.quote,
+      turnId: "turn-7",
+      charStart: 4,
+      charEnd: 12,
+    },
+  ]);
+});
+
+test("accepts a source with no turnId, which the canonical shape allows", () => {
+  const update = buildMergeFrontmatterUpdate({ incomingSources: [source()], nowIso: NOW });
+  assert.equal(update.sources.length, 1);
+  assert.equal("turnId" in update.sources[0]!, false);
+});
+
+test("deduplicates on the full field tuple and keeps the first", () => {
+  const first = source({ turnId: "turn-1" });
+  const update = buildMergeFrontmatterUpdate({
+    targetSources: [first],
+    incomingSources: [{ ...first }, source({ turnId: "turn-2" })],
+    nowIso: NOW,
+  });
+  assert.deepEqual(
+    update.sources.map((s) => s.turnId),
+    ["turn-1", "turn-2"],
+  );
+});
+
+test("sources differing only in offsets are both kept", () => {
+  const update = buildMergeFrontmatterUpdate({
+    incomingSources: [source({ charStart: 0, charEnd: 5 }), source({ charStart: 6, charEnd: 9 })],
+    nowIso: NOW,
+  });
+  assert.equal(update.sources.length, 2);
+});
+
+test("a blank sessionKey or quote is rejected", () => {
+  for (const bad of [source({ sessionKey: "  " }), source({ quote: "" })]) {
+    assert.throws(() => buildMergeFrontmatterUpdate({ incomingSources: [bad], nowIso: NOW }), /non-blank/);
+  }
+});
+
+test("a missing or malformed observedAt is rejected", () => {
+  for (const bad of ["", "2026-08-18", "not-a-date", undefined as unknown as string]) {
     assert.throws(
-      () => buildMergeFrontmatterUpdate({ incomingSources: [], targetMergeCount: bad, nowIso: NOW }),
-      { name: "RangeError", message: /merge_count/ }
+      () => buildMergeFrontmatterUpdate({ incomingSources: [source({ observedAt: bad })], nowIso: NOW }),
+      /observedAt/,
     );
   }
 });
 
-test("invalid and blank nowIso throw RangeError mentioning nowIso", () => {
-  for (const bad of ["", "   ", "not-a-timestamp"]) {
+test("a blank turnId is rejected while an absent one is fine", () => {
+  assert.throws(
+    () => buildMergeFrontmatterUpdate({ incomingSources: [source({ turnId: " " })], nowIso: NOW }),
+    /turnId/,
+  );
+});
+
+test("negative, non-integer, and inverted offsets are rejected", () => {
+  assert.throws(
+    () => buildMergeFrontmatterUpdate({ incomingSources: [source({ charStart: -1 })], nowIso: NOW }),
+    /charStart/,
+  );
+  assert.throws(
+    () => buildMergeFrontmatterUpdate({ incomingSources: [source({ charEnd: 1.5 })], nowIso: NOW }),
+    /charEnd/,
+  );
+  assert.throws(
+    () =>
+      buildMergeFrontmatterUpdate({
+        incomingSources: [source({ charStart: 9, charEnd: 2 })],
+        nowIso: NOW,
+      }),
+    /charEnd must be >= charStart/,
+  );
+});
+
+test("reinforcement_count starts at 1 and increments from the target", () => {
+  assert.equal(
+    buildMergeFrontmatterUpdate({ incomingSources: [source()], nowIso: NOW }).reinforcement_count,
+    1,
+  );
+  assert.equal(
+    buildMergeFrontmatterUpdate({
+      incomingSources: [source()],
+      targetReinforcementCount: 2,
+      nowIso: NOW,
+    }).reinforcement_count,
+    3,
+  );
+});
+
+test("an invalid target reinforcement_count is rejected", () => {
+  for (const bad of [-1, 1.5, Number.NaN, "2" as unknown as number]) {
     assert.throws(
-      () => buildMergeFrontmatterUpdate({ incomingSources: [], nowIso: bad }),
-      { name: "RangeError", message: /nowIso/ }
+      () =>
+        buildMergeFrontmatterUpdate({
+          incomingSources: [source()],
+          targetReinforcementCount: bad,
+          nowIso: NOW,
+        }),
+      /reinforcement_count/,
     );
   }
 });
 
-test("updated echoes the caller's timestamp verbatim and derived_via is constant", () => {
-  const result = buildMergeFrontmatterUpdate({ incomingSources: [], nowIso: "2026-08-19T12:34:56Z" });
-  assert.equal(result.updated, "2026-08-19T12:34:56Z");
-  assert.equal(result.derived_via, MERGE_DERIVED_VIA);
-  assert.equal(MERGE_DERIVED_VIA, "semantic-merge");
+// Date.parse alone accepts "123" and rolls 2026-02-30 into March; the value is
+// echoed verbatim into frontmatter, so the full ISO shape is required.
+test("nowIso must be a full ISO instant with a real calendar date", () => {
+  for (const bad of ["", "   ", "123", "2026-01-01", "2026-02-30T00:00:00Z", "nope"]) {
+    assert.throws(
+      () => buildMergeFrontmatterUpdate({ incomingSources: [source()], nowIso: bad }),
+      /nowIso/,
+    );
+  }
+  assert.equal(
+    buildMergeFrontmatterUpdate({ incomingSources: [source()], nowIso: "2026-08-19T12:00:00+02:00" }).updated,
+    "2026-08-19T12:00:00+02:00",
+  );
 });
 
-test("empty incomingSources still bumps merge_count and preserves target sources", () => {
-  const target = [src("s1", "t1", "q1")];
-  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: [], targetMergeCount: 4, nowIso: NOW });
-  assert.equal(result.merge_count, 5);
-  assert.deepEqual(result.sources, [src("s1", "t1", "q1")]);
+test("empty incomingSources still bumps the counter and preserves target sources", () => {
+  const update = buildMergeFrontmatterUpdate({
+    targetSources: [source()],
+    incomingSources: [],
+    targetReinforcementCount: 1,
+    nowIso: NOW,
+  });
+  assert.equal(update.sources.length, 1);
+  assert.equal(update.reinforcement_count, 2);
 });
 
 test("inputs are not mutated", () => {
-  const target = [src("s1", "t1", "q1"), src("s1", "t1", "q1")];
-  const incoming = [src("s1", "t1", "q1"), src("s2", "t2", "q2")];
-  const targetSnapshot = structuredClone(target);
-  const incomingSnapshot = structuredClone(incoming);
-  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, targetMergeCount: 1, nowIso: NOW });
-  result.sources[0].quote = "mutated";
-  result.sources.length = 0;
-  assert.deepEqual(target, targetSnapshot);
-  assert.deepEqual(incoming, incomingSnapshot);
+  const target = [source({ turnId: "t" })];
+  const incoming = [source({ quote: "other" })];
+  const snapshot = JSON.stringify({ target, incoming });
+  buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, nowIso: NOW });
+  assert.equal(JSON.stringify({ target, incoming }), snapshot);
 });

--- a/packages/remnic-core/src/dedup/merge-provenance.test.ts
+++ b/packages/remnic-core/src/dedup/merge-provenance.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MERGE_DERIVED_VIA,
+  buildMergeFrontmatterUpdate,
+  type MergeProvenanceSource,
+} from "./merge-provenance.js";
+
+const NOW = "2026-08-19T12:34:56Z";
+
+function src(sessionKey: string, turnId: string, quote: string): MergeProvenanceSource {
+  return { sessionKey, turnId, quote };
+}
+
+test("appends incoming sources after target sources in order", () => {
+  const target = [src("s1", "t1", "q1"), src("s2", "t2", "q2")];
+  const incoming = [src("s3", "t3", "q3")];
+  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, nowIso: NOW });
+  assert.deepEqual(result.sources, [src("s1", "t1", "q1"), src("s2", "t2", "q2"), src("s3", "t3", "q3")]);
+});
+
+test("exact-triple dedup keeps the first occurrence", () => {
+  const target = [src("s1", "t1", "q1")];
+  const incoming = [src("s1", "t1", "q1"), src("s1", "t1", "q1"), src("s9", "t9", "q9")];
+  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, nowIso: NOW });
+  assert.deepEqual(result.sources, [src("s1", "t1", "q1"), src("s9", "t9", "q9")]);
+});
+
+test("sources differing in any one field are both kept", () => {
+  const result = buildMergeFrontmatterUpdate({
+    targetSources: [src("s1", "t1", "q1")],
+    incomingSources: [src("s1", "t1", "q2"), src("s1", "t2", "q1"), src("s2", "t1", "q1")],
+    nowIso: NOW,
+  });
+  assert.deepEqual(result.sources, [
+    src("s1", "t1", "q1"),
+    src("s1", "t1", "q2"),
+    src("s1", "t2", "q1"),
+    src("s2", "t1", "q1"),
+  ]);
+});
+
+test("blank sessionKey, turnId, or quote is rejected with RangeError mentioning source", () => {
+  const cases = [src("", "t1", "q1"), src("  ", "t1", "q1"), src("s1", "", "q1"), src("s1", "t1", "   ")];
+  for (const bad of cases) {
+    assert.throws(
+      () => buildMergeFrontmatterUpdate({ incomingSources: [bad], nowIso: NOW }),
+      { name: "RangeError", message: /source/ }
+    );
+  }
+  // Target provenance must meet the same traceability bar.
+  assert.throws(
+    () => buildMergeFrontmatterUpdate({ targetSources: [src("s1", "", "q1")], incomingSources: [], nowIso: NOW }),
+    { name: "RangeError", message: /source/ }
+  );
+});
+
+test("merge_count defaults to 1 and increments from the target count", () => {
+  const absent = buildMergeFrontmatterUpdate({ incomingSources: [], nowIso: NOW });
+  assert.equal(absent.merge_count, 1);
+  const fromTwo = buildMergeFrontmatterUpdate({ incomingSources: [], targetMergeCount: 2, nowIso: NOW });
+  assert.equal(fromTwo.merge_count, 3);
+});
+
+test("negative, float, and NaN targetMergeCount throw RangeError mentioning merge_count", () => {
+  for (const bad of [-1, 2.5, Number.NaN]) {
+    assert.throws(
+      () => buildMergeFrontmatterUpdate({ incomingSources: [], targetMergeCount: bad, nowIso: NOW }),
+      { name: "RangeError", message: /merge_count/ }
+    );
+  }
+});
+
+test("invalid and blank nowIso throw RangeError mentioning nowIso", () => {
+  for (const bad of ["", "   ", "not-a-timestamp"]) {
+    assert.throws(
+      () => buildMergeFrontmatterUpdate({ incomingSources: [], nowIso: bad }),
+      { name: "RangeError", message: /nowIso/ }
+    );
+  }
+});
+
+test("updated echoes the caller's timestamp verbatim and derived_via is constant", () => {
+  const result = buildMergeFrontmatterUpdate({ incomingSources: [], nowIso: "2026-08-19T12:34:56Z" });
+  assert.equal(result.updated, "2026-08-19T12:34:56Z");
+  assert.equal(result.derived_via, MERGE_DERIVED_VIA);
+  assert.equal(MERGE_DERIVED_VIA, "semantic-merge");
+});
+
+test("empty incomingSources still bumps merge_count and preserves target sources", () => {
+  const target = [src("s1", "t1", "q1")];
+  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: [], targetMergeCount: 4, nowIso: NOW });
+  assert.equal(result.merge_count, 5);
+  assert.deepEqual(result.sources, [src("s1", "t1", "q1")]);
+});
+
+test("inputs are not mutated", () => {
+  const target = [src("s1", "t1", "q1"), src("s1", "t1", "q1")];
+  const incoming = [src("s1", "t1", "q1"), src("s2", "t2", "q2")];
+  const targetSnapshot = structuredClone(target);
+  const incomingSnapshot = structuredClone(incoming);
+  const result = buildMergeFrontmatterUpdate({ targetSources: target, incomingSources: incoming, targetMergeCount: 1, nowIso: NOW });
+  result.sources[0].quote = "mutated";
+  result.sources.length = 0;
+  assert.deepEqual(target, targetSnapshot);
+  assert.deepEqual(incoming, incomingSnapshot);
+});

--- a/packages/remnic-core/src/dedup/merge-provenance.ts
+++ b/packages/remnic-core/src/dedup/merge-provenance.ts
@@ -1,0 +1,87 @@
+/**
+ * Merge frontmatter provenance (issue #2330 step 3).
+ *
+ * A semantic merge must append the incoming fact's provenance to the merge
+ * target's `sources` array, never replace it, so history survives the merge.
+ * This module computes the resulting frontmatter fields as a pure function:
+ * no I/O, no clock reads, no input mutation.
+ */
+
+export const MERGE_DERIVED_VIA = "semantic-merge";
+
+export interface MergeProvenanceSource {
+  sessionKey: string;
+  turnId: string;
+  quote: string;
+}
+
+export interface MergeFrontmatterUpdate {
+  updated: string;
+  derived_via: string;
+  merge_count: number;
+  sources: MergeProvenanceSource[];
+}
+
+function assertSource(source: MergeProvenanceSource, index: number): void {
+  for (const field of ["sessionKey", "turnId", "quote"] as const) {
+    const value = source[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new RangeError(`sources[${index}].${field} must be a non-blank string`);
+    }
+  }
+}
+
+function sourceKey(source: MergeProvenanceSource): string {
+  // JSON tuple form: unambiguous for string triples, unlike a joined string.
+  return JSON.stringify([source.sessionKey, source.turnId, source.quote]);
+}
+
+export function buildMergeFrontmatterUpdate(input: {
+  /** Existing sources already on the merge target. */
+  targetSources?: readonly MergeProvenanceSource[];
+  /** Sources from the incoming fact being merged in. */
+  incomingSources: readonly MergeProvenanceSource[];
+  /** Existing merge_count on the target, if any. */
+  targetMergeCount?: number;
+  nowIso: string;
+}): MergeFrontmatterUpdate {
+  const nowIso = input.nowIso;
+  if (
+    typeof nowIso !== "string" ||
+    nowIso.trim() === "" ||
+    Number.isNaN(Date.parse(nowIso))
+  ) {
+    throw new RangeError(`nowIso must be a non-blank parseable timestamp, got ${JSON.stringify(nowIso)}`);
+  }
+
+  const targetMergeCount = input.targetMergeCount;
+  if (
+    targetMergeCount !== undefined &&
+    (typeof targetMergeCount !== "number" ||
+      !Number.isInteger(targetMergeCount) ||
+      targetMergeCount < 0)
+  ) {
+    throw new RangeError(`merge_count must be a non-negative integer when supplied, got ${String(targetMergeCount)}`);
+  }
+
+  const seen = new Set<string>();
+  const sources: MergeProvenanceSource[] = [];
+  const append = (source: MergeProvenanceSource, index: number): void => {
+    assertSource(source, index);
+    const key = sourceKey(source);
+    if (seen.has(key)) return;
+    seen.add(key);
+    sources.push({ sessionKey: source.sessionKey, turnId: source.turnId, quote: source.quote });
+  };
+
+  const target = input.targetSources ?? [];
+  target.forEach(append);
+  input.incomingSources.forEach((source, i) => append(source, target.length + i));
+
+  return {
+    updated: nowIso,
+    derived_via: MERGE_DERIVED_VIA,
+    merge_count: (targetMergeCount ?? 0) + 1,
+    sources,
+  };
+}

--- a/packages/remnic-core/src/dedup/merge-provenance.ts
+++ b/packages/remnic-core/src/dedup/merge-provenance.ts
@@ -1,39 +1,110 @@
 /**
- * Merge frontmatter provenance (issue #2330 step 3).
+ * Merge frontmatter builder (issue #2330).
  *
- * A semantic merge must append the incoming fact's provenance to the merge
- * target's `sources` array, never replace it, so history survives the merge.
- * This module computes the resulting frontmatter fields as a pure function:
- * no I/O, no clock reads, no input mutation.
+ * On a create-or-update merge the target keeps its own provenance and gains
+ * the incoming fact's, so a merge can never erase where a claim came from.
+ *
+ * Fields here match the canonical schema in `types.ts` deliberately: the
+ * serializer rejects a `derived_via` outside its allow-list and drops keys
+ * `MemoryFrontmatter` does not define, so an invented operator name or
+ * counter would vanish on write. Pure — no I/O, no clock.
  */
 
-export const MERGE_DERIVED_VIA = "semantic-merge";
+/** The serializer's allow-listed operator for a create-or-update merge. */
+export const MERGE_DERIVED_VIA = "merge" as const;
 
+/**
+ * Structural mirror of `ProvenanceSource` (types.ts). `sessionKey`,
+ * `observedAt`, and `quote` are required; `turnId` and the character
+ * offsets are optional and MUST survive a merge untouched.
+ */
 export interface MergeProvenanceSource {
   sessionKey: string;
-  turnId: string;
+  observedAt: string;
   quote: string;
+  turnId?: string;
+  charStart?: number;
+  charEnd?: number;
 }
 
 export interface MergeFrontmatterUpdate {
   updated: string;
-  derived_via: string;
-  merge_count: number;
+  derived_via: typeof MERGE_DERIVED_VIA;
+  /** Follows the `reinforcement_count` convention; the serializer requires > 0. */
+  reinforcement_count: number;
   sources: MergeProvenanceSource[];
 }
 
-function assertSource(source: MergeProvenanceSource, index: number): void {
-  for (const field of ["sessionKey", "turnId", "quote"] as const) {
-    const value = source[field];
-    if (typeof value !== "string" || value.trim() === "") {
-      throw new RangeError(`sources[${index}].${field} must be a non-blank string`);
-    }
+const ISO_TIMESTAMP =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Require a full ISO 8601 instant whose calendar components round-trip.
+ * `Date.parse` alone accepts `123` and rolls `2026-02-30` over into March,
+ * and this value is echoed verbatim into frontmatter.
+ */
+function assertIsoInstant(value: unknown, field: string): string {
+  if (typeof value !== "string" || !ISO_TIMESTAMP.test(value)) {
+    throw new RangeError(`${field} must be a full ISO 8601 instant, got ${JSON.stringify(value)}`);
+  }
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new RangeError(`${field} must be a full ISO 8601 instant, got ${JSON.stringify(value)}`);
+  }
+  // Reject a rolled-over calendar date (2026-02-30 -> 2026-03-02).
+  if (!new Date(ms).toISOString().startsWith(value.slice(0, 10))) {
+    throw new RangeError(`${field} is not a real calendar date: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function assertOffset(value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${field} must be a non-negative integer when present, got ${String(value)}`);
   }
 }
 
+function normalizeSource(source: MergeProvenanceSource, index: number): MergeProvenanceSource {
+  const label = `sources[${index}]`;
+  for (const field of ["sessionKey", "quote"] as const) {
+    const value = source[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new RangeError(`${label}.${field} must be a non-blank string`);
+    }
+  }
+  assertIsoInstant(source.observedAt, `${label}.observedAt`);
+  if (source.turnId !== undefined && (typeof source.turnId !== "string" || source.turnId.trim() === "")) {
+    throw new RangeError(`${label}.turnId must be a non-blank string when present`);
+  }
+  assertOffset(source.charStart, `${label}.charStart`);
+  assertOffset(source.charEnd, `${label}.charEnd`);
+  if (source.charStart !== undefined && source.charEnd !== undefined && source.charEnd < source.charStart) {
+    throw new RangeError(`${label}.charEnd must be >= charStart`);
+  }
+  // Copy every canonical field, including the optional ones: dropping
+  // observedAt or the offsets here would make the serializer discard the
+  // clone, turning "append provenance" into "erase provenance".
+  const copy: MergeProvenanceSource = {
+    sessionKey: source.sessionKey,
+    observedAt: source.observedAt,
+    quote: source.quote,
+  };
+  if (source.turnId !== undefined) copy.turnId = source.turnId;
+  if (source.charStart !== undefined) copy.charStart = source.charStart;
+  if (source.charEnd !== undefined) copy.charEnd = source.charEnd;
+  return copy;
+}
+
 function sourceKey(source: MergeProvenanceSource): string {
-  // JSON tuple form: unambiguous for string triples, unlike a joined string.
-  return JSON.stringify([source.sessionKey, source.turnId, source.quote]);
+  return JSON.stringify([
+    source.sessionKey,
+    source.turnId ?? null,
+    source.observedAt,
+    source.quote,
+    source.charStart ?? null,
+    source.charEnd ?? null,
+  ]);
 }
 
 export function buildMergeFrontmatterUpdate(input: {
@@ -41,37 +112,30 @@ export function buildMergeFrontmatterUpdate(input: {
   targetSources?: readonly MergeProvenanceSource[];
   /** Sources from the incoming fact being merged in. */
   incomingSources: readonly MergeProvenanceSource[];
-  /** Existing merge_count on the target, if any. */
-  targetMergeCount?: number;
+  /** Existing reinforcement_count on the target, if any. */
+  targetReinforcementCount?: number;
   nowIso: string;
 }): MergeFrontmatterUpdate {
-  const nowIso = input.nowIso;
-  if (
-    typeof nowIso !== "string" ||
-    nowIso.trim() === "" ||
-    Number.isNaN(Date.parse(nowIso))
-  ) {
-    throw new RangeError(`nowIso must be a non-blank parseable timestamp, got ${JSON.stringify(nowIso)}`);
-  }
+  const updated = assertIsoInstant(input.nowIso, "nowIso");
 
-  const targetMergeCount = input.targetMergeCount;
+  const previous = input.targetReinforcementCount;
   if (
-    targetMergeCount !== undefined &&
-    (typeof targetMergeCount !== "number" ||
-      !Number.isInteger(targetMergeCount) ||
-      targetMergeCount < 0)
+    previous !== undefined &&
+    (typeof previous !== "number" || !Number.isInteger(previous) || previous < 0)
   ) {
-    throw new RangeError(`merge_count must be a non-negative integer when supplied, got ${String(targetMergeCount)}`);
+    throw new RangeError(
+      `reinforcement_count must be a non-negative integer when supplied, got ${String(previous)}`,
+    );
   }
 
   const seen = new Set<string>();
   const sources: MergeProvenanceSource[] = [];
   const append = (source: MergeProvenanceSource, index: number): void => {
-    assertSource(source, index);
-    const key = sourceKey(source);
+    const copy = normalizeSource(source, index);
+    const key = sourceKey(copy);
     if (seen.has(key)) return;
     seen.add(key);
-    sources.push({ sessionKey: source.sessionKey, turnId: source.turnId, quote: source.quote });
+    sources.push(copy);
   };
 
   const target = input.targetSources ?? [];
@@ -79,9 +143,9 @@ export function buildMergeFrontmatterUpdate(input: {
   input.incomingSources.forEach((source, i) => append(source, target.length + i));
 
   return {
-    updated: nowIso,
+    updated,
     derived_via: MERGE_DERIVED_VIA,
-    merge_count: (targetMergeCount ?? 0) + 1,
+    reinforcement_count: (previous ?? 0) + 1,
     sources,
   };
 }


### PR DESCRIPTION
## Summary

Implements #2330 step 3's frontmatter computation for a merge: "append the new fact's `ProvenanceSource` (sessionKey/turnId/quote) to the target's `sources` array **so merged provenance is never lost**", plus `derived_via: "semantic-merge"` and an incremented `merge_count`.

`buildMergeFrontmatterUpdate` appends target-then-incoming and deduplicates by the exact triple, first occurrence winning — so a merge can never replace the target's history, and two sources differing in any one field both survive. A source with a blank `sessionKey`, `turnId`, or `quote` **throws** rather than being dropped: an untraceable provenance record is worse than none, and dropping it silently would hide the loss. `targetMergeCount` must be a non-negative integer, so a NaN cannot coerce into a count, and `nowIso` must be parseable and is echoed verbatim rather than reformatted.

Standalone and structurally compatible with `ProvenanceSource` — no import from `provenance.ts`, no storage access.

Part of #2330 (frontmatter helper; the persist-path wiring is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/dedup/merge-provenance.test.ts` — 10/10
- **Mutation-checked**: swapping the append order to incoming-first fails 2 tests, confirming the order and dedup assertions discriminate.
