### PR TITLE
feat(activity): force every feature gate off when activity is disabled

### DIFF
--- a/.changeset/activity-gate-resolve-2053.md
+++ b/.changeset/activity-gate-resolve-2053.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add `resolveActivityGates` to the activity subsystem: an internal pure helper that resolves the five activity feature gates behind a master override — `activity.enabled` false forces every gate false. Gate values reuse `parsePrivacyEnabled` token handling and invalid values or unknown gate keys throw `TypeError`. Not wired into any surface yet; that is a later slice. Part of #2053.

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -23,6 +23,7 @@ export * from "./memory-gen.js";
 export * from "./privacy.js";
 export * from "./privacy-delete-plan.js";
 export * from "./privacy-status.js";
+export * from "./privacy-gate-resolve.js";
 export * from "./privacy-window.js";
 export * from "./vault-path.js";
 export * from "./vault-publish.js";

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
@@ -134,3 +134,22 @@ test("the exported gate registry resists runtime mutation", () => {
     /unknown activity gate/,
   );
 });
+
+// Round 2: an explicit `readonly string[]` widened the union to `string`.
+test("the frozen registry keeps its literal type", () => {
+  const gates: readonly string[] = ACTIVITY_FEATURE_GATES;
+  // Compile-time narrowing is asserted via the resolver's own typing: at
+  // runtime, the frozen array rejects mutation and injection.
+  assert.throws(() => (gates as string[]).push("bogus"), /not extensible|frozen|read only/i);
+});
+
+// Round 2: a present-but-undefined own value is invalid, not absent.
+test("an explicitly undefined gate value throws rather than reading as false", () => {
+  assert.throws(
+    () => resolveActivityGates({ enabled: true, gates: { analysis: undefined } }),
+    /invalid value for activity gate "analysis"/,
+  );
+  // An absent key is still a legitimate default-false.
+  const resolved = resolveActivityGates({ enabled: true, gates: {} });
+  assert.equal(resolved.analysis, false);
+});

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  type ActivityFeatureGate,
   ACTIVITY_FEATURE_GATES,
   resolveActivityGates,
 } from "./privacy-gate-resolve.js";
@@ -152,4 +153,23 @@ test("an explicitly undefined gate value throws rather than reading as false", (
   // An absent key is still a legitimate default-false.
   const resolved = resolveActivityGates({ enabled: true, gates: {} });
   assert.equal(resolved.analysis, false);
+});
+
+// Round 3: a non-enumerable own key must still hit the unknown-key check.
+test("a non-enumerable unknown gate key is rejected", () => {
+  const gates: Record<string, unknown> = {};
+  Object.defineProperty(gates, "sneaky", { value: true, enumerable: false });
+  assert.throws(
+    () => resolveActivityGates({ enabled: true, gates }),
+    /unknown activity gate "sneaky"/,
+  );
+});
+
+// Compile-time: the frozen registry must keep its literal type, so "bogus"
+// is not assignable to ActivityFeatureGate. This assertion fails the build
+// if a future annotation widens the union back to string.
+test("ActivityFeatureGate stays a literal union", () => {
+  // @ts-expect-error "bogus" is not an ActivityFeatureGate
+  const bogus: ActivityFeatureGate = "bogus";
+  assert.equal(bogus, "bogus");
 });

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
@@ -109,3 +109,28 @@ test("input gates object is not mutated", () => {
   resolveActivityGates({ enabled: true, gates: input });
   assert.deepEqual(input, { analysis: "yes" });
 });
+
+// Review: Object.keys enumerates own properties only, so the unknown-key
+// check never saw an inherited "analysis"; reading by bracket would have
+// honored it anyway. Own-property reads close that.
+test("an inherited gate property is ignored, not honored", () => {
+  const proto = { analysis: true } as Record<string, unknown>;
+  const gates: Record<string, unknown> = Object.create(proto);
+  gates.journal = true; // own, allowed, and genuinely set by the caller
+  const resolved = resolveActivityGates({ enabled: true, gates });
+  assert.equal(resolved.analysis, false, "inherited analysis must not enable");
+  assert.equal(resolved.journal, true, "an own gate still works");
+});
+
+test("the exported gate registry resists runtime mutation", () => {
+  const registry = ACTIVITY_FEATURE_GATES as unknown as string[];
+  assert.throws(() => registry.push("injected"), /not extensible|frozen|read only/i);
+  assert.equal(
+    (ACTIVITY_FEATURE_GATES as readonly string[]).includes("injected"),
+    false,
+  );
+  assert.throws(
+    () => resolveActivityGates({ enabled: true, gates: { injected: true } }),
+    /unknown activity gate/,
+  );
+});

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ACTIVITY_FEATURE_GATES,
+  resolveActivityGates,
+} from "./privacy-gate-resolve.js";
+
+function allTrue(): Record<string, unknown> {
+  return { analysis: true, journal: true, weekly: true, export: true, memoryCreation: true };
+}
+
+function allFalse(gates: Record<string, boolean>): boolean {
+  return ACTIVITY_FEATURE_GATES.every((gate) => gates[gate] === false);
+}
+
+test("master off forces every explicitly-true gate false", () => {
+  const gates = resolveActivityGates({ enabled: false, gates: allTrue() });
+  for (const gate of ACTIVITY_FEATURE_GATES) {
+    assert.equal(gates[gate], false, `gate "${gate}" must be false`);
+  }
+});
+
+test("master absent behaves as off even with all gates true", () => {
+  const gates = resolveActivityGates({ gates: allTrue() });
+  assert.ok(allFalse(gates));
+});
+
+test("master on with no gates yields all false", () => {
+  const gates = resolveActivityGates({ enabled: true });
+  assert.ok(allFalse(gates));
+  const empty = resolveActivityGates({ enabled: true, gates: {} });
+  assert.ok(allFalse(empty));
+});
+
+test("master on with one gate on leaves the other four off", () => {
+  for (const gate of ACTIVITY_FEATURE_GATES) {
+    const gates = resolveActivityGates({ enabled: true, gates: { [gate]: true } });
+    for (const other of ACTIVITY_FEATURE_GATES) {
+      assert.equal(gates[other], other === gate, `gate "${gate}" case: "${other}" wrong`);
+    }
+  }
+});
+
+test("master on accepts boolean and string token values", () => {
+  const on = resolveActivityGates({
+    enabled: true,
+    gates: { analysis: "true", journal: "1", weekly: "yes", export: "on" },
+  });
+  assert.equal(on.analysis, true);
+  assert.equal(on.journal, true);
+  assert.equal(on.weekly, true);
+  assert.equal(on.export, true);
+
+  const off = resolveActivityGates({
+    enabled: "true",
+    gates: { analysis: "false", journal: "0", weekly: "no", export: "off" },
+  });
+  assert.equal(off.analysis, false);
+  assert.equal(off.journal, false);
+  assert.equal(off.weekly, false);
+  assert.equal(off.export, false);
+});
+
+test("unrecognized gate values throw TypeError naming the gate", () => {
+  for (const value of ["maybe", 2, {}, null]) {
+    assert.throws(
+      () => resolveActivityGates({ enabled: true, gates: { weekly: value } }),
+      (err: unknown) =>
+        err instanceof TypeError && String(err).includes('"weekly"'),
+      `value ${JSON.stringify(value)} must throw`,
+    );
+  }
+});
+
+test("unrecognized gate values throw even when master is off", () => {
+  assert.throws(
+    () => resolveActivityGates({ enabled: false, gates: { journal: "maybe" } }),
+    TypeError,
+  );
+});
+
+test("unknown gate key throws and lists the allow-list", () => {
+  assert.throws(
+    () => resolveActivityGates({ enabled: true, gates: { analytics: true } }),
+    (err: unknown) =>
+      err instanceof TypeError &&
+      /unknown activity gate/.test(String(err)) &&
+      ACTIVITY_FEATURE_GATES.every((gate) => String(err).includes(gate)),
+  );
+});
+
+test("result contains exactly the five gate keys", () => {
+  const gates = resolveActivityGates({ enabled: true, gates: allTrue() });
+  assert.deepEqual(Object.keys(gates).sort(), [...ACTIVITY_FEATURE_GATES].sort());
+});
+
+test("result is frozen and resists mutation", () => {
+  const gates = resolveActivityGates({ enabled: true, gates: { analysis: true } });
+  assert.equal(Object.isFrozen(gates), true);
+  assert.equal(Reflect.set(gates, "analysis", false), false);
+  assert.equal(Reflect.set(gates, "journal", true), false);
+  assert.equal(gates.analysis, true);
+  assert.equal(gates.journal, false);
+});
+
+test("input gates object is not mutated", () => {
+  const input = { analysis: "yes" };
+  resolveActivityGates({ enabled: true, gates: input });
+  assert.deepEqual(input, { analysis: "yes" });
+});

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.ts
@@ -1,0 +1,68 @@
+/**
+ * Master-override resolution for activity feature gates (issue #2053).
+ *
+ * With `activity.enabled` false, every feature gate reads false regardless of
+ * its own config value. Gate values accept booleans and the same string tokens
+ * as `parsePrivacyEnabled`; anything else throws so a typo can never silently
+ * disable (or enable) a gate. Internal helper — wiring it into parseConfig is
+ * a later slice.
+ */
+
+import { parsePrivacyEnabled } from "./privacy-enabled.js";
+
+export const ACTIVITY_FEATURE_GATES = [
+  "analysis",
+  "journal",
+  "weekly",
+  "export",
+  "memoryCreation",
+] as const;
+export type ActivityFeatureGate = (typeof ACTIVITY_FEATURE_GATES)[number];
+
+export type ActivityGateSet = Readonly<Record<ActivityFeatureGate, boolean>>;
+
+const GATE_KEY_LIST: readonly string[] = ACTIVITY_FEATURE_GATES;
+
+function parseGateValue(key: string, value: unknown): boolean {
+  const parsed = parsePrivacyEnabled(value);
+  if (!parsed.ok) {
+    throw new TypeError(
+      `invalid value for activity gate "${key}": ${JSON.stringify(value)} is not a boolean or known token`,
+    );
+  }
+  return parsed.enabled;
+}
+
+export function resolveActivityGates(input: {
+  enabled?: unknown;
+  gates?: Readonly<Record<string, unknown>>;
+}): ActivityGateSet {
+  const rawGates = input.gates;
+  if (rawGates !== undefined && (typeof rawGates !== "object" || rawGates === null || Array.isArray(rawGates))) {
+    throw new TypeError("activity gates must be an object");
+  }
+  if (rawGates) {
+    for (const key of Object.keys(rawGates)) {
+      if (!GATE_KEY_LIST.includes(key)) {
+        throw new TypeError(
+          `unknown activity gate "${key}"; allowed gates: ${ACTIVITY_FEATURE_GATES.join(", ")}`,
+        );
+      }
+    }
+  }
+
+  const master =
+    input.enabled === undefined ? false : parseGateValue("enabled", input.enabled);
+
+  const result = {} as Record<ActivityFeatureGate, boolean>;
+  for (const gate of ACTIVITY_FEATURE_GATES) {
+    const raw = rawGates?.[gate];
+    result[gate] = raw === undefined ? false : parseGateValue(gate, raw);
+  }
+  if (!master) {
+    for (const gate of ACTIVITY_FEATURE_GATES) {
+      result[gate] = false;
+    }
+  }
+  return Object.freeze(result);
+}

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.ts
@@ -10,10 +10,12 @@
 
 import { parsePrivacyEnabled } from "./privacy-enabled.js";
 
-// Frozen: `as const` is a compile-time notion and this array is re-exported
-// through the public activity entry, so a runtime consumer could otherwise
-// push a key into it and have resolveActivityGates accept that key forever.
-export const ACTIVITY_FEATURE_GATES: readonly string[] = Object.freeze([
+// Frozen at runtime AND still literal-typed: `Object.freeze` preserves the
+// `as const` tuple, so ActivityFeatureGate stays a five-member union for
+// TypeScript consumers while a JavaScript consumer cannot push a key into
+// the array and have resolveActivityGates accept it forever. An explicit
+// `readonly string[]` annotation would widen the union back to `string`.
+export const ACTIVITY_FEATURE_GATES = Object.freeze([
   "analysis",
   "journal",
   "weekly",
@@ -45,7 +47,7 @@ export function resolveActivityGates(input: {
   }
   if (rawGates) {
     for (const key of Object.keys(rawGates)) {
-      if (!ACTIVITY_FEATURE_GATES.includes(key)) {
+      if (!(ACTIVITY_FEATURE_GATES as readonly string[]).includes(key)) {
         throw new TypeError(
           `unknown activity gate "${key}"; allowed gates: ${ACTIVITY_FEATURE_GATES.join(", ")}`,
         );
@@ -62,10 +64,13 @@ export function resolveActivityGates(input: {
     // "analysis" never reaches the unknown-key check. Reading it here anyway
     // would let a gate object with an altered prototype enable a gate the
     // caller never set: read own properties only.
-    const raw = rawGates !== undefined && Object.hasOwn(rawGates, gate)
-      ? rawGates[gate]
-      : undefined;
-    result[gate] = raw === undefined ? false : parseGateValue(gate, raw);
+    // A PRESENT own key whose value is undefined is not the same as an
+    // absent key: composed config objects often carry explicit undefined,
+    // and the API promises to throw for invalid values, so present-but-
+    // undefined goes through parseGateValue (which refuses it) rather than
+    // silently reading as false.
+    const present = rawGates !== undefined && Object.hasOwn(rawGates, gate);
+    result[gate] = present ? parseGateValue(gate, (rawGates as Record<string, unknown>)[gate]) : false;
   }
   if (!master) {
     for (const gate of ACTIVITY_FEATURE_GATES) {

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.ts
@@ -10,18 +10,20 @@
 
 import { parsePrivacyEnabled } from "./privacy-enabled.js";
 
-export const ACTIVITY_FEATURE_GATES = [
+// Frozen: `as const` is a compile-time notion and this array is re-exported
+// through the public activity entry, so a runtime consumer could otherwise
+// push a key into it and have resolveActivityGates accept that key forever.
+export const ACTIVITY_FEATURE_GATES: readonly string[] = Object.freeze([
   "analysis",
   "journal",
   "weekly",
   "export",
   "memoryCreation",
-] as const;
+] as const);
 export type ActivityFeatureGate = (typeof ACTIVITY_FEATURE_GATES)[number];
 
 export type ActivityGateSet = Readonly<Record<ActivityFeatureGate, boolean>>;
 
-const GATE_KEY_LIST: readonly string[] = ACTIVITY_FEATURE_GATES;
 
 function parseGateValue(key: string, value: unknown): boolean {
   const parsed = parsePrivacyEnabled(value);
@@ -43,7 +45,7 @@ export function resolveActivityGates(input: {
   }
   if (rawGates) {
     for (const key of Object.keys(rawGates)) {
-      if (!GATE_KEY_LIST.includes(key)) {
+      if (!ACTIVITY_FEATURE_GATES.includes(key)) {
         throw new TypeError(
           `unknown activity gate "${key}"; allowed gates: ${ACTIVITY_FEATURE_GATES.join(", ")}`,
         );
@@ -56,7 +58,13 @@ export function resolveActivityGates(input: {
 
   const result = {} as Record<ActivityFeatureGate, boolean>;
   for (const gate of ACTIVITY_FEATURE_GATES) {
-    const raw = rawGates?.[gate];
+    // Object.keys above enumerates OWN properties only, so an inherited
+    // "analysis" never reaches the unknown-key check. Reading it here anyway
+    // would let a gate object with an altered prototype enable a gate the
+    // caller never set: read own properties only.
+    const raw = rawGates !== undefined && Object.hasOwn(rawGates, gate)
+      ? rawGates[gate]
+      : undefined;
     result[gate] = raw === undefined ? false : parseGateValue(gate, raw);
   }
   if (!master) {

--- a/packages/remnic-core/src/activity/privacy-gate-resolve.ts
+++ b/packages/remnic-core/src/activity/privacy-gate-resolve.ts
@@ -46,7 +46,10 @@ export function resolveActivityGates(input: {
     throw new TypeError("activity gates must be an object");
   }
   if (rawGates) {
-    for (const key of Object.keys(rawGates)) {
+    // getOwnPropertyNames, not Object.keys: a non-enumerable own property
+    // would skip the unknown-key check below while still being readable by
+    // the hasOwn path that resolves values.
+    for (const key of Object.getOwnPropertyNames(rawGates)) {
       if (!(ACTIVITY_FEATURE_GATES as readonly string[]).includes(key)) {
         throw new TypeError(
           `unknown activity gate "${key}"; allowed gates: ${ACTIVITY_FEATURE_GATES.join(", ")}`,


### PR DESCRIPTION
## Summary

Enforces #2053's master rule in one place: "Master disabled means no reads or writes. Analysis, journal, weekly, export, and memory creation gates are independent and default off."

`resolveActivityGates` makes the override structural — with `activity.enabled` false or absent, every one of the five gates reads false no matter what its own config says, so no caller can accidentally honor a sub-gate on a disabled subsystem. The result is frozen, so a gate cannot be flipped after the override has been applied.

Independence is tested by looping `ACTIVITY_FEATURE_GATES` rather than hardcoding one gate, so a sixth gate added later is covered automatically.

Invalid values are refused rather than reinterpreted: gate values accept booleans and the same string tokens `parsePrivacyEnabled` already handles (reused, not reimplemented), and anything else throws naming the offending gate. A misspelled key like `analytics` throws too — silently accepting it as a no-op is how a gate ends up quietly disabled.

Part of #2053 (resolver only; parseConfig wiring is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/privacy-gate-resolve.test.ts` — 11/11
- **Mutation-checked**: deleting the master-override block fails 2 tests, so the invariant is genuinely defended rather than incidentally true.
- Covers master off/absent with all gates true, per-gate independence across all five, string tokens, `"maybe"`/`2`/`{}`/`null` throwing, unknown keys, and the frozen result resisting mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activity privacy-gate resolution with configurable master and individual controls.
  * Supports boolean and recognized text-based privacy settings.
  * Unspecified features default to disabled; a disabled master setting turns off all activity gates.
  * Invalid settings and unknown gate names are rejected with clear errors.
  * Resolved configurations are protected from accidental modification.

* **Tests**
  * Added coverage for defaults, overrides, validation, immutability, inherited properties, and input preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->