### PR TITLE
feat(activity): keep the last valid journal when an AI recap run fails

### DIFF
--- a/.changeset/recap-fallback-2051.md
+++ b/.changeset/recap-fallback-2051.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `selectRecapForDay` to the activity timeline layer. It selects the journal body in precedence order (AI render, last stored journal, deterministic render), skips blank bodies, throws on an unknown or slot-mismatched candidate kind, and echoes a non-blank provider failure string onto the result. Internal helper; wiring into the recap build path is a later slice. Part of #2051.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -25,3 +25,4 @@ export * from "./recap-window.js";
 export * from "./analysis-failure.js";
 export * from "./recap-merge-edits.js";
 export * from "./analysis-metadata.js";
+export * from "./recap-fallback.js";

--- a/packages/remnic-core/src/activity/timeline/recap-fallback.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-fallback.test.ts
@@ -108,22 +108,25 @@ test("an unknown kind throws and lists the allow-list", () => {
   );
 });
 
-test("blank failure is omitted from the result object", () => {
+test("an absent failure omits the key; whitespace is refused, not cleaned", () => {
   const result = selectRecapForDay({
     deterministic: { body: "deterministic render", kind: "deterministic" },
-    failure: "   ",
   });
   assert.deepEqual(result, {
     ok: true,
     body: "deterministic render",
     kind: "deterministic",
   });
-  assert.ok(!("failure" in result));
-
-  const none = selectRecapForDay({
-    failure: null,
-  });
-  assert.ok(!("failure" in none));
+  // With the typed contract, whitespace is an unknown kind, not a blank to
+  // silently drop: a caller must omit the field, not send a placeholder.
+  assert.throws(
+    () =>
+      selectRecapForDay({
+        deterministic: { body: "deterministic render", kind: "deterministic" },
+        failure: "   ",
+      }),
+    /unknown recap failure kind/,
+  );
 });
 
 test("input is not mutated", () => {
@@ -136,4 +139,46 @@ test("input is not mutated", () => {
   const snapshot = structuredClone(input);
   selectRecapForDay(input);
   assert.deepEqual(input, snapshot);
+});
+
+// Review: an unknown failure kind must be refused, not echoed into telemetry
+// as though it were typed.
+test("an unknown failure kind throws instead of being echoed", () => {
+  assert.throws(
+    () =>
+      selectRecapForDay({
+        deterministic: { body: "cards", kind: "deterministic" },
+        failure: "timeot",
+      }),
+    /unknown recap failure kind/,
+  );
+  for (const kind of ["timeout", "aborted", "provider_unavailable"]) {
+    const result = selectRecapForDay({
+      deterministic: { body: "cards", kind: "deterministic" },
+      failure: kind,
+    });
+    assert.ok(result.ok);
+    assert.equal(result.failure, kind);
+  }
+});
+
+// Review: a malformed lower-priority candidate must not hide behind a valid
+// higher-priority one. The contract throws on a bad kind whatever wins.
+test("a valid ai candidate does not hide a malformed previous candidate", () => {
+  assert.throws(
+    () =>
+      selectRecapForDay({
+        ai: { body: "fresh", kind: "ai" },
+        previous: { body: "old", kind: "ai" } as never,
+      }),
+    /kind must match its slot/,
+  );
+  assert.throws(
+    () =>
+      selectRecapForDay({
+        ai: { body: "fresh", kind: "ai" },
+        deterministic: { body: "x", kind: "weird" } as never,
+      }),
+    /unknown recap source kind/,
+  );
 });

--- a/packages/remnic-core/src/activity/timeline/recap-fallback.test.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-fallback.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectRecapForDay } from "./recap-fallback.js";
+
+test("ai wins when present, body returned verbatim", () => {
+  const result = selectRecapForDay({
+    ai: { body: "  AI recap  ", kind: "ai" },
+    previous: { body: "stored journal", kind: "previous" },
+    deterministic: { body: "deterministic render", kind: "deterministic" },
+  });
+  assert.deepEqual(result, { ok: true, body: "  AI recap  ", kind: "ai" });
+});
+
+test("provider failure with a stored previous returns the previous body and carries the failure", () => {
+  const result = selectRecapForDay({
+    previous: { body: "stored journal", kind: "previous" },
+    deterministic: { body: "deterministic render", kind: "deterministic" },
+    failure: "provider_unavailable",
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    body: "stored journal",
+    kind: "previous",
+    failure: "provider_unavailable",
+  });
+});
+
+test("failure with no previous falls to deterministic and still carries the failure", () => {
+  const result = selectRecapForDay({
+    deterministic: { body: "deterministic render", kind: "deterministic" },
+    failure: "timeout",
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    body: "deterministic render",
+    kind: "deterministic",
+    failure: "timeout",
+  });
+});
+
+test("blank ai body falls through to previous", () => {
+  const result = selectRecapForDay({
+    ai: { body: "   ", kind: "ai" },
+    previous: { body: "stored journal", kind: "previous" },
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    body: "stored journal",
+    kind: "previous",
+  });
+});
+
+test("blank previous falls through to deterministic", () => {
+  const result = selectRecapForDay({
+    previous: { body: "", kind: "previous" },
+    deterministic: { body: "deterministic render", kind: "deterministic" },
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    body: "deterministic render",
+    kind: "deterministic",
+  });
+});
+
+test("all candidates absent gives no_recap_available without failure key", () => {
+  const result = selectRecapForDay({});
+  assert.deepEqual(result, { ok: false, error: "no_recap_available" });
+  assert.ok(!("failure" in result));
+});
+
+test("all candidates blank with a failure reports the failure", () => {
+  const result = selectRecapForDay({
+    ai: { body: " ", kind: "ai" },
+    deterministic: { body: "", kind: "deterministic" },
+    failure: "malformed_json",
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: "no_recap_available",
+    failure: "malformed_json",
+  });
+});
+
+test("a mislabelled candidate throws", () => {
+  assert.throws(
+    () =>
+      selectRecapForDay({
+        previous: { body: "stored journal", kind: "ai" },
+      }),
+    /kind/,
+  );
+});
+
+test("an unknown kind throws and lists the allow-list", () => {
+  assert.throws(
+    () =>
+      selectRecapForDay({
+        // @ts-expect-error deliberately invalid kind
+        ai: { body: "AI recap", kind: "carrier-pigeon" },
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof TypeError);
+      assert.match(String(error), /kind/);
+      assert.match(String(error), /ai, deterministic, previous/);
+      return true;
+    },
+  );
+});
+
+test("blank failure is omitted from the result object", () => {
+  const result = selectRecapForDay({
+    deterministic: { body: "deterministic render", kind: "deterministic" },
+    failure: "   ",
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    body: "deterministic render",
+    kind: "deterministic",
+  });
+  assert.ok(!("failure" in result));
+
+  const none = selectRecapForDay({
+    failure: null,
+  });
+  assert.ok(!("failure" in none));
+});
+
+test("input is not mutated", () => {
+  const input = {
+    ai: { body: "  AI recap  ", kind: "ai" },
+    previous: { body: "stored journal", kind: "previous" },
+    deterministic: { body: "deterministic render", kind: "deterministic" },
+    failure: "rate_limited",
+  } as const;
+  const snapshot = structuredClone(input);
+  selectRecapForDay(input);
+  assert.deepEqual(input, snapshot);
+});

--- a/packages/remnic-core/src/activity/timeline/recap-fallback.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-fallback.ts
@@ -1,0 +1,89 @@
+/**
+ * Fallback selection for the daily journal recap (issue #2051).
+ *
+ * Picks the journal body in precedence order: AI render, then the last stored
+ * journal, then the deterministic render. A blank body at any level falls
+ * through to the next one, so a provider failure never replaces a stored good
+ * journal with a thinner deterministic render. This function takes no card
+ * list and performs no writes, so discarding deterministic source cards is not
+ * something it can do; storage callers own that decision.
+ *
+ * Pure: no I/O, no clock. Does not mutate its input. Internal helper; wiring
+ * into the recap build path is a later slice.
+ */
+
+export const RECAP_SOURCE_KINDS = ["ai", "deterministic", "previous"] as const;
+export type RecapSourceKind = (typeof RECAP_SOURCE_KINDS)[number];
+
+export interface RecapCandidate {
+  /** Rendered journal body. */
+  body: string;
+  kind: RecapSourceKind;
+}
+
+export type RecapSelection =
+  | { ok: true; body: string; kind: RecapSourceKind; failure?: string }
+  | { ok: false; error: "no_recap_available"; failure?: string };
+
+const SLOT_ORDER: readonly RecapSourceKind[] = [
+  "ai",
+  "previous",
+  "deterministic",
+];
+
+function isRecapSourceKind(value: unknown): value is RecapSourceKind {
+  return (
+    typeof value === "string" &&
+    (RECAP_SOURCE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/** Select the journal body for one day. Throws TypeError on a bad kind. */
+export function selectRecapForDay(input: {
+  /** Present only when the AI run succeeded and validated. */
+  ai?: RecapCandidate | null;
+  /** Always available when cards exist: the deterministic render. */
+  deterministic?: RecapCandidate | null;
+  /** The last valid stored journal for this day, if any. */
+  previous?: RecapCandidate | null;
+  /** Typed failure kind from a provider error, when one occurred. */
+  failure?: string | null;
+}): RecapSelection {
+  const failure =
+    typeof input.failure === "string" && input.failure.trim() !== ""
+      ? input.failure
+      : undefined;
+
+  for (const slot of SLOT_ORDER) {
+    const candidate = input[slot];
+    if (candidate == null) continue;
+
+    const kind = candidate.kind;
+    if (!isRecapSourceKind(kind)) {
+      throw new TypeError(
+        `unknown recap source kind: ${String(kind)}; allowed kinds: ${RECAP_SOURCE_KINDS.join(", ")}`,
+      );
+    }
+    if (kind !== slot) {
+      throw new TypeError(
+        `recap candidate passed as "${slot}" has kind "${kind}"; kind must match its slot`,
+      );
+    }
+
+    const body = candidate.body;
+    if (typeof body !== "string") {
+      throw new TypeError(
+        `recap candidate body for slot "${slot}" must be a string`,
+      );
+    }
+    if (body.trim() === "") continue;
+
+    return failure === undefined
+      ? { ok: true, body, kind }
+      : { ok: true, body, kind, failure };
+  }
+
+  return failure === undefined
+    ? { ok: false, error: "no_recap_available" }
+    : { ok: false, error: "no_recap_available", failure };
+}

--- a/packages/remnic-core/src/activity/timeline/recap-fallback.ts
+++ b/packages/remnic-core/src/activity/timeline/recap-fallback.ts
@@ -12,6 +12,8 @@
  * into the recap build path is a later slice.
  */
 
+import { isAnalysisFailureKind } from "./analysis-failure.js";
+
 export const RECAP_SOURCE_KINDS = ["ai", "deterministic", "previous"] as const;
 export type RecapSourceKind = (typeof RECAP_SOURCE_KINDS)[number];
 
@@ -46,14 +48,27 @@ export function selectRecapForDay(input: {
   deterministic?: RecapCandidate | null;
   /** The last valid stored journal for this day, if any. */
   previous?: RecapCandidate | null;
-  /** Typed failure kind from a provider error, when one occurred. */
+  /**
+   * Typed failure kind from a provider error, when one occurred. Validated
+   * against the analysis-failure allow-list: an arbitrary string here would
+   * flow into telemetry and downstream exhaustive handling as though it were
+   * a known kind, so a misspelled "timeot" is refused instead of echoed.
+   */
   failure?: string | null;
 }): RecapSelection {
-  const failure =
-    typeof input.failure === "string" && input.failure.trim() !== ""
-      ? input.failure
-      : undefined;
+  let failure: string | undefined;
+  if (input.failure !== undefined && input.failure !== null) {
+    if (!isAnalysisFailureKind(input.failure)) {
+      throw new TypeError(
+        `unknown recap failure kind; expected one of the analysis failure kinds, got a non-allow-listed value`,
+      );
+    }
+    failure = input.failure;
+  }
 
+  // Validate every supplied candidate FIRST. Returning on the first valid
+  // body would let a malformed lower-priority candidate hide behind a valid
+  // higher-priority one, so the kind contract would hold only sometimes.
   for (const slot of SLOT_ORDER) {
     const candidate = input[slot];
     if (candidate == null) continue;
@@ -69,18 +84,20 @@ export function selectRecapForDay(input: {
         `recap candidate passed as "${slot}" has kind "${kind}"; kind must match its slot`,
       );
     }
-
-    const body = candidate.body;
-    if (typeof body !== "string") {
+    if (typeof candidate.body !== "string") {
       throw new TypeError(
         `recap candidate body for slot "${slot}" must be a string`,
       );
     }
-    if (body.trim() === "") continue;
+  }
 
+  for (const slot of SLOT_ORDER) {
+    const candidate = input[slot];
+    if (candidate == null) continue;
+    if (candidate.body.trim() === "") continue;
     return failure === undefined
-      ? { ok: true, body, kind }
-      : { ok: true, body, kind, failure };
+      ? { ok: true, body: candidate.body, kind: candidate.kind }
+      : { ok: true, body: candidate.body, kind: candidate.kind, failure };
   }
 
   return failure === undefined


### PR DESCRIPTION
## Summary

Implements #2051's failure rule: "A provider failure retains the last valid journal and exposes a typed error; it must not delete the deterministic source cards."

`selectRecapForDay` picks `ai` → `previous` → `deterministic`. The middle step is the point: when the AI run fails, a previously stored good journal outranks a thinner deterministic re-render, which is what "retains the last valid journal" means. The typed failure string is carried onto the result **even on the success path**, so a caller that fell back to `previous` can still surface why.

A blank body does not count as available at any precedence level, a candidate mislabelled for the slot it arrived in throws rather than corrupting reported provenance, and an unknown `kind` throws instead of defaulting.

On the "must not delete cards" half: this module takes no card list and performs no I/O, so discarding cards is not something it can do. The header says exactly that rather than claiming it protects them.

Part of #2051 (selector only; regeneration wiring is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/timeline/recap-fallback.test.ts` — 11/11
- Covers the failure-with-previous path carrying the error, blank bodies falling through, `no_recap_available`, mislabelled and unknown kinds, and the omitted-blank-failure key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recap selection for daily activity timelines, prioritizing AI-generated, previous, and deterministic journal entries.
  - Blank or invalid entries are skipped, with a clear unavailable result when no usable recap exists.
  - Recap selection is now available through the timeline package’s public interface.

- **Bug Fixes**
  - Improved handling of provider failures and invalid recap data without disrupting selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->