### PR TITLE
chore(ci): name missing installs, guard gh bodies, require discriminating tests

### DIFF
--- a/.changeset/ci-b7-hardening.md
+++ b/.changeset/ci-b7-hardening.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Harden the review loop after a five-PR parallel run: preflight now names a missing local install so cross-package resolution errors are not read as defects, a stream rule keeps PR bodies out of expanding heredocs, and the test-quality checklist requires proving each new regression actually discriminates.

--- a/.omp/rules/README.md
+++ b/.omp/rules/README.md
@@ -72,6 +72,22 @@ conditions without new evidence; each baseline below is the receipt.
   (`access-service.ts:843`). Only the `.every(...)` "all empty" shape can
   disagree with a nullish top-level branch, so
   `remnic-guard-inner-nullish` conditions on `.every(` alone.
+- **`Date.parse(...)` used in a comparison without a NaN guard** — the
+  underlying bug is real (an unparseable timestamp makes every `<`/`>`
+  false, so a comparator loses antisymmetry and a retention check reads
+  as "not retained"), but the signature matches 30+ files of correct
+  code: comparators subtracting two parses of known-valid frontmatter,
+  DST window assertions, and half-open interval math. Sort instability
+  is already covered by `remnic-comparator-total-order`; the
+  non-finite-into-a-destructive-branch half is semantic and lives in the
+  `AGENTS.md` checklist instead.
+- **Single-argument `assert.throws(fn)` / `assert.rejects(fn)`** (no
+  error matcher) — a real hazard, and it did let one test pass for the
+  wrong reason (a raw `ENOTDIR` incidentally matched a loose
+  `/not a directory/`), but 18+ existing test files use the bare form
+  where *any* rejection is precisely the contract (`readFile` on a
+  deleted path, a loop of clearly-typed invalid inputs). Tightening the
+  matcher is a review judgement, not a signature.
 
 The dominant review clusters in the 2026-06-20..07-04 subset (605
 findings across 40 PRs; the full derivation corpus spans four weeks) —

--- a/.omp/rules/remnic-gh-body-from-file.md
+++ b/.omp/rules/remnic-gh-body-from-file.md
@@ -1,0 +1,38 @@
+---
+name: remnic-gh-body-from-file
+description: "Pass PR/issue bodies to gh from a file, never an inline command-substitution heredoc"
+condition:
+  - 'body="\$\(cat\s*<<'
+  - "body='\\$\\(cat\\s*<<"
+globs:
+  - "**/*.sh"
+  - "**/*.bash"
+  - "**/*.md"
+  - "**/*.yml"
+  - "**/*.yaml"
+interruptMode: never
+---
+
+Advisory: a PR or issue body built as `-f body="$(cat <<'EOF' ... EOF)"`
+is inside double quotes, so the shell expands it before `gh` ever sees
+it. Any backtick in the body — and Markdown bodies are full of them,
+`--flag`, `path/to/file.ts`, `command --arg` — starts a command
+substitution. The usual outcome is not an error: it is a body that
+silently arrives truncated or rewritten, because the shell consumed the
+backticked spans and whatever they "returned" replaced them.
+
+Observed failure: a PR body of ~1.2 KB landed as 32 characters,
+keeping only the fragments between the backticks and a stray `EOF`.
+The PR looked created and healthy; only the body was destroyed. It had
+to be repaired with a follow-up `PATCH`.
+
+Use a file instead, so no shell expansion happens at all:
+
+    # write the body with a tool that does not interpolate, then:
+    gh api -X POST repos/OWNER/REPO/pulls \
+      -f title="..." -f head="..." -f base=main \
+      -F body=@/tmp/pr-body.md
+
+`gh pr create --body-file <path>` is equivalent for the CLI form. If a
+heredoc is unavoidable, quote the delimiter (`<<'EOF'`) AND keep it out
+of double quotes — but a file is simpler and cannot regress.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -582,6 +582,16 @@ Reviewers caught multiple tests that passed vacuously.
   test that forces the error path and asserts recovery behavior.
 - **Don't use fragile CWD-relative paths** — use `import.meta.dirname` or
   `path.resolve(__dirname, ...)` instead of assuming CWD.
+- **Prove each new test discriminates, mechanically.** "Looks like it tests
+  the fix" is not evidence. Before committing, either (a) stash the source
+  change and re-run — every new test defending it MUST fail, or (b) mutate
+  the specific behavior (flip a comparator's sign, swap an append order)
+  and confirm the suite goes red. A test that passes with AND without the
+  change proves nothing: delete it rather than keep it green. This is
+  cheap — a stash plus one test-file run — and it is the only way to tell a
+  regression test from decoration. Three vacuous tests were deleted and two
+  suites confirmed via killed mutants in one recent multi-PR run; each of
+  those would otherwise have shipped as false coverage.
 
 ### 7. Documentation Accuracy — Examples Must Be Copy-Pasteable
 
@@ -1256,6 +1266,34 @@ allowed dispatching from any branch without branch protection.
   property in the schema, write a test that sets it and verifies it affects
   the documented behavior. Missing tests mean the property may be silently
   ignored.
+
+### 45. Validate the Exact Value — Never Normalize First, Never Let Non-Finite Fall Through
+
+Two failure shapes, both caught in review on a *deletion planner*, both of
+which resolve toward the destructive branch. Neither has a textual
+signature (see the receipts in `.omp/rules/README.md`), so they are checked
+here, by hand, on every validator you write.
+
+- **Never normalize an input before validating it.** `isRefusable(p)` that
+  starts with `p.trim()` will accept `" activity/x.md"` as owned and then
+  act on `"activity/x.md"` — a value the caller never supplied. Validate
+  the exact string; use `trim()` only to detect blankness, and treat
+  surrounding whitespace as a refusal in its own right. The same applies to
+  case folding, separator rewriting, and Unicode normalization: every
+  "helpful" transform before the check widens what passes it.
+- **Never let a non-finite number fall through a comparison.** Every
+  comparison against `NaN` is `false`, so a corrupt timestamp makes
+  `now - captured < window` false, which a retention check reads as
+  "not retained" — and the item is queued for deletion. Reject or refuse
+  non-finite numbers explicitly, before the decision, and choose the
+  refusal branch rather than the permissive one. `Number.isFinite` on every
+  externally-sourced number that feeds a delete, supersede, tombstone, or
+  authority decision.
+
+The general rule both instances share: when a guard's two outcomes are
+"keep data" and "destroy data", an unparseable or unexpected input MUST
+resolve to "keep". Write the test that feeds it `NaN`, `Infinity`, and a
+whitespace-padded path, and assert nothing was planned for deletion.
 
 ---
 

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -10,6 +10,18 @@ case " ${NODE_OPTIONS:-} " in
   *) export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" ;;
 esac
 
+# A fresh `git worktree` has no node_modules of its own. Workspace packages
+# then resolve `@remnic/*` against absent build output, so unrelated packages
+# fail check-types with "has no exported member" errors that read like real
+# defects. Say so once, up front, instead of letting a resolution artifact
+# masquerade as a finding.
+if [ ! -d node_modules ]; then
+  echo "[preflight] NOTE: node_modules is missing in this checkout." >&2
+  echo "[preflight]   Install dependencies here first; without them," >&2
+  echo "[preflight]   cross-package \"has no exported member\" type errors" >&2
+  echo "[preflight]   are resolution artifacts, not defects." >&2
+fi
+
 run() {
   echo "[preflight] $*"
   "$@"


### PR DESCRIPTION
## Summary

The five process/CI fixes this multi-PR run actually hit. Two more candidates were **measured and rejected** rather than shipped as noise; the receipts are in the diff.

### Shipped

1. **`scripts/pr-preflight.sh` names a missing install.** A fresh `git worktree` has no `node_modules`, so workspace packages resolve `@remnic/*` against absent build output and unrelated packages fail `check-types` with `has no exported member`. That was read as a real defect more than once before being traced to the missing install. Preflight now says so before the first gate.
2. **New advisory rule `remnic-gh-body-from-file`.** A body passed as `-f body="$(cat <<EOF ...)"` sits inside double quotes, so backticks in Markdown become command substitutions. One PR body in this run silently landed as **32 of 1238 characters** and needed a repair `PATCH`. The failure is silent — the PR looks created and healthy. Zero matches against the tree.
3. **`AGENTS.md` pattern 6 now requires proving a test discriminates** — stash the source change or mutate the behavior and confirm the suite goes red. Three vacuous tests were deleted and two suites confirmed by killed mutants during this run; each would otherwise have shipped as false coverage.
4. **`AGENTS.md` pattern 45** records the two semantic defect classes found in a deletion planner: normalizing an input before validating it, and letting a non-finite number fall through a comparison into the destructive branch. Both resolve toward destroying data, and neither has a textual signature.
5. **`.omp/rules/README.md` records the rejected candidates** with their measured counts, so neither is re-proposed without new evidence.

### Measured and rejected

Per the README ground rule — run a condition against the tree before shipping it:

- `Date.parse(...)` in a comparison without a NaN guard: **30+ files** of correct code match (comparators over known-valid frontmatter, DST window assertions, half-open interval math). The sort-instability half is already covered by `remnic-comparator-total-order`; the destructive-branch half is semantic and now lives in pattern 45.
- Single-argument `assert.throws(fn)` / `assert.rejects(fn)`: **18+ files** legitimately use the bare form where *any* rejection is the contract (`readFile` on a deleted path, loops of clearly-typed invalid inputs).

Shipping either would have trained agents to ignore the rule directory, which costs more than the bugs they would catch.

## Test plan

- `bash -n scripts/pr-preflight.sh` clean; ran the script in a worktree with no `node_modules` and confirmed the notice fires ahead of the first gate.
- New rule conditions: 0 matches across `*.sh`, `*.bash`, `*.md`, `*.yml`, `*.yaml`.
- Remaining changes are documentation.
