### PR TITLE
feat(recall): allow only strictly deeper disclosure expansions

### DIFF
--- a/.changeset/1956-navigate-disclosure.md
+++ b/.changeset/1956-navigate-disclosure.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add the disclosure ladder for recall navigation: `DISCLOSURE_LEVELS` (chunk→section→raw), `disclosureRank`, and `planDisclosureStep`, which allows only strictly deeper expansions so a caller cannot re-pay budget for output it already has. Part of #1956.

--- a/.changeset/1956-navigate-disclosure.md
+++ b/.changeset/1956-navigate-disclosure.md
@@ -2,4 +2,4 @@
 "@remnic/core": patch
 ---
 
-Add the disclosure ladder for recall navigation: `DISCLOSURE_LEVELS` (chunk→section→raw), `disclosureRank`, and `planDisclosureStep`, which allows only strictly deeper expansions so a caller cannot re-pay budget for output it already has. Part of #1956.
+Add `disclosureRank` and `planDisclosureStep` for recall navigation, which allow only strictly deeper expansions (chunk -> section -> raw) so a caller cannot re-pay budget for output it already holds. Both read the canonical `RECALL_DISCLOSURE_LEVELS` from `types.ts` rather than defining a second ladder. Internal helpers only — the expand and traverse surfaces land in a later slice. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-disclosure.test.ts
+++ b/packages/remnic-core/src/recall-navigate-disclosure.test.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  DISCLOSURE_LEVELS,
   disclosureRank,
   planDisclosureStep,
 } from "./recall-navigate-disclosure.js";
+import { RECALL_DISCLOSURE_LEVELS } from "./types.js";
 
 // The declared input type is strings; agents send arbitrary JSON. Cast only
 // at this boundary so the invalid-shape cases stay one line each.
@@ -13,14 +13,14 @@ const plan = (from: unknown, to: unknown) =>
   planDisclosureStep({ from, to } as unknown as { from: string; to: string });
 
 test("disclosureRank returns the index of every level, shallowest first", () => {
-  for (const [i, level] of DISCLOSURE_LEVELS.entries()) {
+  for (const [i, level] of RECALL_DISCLOSURE_LEVELS.entries()) {
     assert.equal(disclosureRank(level), i);
   }
   assert.ok(
-    disclosureRank(DISCLOSURE_LEVELS[0]) < disclosureRank(DISCLOSURE_LEVELS[1]),
+    disclosureRank(RECALL_DISCLOSURE_LEVELS[0]) < disclosureRank(RECALL_DISCLOSURE_LEVELS[1]),
   );
   assert.ok(
-    disclosureRank(DISCLOSURE_LEVELS[1]) < disclosureRank(DISCLOSURE_LEVELS[2]),
+    disclosureRank(RECALL_DISCLOSURE_LEVELS[1]) < disclosureRank(RECALL_DISCLOSURE_LEVELS[2]),
   );
 });
 
@@ -64,8 +64,8 @@ test("chunk→raw is two steps", () => {
 });
 
 test("every level pair is only deeper in one direction", () => {
-  for (const shallower of DISCLOSURE_LEVELS) {
-    for (const deeper of DISCLOSURE_LEVELS) {
+  for (const shallower of RECALL_DISCLOSURE_LEVELS) {
+    for (const deeper of RECALL_DISCLOSURE_LEVELS) {
       const result = planDisclosureStep({ from: shallower, to: deeper });
       if (disclosureRank(shallower) < disclosureRank(deeper)) {
         assert.deepEqual(result, {
@@ -82,7 +82,7 @@ test("every level pair is only deeper in one direction", () => {
 });
 
 test("equal levels are not_deeper", () => {
-  for (const level of DISCLOSURE_LEVELS) {
+  for (const level of RECALL_DISCLOSURE_LEVELS) {
     assert.deepEqual(planDisclosureStep({ from: level, to: level }), {
       ok: false,
       error: "not_deeper",

--- a/packages/remnic-core/src/recall-navigate-disclosure.test.ts
+++ b/packages/remnic-core/src/recall-navigate-disclosure.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DISCLOSURE_LEVELS,
+  disclosureRank,
+  planDisclosureStep,
+} from "./recall-navigate-disclosure.js";
+
+// The declared input type is strings; agents send arbitrary JSON. Cast only
+// at this boundary so the invalid-shape cases stay one line each.
+const plan = (from: unknown, to: unknown) =>
+  planDisclosureStep({ from, to } as unknown as { from: string; to: string });
+
+test("disclosureRank returns the index of every level, shallowest first", () => {
+  for (const [i, level] of DISCLOSURE_LEVELS.entries()) {
+    assert.equal(disclosureRank(level), i);
+  }
+  assert.ok(
+    disclosureRank(DISCLOSURE_LEVELS[0]) < disclosureRank(DISCLOSURE_LEVELS[1]),
+  );
+  assert.ok(
+    disclosureRank(DISCLOSURE_LEVELS[1]) < disclosureRank(DISCLOSURE_LEVELS[2]),
+  );
+});
+
+test("disclosureRank throws a RangeError listing allowed values", () => {
+  assert.throws(
+    () => disclosureRank("full"),
+    (err: unknown) =>
+      err instanceof RangeError &&
+      /disclosure level/.test(err.message) &&
+      err.message.includes("chunk") &&
+      err.message.includes("section") &&
+      err.message.includes("raw"),
+  );
+});
+
+test("chunk→section is one step", () => {
+  assert.deepEqual(planDisclosureStep({ from: "chunk", to: "section" }), {
+    ok: true,
+    from: "chunk",
+    to: "section",
+    steps: 1,
+  });
+});
+
+test("section→raw is one step", () => {
+  assert.deepEqual(planDisclosureStep({ from: "section", to: "raw" }), {
+    ok: true,
+    from: "section",
+    to: "raw",
+    steps: 1,
+  });
+});
+
+test("chunk→raw is two steps", () => {
+  assert.deepEqual(planDisclosureStep({ from: "chunk", to: "raw" }), {
+    ok: true,
+    from: "chunk",
+    to: "raw",
+    steps: 2,
+  });
+});
+
+test("every level pair is only deeper in one direction", () => {
+  for (const shallower of DISCLOSURE_LEVELS) {
+    for (const deeper of DISCLOSURE_LEVELS) {
+      const result = planDisclosureStep({ from: shallower, to: deeper });
+      if (disclosureRank(shallower) < disclosureRank(deeper)) {
+        assert.deepEqual(result, {
+          ok: true,
+          from: shallower,
+          to: deeper,
+          steps: disclosureRank(deeper) - disclosureRank(shallower),
+        });
+      } else {
+        assert.deepEqual(result, { ok: false, error: "not_deeper" });
+      }
+    }
+  }
+});
+
+test("equal levels are not_deeper", () => {
+  for (const level of DISCLOSURE_LEVELS) {
+    assert.deepEqual(planDisclosureStep({ from: level, to: level }), {
+      ok: false,
+      error: "not_deeper",
+    });
+  }
+});
+
+test("shallower pairs are not_deeper", () => {
+  for (const [from, to] of [
+    ["section", "chunk"],
+    ["raw", "section"],
+    ["raw", "chunk"],
+  ] as const) {
+    assert.deepEqual(planDisclosureStep({ from, to }), {
+      ok: false,
+      error: "not_deeper",
+    });
+  }
+});
+
+test("unknown level on either side is unknown_level, not a throw", () => {
+  assert.deepEqual(plan("full", "raw"), { ok: false, error: "unknown_level" });
+  assert.deepEqual(plan("chunk", "full"), { ok: false, error: "unknown_level" });
+  assert.deepEqual(plan("full", "worse"), { ok: false, error: "unknown_level" });
+});
+
+test("non-string level on either side is unknown_level", () => {
+  for (const bad of [5, null, undefined, true, { level: "raw" }, ["raw"]]) {
+    assert.deepEqual(plan(bad, "raw"), { ok: false, error: "unknown_level" });
+    assert.deepEqual(plan("chunk", bad), { ok: false, error: "unknown_level" });
+  }
+});
+
+test("empty string level is unknown_level", () => {
+  assert.deepEqual(plan("", "raw"), { ok: false, error: "unknown_level" });
+  assert.deepEqual(plan("chunk", ""), { ok: false, error: "unknown_level" });
+});
+
+test("levels match exactly — no case folding, no trimming", () => {
+  assert.deepEqual(plan("Raw", "chunk"), { ok: false, error: "unknown_level" });
+  assert.deepEqual(plan(" raw", "raw"), { ok: false, error: "unknown_level" });
+  assert.deepEqual(plan("raw", "RAW"), { ok: false, error: "unknown_level" });
+});

--- a/packages/remnic-core/src/recall-navigate-disclosure.ts
+++ b/packages/remnic-core/src/recall-navigate-disclosure.ts
@@ -1,52 +1,45 @@
 /**
- * Disclosure ladder for recall navigation (issue #1956).
+ * Disclosure-step planning for recall navigation (issue #1956).
  *
- * Pure. Levels are ordered shallowest→deepest and matched exactly:
- * no trimming, no case folding. `planDisclosureStep` allows only
- * strictly deeper expansions so a caller cannot re-pay budget for
- * output it already has.
+ * The ladder itself is NOT redefined here: `types.ts` designates
+ * `RECALL_DISCLOSURE_LEVELS` the single source of truth and forbids
+ * hard-coding disclosure strings elsewhere, so a second copy could drift out
+ * of agreement with recall validation and rendering. This module only adds
+ * the rule that an expansion must go strictly deeper, so a caller cannot
+ * re-pay recall budget for output it already holds. Pure — no I/O.
  */
-export const DISCLOSURE_LEVELS = ["chunk", "section", "raw"] as const;
-export type DisclosureLevel = (typeof DISCLOSURE_LEVELS)[number];
+
+import {
+  isRecallDisclosure,
+  RECALL_DISCLOSURE_LEVELS,
+  type RecallDisclosure,
+} from "./types.js";
 
 export type DisclosureStepResult =
-  | { ok: true; from: DisclosureLevel; to: DisclosureLevel; steps: number }
+  | { ok: true; from: RecallDisclosure; to: RecallDisclosure; steps: number }
   | { ok: false; error: "unknown_level" | "not_deeper" };
 
+/** Index in the canonical shallow-to-deep ladder. Throws for a non-level. */
 export function disclosureRank(level: string): number {
-  const index = (DISCLOSURE_LEVELS as readonly string[]).indexOf(level);
-  if (index === -1) {
+  const index = (RECALL_DISCLOSURE_LEVELS as readonly string[]).indexOf(level);
+  if (index < 0) {
     throw new RangeError(
-      `unknown disclosure level ${JSON.stringify(level)}; allowed values: ${DISCLOSURE_LEVELS.join(", ")}`,
+      `unknown disclosure level ${JSON.stringify(level)}; expected one of ${RECALL_DISCLOSURE_LEVELS.join(", ")}`,
     );
   }
   return index;
 }
 
-export function planDisclosureStep(input: {
-  from: string;
-  to: string;
-}): DisclosureStepResult {
-  // Runtime guard: the declared type says string, but callers pass
-  // agent-supplied JSON. A bad request is a typed refusal, not a crash.
-  if (typeof input.from !== "string" || typeof input.to !== "string") {
+/**
+ * Plan one expansion. A bad level from an agent is a typed refusal rather
+ * than a throw; equal or shallower targets are `not_deeper`.
+ */
+export function planDisclosureStep(input: { from: string; to: string }): DisclosureStepResult {
+  if (!isRecallDisclosure(input.from) || !isRecallDisclosure(input.to)) {
     return { ok: false, error: "unknown_level" };
   }
-  let fromRank: number;
-  let toRank: number;
-  try {
-    fromRank = disclosureRank(input.from);
-    toRank = disclosureRank(input.to);
-  } catch {
-    return { ok: false, error: "unknown_level" };
-  }
-  if (toRank <= fromRank) {
-    return { ok: false, error: "not_deeper" };
-  }
-  return {
-    ok: true,
-    from: DISCLOSURE_LEVELS[fromRank],
-    to: DISCLOSURE_LEVELS[toRank],
-    steps: toRank - fromRank,
-  };
+  const fromRank = disclosureRank(input.from);
+  const toRank = disclosureRank(input.to);
+  if (toRank <= fromRank) return { ok: false, error: "not_deeper" };
+  return { ok: true, from: input.from, to: input.to, steps: toRank - fromRank };
 }

--- a/packages/remnic-core/src/recall-navigate-disclosure.ts
+++ b/packages/remnic-core/src/recall-navigate-disclosure.ts
@@ -1,0 +1,52 @@
+/**
+ * Disclosure ladder for recall navigation (issue #1956).
+ *
+ * Pure. Levels are ordered shallowest→deepest and matched exactly:
+ * no trimming, no case folding. `planDisclosureStep` allows only
+ * strictly deeper expansions so a caller cannot re-pay budget for
+ * output it already has.
+ */
+export const DISCLOSURE_LEVELS = ["chunk", "section", "raw"] as const;
+export type DisclosureLevel = (typeof DISCLOSURE_LEVELS)[number];
+
+export type DisclosureStepResult =
+  | { ok: true; from: DisclosureLevel; to: DisclosureLevel; steps: number }
+  | { ok: false; error: "unknown_level" | "not_deeper" };
+
+export function disclosureRank(level: string): number {
+  const index = (DISCLOSURE_LEVELS as readonly string[]).indexOf(level);
+  if (index === -1) {
+    throw new RangeError(
+      `unknown disclosure level ${JSON.stringify(level)}; allowed values: ${DISCLOSURE_LEVELS.join(", ")}`,
+    );
+  }
+  return index;
+}
+
+export function planDisclosureStep(input: {
+  from: string;
+  to: string;
+}): DisclosureStepResult {
+  // Runtime guard: the declared type says string, but callers pass
+  // agent-supplied JSON. A bad request is a typed refusal, not a crash.
+  if (typeof input.from !== "string" || typeof input.to !== "string") {
+    return { ok: false, error: "unknown_level" };
+  }
+  let fromRank: number;
+  let toRank: number;
+  try {
+    fromRank = disclosureRank(input.from);
+    toRank = disclosureRank(input.to);
+  } catch {
+    return { ok: false, error: "unknown_level" };
+  }
+  if (toRank <= fromRank) {
+    return { ok: false, error: "not_deeper" };
+  }
+  return {
+    ok: true,
+    from: DISCLOSURE_LEVELS[fromRank],
+    to: DISCLOSURE_LEVELS[toRank],
+    steps: toRank - fromRank,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the disclosure ladder #1956 defines for `expandMemory(id, disclosure)` — "re-render one already-recalled memory at deeper disclosure (chunk→section→raw)". The levels existed only as an up-front whole-result setting; the step rule did not exist anywhere.

`planDisclosureStep` enforces that an expansion is **strictly deeper**. `section`→`section` and `raw`→`chunk` are `not_deeper`, which is what stops a caller re-paying recall budget for output it already has. `steps` reports the rank distance so a multi-level jump can be priced. A bad level from an agent is a typed refusal (`unknown_level`), not a throw, while `disclosureRank` throws for programmer error.

Levels match exactly: `"Raw"` and `" raw"` are `unknown_level`, because normalizing an input into validity is the failure mode that produced two review findings earlier in this series.

Part of #1956 (ladder helper; the MCP/CLI/HTTP expand and traverse tools remain, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/recall-navigate-disclosure.test.ts` — 12/12
- Asserts the ordering by looping `DISCLOSURE_LEVELS` rather than hardcoding a single pair, plus every equal and shallower pair.
