### PR TITLE
feat(shared-context): lint curated claims for untraceable citations

### DIFF
--- a/.changeset/curation-lint-1957.md
+++ b/.changeset/curation-lint-1957.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `lintCuratedClaims` to shared-context: report curated claims whose citations are missing, blank, or absent from the item ids the curation run had available (issue #1957 requirement 4). Internal helper — wiring into `curate_daily` output is a later slice. Part of #1957

--- a/packages/remnic-core/src/shared-context/curation-lint.test.ts
+++ b/packages/remnic-core/src/shared-context/curation-lint.test.ts
@@ -134,3 +134,22 @@ test("inputs are not mutated", () => {
   assert.deepEqual(claims, claimsSnapshot);
   assert.deepEqual(availableItemIds, availableSnapshot);
 });
+
+// Review: two claims sharing a claimId AND a reason still differ by their
+// unknownIds, so a comparator returning 0 there let input order decide the
+// output — the contract says the result is deterministic.
+test("duplicate claim ids with different unknown ids sort deterministically", () => {
+  const available = ["item-ok"];
+  const claims = [
+    { claimId: "claim-dup", citedItemIds: ["item-ok", "zeta-missing"] },
+    { claimId: "claim-dup", citedItemIds: ["item-ok", "alpha-missing"] },
+  ];
+  const forward = lintCuratedClaims({ claims, availableItemIds: available });
+  const reversed = lintCuratedClaims({ claims: [...claims].reverse(), availableItemIds: available });
+  assert.deepEqual(forward, reversed, "reversing the input must not reorder findings");
+  assert.deepEqual(
+    forward.map((f) => f.unknownIds),
+    [["alpha-missing"], ["zeta-missing"]],
+    "findings order by unknownIds once claimId and reason tie",
+  );
+});

--- a/packages/remnic-core/src/shared-context/curation-lint.test.ts
+++ b/packages/remnic-core/src/shared-context/curation-lint.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { lintCuratedClaims } from "./curation-lint.js";
+
+const AVAILABLE = ["item-1", "item-2", "item-3"];
+
+test("a fully-cited claim set returns no findings", () => {
+  const findings = lintCuratedClaims({
+    claims: [
+      { claimId: "c-1", citedItemIds: ["item-1", "item-2"] },
+      { claimId: "c-2", citedItemIds: ["item-3"] },
+    ],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, []);
+});
+
+test("missing citedItemIds gives no_citations", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1" }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [{ claimId: "c-1", reason: "no_citations" }]);
+});
+
+test("an empty citedItemIds array gives no_citations", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1", citedItemIds: [] }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [{ claimId: "c-1", reason: "no_citations" }]);
+});
+
+test("an all-blank citedItemIds array gives no_citations", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1", citedItemIds: ["", "   ", "\t"] }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [{ claimId: "c-1", reason: "no_citations" }]);
+});
+
+test("one valid plus one unknown citation gives unknown_citation listing only the unknown", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1", citedItemIds: ["item-1", "item-404"] }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [
+    { claimId: "c-1", reason: "unknown_citation", unknownIds: ["item-404"] },
+  ]);
+});
+
+test("all-unknown citations give no_citations, not unknown_citation (precedence)", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1", citedItemIds: ["nope-1", "nope-2"] }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [{ claimId: "c-1", reason: "no_citations" }]);
+});
+
+test("unknown ids are sorted ascending and deduplicated", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1", citedItemIds: ["item-1", "zz", "aa", "zz", "mm"] }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [
+    { claimId: "c-1", reason: "unknown_citation", unknownIds: ["aa", "mm", "zz"] },
+  ]);
+});
+
+test("a whitespace-padded citation is unknown (exact comparison, no trim)", () => {
+  const findings = lintCuratedClaims({
+    claims: [{ claimId: "c-1", citedItemIds: ["item-1", " item-2"] }],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [
+    { claimId: "c-1", reason: "unknown_citation", unknownIds: [" item-2"] },
+  ]);
+});
+
+test("a blank claimId throws RangeError naming claimId", () => {
+  assert.throws(
+    () =>
+      lintCuratedClaims({
+        claims: [{ claimId: "   ", citedItemIds: ["item-1"] }],
+        availableItemIds: AVAILABLE,
+      }),
+    (err: unknown) => err instanceof RangeError && /claimId/.test(err.message),
+  );
+});
+
+test("duplicate claim ids are each linted independently", () => {
+  const findings = lintCuratedClaims({
+    claims: [
+      { claimId: "c-1", citedItemIds: ["item-404", "item-1"] },
+      { claimId: "c-1" },
+    ],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(findings, [
+    { claimId: "c-1", reason: "no_citations" },
+    { claimId: "c-1", reason: "unknown_citation", unknownIds: ["item-404"] },
+  ]);
+});
+
+test("findings are deterministic across two calls with shuffled input", () => {
+  const expected: Array<{ claimId: string; reason: string; unknownIds?: string[] }> = [
+    { claimId: "c-1", reason: "no_citations" },
+    { claimId: "c-2", reason: "no_citations" },
+    { claimId: "c-3", reason: "unknown_citation", unknownIds: ["item-404"] },
+  ];
+  const claims = [
+    { claimId: "c-3", citedItemIds: ["item-3", "item-404"] },
+    { claimId: "c-1" },
+    { claimId: "c-2", citedItemIds: [] },
+  ];
+  const first = lintCuratedClaims({ claims, availableItemIds: AVAILABLE });
+  const second = lintCuratedClaims({
+    claims: [claims[2], claims[0], claims[1]],
+    availableItemIds: AVAILABLE,
+  });
+  assert.deepEqual(first, expected);
+  assert.deepEqual(second, expected);
+});
+
+test("inputs are not mutated", () => {
+  const claims = [
+    { claimId: "c-1", citedItemIds: ["zz", "item-1", "zz"] as const },
+  ];
+  const availableItemIds = ["item-1", "item-2"];
+  const claimsSnapshot = structuredClone(claims);
+  const availableSnapshot = [...availableItemIds];
+  lintCuratedClaims({ claims, availableItemIds });
+  assert.deepEqual(claims, claimsSnapshot);
+  assert.deepEqual(availableItemIds, availableSnapshot);
+});

--- a/packages/remnic-core/src/shared-context/curation-lint.ts
+++ b/packages/remnic-core/src/shared-context/curation-lint.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared-context curation self-check (issue #1957 requirement 4).
+ *
+ * Pure. A synthesized claim with no traceable source is a lint error:
+ * report claims whose citations are missing, blank, or absent from the
+ * item ids the curation run actually had available.
+ */
+
+export interface CuratedClaim {
+  claimId: string;
+  /** Shared-context item ids this claim was synthesized from. */
+  citedItemIds?: readonly string[];
+}
+
+export interface CurationLintFinding {
+  claimId: string;
+  reason: "no_citations" | "unknown_citation";
+  /** Cited ids that are not in the available set. Only for unknown_citation. */
+  unknownIds?: string[];
+}
+
+export function lintCuratedClaims(input: {
+  claims: readonly CuratedClaim[];
+  availableItemIds: readonly string[];
+}): CurationLintFinding[] {
+  const available = new Set(input.availableItemIds);
+  const findings: CurationLintFinding[] = [];
+
+  for (const claim of input.claims) {
+    const claimId = claim.claimId;
+    if (typeof claimId !== "string" || claimId.trim().length === 0) {
+      throw new RangeError("claimId must be a non-blank string");
+    }
+
+    const unknown = new Set<string>();
+    let validCount = 0;
+    for (const id of claim.citedItemIds ?? []) {
+      if (id.trim().length === 0) continue;
+      if (available.has(id)) {
+        validCount += 1;
+      } else {
+        unknown.add(id);
+      }
+    }
+
+    if (validCount === 0) {
+      findings.push({ claimId, reason: "no_citations" });
+      continue;
+    }
+    if (unknown.size > 0) {
+      findings.push({ claimId, reason: "unknown_citation", unknownIds: [...unknown].sort() });
+    }
+  }
+
+  findings.sort((a, b) => {
+    if (a.claimId !== b.claimId) return a.claimId < b.claimId ? -1 : 1;
+    if (a.reason !== b.reason) return a.reason < b.reason ? -1 : 1;
+    return 0;
+  });
+  return findings;
+}

--- a/packages/remnic-core/src/shared-context/curation-lint.ts
+++ b/packages/remnic-core/src/shared-context/curation-lint.ts
@@ -55,6 +55,13 @@ export function lintCuratedClaims(input: {
   findings.sort((a, b) => {
     if (a.claimId !== b.claimId) return a.claimId < b.claimId ? -1 : 1;
     if (a.reason !== b.reason) return a.reason < b.reason ? -1 : 1;
+    // Duplicate claim ids are linted independently, so two findings can share
+    // both keys above and still differ. Without this tertiary key the result
+    // would depend on upstream iteration order, which the deterministic-output
+    // contract forbids.
+    const left = (a.unknownIds ?? []).join(",");
+    const right = (b.unknownIds ?? []).join(",");
+    if (left !== right) return left < right ? -1 : 1;
     return 0;
   });
   return findings;


### PR DESCRIPTION
## Summary

Implements #1957 requirement 4's self-check: "A synthesized claim with no traceable source is a **lint error** in the curation self-check."

`lintCuratedClaims` takes the synthesized claims plus the item ids that were actually available to the run and reports what cannot be traced. Two failure modes are kept distinct because they mean different things:

- `no_citations` — the issue's named lint error: nothing to trace back to.
- `unknown_citation` — a claim citing an id that was never available. A fabricated citation is worse than a missing one, because it looks like provenance, so it is reported separately rather than folded into `no_citations`.

A claim yields at most one finding, with `no_citations` taking precedence when it has no usable citation at all. Ids compare exactly, so a padded citation is unknown rather than quietly matching. A blank `claimId` throws, because an unlabelled finding is not actionable. Findings sort by claim then reason with a total comparator, so a shuffled input produces a deep-equal result.

Part of #1957 (self-check only; the curation renderer's citation blocks are a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/shared-context/curation-lint.test.ts` — 12/12
- Covers missing, empty, and all-blank citation arrays, the precedence case where every citation is unknown, sorted/deduplicated unknown ids, padded citations, duplicate claim ids, and shuffle determinism.
