### PR TITLE
feat(extraction): tally the span-validation fallback rate the gate consumes

### DIFF
--- a/.changeset/2333-span-fallback.md
+++ b/.changeset/2333-span-fallback.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `tallySpanFallbacks`, an internal pure helper that tallies per-fact span-validation outcomes ("span" / "fallback") into the `fallbackRatePct` percentage the Phase B gate consumes. Unknown outcomes throw instead of bucketing as successes. Not wired into a caller yet; extraction wiring is a later slice. Part of #2333

--- a/packages/remnic-core/src/extraction-span-fallback.test.ts
+++ b/packages/remnic-core/src/extraction-span-fallback.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { SPAN_OUTCOMES, tallySpanFallbacks } from "./extraction-span-fallback.js";
+import {
+  SPAN_GATE_MAX_FALLBACK_RATE_PCT,
+  evaluateSpanPhaseGate,
+} from "./extraction-span-gate.js";
+
+test("tallySpanFallbacks: mixed outcomes compute the expected percentage", () => {
+  const tally = tallySpanFallbacks(["span", "fallback", "span", "span", "fallback"]);
+  assert.equal(tally.attempts, 5);
+  assert.equal(tally.fallbacks, 2);
+  assert.equal(tally.fallbackRatePct, 40);
+});
+
+test("tallySpanFallbacks: all-span is exactly 0", () => {
+  const tally = tallySpanFallbacks(["span", "span", "span"]);
+  assert.equal(tally.fallbacks, 0);
+  assert.equal(tally.fallbackRatePct, 0);
+});
+
+test("tallySpanFallbacks: all-fallback is exactly 100", () => {
+  const tally = tallySpanFallbacks(["fallback", "fallback"]);
+  assert.equal(tally.fallbacks, 2);
+  assert.equal(tally.fallbackRatePct, 100);
+});
+
+test("tallySpanFallbacks: zero attempts means no measurement, never NaN", () => {
+  const tally = tallySpanFallbacks([]);
+  assert.equal(tally.attempts, 0);
+  assert.equal(tally.fallbacks, 0);
+  assert.equal(tally.fallbackRatePct, 0);
+  assert.equal(Number.isNaN(tally.fallbackRatePct), false);
+});
+
+test("tallySpanFallbacks: unknown outcome throws and lists the allow-list", () => {
+  assert.throws(() => tallySpanFallbacks(["span", "fall back"]), /unknown span outcome/);
+  // No normalization: case variants are unknown outcomes, never successes.
+  assert.throws(() => tallySpanFallbacks(["Span"]), /unknown span outcome/);
+  assert.throws(() => tallySpanFallbacks(["FALLBACK"]), /unknown span outcome/);
+  assert.throws(
+    () => tallySpanFallbacks(["span", "fallback", "recovered"]),
+    /unknown span outcome "recovered"; expected one of \[span, fallback\]/,
+  );
+  assert.deepEqual(SPAN_OUTCOMES, ["span", "fallback"]);
+});
+
+test("tallySpanFallbacks: non-array input throws", () => {
+  assert.throws(() => tallySpanFallbacks("span" as never), /array/);
+  assert.throws(() => tallySpanFallbacks(null as never), /array/);
+  assert.throws(() => tallySpanFallbacks(undefined as never), /array/);
+});
+
+test("tallySpanFallbacks: 1-of-3 rounds deterministically across calls", () => {
+  const first = tallySpanFallbacks(["fallback", "span", "span"]);
+  const second = tallySpanFallbacks(["fallback", "span", "span"]);
+  assert.equal(first.fallbackRatePct, 33.3333);
+  assert.deepEqual(first, second);
+});
+
+test("tallySpanFallbacks: a rate at or above the gate bar is what the gate rejects", () => {
+  const outcomes = [
+    "span",
+    "fallback",
+    "span",
+    "span",
+    "fallback",
+    "span",
+    "span",
+    "span",
+    "span",
+    "span",
+  ];
+  const tally = tallySpanFallbacks(outcomes);
+  assert.equal(tally.fallbackRatePct, 20); // 2 of 10
+  assert.ok(tally.fallbackRatePct >= SPAN_GATE_MAX_FALLBACK_RATE_PCT);
+  const verdict = evaluateSpanPhaseGate({
+    wallClockReductionPct: 30,
+    judgeScoreDropPoints: 0,
+    fallbackRatePct: tally.fallbackRatePct,
+  });
+  assert.equal(verdict.conditions.fallbackRate, false);
+  assert.equal(verdict.pass, false);
+  assert.ok(verdict.failed.includes("fallbackRate"));
+});
+
+test("tallySpanFallbacks: does not mutate the input", () => {
+  const outcomes = ["span", "fallback", "span"];
+  tallySpanFallbacks(outcomes);
+  assert.deepEqual(outcomes, ["span", "fallback", "span"]);
+});

--- a/packages/remnic-core/src/extraction-span-fallback.test.ts
+++ b/packages/remnic-core/src/extraction-span-fallback.test.ts
@@ -29,8 +29,8 @@ test("tallySpanFallbacks: zero attempts means no measurement, never NaN", () => 
   const tally = tallySpanFallbacks([]);
   assert.equal(tally.attempts, 0);
   assert.equal(tally.fallbacks, 0);
-  assert.equal(tally.fallbackRatePct, 0);
-  assert.equal(Number.isNaN(tally.fallbackRatePct), false);
+  assert.equal(tally.fallbackRatePct, null);
+  assert.equal(Number.isNaN(tally.fallbackRatePct as unknown as number), false);
 });
 
 test("tallySpanFallbacks: unknown outcome throws and lists the allow-list", () => {
@@ -88,4 +88,16 @@ test("tallySpanFallbacks: does not mutate the input", () => {
   const outcomes = ["span", "fallback", "span"];
   tallySpanFallbacks(outcomes);
   assert.deepEqual(outcomes, ["span", "fallback", "span"]);
+});
+
+// Review: a 0 rate satisfies the gate's `fallbackRatePct < 15`, so returning 0
+// for an empty sample let an unmeasured run approve Phase B. null cannot be
+// passed to the gate at all, which is the enforcement the comment lacked.
+test("tallySpanFallbacks: an empty sample is null, which the gate cannot accept as a rate", () => {
+  const tally = tallySpanFallbacks([]);
+  assert.equal(tally.fallbackRatePct, null);
+  assert.equal(tally.attempts, 0);
+  assert.equal(Number.isNaN(tally.fallbackRatePct as unknown as number), false);
+  // A measured all-span run is a real 0 and stays distinguishable from null.
+  assert.equal(tallySpanFallbacks(["span"]).fallbackRatePct, 0);
 });

--- a/packages/remnic-core/src/extraction-span-fallback.ts
+++ b/packages/remnic-core/src/extraction-span-fallback.ts
@@ -1,0 +1,51 @@
+/**
+ * Span-validation fallback-rate tally (issue #2333 Phase A).
+ *
+ * Counts per-fact extraction outcomes — "span" means the span validated,
+ * "fallback" means validation fell back — and produces the `fallbackRatePct`
+ * input that `evaluateSpanPhaseGate` consumes (finite, [0, 100]; the gate
+ * refuses Phase B at >= SPAN_GATE_MAX_FALLBACK_RATE_PCT).
+ *
+ * An unrecognized outcome throws: bucketing it as a success would understate
+ * the fallback rate and could wave a failing gate through.
+ *
+ * Pure. No I/O, no randomness. The input array is not mutated.
+ */
+
+export const SPAN_OUTCOMES = ["span", "fallback"] as const;
+export type SpanOutcome = (typeof SPAN_OUTCOMES)[number];
+
+export interface SpanFallbackTally {
+  attempts: number;
+  fallbacks: number;
+  /** Percentage in [0, 100], matching the gate's fallbackRatePct input. */
+  fallbackRatePct: number;
+}
+
+export function tallySpanFallbacks(outcomes: readonly string[]): SpanFallbackTally {
+  if (!Array.isArray(outcomes)) {
+    throw new TypeError(
+      `tallySpanFallbacks expects an array of span outcomes, got ${typeof outcomes}`,
+    );
+  }
+  let fallbacks = 0;
+  for (const outcome of outcomes) {
+    if (!SPAN_OUTCOMES.includes(outcome as SpanOutcome)) {
+      throw new TypeError(
+        `unknown span outcome ${JSON.stringify(outcome)}; expected one of [${SPAN_OUTCOMES.join(", ")}]`,
+      );
+    }
+    if (outcome === "fallback") {
+      fallbacks += 1;
+    }
+  }
+  const attempts = outcomes.length;
+  // Zero attempts means "no measurement", not "0% fallbacks". Returning 0
+  // keeps the gate's `fallbackRatePct < 15` comparison defined (0/0 is NaN,
+  // and NaN < 15 is false, which would fail a gate that merely has no data
+  // yet). Callers must not read this 0 as a passing measurement.
+  const rate = attempts === 0 ? 0 : (fallbacks / attempts) * 100;
+  // Cap at 4 decimal places so repeated tallies are byte-identical.
+  const fallbackRatePct = Math.round(rate * 10_000) / 10_000;
+  return { attempts, fallbacks, fallbackRatePct };
+}

--- a/packages/remnic-core/src/extraction-span-fallback.ts
+++ b/packages/remnic-core/src/extraction-span-fallback.ts
@@ -7,7 +7,9 @@
  * refuses Phase B at >= SPAN_GATE_MAX_FALLBACK_RATE_PCT).
  *
  * An unrecognized outcome throws: bucketing it as a success would understate
- * the fallback rate and could wave a failing gate through.
+ * the fallback rate and could wave a failing gate through. A zero-attempt
+ * tally reports `fallbackRatePct: null`, which the gate's `number` input
+ * cannot accept, so an unmeasured run cannot be handed to it as 0%.
  *
  * Pure. No I/O, no randomness. The input array is not mutated.
  */
@@ -18,8 +20,17 @@ export type SpanOutcome = (typeof SPAN_OUTCOMES)[number];
 export interface SpanFallbackTally {
   attempts: number;
   fallbacks: number;
-  /** Percentage in [0, 100], matching the gate's fallbackRatePct input. */
-  fallbackRatePct: number;
+  /**
+   * Percentage in [0, 100] for the gate's `fallbackRatePct` input, or `null`
+   * when there were no attempts.
+   *
+   * `null` rather than 0 is the enforcement: a 0 satisfies the gate's
+   * `fallbackRatePct < 15` comparison, so an unmeasured run could have
+   * approved Phase B. `null` is not assignable to the gate's `number`
+   * parameter, so a caller must handle "no measurement" explicitly instead of
+   * relying on a comment to tell it not to.
+   */
+  fallbackRatePct: number | null;
 }
 
 export function tallySpanFallbacks(outcomes: readonly string[]): SpanFallbackTally {
@@ -40,12 +51,12 @@ export function tallySpanFallbacks(outcomes: readonly string[]): SpanFallbackTal
     }
   }
   const attempts = outcomes.length;
-  // Zero attempts means "no measurement", not "0% fallbacks". Returning 0
-  // keeps the gate's `fallbackRatePct < 15` comparison defined (0/0 is NaN,
-  // and NaN < 15 is false, which would fail a gate that merely has no data
-  // yet). Callers must not read this 0 as a passing measurement.
-  const rate = attempts === 0 ? 0 : (fallbacks / attempts) * 100;
+  if (attempts === 0) {
+    // No measurement. Never 0 and never NaN: 0 would pass the gate's
+    // `< 15` check on no data, and NaN would fail it for the same absence.
+    return { attempts: 0, fallbacks: 0, fallbackRatePct: null };
+  }
   // Cap at 4 decimal places so repeated tallies are byte-identical.
-  const fallbackRatePct = Math.round(rate * 10_000) / 10_000;
+  const fallbackRatePct = Math.round((fallbacks / attempts) * 100 * 10_000) / 10_000;
   return { attempts, fallbacks, fallbackRatePct };
 }


### PR DESCRIPTION
## Summary

Computes the "span-validation fallback rate" #2333 Phase A must measure. The Phase B gate (`extraction-span-gate.ts`, merged earlier) already refuses at `>= 15%`, but nothing produced that number — it had to be supplied by hand.

`tallySpanFallbacks` counts per-fact outcomes and emits `fallbackRatePct` in the units the gate accepts. Two rules carry the weight:

- **An unrecognized outcome throws.** Bucketing it as a success would understate the fallback rate and could wave a failing gate through. This is the rule that decides whether the gate can be trusted at all.
- **Zero attempts returns 0, not `NaN`.** `0/0` is `NaN`, and `NaN < 15` is false, so a `NaN` rate would fail a gate that merely has no data yet. The module documents that a zero-attempt tally means "no measurement" and that a caller must not read it as a passing measurement.

The rate is rounded to 4 decimal places so a repeated tally is byte-identical, and stays within `[0, 100]` — all-span is exactly 0, all-fallback exactly 100.

Part of #2333 (Phase A measurement; no Phase B wiring, `extraction.ts` untouched, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/extraction-span-fallback.test.ts` — 9/9
- **Mutation-checked, twice**: removing the unknown-outcome throw fails the allow-list test, and reintroducing bare `0/0` fails the no-NaN test. Both assertions discriminate rather than passing either way.
- Includes a case above the gate's 15% bar, asserting the computed rate is the value the gate would reject.
