### PR TITLE
feat(dedup): refuse empty or runaway merged content

### DIFF
--- a/.changeset/2330-merge-content.md
+++ b/.changeset/2330-merge-content.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a merged-content acceptance check for merge-on-write. Blank or runaway judge-merged bodies (`length > 4 * (incoming + target)`) are refused with the computed limit so the write path can fall back to create; accepted content is returned unchanged. Internal helper; write-path wiring is a later slice. Part of #2330.

--- a/packages/remnic-core/src/dedup/index.ts
+++ b/packages/remnic-core/src/dedup/index.ts
@@ -481,3 +481,9 @@ export {
   type MergeFrontmatterUpdate,
   type MergeProvenanceSource,
 } from "./merge-provenance.js";
+
+export {
+  MERGE_CONTENT_LENGTH_FACTOR,
+  checkMergedContent,
+  type MergeContentCheck,
+} from "./merge-content.js";

--- a/packages/remnic-core/src/dedup/merge-content.test.ts
+++ b/packages/remnic-core/src/dedup/merge-content.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MERGE_CONTENT_LENGTH_FACTOR,
+  checkMergedContent,
+} from "./merge-content.js";
+
+const INCOMING = "alpha";
+const TARGET = "beta";
+
+test("normal merge passes and returns the content unchanged", () => {
+  const merged = "alpha and beta combined";
+  const result = checkMergedContent({
+    mergedContent: merged,
+    incomingContent: INCOMING,
+    targetContent: TARGET,
+  });
+  assert.deepEqual(result, { ok: true, content: merged });
+});
+
+test("merged content at exactly the limit is accepted", () => {
+  const limit = MERGE_CONTENT_LENGTH_FACTOR * (INCOMING.length + TARGET.length);
+  const merged = "x".repeat(limit);
+  const result = checkMergedContent({
+    mergedContent: merged,
+    incomingContent: INCOMING,
+    targetContent: TARGET,
+  });
+  assert.deepEqual(result, { ok: true, content: merged });
+});
+
+test("merged content one character over the limit is oversized with the reported limit", () => {
+  const limit = MERGE_CONTENT_LENGTH_FACTOR * (INCOMING.length + TARGET.length);
+  const result = checkMergedContent({
+    mergedContent: "x".repeat(limit + 1),
+    incomingContent: INCOMING,
+    targetContent: TARGET,
+  });
+  assert.deepEqual(result, { ok: false, reason: "oversized", limit });
+});
+
+test("empty, whitespace-only, null, undefined, object, and bigint merged content are all empty refusals", () => {
+  const cases: unknown[] = ["", "   ", "\t\n", null, undefined, { body: 1 }, 42n];
+  for (const mergedContent of cases) {
+    const result = checkMergedContent({
+      mergedContent,
+      incomingContent: INCOMING,
+      targetContent: TARGET,
+    });
+    assert.deepEqual(result, {
+      ok: false,
+      reason: "empty",
+      limit: MERGE_CONTENT_LENGTH_FACTOR * (INCOMING.length + TARGET.length),
+    });
+  }
+});
+
+test("two empty inputs make the limit zero, so any content is oversized", () => {
+  const result = checkMergedContent({
+    mergedContent: "x",
+    incomingContent: "",
+    targetContent: "",
+  });
+  assert.deepEqual(result, { ok: false, reason: "oversized", limit: 0 });
+});
+
+test("non-string incomingContent throws RangeError naming the field", () => {
+  assert.throws(
+    () =>
+      checkMergedContent({
+        mergedContent: "ok",
+        incomingContent: 7 as unknown as string,
+        targetContent: TARGET,
+      }),
+    (error: unknown) =>
+      error instanceof RangeError && /incomingContent/.test(error.message),
+  );
+});
+
+test("non-string targetContent throws RangeError naming the field", () => {
+  assert.throws(
+    () =>
+      checkMergedContent({
+        mergedContent: "ok",
+        incomingContent: INCOMING,
+        targetContent: null as unknown as string,
+      }),
+    (error: unknown) =>
+      error instanceof RangeError && /targetContent/.test(error.message),
+  );
+});
+
+test("the rejected merged content never appears in an error message or refusal result", () => {
+  const sentinel = "UNIQUE-LEAK-SENTINEL";
+  const leakyObject = { body: sentinel };
+
+  const refusal = checkMergedContent({
+    mergedContent: leakyObject,
+    incomingContent: INCOMING,
+    targetContent: TARGET,
+  });
+  assert.ok(!refusal.ok);
+  assert.ok(!JSON.stringify(refusal).includes(sentinel));
+
+  assert.throws(
+    () =>
+      checkMergedContent({
+        mergedContent: sentinel,
+        incomingContent: undefined as unknown as string,
+        targetContent: TARGET,
+      }),
+    (error: unknown) =>
+      error instanceof RangeError && !error.message.includes(sentinel),
+  );
+});

--- a/packages/remnic-core/src/dedup/merge-content.ts
+++ b/packages/remnic-core/src/dedup/merge-content.ts
@@ -1,0 +1,40 @@
+/**
+ * Merged-content acceptance check (issue #2330).
+ *
+ * A judge-merged body that is blank or a runaway continuation is refused so
+ * the write path can fall back to create. `mergedContent` arrives from a
+ * model and gets a typed refusal; non-string `incomingContent`/
+ * `targetContent` is a caller bug and throws. Internal helper; wiring into
+ * the write path is a later slice.
+ */
+export const MERGE_CONTENT_LENGTH_FACTOR = 4;
+
+export type MergeContentCheck =
+  | { ok: true; content: string }
+  | { ok: false; reason: "empty" | "oversized"; limit: number };
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new RangeError(`merge ${field} must be a string`);
+  }
+  return value;
+}
+
+export function checkMergedContent(input: {
+  mergedContent: unknown;
+  incomingContent: string;
+  targetContent: string;
+}): MergeContentCheck {
+  const incoming = requireString(input.incomingContent, "incomingContent");
+  const target = requireString(input.targetContent, "targetContent");
+  const limit = MERGE_CONTENT_LENGTH_FACTOR * (incoming.length + target.length);
+
+  const merged = input.mergedContent;
+  if (typeof merged !== "string" || merged.trim() === "") {
+    return { ok: false, reason: "empty", limit };
+  }
+  if (merged.length > limit) {
+    return { ok: false, reason: "oversized", limit };
+  }
+  return { ok: true, content: merged };
+}


### PR DESCRIPTION
## Summary

Implements #2330's judge-validation rule: "`mergedContent` non-empty, and `mergedContent.length <= 4 * (new.length + target.length)`", with the issue's stated consequence — "empty/oversized `mergedContent` → create".

An LLM asked to merge two facts can return an empty string or a runaway continuation. Either would overwrite a good memory with junk, so both are refused and the caller falls back to creating a new entry. The reported `limit` travels with the refusal so a caller can log why.

Boundary handling is the point of the module: exactly at the limit is accepted, one character over is `oversized`, and both sides are tested. The degenerate case where both inputs are empty (limit 0, so any content is oversized) is covered rather than special-cased.

`mergedContent` never throws for any value — `null`, an object, a bigint all return `empty` — because this sits on the write path and must not crash on a bad model answer, and the rejected value is never interpolated into a message. Non-string `incomingContent`/`targetContent` do throw, since those are caller bugs rather than model output.

Part of #2330 (validator only; the persist-path wiring is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/dedup/merge-content.test.ts` — 8/8
- **Mutation-checked**: changing the limit comparison from `>` to `>=` fails the at-the-limit test, so the boundary assertion discriminates.
