### PR TITLE
feat(activity): report every unmet vault journal prerequisite at once

### DIFF
--- a/.changeset/journal-vault-prereq-1987.md
+++ b/.changeset/journal-vault-prereq-1987.md
@@ -1,0 +1,13 @@
+---
+"@remnic/core": patch
+---
+
+Add `checkVaultJournalPrerequisites`: given the caller-resolved config
+values, reports EVERY unmet vault journal read-back prerequisite
+(`vault.enabled`, `vault.dailyNotePath`, `vault.readback.journalSection`)
+in one single-line message, instead of failing on the first one hit.
+`vault.enabled` counts as satisfied only for boolean `true`; path and
+section only for non-blank strings. Internal helper exported from the
+activity surface — not yet wired into config parsing; that wiring is a
+later slice of #1987.
+Part of #1987.

--- a/.changeset/journal-vault-prereq-1987.md
+++ b/.changeset/journal-vault-prereq-1987.md
@@ -5,7 +5,7 @@
 Add `checkVaultJournalPrerequisites`: given the caller-resolved config
 values, reports EVERY unmet vault journal read-back prerequisite
 (`vault.enabled`, `vault.dailyNotePath`, `vault.readback.journalSection`)
-in one single-line message, instead of failing on the first one hit.
+in one single-line message, instead of failing on the first unmet prerequisite.
 `vault.enabled` counts as satisfied only for boolean `true`; path and
 section only for non-blank strings. Internal helper exported from the
 activity surface — not yet wired into config parsing; that wiring is a

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -17,6 +17,7 @@ export * from "./reindex.js";
 export * from "./timeline/index.js";
 export * from "./journal.js";
 export * from "./journal-vault-read.js";
+export * from "./journal-vault-prereq.js";
 export { stripRemnicOwnedRegions } from "./journal-strip.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";

--- a/packages/remnic-core/src/activity/journal-vault-prereq.test.ts
+++ b/packages/remnic-core/src/activity/journal-vault-prereq.test.ts
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  VAULT_JOURNAL_PREREQUISITES,
+  checkVaultJournalPrerequisites,
+  type VaultJournalPrereqResult,
+} from "./journal-vault-prereq.js";
+
+const SATISFIED = {
+  vaultEnabled: true,
+  dailyNotePath: "/vault/journal/2026-08-20.md",
+  journalSection: "Journal",
+} as const;
+
+test("all three satisfied returns exactly ok", () => {
+  assert.deepEqual(
+    checkVaultJournalPrerequisites(SATISFIED),
+    { ok: true } satisfies VaultJournalPrereqResult,
+  );
+});
+
+test("vault.enabled unmet alone", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    vaultEnabled: false,
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.enabled"]);
+});
+
+test("vault.dailyNotePath unmet alone", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    dailyNotePath: undefined,
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.dailyNotePath"]);
+});
+
+test("vault.readback.journalSection unmet alone", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    journalSection: "",
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.readback.journalSection"]);
+});
+
+test("all three unmet lists all three in declaration order", () => {
+  const result = checkVaultJournalPrerequisites({
+    vaultEnabled: undefined,
+    dailyNotePath: undefined,
+    journalSection: undefined,
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, [...VAULT_JOURNAL_PREREQUISITES]);
+});
+
+test("string \"true\" does not satisfy vault.enabled", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    vaultEnabled: "true",
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.enabled"]);
+});
+
+test("number 1 does not satisfy vault.enabled", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    vaultEnabled: 1,
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.enabled"]);
+});
+
+test("whitespace-only dailyNotePath is unmet", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    dailyNotePath: "   ",
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.dailyNotePath"]);
+});
+
+test("whitespace-only journalSection is unmet", () => {
+  const result = checkVaultJournalPrerequisites({
+    ...SATISFIED,
+    journalSection: "\t\n",
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missing, ["vault.readback.journalSection"]);
+});
+
+test("message names every missing key and is a single line", () => {
+  const result = checkVaultJournalPrerequisites({
+    vaultEnabled: "true",
+    dailyNotePath: 42,
+    journalSection: "  ",
+  });
+  assert.equal(result.ok, false);
+  for (const key of result.missing) {
+    assert.ok(result.message.includes(key), `message must name ${key}`);
+  }
+  for (const key of VAULT_JOURNAL_PREREQUISITES) {
+    assert.ok(result.message.includes(key), `message must name ${key}`);
+  }
+  assert.ok(!result.message.includes("\n"), "message must be a single line");
+});
+
+test("input is not mutated", () => {
+  const input = Object.freeze({
+    vaultEnabled: false,
+    dailyNotePath: " ",
+    journalSection: "",
+  });
+  const snapshot = { ...input };
+  checkVaultJournalPrerequisites(input);
+  assert.deepEqual(input, snapshot);
+});

--- a/packages/remnic-core/src/activity/journal-vault-prereq.ts
+++ b/packages/remnic-core/src/activity/journal-vault-prereq.ts
@@ -1,0 +1,41 @@
+/**
+ * Vault journal read-back prerequisites (issue #1987).
+ *
+ * Pure. `journal.source: "vault"` requires all three prerequisites; the
+ * caller checks `source` first via the journal-source parser and calls this
+ * only for vault mode. Reports EVERY unmet prerequisite at once so the user
+ * gets one actionable error, not the first hit.
+ */
+
+export const VAULT_JOURNAL_PREREQUISITES = [
+  "vault.enabled",
+  "vault.dailyNotePath",
+  "vault.readback.journalSection",
+] as const;
+export type VaultJournalPrerequisite = (typeof VAULT_JOURNAL_PREREQUISITES)[number];
+
+export type VaultJournalPrereqResult =
+  | { ok: true }
+  | { ok: false; missing: VaultJournalPrerequisite[]; message: string };
+
+export function checkVaultJournalPrerequisites(input: {
+  vaultEnabled?: unknown;
+  dailyNotePath?: unknown;
+  journalSection?: unknown;
+}): VaultJournalPrereqResult {
+  const missing: VaultJournalPrerequisite[] = [];
+  if (input.vaultEnabled !== true) missing.push("vault.enabled");
+  // Exact values are validated: trim() only detects blankness, never rewrites.
+  if (typeof input.dailyNotePath !== "string" || input.dailyNotePath.trim().length === 0) {
+    missing.push("vault.dailyNotePath");
+  }
+  if (typeof input.journalSection !== "string" || input.journalSection.trim().length === 0) {
+    missing.push("vault.readback.journalSection");
+  }
+  if (missing.length === 0) return { ok: true };
+  return {
+    ok: false,
+    missing,
+    message: `vault journal read-back prerequisites unmet: ${missing.join(", ")}`,
+  };
+}


### PR DESCRIPTION
## Summary

Implements #1987's parse-time validation: `journal.source: "vault"` requires `vault.enabled: true`, a resolvable `dailyNotePath`, and a non-empty `readback.journalSection` — "reject at parse time with an error **naming all three prerequisites**".

The point of the slice is that single actionable error. `checkVaultJournalPrerequisites` reports **every** unmet prerequisite in declaration order, not the first one it happens to hit, so an operator fixes one thing and does not come back to discover two more. A test asserts each missing key's literal name appears in the message, so the prose cannot drift away from the list.

`vaultEnabled` is satisfied only by boolean `true`: a string `"true"` from a CLI flag is not a boolean and must not silently enable vault read-back. Paths and section names are validated as the exact value, so a whitespace-only entry is unmet rather than trimmed into validity.

This helper deliberately does not re-implement the `source` allow-list — `journal-source.ts` already owns that, and the caller checks it first.

Part of #1987 (validator only; the parseConfig wiring is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/journal-vault-prereq.test.ts` — 11/11
- Covers each prerequisite unmet in isolation, all three unmet in declaration order, `vaultEnabled` as `"true"` and `1`, whitespace-only path and section, and the message-content assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for vault journal read-back prerequisites.
  * Reports all missing requirements together, including vault enablement, daily note path, and journal section.
  * Provides actionable success or failure results for prerequisite checks.
* **Documentation**
  * Added release documentation for the new validation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->