### PR TITLE
feat(recall): refuse foreign expand ids and truncate oversized requests

### DIFF
--- a/.changeset/expand-select-2332.md
+++ b/.changeset/expand-select-2332.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `selectExpandNodeIds` (internal, `recall-deep-expand-select.ts`): validate a deep-recall policy's EXPAND node selection. Any requested id outside the current frontier refuses the whole selection with `invalid_policy_output` and the sorted, deduplicated foreign ids; an oversized request truncates to the first `maxExpandPerStep` ids after duplicate collapse. Pure helper only — stepper wiring is a later slice of #2332. Part of #2332.

--- a/packages/remnic-core/src/recall-deep-expand-select.test.ts
+++ b/packages/remnic-core/src/recall-deep-expand-select.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_MAX_EXPAND_PER_STEP,
+  selectExpandNodeIds,
+} from "./recall-deep-expand-select.js";
+
+const FRONTIER = ["n1", "n2", "n3", "n4", "n5"] as const;
+
+test("subset request passes untruncated", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["n3", "n1"],
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    nodeIds: ["n3", "n1"],
+    truncated: false,
+  });
+});
+
+test("five-id valid request truncates to three in requested order", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["n5", "n2", "n4", "n1", "n3"],
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    nodeIds: ["n5", "n2", "n4"],
+    truncated: true,
+  });
+});
+
+test("one foreign id among valid ones refuses and lists only the foreign id", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["n1", "ghost", "n2"],
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: "invalid_policy_output",
+    foreignIds: ["ghost"],
+  });
+});
+
+test("several foreign ids are sorted and deduplicated", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["z9", "a1", "z9", "n1"],
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: "invalid_policy_output",
+    foreignIds: ["a1", "z9"],
+  });
+});
+
+test("duplicates collapse before the cap", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["n1", "n1", "n1", "n2"],
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    nodeIds: ["n1", "n2"],
+    truncated: false,
+  });
+});
+
+test("padded and case-different ids are foreign", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: [" n1", "N1"],
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: "invalid_policy_output",
+    foreignIds: [" n1", "N1"],
+  });
+});
+
+test("non-array requestedIds refuses with empty foreignIds", () => {
+  for (const bad of [undefined, null, "n1"]) {
+    const result = selectExpandNodeIds({
+      frontierIds: FRONTIER,
+      requestedIds: bad,
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      error: "invalid_policy_output",
+      foreignIds: [],
+    });
+  }
+});
+
+test("non-string array entry is reported as its String form", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["n1", 42],
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: "invalid_policy_output",
+    foreignIds: ["42"],
+  });
+});
+
+test("blank string entry is foreign", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["   "],
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: "invalid_policy_output",
+    foreignIds: ["   "],
+  });
+});
+
+test("empty array succeeds and expands nothing", () => {
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: [],
+  });
+  assert.deepEqual(result, { ok: true, nodeIds: [], truncated: false });
+});
+
+test("default cap is three", () => {
+  assert.equal(DEFAULT_MAX_EXPAND_PER_STEP, 3);
+  const result = selectExpandNodeIds({
+    frontierIds: FRONTIER,
+    requestedIds: ["n1", "n2", "n3", "n4"],
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    nodeIds: ["n1", "n2", "n3"],
+    truncated: true,
+  });
+});
+
+test("maxExpandPerStep 0, -1, and 1.5 throw RangeError naming the field", () => {
+  for (const bad of [0, -1, 1.5]) {
+    assert.throws(
+      () =>
+        selectExpandNodeIds({
+          frontierIds: FRONTIER,
+          requestedIds: ["n1"],
+          maxExpandPerStep: bad,
+        }),
+      (err: unknown) =>
+        err instanceof RangeError && /maxExpandPerStep/.test(err.message),
+    );
+  }
+});
+
+test("inputs are not mutated", () => {
+  const frontierIds = ["n1", "n2"];
+  const requestedIds = ["n2", "n2", "ghost"];
+  selectExpandNodeIds({ frontierIds, requestedIds });
+  assert.deepEqual(frontierIds, ["n1", "n2"]);
+  assert.deepEqual(requestedIds, ["n2", "n2", "ghost"]);
+});

--- a/packages/remnic-core/src/recall-deep-expand-select.ts
+++ b/packages/remnic-core/src/recall-deep-expand-select.ts
@@ -1,0 +1,65 @@
+/**
+ * Select EXPAND node ids for deep recall (issue #2332).
+ *
+ * A foreign id refuses the whole selection; an oversized request truncates.
+ * Duplicates collapse before the cap. Pure. Surfaces wait.
+ */
+export const DEFAULT_MAX_EXPAND_PER_STEP = 3;
+
+export type ExpandSelectionResult =
+  | { ok: true; nodeIds: string[]; truncated: boolean }
+  | { ok: false; error: "invalid_policy_output"; foreignIds: string[] };
+
+export function selectExpandNodeIds(input: {
+  frontierIds: readonly string[];
+  requestedIds: unknown;
+  maxExpandPerStep?: number;
+}): ExpandSelectionResult {
+  const max =
+    input.maxExpandPerStep === undefined
+      ? DEFAULT_MAX_EXPAND_PER_STEP
+      : input.maxExpandPerStep;
+  if (!Number.isInteger(max) || max < 1) {
+    throw new RangeError(
+      `maxExpandPerStep must be an integer >= 1; got ${JSON.stringify(max)}`,
+    );
+  }
+
+  if (!Array.isArray(input.requestedIds)) {
+    return { ok: false, error: "invalid_policy_output", foreignIds: [] };
+  }
+
+  const frontier = new Set(input.frontierIds);
+  const seen = new Set<string>();
+  const foreign = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const entry of input.requestedIds) {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      foreign.add(String(entry));
+      continue;
+    }
+    if (!frontier.has(entry)) {
+      foreign.add(entry);
+      continue;
+    }
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    ordered.push(entry);
+  }
+
+  if (foreign.size > 0) {
+    return {
+      ok: false,
+      error: "invalid_policy_output",
+      foreignIds: [...foreign].sort(),
+    };
+  }
+
+  const truncated = ordered.length > max;
+  return {
+    ok: true,
+    nodeIds: truncated ? ordered.slice(0, max) : ordered,
+    truncated,
+  };
+}


### PR DESCRIPTION
## Summary

Implements #2332's EXPAND validation: "`expandNodeIds` ⊆ current frontier ids, length ≤ `maxExpandPerStep`", whose test plan calls for two *different* outcomes — "expandNodeIds outside frontier → STOP + `invalid_policy_output`; oversized expand list truncated to `maxExpandPerStep`".

Keeping those distinct is the whole point. Conflating them either lets an LLM policy fish for node ids it was never served, or throws away a legitimate over-long request:

- **Any** foreign id refuses the entire selection with every offending id listed. Silently dropping the foreign entries and proceeding with the rest would turn a refusal into a probe oracle.
- A valid but over-long request is **truncated**, not refused, keeping the policy's own ordering.
- Duplicates collapse **before** the cap, so a policy cannot spend its whole expand budget on one node repeated three times.
- Ids match exactly: a padded or case-different id is foreign, not a match.
- A non-array `requestedIds` is malformed policy output, not an empty request.
- `maxExpandPerStep` of 0 throws, since it would make every EXPAND a no-op that still burns a step.

Part of #2332 (selection validator only; no diff inside `recall-internal.ts`, and the surfaces remain, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/recall-deep-expand-select.test.ts` — 13/13
- **Mutation-checked**: replacing the refusal with a silent empty success fails the suite, so the foreign-id assertion genuinely discriminates.
