### PR TITLE
feat(extraction): stamp and verify the span source string to catch offset drift

### DIFF
--- a/.changeset/2333-span-source-hash.md
+++ b/.changeset/2333-span-source-hash.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a span source stamp and verify helper. The stamp records the sha256 and length of the exact string sent to the model; verification compares length first, then the digest, and reports `length_mismatch` or `hash_mismatch` with both stamps. Malformed stamps throw before comparison. The helper is exported from `@remnic/core`; extraction wiring is unchanged. Part of #2333.

--- a/.changeset/2333-span-source-hash.md
+++ b/.changeset/2333-span-source-hash.md
@@ -2,4 +2,4 @@
 "@remnic/core": patch
 ---
 
-Add a span source stamp and verify helper. The stamp records the sha256 and length of the exact string sent to the model; verification compares length first, then the digest, and reports `length_mismatch` or `hash_mismatch` with both stamps. Malformed stamps throw before comparison. The helper is exported from `@remnic/core`; extraction wiring is unchanged. Part of #2333.
+Add a span source stamp and verify helper. The stamp records the length and a sha256 over the string's UTF-16LE code units — not its UTF-8 bytes, because Node's UTF-8 encoder collapses unpaired surrogates to U+FFFD and would give distinct sources one digest. Verification compares length first, then the digest, and reports `length_mismatch` or `hash_mismatch` carrying only the two stamp fields, never the text. Malformed stamps throw before comparison. Source-internal like its sibling `extraction-span-*` modules; extraction wiring is unchanged. Part of #2333.

--- a/packages/remnic-core/src/extraction-span-source-hash.test.ts
+++ b/packages/remnic-core/src/extraction-span-source-hash.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  stampSpanSource,
+  verifySpanSource,
+  type SpanSourceStamp,
+} from "./extraction-span-source-hash.js";
+
+const TEXT = "The canary offset string, version one.";
+
+test("stampSpanSource: round trip verifies ok", () => {
+  const stamp = stampSpanSource(TEXT);
+  const check = verifySpanSource(TEXT, stamp);
+  assert.deepEqual(check, { ok: true });
+});
+
+test("stampSpanSource: empty string gets a real stamp and round trips", () => {
+  const stamp = stampSpanSource("");
+  assert.match(stamp.hash, /^[0-9a-f]{64}$/);
+  assert.equal(stamp.length, 0);
+  assert.equal(
+    stamp.hash,
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  );
+  assert.deepEqual(verifySpanSource("", stamp), { ok: true });
+});
+
+test("verifySpanSource: same-length single-character edit is hash_mismatch", () => {
+  const stamp = stampSpanSource(TEXT);
+  const edited = TEXT.replace("canary", "canarz");
+  assert.equal(edited.length, TEXT.length);
+  const check = verifySpanSource(edited, stamp);
+  assert.equal(check.ok, false);
+  if (!check.ok) {
+    assert.equal(check.error, "hash_mismatch");
+  }
+});
+
+test("verifySpanSource: added character is length_mismatch even though hash also differs", () => {
+  const stamp = stampSpanSource(TEXT);
+  const longer = `${TEXT}!`;
+  const check = verifySpanSource(longer, stamp);
+  assert.equal(check.ok, false);
+  if (!check.ok) {
+    assert.equal(check.error, "length_mismatch");
+    assert.equal(check.expected.length, TEXT.length);
+    assert.equal(check.actual.length, longer.length);
+  }
+});
+
+test("verifySpanSource: failure result carries no source text", () => {
+  const original = "original driftmarker-alpha payload";
+  const edited = "original driftmarker-beta payload";
+  const stamp = stampSpanSource(original);
+  const check = verifySpanSource(edited, stamp);
+  assert.equal(check.ok, false);
+  const serialized = JSON.stringify(check);
+  assert.ok(!serialized.includes("driftmarker-alpha"));
+  assert.ok(!serialized.includes("driftmarker-beta"));
+});
+
+test("stampSpanSource: non-string text throws TypeError naming text", () => {
+  assert.throws(() => stampSpanSource(42 as unknown as string), /text/);
+  assert.throws(() => stampSpanSource(null as unknown as string), /text/);
+  assert.throws(
+    () => stampSpanSource(undefined as unknown as string),
+    /text/,
+  );
+});
+
+test("verifySpanSource: non-string text throws TypeError naming text", () => {
+  const stamp = stampSpanSource(TEXT);
+  assert.throws(
+    () => verifySpanSource(7 as unknown as string, stamp),
+    /text/,
+  );
+});
+
+function stampWithHash(hash: unknown): SpanSourceStamp {
+  return { hash: hash as string, length: TEXT.length };
+}
+
+test("verifySpanSource: malformed expected hash throws RangeError naming the field", () => {
+  const good = stampSpanSource(TEXT);
+  const tooShort = good.hash.slice(0, 63);
+  const upper = good.hash.toUpperCase();
+  const nonHex = `${good.hash.slice(0, 63)}z`;
+  for (const bad of [tooShort, upper, nonHex, 123, null]) {
+    assert.throws(
+      () => verifySpanSource(TEXT, stampWithHash(bad)),
+      (err: unknown) => {
+        assert.ok(err instanceof RangeError);
+        assert.match((err as Error).message, /hash/);
+        return true;
+      },
+    );
+  }
+});
+
+test("verifySpanSource: inherited stamp fields are rejected", () => {
+  const good = stampSpanSource(TEXT);
+  const inherited = Object.create(good) as SpanSourceStamp;
+  assert.throws(
+    () => verifySpanSource(TEXT, inherited),
+    (err: unknown) => {
+      assert.ok(err instanceof RangeError);
+      assert.match((err as Error).message, /hash/);
+      return true;
+    },
+  );
+});
+
+test("verifySpanSource: negative or fractional expected length throws", () => {
+  const good = stampSpanSource(TEXT);
+  for (const bad of [-1, -0.5, 4.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => verifySpanSource(TEXT, { hash: good.hash, length: bad }),
+      (err: unknown) => {
+        assert.ok(err instanceof RangeError);
+        assert.match((err as Error).message, /length/);
+        return true;
+      },
+    );
+  }
+});
+
+test("stampSpanSource: two stamps of the same string are identical", () => {
+  const a = stampSpanSource(TEXT);
+  const b = stampSpanSource(TEXT);
+  assert.deepEqual(a, b);
+  assert.equal(JSON.stringify(a), JSON.stringify(b));
+});

--- a/packages/remnic-core/src/extraction-span-source-hash.test.ts
+++ b/packages/remnic-core/src/extraction-span-source-hash.test.ts
@@ -130,3 +130,36 @@ test("stampSpanSource: two stamps of the same string are identical", () => {
   assert.deepEqual(a, b);
   assert.equal(JSON.stringify(a), JSON.stringify(b));
 });
+
+// Review: Node's UTF-8 encoder replaces an unpaired surrogate with U+FFFD, so
+// hashing utf8 gave these three distinct strings ONE digest and drift between
+// them verified as unchanged. Unpaired surrogates arrive via JSON escapes.
+test("unpaired surrogates produce distinct stamps", () => {
+  const a = stampSpanSource("\ud800");
+  const b = stampSpanSource("\ud801");
+  const replacement = stampSpanSource("\ufffd");
+  assert.notEqual(a.hash, b.hash);
+  assert.notEqual(a.hash, replacement.hash);
+  assert.notEqual(b.hash, replacement.hash);
+  // And drift between them is now caught rather than passing.
+  assert.deepEqual(verifySpanSource("\ud801", a), {
+    ok: false,
+    error: "hash_mismatch",
+    expected: { hash: a.hash, length: a.length },
+    actual: b,
+  });
+});
+
+// Review: the result echoed the caller's stamp object, so an extra property
+// holding the source text would travel with the failure.
+test("a failure result carries only the two stamp fields", () => {
+  const stamped = stampSpanSource("the original source text");
+  const contaminated = { ...stamped, source: "SENSITIVE-SOURCE-TEXT" } as typeof stamped;
+  const result = verifySpanSource("a different source text!", contaminated);
+  assert.equal(result.ok, false);
+  const serialized = JSON.stringify(result);
+  assert.equal(serialized.includes("SENSITIVE-SOURCE-TEXT"), false);
+  assert.equal(serialized.includes("source"), false);
+  assert.ok(!result.ok && result.error === "hash_mismatch");
+  assert.deepEqual(Object.keys(result.ok === false ? result.expected : {}).sort(), ["hash", "length"]);
+});

--- a/packages/remnic-core/src/extraction-span-source-hash.ts
+++ b/packages/remnic-core/src/extraction-span-source-hash.ts
@@ -56,10 +56,20 @@ function requireStamp(expected: SpanSourceStamp): void {
   }
 }
 
-/** Hash the exact string. No trimming, no newline normalization. */
+/**
+ * Hash the exact string. No trimming, no newline normalization.
+ *
+ * The digest covers UTF-16LE code units, not UTF-8 bytes: Node's UTF-8
+ * encoder replaces an unpaired surrogate with U+FFFD before hashing, so
+ * "\ud800", "\ud801", and "\ufffd" all produce ONE digest under utf8 and
+ * drift between them would verify as unchanged. Unpaired surrogates reach
+ * real memory text through JSON escapes, and this stamp exists to catch
+ * exactly that class of silent substitution, so it hashes a lossless
+ * representation of the string instead.
+ */
 export function stampSpanSource(text: string): SpanSourceStamp {
   requireText(text);
-  const hash = createHash("sha256").update(text, "utf8").digest("hex");
+  const hash = createHash("sha256").update(Buffer.from(text, "utf16le")).digest("hex");
   return { hash, length: text.length };
 }
 
@@ -75,11 +85,16 @@ export function verifySpanSource(
   requireText(text);
   requireStamp(expected);
   const actual = stampSpanSource(text);
-  if (actual.length !== expected.length) {
-    return { ok: false, error: "length_mismatch", expected, actual };
+  // Project the caller's stamp down to exactly the two stamp fields. Echoing
+  // the original object would re-export any extra property it carries — a
+  // `source` field holding the text defeats the whole point of a stamp, which
+  // exists so the content does not have to travel.
+  const safeExpected: SpanSourceStamp = { hash: expected.hash, length: expected.length };
+  if (actual.length !== safeExpected.length) {
+    return { ok: false, error: "length_mismatch", expected: safeExpected, actual };
   }
-  if (actual.hash !== expected.hash) {
-    return { ok: false, error: "hash_mismatch", expected, actual };
+  if (actual.hash !== safeExpected.hash) {
+    return { ok: false, error: "hash_mismatch", expected: safeExpected, actual };
   }
   return { ok: true };
 }

--- a/packages/remnic-core/src/extraction-span-source-hash.ts
+++ b/packages/remnic-core/src/extraction-span-source-hash.ts
@@ -1,0 +1,85 @@
+/**
+ * Span source stamp/verify (issue #2333).
+ *
+ * Offsets index the exact normalized string sent to the model. If that string
+ * drifts before materialization, the offsets point at different characters and
+ * a wrong quote is persisted as verbatim source. The stamp lets materialization
+ * detect the drift without carrying the source text alongside it.
+ *
+ * Pure apart from hashing: no I/O, no clock, no randomness. The input text is
+ * never mutated and never appears in a result or error message.
+ */
+
+import { createHash } from "node:crypto";
+
+export interface SpanSourceStamp {
+  /** Hex digest of the exact string the model was shown. */
+  hash: string;
+  /** Length of that string, so a mismatch reports which dimension drifted. */
+  length: number;
+}
+
+export type SpanSourceCheck =
+  | { ok: true }
+  | {
+      ok: false;
+      error: "length_mismatch" | "hash_mismatch";
+      expected: SpanSourceStamp;
+      actual: SpanSourceStamp;
+    };
+
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+function requireText(text: string): void {
+  if (typeof text !== "string") {
+    throw new TypeError(`text must be a string, got ${typeof text}`);
+  }
+}
+
+function requireStamp(expected: SpanSourceStamp): void {
+  if (!Object.hasOwn(expected, "hash")) {
+    throw new RangeError("expected stamp is missing field hash");
+  }
+  if (!Object.hasOwn(expected, "length")) {
+    throw new RangeError("expected stamp is missing field length");
+  }
+  const { hash, length } = expected;
+  if (typeof hash !== "string" || !HASH_PATTERN.test(hash)) {
+    throw new RangeError(
+      "expected stamp field hash must be 64 lowercase hex characters",
+    );
+  }
+  if (!Number.isInteger(length) || length < 0) {
+    throw new RangeError(
+      "expected stamp field length must be a non-negative integer",
+    );
+  }
+}
+
+/** Hash the exact string. No trimming, no newline normalization. */
+export function stampSpanSource(text: string): SpanSourceStamp {
+  requireText(text);
+  const hash = createHash("sha256").update(text, "utf8").digest("hex");
+  return { hash, length: text.length };
+}
+
+/**
+ * Verify the materialized string against its stamp. Length is compared first:
+ * it is the cheaper, more diagnostic dimension. Mismatch results carry both
+ * stamps and never the text itself.
+ */
+export function verifySpanSource(
+  text: string,
+  expected: SpanSourceStamp,
+): SpanSourceCheck {
+  requireText(text);
+  requireStamp(expected);
+  const actual = stampSpanSource(text);
+  if (actual.length !== expected.length) {
+    return { ok: false, error: "length_mismatch", expected, actual };
+  }
+  if (actual.hash !== expected.hash) {
+    return { ok: false, error: "hash_mismatch", expected, actual };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Implements #2333's corruption guard: "Offsets must index the exact normalized string sent to the model — hash that string and assert the hash matches at materialization time (offset drift = silent corruption; reject on mismatch)."

This is the check that makes span mode safe to trust. If the text is re-normalized between prompt and materialization, the offsets still resolve — they just point at different characters, and a wrong quote gets persisted as verbatim source with no error anywhere.

`stampSpanSource` takes a SHA-256 over the exact bytes, with no trimming or newline normalization, because byte-identity is the entire property being asserted. `verifySpanSource` reports `length_mismatch` before comparing digests so the failure names the cheaper, more diagnostic dimension first, and a same-length single-character edit still surfaces as `hash_mismatch`.

Neither the result nor any error message carries the text: the source string is user content, and this stamp exists precisely so that content does not have to travel. A malformed `expected` stamp throws rather than comparing unequal, so a corrupt stamp cannot masquerade as drift.

Part of #2333 (Phase A guard; no Phase B wiring, `extraction.ts` untouched, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/extraction-span-source-hash.test.ts` — 11/11
- **Mutation-checked**: disabling the digest comparison (length-only verification) fails the same-length-edit test, so drift detection is genuinely asserted.
- Covers the empty string, both mismatch kinds, malformed stamps (wrong length, uppercase, non-hex, non-string, negative length), and that a failure result leaks neither the original nor the drifted text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source stamping for extracted spans using a secure hash and recorded text length.
  * Added verification that detects source length or content mismatches with structured results.
  * Added validation for invalid or malformed source stamps without exposing source text.

* **Bug Fixes**
  * Improved handling of empty text and malformed verification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->