### PR TITLE
feat(recall): select traverse neighbors by relation with a deterministic cap

### DIFF
--- a/.changeset/1956-traverse-selection.md
+++ b/.changeset/1956-traverse-selection.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add an internal pure selection helper for recall traverse (`selectTraverseNeighbors`): filter a recalled memory's typed frontmatter links by relation, skip unknown link types and blank or duplicate targets, sort deterministically, and cap with a validated limit. Not wired to any surface yet; wiring is a later slice. Part of #1956.

--- a/packages/remnic-core/src/recall-navigate-link.test.ts
+++ b/packages/remnic-core/src/recall-navigate-link.test.ts
@@ -3,17 +3,22 @@ import test from "node:test";
 
 import { parseNavigateLinkType } from "./recall-navigate-link.js";
 
-test("parses each allowed link type", () => {
-  for (const type of ["supports", "contradicts", "elaborates", "causes", "caused_by"] as const) {
+test("every navigation relation parses", () => {
+  for (const type of ["supports", "contradicts", "elaborates", "causes", "caused_by"]) {
     assert.deepEqual(parseNavigateLinkType(type), { ok: true, type });
   }
 });
 
-test("unknown link is unknown_link", () => {
-  assert.deepEqual(parseNavigateLinkType("supersedes"), { ok: false, error: "unknown_link" });
-  assert.deepEqual(parseNavigateLinkType("related"), { ok: false, error: "unknown_link" });
+// Persisted MemoryLinkType values must parse too: real frontmatter carries
+// them, and a traversal over stored links loses those neighbors otherwise.
+test("persisted MemoryLinkType values parse", () => {
+  for (const type of ["follows", "references", "related"]) {
+    assert.deepEqual(parseNavigateLinkType(type), { ok: true, type });
+  }
 });
 
-test("empty link is unknown_link", () => {
+test("unknown or empty link types are refused", () => {
+  assert.deepEqual(parseNavigateLinkType("supersedes"), { ok: false, error: "unknown_link" });
   assert.deepEqual(parseNavigateLinkType(""), { ok: false, error: "unknown_link" });
+  assert.deepEqual(parseNavigateLinkType("Supports"), { ok: false, error: "unknown_link" });
 });

--- a/packages/remnic-core/src/recall-navigate-link.test.ts
+++ b/packages/remnic-core/src/recall-navigate-link.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { parseNavigateLinkType } from "./recall-navigate-link.js";
+import { selectTraverseNeighbors } from "./recall-navigate-traverse.js";
 
 test("every navigation relation parses", () => {
   for (const type of ["supports", "contradicts", "elaborates", "causes", "caused_by"]) {
@@ -18,7 +19,23 @@ test("persisted MemoryLinkType values parse", () => {
 });
 
 test("unknown or empty link types are refused", () => {
-  assert.deepEqual(parseNavigateLinkType("supersedes"), { ok: false, error: "unknown_link" });
+  assert.deepEqual(parseNavigateLinkType("supersedesX"), { ok: false, error: "unknown_link" });
   assert.deepEqual(parseNavigateLinkType(""), { ok: false, error: "unknown_link" });
   assert.deepEqual(parseNavigateLinkType("Supports"), { ok: false, error: "unknown_link" });
+});
+
+
+// Round 3: the stepper's navigation contract accepts supersedes, so the
+// shared selector vocabulary must too.
+test("supersedes parses and filters", () => {
+  assert.deepEqual(parseNavigateLinkType("supersedes"), { ok: true, type: "supersedes" });
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-1", linkType: "supersedes" },
+      { targetId: "m-2", linkType: "supports" },
+    ],
+    relation: "supersedes",
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [{ targetId: "m-1", linkType: "supersedes" }]);
 });

--- a/packages/remnic-core/src/recall-navigate-link.ts
+++ b/packages/remnic-core/src/recall-navigate-link.ts
@@ -1,7 +1,13 @@
 /**
- * Recall navigation link-type parse (issue #1956 leftover).
+ * Recall navigation link-type parse (issue #1956).
  *
- * Pure. Surfaces wait. Unknown or empty is unknown_link.
+ * One allow-list covering BOTH vocabularies a traversal can meet:
+ * the navigation set this module originally defined and the persisted
+ * `MemoryLinkType` values (`follows | references | related`) that real
+ * memory frontmatter carries. Review found the narrower list silently
+ * dropped every persisted `follows`/`references`/`related` edge and
+ * rejected `relation: "related"` as unknown — a traversal over actual
+ * stored links would lose valid neighbors. Surfaces wait.
  */
 
 const NAVIGATE_LINK_TYPES = [
@@ -10,6 +16,10 @@ const NAVIGATE_LINK_TYPES = [
   "elaborates",
   "causes",
   "caused_by",
+  // Persisted MemoryLinkType values (types.ts) that real frontmatter carries.
+  "follows",
+  "references",
+  "related",
 ] as const;
 
 export type NavigateLinkType = (typeof NAVIGATE_LINK_TYPES)[number];

--- a/packages/remnic-core/src/recall-navigate-link.ts
+++ b/packages/remnic-core/src/recall-navigate-link.ts
@@ -20,6 +20,10 @@ const NAVIGATE_LINK_TYPES = [
   "follows",
   "references",
   "related",
+  // The stepper's own navigation contract (recall-navigate.ts) accepts
+  // supersedes; omitting it here would reject a relation that surface is
+  // prepared to handle.
+  "supersedes",
 ] as const;
 
 export type NavigateLinkType = (typeof NAVIGATE_LINK_TYPES)[number];

--- a/packages/remnic-core/src/recall-navigate-traverse.test.ts
+++ b/packages/remnic-core/src/recall-navigate-traverse.test.ts
@@ -165,3 +165,56 @@ test("inputs are not mutated", () => {
     { targetId: "m-1", linkType: "causes" },
   ]);
 });
+
+// Review: the contract said bad stored data is skipped, but a nullish
+// targetId threw before the skip checks could run.
+test("a nullish or non-string targetId is skipped, never thrown", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: undefined as unknown as string, linkType: "supports" },
+      { targetId: null as unknown as string, linkType: "supports" },
+      { targetId: 42 as unknown as string, linkType: "supports" },
+      { targetId: "m-real", linkType: "supports" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [{ targetId: "m-real", linkType: "supports" }]);
+});
+
+// A padded id is malformed, not a variant of the trimmed id: trimming would
+// guess at an identity, so the row is skipped.
+test("a whitespace-padded targetId is skipped rather than trimmed", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: " m-1", linkType: "supports" },
+      { targetId: "m-2", linkType: "supports" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [{ targetId: "m-2", linkType: "supports" }]);
+});
+
+// Review: dedup ran before sorting, so input order decided which relation
+// survived for a doubly-linked target. Sorting first fixes the survivor.
+test("a target under two relations keeps the smallest linkType regardless of input order", () => {
+  const a = { targetId: "m-1", linkType: "supports" };
+  const b = { targetId: "m-1", linkType: "contradicts" };
+  const forward = selectTraverseNeighbors({ links: [a, b] });
+  const reversed = selectTraverseNeighbors({ links: [b, a] });
+  assert.ok(forward.ok && reversed.ok);
+  assert.deepEqual(forward.neighbors, reversed.neighbors);
+  assert.deepEqual(forward.neighbors, [{ targetId: "m-1", linkType: "contradicts" }]);
+});
+
+test("sort-then-dedup also decides which target survives a tight limit", () => {
+  const links = [
+    { targetId: "m-z", linkType: "supports" },
+    { targetId: "m-a", linkType: "supports" },
+    { targetId: "m-a", linkType: "elaborates" },
+  ];
+  const shuffled = selectTraverseNeighbors({ links: [...links].reverse(), limit: 1 });
+  const straight = selectTraverseNeighbors({ links, limit: 1 });
+  assert.ok(shuffled.ok && straight.ok);
+  assert.deepEqual(shuffled.neighbors, straight.neighbors);
+  assert.deepEqual(straight.neighbors, [{ targetId: "m-a", linkType: "elaborates" }]);
+});

--- a/packages/remnic-core/src/recall-navigate-traverse.test.ts
+++ b/packages/remnic-core/src/recall-navigate-traverse.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DEFAULT_TRAVERSE_LIMIT } from "./recall-navigate-traverse.js";
+import { selectTraverseNeighbors } from "./recall-navigate-traverse.js";
+
+test("no relation returns all known-type links sorted", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-3", linkType: "supports" },
+      { targetId: "m-1", linkType: "elaborates" },
+      { targetId: "m-2", linkType: "causes" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.equal(result.truncated, false);
+  assert.deepEqual(result.neighbors, [
+    { targetId: "m-2", linkType: "causes" },
+    { targetId: "m-1", linkType: "elaborates" },
+    { targetId: "m-3", linkType: "supports" },
+  ]);
+});
+
+test("relation filter returns only that relation", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-1", linkType: "supports" },
+      { targetId: "m-2", linkType: "contradicts" },
+      { targetId: "m-3", linkType: "supports" },
+    ],
+    relation: "supports",
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [
+    { targetId: "m-1", linkType: "supports" },
+    { targetId: "m-3", linkType: "supports" },
+  ]);
+});
+
+test("unknown relation is refused with unknown_relation", () => {
+  const result = selectTraverseNeighbors({
+    links: [{ targetId: "m-1", linkType: "supports" }],
+    relation: "destroys",
+  });
+  assert.deepEqual(result, { ok: false, error: "unknown_relation" });
+});
+
+test("unknown linkType link is skipped while siblings survive", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-1", linkType: "hyperlinks" },
+      { targetId: "m-2", linkType: "supports" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [{ targetId: "m-2", linkType: "supports" }]);
+});
+
+test("duplicate targetIds collapse to the first occurrence", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-1", linkType: "causes" },
+      { targetId: "m-1", linkType: "supports" },
+      { targetId: "m-2", linkType: "elaborates" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [
+    { targetId: "m-1", linkType: "causes" },
+    { targetId: "m-2", linkType: "elaborates" },
+  ]);
+});
+
+test("blank targetId is skipped", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "", linkType: "supports" },
+      { targetId: "  ", linkType: "supports" },
+      { targetId: "m-1", linkType: "supports" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [{ targetId: "m-1", linkType: "supports" }]);
+});
+
+test("limit truncates after sorting and sets truncated", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-9", linkType: "supports" },
+      { targetId: "m-2", linkType: "causes" },
+      { targetId: "m-5", linkType: "elaborates" },
+    ],
+    limit: 2,
+  });
+  assert.ok(result.ok);
+  assert.equal(result.truncated, true);
+  assert.deepEqual(result.neighbors, [
+    { targetId: "m-2", linkType: "causes" },
+    { targetId: "m-5", linkType: "elaborates" },
+  ]);
+});
+
+test("default limit caps at DEFAULT_TRAVERSE_LIMIT", () => {
+  const links = Array.from({ length: DEFAULT_TRAVERSE_LIMIT + 3 }, (_, i) => ({
+    targetId: `m-${i}`,
+    linkType: "supports",
+  }));
+  const result = selectTraverseNeighbors({ links });
+  assert.ok(result.ok);
+  assert.equal(result.truncated, true);
+  assert.equal(result.neighbors.length, DEFAULT_TRAVERSE_LIMIT);
+});
+
+test("limit 0 is invalid_limit", () => {
+  assert.deepEqual(
+    selectTraverseNeighbors({ links: [], limit: 0 }),
+    { ok: false, error: "invalid_limit" },
+  );
+});
+
+test("limit -1 is invalid_limit", () => {
+  assert.deepEqual(
+    selectTraverseNeighbors({ links: [], limit: -1 }),
+    { ok: false, error: "invalid_limit" },
+  );
+});
+
+test("limit 1.5 is invalid_limit", () => {
+  assert.deepEqual(
+    selectTraverseNeighbors({ links: [], limit: 1.5 }),
+    { ok: false, error: "invalid_limit" },
+  );
+});
+
+test("limit NaN is invalid_limit", () => {
+  assert.deepEqual(
+    selectTraverseNeighbors({ links: [], limit: Number.NaN }),
+    { ok: false, error: "invalid_limit" },
+  );
+});
+
+test("shuffled input is deep-equal to sorted-input result", () => {
+  const sorted = [
+    { targetId: "m-2", linkType: "caused_by" },
+    { targetId: "m-1", linkType: "causes" },
+    { targetId: "m-3", linkType: "elaborates" },
+    { targetId: "m-4", linkType: "supports" },
+  ];
+  const result = selectTraverseNeighbors({
+    links: [...sorted].reverse(),
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, sorted);
+  assert.deepEqual(selectTraverseNeighbors({ links: sorted }), result);
+});
+
+test("inputs are not mutated", () => {
+  const links = [
+    { targetId: "m-2", linkType: "supports" },
+    { targetId: "m-1", linkType: "causes" },
+  ];
+  selectTraverseNeighbors({ links, relation: "causes", limit: 1 });
+  assert.deepEqual(links, [
+    { targetId: "m-2", linkType: "supports" },
+    { targetId: "m-1", linkType: "causes" },
+  ]);
+});

--- a/packages/remnic-core/src/recall-navigate-traverse.test.ts
+++ b/packages/remnic-core/src/recall-navigate-traverse.test.ts
@@ -218,3 +218,30 @@ test("sort-then-dedup also decides which target survives a tight limit", () => {
   assert.deepEqual(shuffled.neighbors, straight.neighbors);
   assert.deepEqual(straight.neighbors, [{ targetId: "m-a", linkType: "elaborates" }]);
 });
+
+
+// Round 2: the persisted MemoryLinkType values are real neighbors, not
+// unknown rows to drop. The selector gets them from the widened parser.
+test("persisted link types survive an unfiltered traversal", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-1", linkType: "follows" },
+      { targetId: "m-2", linkType: "references" },
+      { targetId: "m-3", linkType: "related" },
+    ],
+  });
+  assert.ok(result.ok);
+  assert.equal(result.neighbors.length, 3);
+});
+
+test("relation: related is a valid filter, not unknown", () => {
+  const result = selectTraverseNeighbors({
+    links: [
+      { targetId: "m-1", linkType: "related" },
+      { targetId: "m-2", linkType: "supports" },
+    ],
+    relation: "related",
+  });
+  assert.ok(result.ok);
+  assert.deepEqual(result.neighbors, [{ targetId: "m-1", linkType: "related" }]);
+});

--- a/packages/remnic-core/src/recall-navigate-traverse.ts
+++ b/packages/remnic-core/src/recall-navigate-traverse.ts
@@ -1,0 +1,58 @@
+/**
+ * Recall navigation traverse selection (issue #1956).
+ *
+ * Pure selection step for `traverseLinks(id, relation?, limit)`: given a
+ * recalled memory's links, pick which neighbors a traverse would visit.
+ * Internal; surfaces wire it in a later slice.
+ */
+import { parseNavigateLinkType } from "./recall-navigate-link.js";
+
+export const DEFAULT_TRAVERSE_LIMIT = 10;
+
+export interface TraverseNeighbor {
+  targetId: string;
+  linkType: string;
+}
+
+export type TraverseSelectionResult =
+  | { ok: true; neighbors: TraverseNeighbor[]; truncated: boolean }
+  | { ok: false; error: "unknown_relation" | "invalid_limit" };
+
+export function selectTraverseNeighbors(input: {
+  links: readonly TraverseNeighbor[];
+  /** Optional relation filter; omitted means every known relation. */
+  relation?: string;
+  limit?: number;
+}): TraverseSelectionResult {
+  const limit = input.limit ?? DEFAULT_TRAVERSE_LIMIT;
+  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
+    return { ok: false, error: "invalid_limit" };
+  }
+  if (input.relation !== undefined && !parseNavigateLinkType(input.relation).ok) {
+    return { ok: false, error: "unknown_relation" };
+  }
+
+  const seen = new Set<string>();
+  const kept: TraverseNeighbor[] = [];
+  // Asymmetry is intentional: a bad request (unknown relation, invalid
+  // limit) is refused, but bad stored data (a link whose linkType is not a
+  // known type, or a blank targetId) is skipped — stored data may predate a
+  // type, and one bad row must not fail the whole traverse.
+  for (const link of input.links) {
+    if (!parseNavigateLinkType(link.linkType).ok) continue;
+    if (input.relation !== undefined && link.linkType !== input.relation) continue;
+    if (link.targetId.trim() === "") continue;
+    if (seen.has(link.targetId)) continue;
+    seen.add(link.targetId);
+    kept.push({ targetId: link.targetId, linkType: link.linkType });
+  }
+
+  kept.sort((a, b) => {
+    if (a.linkType !== b.linkType) return a.linkType < b.linkType ? -1 : 1;
+    if (a.targetId !== b.targetId) return a.targetId < b.targetId ? -1 : 1;
+    return 0;
+  });
+
+  const truncated = kept.length > limit;
+  return { ok: true, neighbors: truncated ? kept.slice(0, limit) : kept, truncated };
+}

--- a/packages/remnic-core/src/recall-navigate-traverse.ts
+++ b/packages/remnic-core/src/recall-navigate-traverse.ts
@@ -32,27 +32,42 @@ export function selectTraverseNeighbors(input: {
     return { ok: false, error: "unknown_relation" };
   }
 
-  const seen = new Set<string>();
   const kept: TraverseNeighbor[] = [];
   // Asymmetry is intentional: a bad request (unknown relation, invalid
-  // limit) is refused, but bad stored data (a link whose linkType is not a
-  // known type, or a blank targetId) is skipped — stored data may predate a
-  // type, and one bad row must not fail the whole traverse.
+  // limit) is refused, but bad stored data is skipped — stored data may
+  // predate a type or carry a malformed id, and one bad row must not fail
+  // the whole traverse. A targetId that is not a non-blank string, including
+  // undefined/null and whitespace-only, is malformed and skipped. Padded ids
+  // are NOT trimmed into validity: an id is an exact identity, and guessing
+  // the intended target is worse than skipping the row.
   for (const link of input.links) {
     if (!parseNavigateLinkType(link.linkType).ok) continue;
     if (input.relation !== undefined && link.linkType !== input.relation) continue;
-    if (link.targetId.trim() === "") continue;
-    if (seen.has(link.targetId)) continue;
-    seen.add(link.targetId);
+    if (typeof link.targetId !== "string" || link.targetId.trim() === "" || link.targetId.trim() !== link.targetId) {
+      continue;
+    }
     kept.push({ targetId: link.targetId, linkType: link.linkType });
   }
 
+  // Sort BEFORE deduplicating: first-occurrence dedup on an unsorted list
+  // lets input order decide which relation survives for a target that is
+  // linked under two types, and after the cap is applied, which target is
+  // returned at all. Sorting first makes the survivor deterministic
+  // (smallest linkType wins the tie).
   kept.sort((a, b) => {
     if (a.linkType !== b.linkType) return a.linkType < b.linkType ? -1 : 1;
     if (a.targetId !== b.targetId) return a.targetId < b.targetId ? -1 : 1;
     return 0;
   });
 
-  const truncated = kept.length > limit;
-  return { ok: true, neighbors: truncated ? kept.slice(0, limit) : kept, truncated };
+  const seen = new Set<string>();
+  const deduped: TraverseNeighbor[] = [];
+  for (const link of kept) {
+    if (seen.has(link.targetId)) continue;
+    seen.add(link.targetId);
+    deduped.push(link);
+  }
+
+  const truncated = deduped.length > limit;
+  return { ok: true, neighbors: truncated ? deduped.slice(0, limit) : deduped, truncated };
 }


### PR DESCRIPTION
## Summary

Implements the selection step of #1956's `traverseLinks(id, relation?, limit)` — "follow typed frontmatter links from a recalled memory".

The load-bearing decision is an asymmetry between a bad *request* and bad *stored data*:

- An unknown `relation` is a typed refusal (`unknown_relation`), not an empty success, so an agent learns its filter was wrong instead of concluding the memory has no neighbors.
- A stored link whose `linkType` is unknown is **skipped**, not an error, because stored data can predate a link type and one bad row must not fail the whole traverse. That asymmetry is stated in a comment where a reader will hit it.

`limit` is refused in the result type rather than thrown, for the same reason — it arrives from an agent request. Truncation happens after filtering, dedup, and sorting, so the cap always keeps the same neighbors. Relation validation reuses `parseNavigateLinkType` from `recall-navigate-link.ts`; no second list of link types is defined here.

Part of #1956 (selector only; the MCP/CLI/HTTP traverse surface is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/recall-navigate-traverse.test.ts` — 14/14
- Covers relation filtering, unknown relation refusal, unknown stored link types skipped while siblings survive, duplicate and blank target ids, truncation after sort, every invalid `limit`, and shuffle determinism.

## Note for a follow-up

While reading for this slice I noticed `recall-navigate-link.ts` accepts `causes`/`caused_by` and omits `supersedes`, while the canonical `MemoryLinkType` in `types.ts` is `follows | references | contradicts | supports | related` and the #1956 issue text lists `supports/contradicts/elaborates/supersedes/causes`. Three different sets. I did not change any of them here — reconciling them is a decision, not a cleanup, and it deserves its own PR.
