### PR TITLE
feat(activity): compute an order-stable weekly snapshot config hash

### DIFF
--- a/.changeset/week-config-hash-2052.md
+++ b/.changeset/week-config-hash-2052.md
@@ -1,0 +1,8 @@
+---
+"@remnic/core": patch
+---
+
+Add `computeWeeklyConfigHash`: an order-stable digest of timezone, week start,
+and category definitions for weekly snapshot identity. The helper is exported
+from the activity timeline entry; caller wiring is a later slice.
+Part of #2052.

--- a/packages/remnic-core/src/activity/timeline/index.ts
+++ b/packages/remnic-core/src/activity/timeline/index.ts
@@ -16,6 +16,7 @@ export * from "./week-export.js";
 export * from "./week-snapshot.js";
 export * from "./week-previous.js";
 export * from "./week-recurring.js";
+export * from "./week-config-hash.js";
 export * from "./analysis-batch.js";
 export * from "./analysis-evidence.js";
 export * from "./analysis-prompt.js";

--- a/packages/remnic-core/src/activity/timeline/week-config-hash.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-config-hash.test.ts
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { computeWeeklyConfigHash, type WeeklyConfigInput } from "./week-config-hash.js";
+
+const BASE: WeeklyConfigInput = {
+  timezone: "Europe/Paris",
+  weekStartsOn: "monday",
+  categories: [
+    { id: "development", name: "Development" },
+    { id: "communication", name: "Communication" },
+    { id: "system.unknown", name: "Uncategorized" },
+  ],
+};
+
+test("identical inputs produce identical hashes", () => {
+  const again: WeeklyConfigInput = {
+    timezone: "Europe/Paris",
+    weekStartsOn: "monday",
+    categories: BASE.categories.map((category) => ({ id: category.id, name: category.name })),
+  };
+  assert.strictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(again));
+});
+
+test("category order does not change the hash", () => {
+  const reordered: WeeklyConfigInput = {
+    ...BASE,
+    categories: [...BASE.categories].reverse(),
+  };
+  assert.strictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(reordered));
+});
+
+test("key insertion order does not change the hash", () => {
+  const rotated: WeeklyConfigInput = {
+    categories: [
+      { name: "Development", id: "development" },
+      { name: "Communication", id: "communication" },
+      { name: "Uncategorized", id: "system.unknown" },
+    ],
+    weekStartsOn: "monday",
+    timezone: "Europe/Paris",
+  };
+  assert.strictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(rotated));
+});
+
+test("a renamed category changes the hash", () => {
+  const renamed: WeeklyConfigInput = {
+    ...BASE,
+    categories: BASE.categories.map((category) =>
+      category.id === "development" ? { id: "development", name: "Coding" } : category,
+    ),
+  };
+  assert.notStrictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(renamed));
+});
+
+test("an added category changes the hash", () => {
+  const added: WeeklyConfigInput = {
+    ...BASE,
+    categories: [...BASE.categories, { id: "design", name: "Design" }],
+  };
+  assert.notStrictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(added));
+});
+
+test("a removed category changes the hash", () => {
+  const removed: WeeklyConfigInput = {
+    ...BASE,
+    categories: BASE.categories.slice(0, 2),
+  };
+  assert.notStrictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(removed));
+});
+
+test("a different timezone changes the hash", () => {
+  const shifted: WeeklyConfigInput = { ...BASE, timezone: "UTC" };
+  assert.notStrictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(shifted));
+});
+
+test("a different weekStartsOn changes the hash", () => {
+  const shifted: WeeklyConfigInput = { ...BASE, weekStartsOn: "sunday" };
+  assert.notStrictEqual(computeWeeklyConfigHash(BASE), computeWeeklyConfigHash(shifted));
+});
+
+test("duplicate category ids throw RangeError", () => {
+  const duplicated: WeeklyConfigInput = {
+    ...BASE,
+    categories: [
+      { id: "development", name: "Development" },
+      { id: "development", name: "Dev" },
+    ],
+  };
+  assert.throws(() => computeWeeklyConfigHash(duplicated), RangeError);
+  assert.throws(() => computeWeeklyConfigHash(duplicated), /duplicate/);
+});
+
+test("blank fields throw RangeError naming the field", () => {
+  assert.throws(
+    () => computeWeeklyConfigHash({ ...BASE, timezone: "" }),
+    RangeError,
+  );
+  assert.throws(
+    () => computeWeeklyConfigHash({ ...BASE, timezone: "   " }),
+    /timezone/,
+  );
+  assert.throws(
+    () => computeWeeklyConfigHash({ ...BASE, weekStartsOn: "" }),
+    /weekStartsOn/,
+  );
+  assert.throws(
+    () => computeWeeklyConfigHash({ ...BASE, categories: [{ id: "", name: "Dev" }] }),
+    /categories\[0\]\.id/,
+  );
+  assert.throws(
+    () => computeWeeklyConfigHash({ ...BASE, categories: [{ id: "dev", name: " " }] }),
+    /categories\[0\]\.name/,
+  );
+});
+
+test("digest is lowercase hex of the documented length", () => {
+  const digest = computeWeeklyConfigHash(BASE);
+  assert.match(digest, /^[0-9a-f]{64}$/);
+  assert.strictEqual(digest.length, 64);
+});
+
+test("the caller's category array is not mutated", () => {
+  const input: WeeklyConfigInput = {
+    timezone: "UTC",
+    weekStartsOn: "monday",
+    categories: [
+      { id: "b", name: "B" },
+      { id: "a", name: "A" },
+    ],
+  };
+  const before = structuredClone(input);
+  computeWeeklyConfigHash(input);
+  assert.deepStrictEqual(input, before);
+});

--- a/packages/remnic-core/src/activity/timeline/week-config-hash.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-config-hash.test.ts
@@ -184,3 +184,24 @@ test("weekStartsOn must be a known weekday", () => {
     );
   }
 });
+
+// Review round 2: equivalent zone identifiers must not fork one snapshot
+// history. Canonicalization happens before hashing.
+test("equivalent timezone identifiers hash identically", () => {
+  const base = { weekStartsOn: "monday", categories: [{ id: "c", name: "Code" }] };
+  assert.equal(
+    computeWeeklyConfigHash({ ...base, timezone: "utc" }),
+    computeWeeklyConfigHash({ ...base, timezone: "UTC" }),
+    "casing is not a semantic change",
+  );
+  assert.equal(
+    computeWeeklyConfigHash({ ...base, timezone: "US/Eastern" }),
+    computeWeeklyConfigHash({ ...base, timezone: "America/New_York" }),
+    "an alias is not a semantic change",
+  );
+  assert.notEqual(
+    computeWeeklyConfigHash({ ...base, timezone: "UTC" }),
+    computeWeeklyConfigHash({ ...base, timezone: "America/New_York" }),
+    "genuinely different zones still differ",
+  );
+});

--- a/packages/remnic-core/src/activity/timeline/week-config-hash.test.ts
+++ b/packages/remnic-core/src/activity/timeline/week-config-hash.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { computeWeeklyConfigHash, type WeeklyConfigInput } from "./week-config-hash.js";
+import { computeWeeklyConfigHash, WEEK_START_DAYS, type WeeklyConfigInput } from "./week-config-hash.js";
 
 const BASE: WeeklyConfigInput = {
   timezone: "Europe/Paris",
@@ -132,4 +132,55 @@ test("the caller's category array is not mutated", () => {
   const before = structuredClone(input);
   computeWeeklyConfigHash(input);
   assert.deepStrictEqual(input, before);
+});
+
+// Review: a non-blank check let a typo acquire a durable snapshot identity,
+// so correcting the typo later forked the stored history.
+test("an invalid IANA timezone is refused before hashing", () => {
+  // "utc" is deliberately absent: IANA zone names are case-insensitive, so
+  // the shared validator accepts it and it is not a typo.
+  for (const timezone of ["Not/AZone", "America/Nowhere", "Chicago"]) {
+    assert.throws(
+      () =>
+        computeWeeklyConfigHash({
+          timezone,
+          weekStartsOn: "monday",
+          categories: [{ id: "dev", name: "Development" }],
+        }),
+      /timezone/i,
+    );
+  }
+  // A real zone still works.
+  assert.match(
+    computeWeeklyConfigHash({
+      timezone: "America/Chicago",
+      weekStartsOn: "monday",
+      categories: [{ id: "dev", name: "Development" }],
+    }),
+    /^[0-9a-f]+$/,
+  );
+});
+
+test("weekStartsOn must be a known weekday", () => {
+  for (const weekStartsOn of ["monady", "Monday", "mon", ""]) {
+    assert.throws(
+      () =>
+        computeWeeklyConfigHash({
+          timezone: "UTC",
+          weekStartsOn,
+          categories: [{ id: "dev", name: "Development" }],
+        }),
+      /weekStartsOn/,
+    );
+  }
+  for (const weekStartsOn of WEEK_START_DAYS) {
+    assert.match(
+      computeWeeklyConfigHash({
+        timezone: "UTC",
+        weekStartsOn,
+        categories: [{ id: "dev", name: "Development" }],
+      }),
+      /^[0-9a-f]+$/,
+    );
+  }
 });

--- a/packages/remnic-core/src/activity/timeline/week-config-hash.ts
+++ b/packages/remnic-core/src/activity/timeline/week-config-hash.ts
@@ -1,0 +1,56 @@
+/**
+ * Weekly snapshot config hash (issue #2052).
+ *
+ * `persistWeeklySnapshot` keys each snapshot file by a `configHash`; this
+ * computes that digest deterministically from the weekly config so every
+ * caller derives the same value for the same inputs. Stable across category
+ * order and key insertion order; any semantic change produces a new digest,
+ * which keys a new snapshot file instead of mutating an unrelated period.
+ */
+import { hashActivityBody } from "../digest.js";
+
+export interface WeeklyConfigInput {
+  timezone: string;
+  weekStartsOn: string;
+  /** Category definitions that shape the snapshot. */
+  categories: readonly { id: string; name: string }[];
+}
+
+function requireNonBlank(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new RangeError(`${field} must be a non-blank string`);
+  }
+  return value;
+}
+
+export function computeWeeklyConfigHash(input: WeeklyConfigInput): string {
+  if (typeof input !== "object" || input === null) {
+    throw new RangeError("input must be a WeeklyConfigInput object");
+  }
+  const timezone = requireNonBlank(input.timezone, "timezone");
+  const weekStartsOn = requireNonBlank(input.weekStartsOn, "weekStartsOn");
+  if (!Array.isArray(input.categories)) {
+    throw new RangeError("categories must be an array of category definitions");
+  }
+  // Copy + sort: never sort the caller's array in place, and hash category
+  // order-independently so a harmless reorder cannot orphan stored snapshots.
+  const sorted = input.categories
+    .map((category, index) => ({
+      id: requireNonBlank(category?.id, `categories[${index}].id`),
+      name: requireNonBlank(category?.name, `categories[${index}].name`),
+    }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  for (let index = 1; index < sorted.length; index++) {
+    if (sorted[index].id === sorted[index - 1].id) {
+      throw new RangeError(`duplicate category id: ${sorted[index].id}`);
+    }
+  }
+  // Fixed field order; JSON.stringify each part so no separator can collide
+  // with category content.
+  const body = [
+    JSON.stringify(timezone),
+    JSON.stringify(weekStartsOn),
+    ...sorted.map((category) => JSON.stringify([category.id, category.name])),
+  ].join("\n");
+  return hashActivityBody(body);
+}

--- a/packages/remnic-core/src/activity/timeline/week-config-hash.ts
+++ b/packages/remnic-core/src/activity/timeline/week-config-hash.ts
@@ -42,10 +42,14 @@ export function computeWeeklyConfigHash(input: WeeklyConfigInput): string {
   if (typeof input !== "object" || input === null) {
     throw new RangeError("input must be a WeeklyConfigInput object");
   }
-  const timezone = requireNonBlank(input.timezone, "timezone");
-  // Same IANA check the activity config and weekly builder apply, so an
-  // unusable timezone cannot acquire a snapshot identity here.
-  assertValidTimezone(timezone);
+  const rawTimezone = requireNonBlank(input.timezone, "timezone");
+  assertValidTimezone(rawTimezone);
+  // Canonicalize before hashing: `utc` and `UTC` are the same zone, and
+  // `US/Eastern` is an alias of `America/New_York`. Hashing the raw string
+  // gives two callers two identities for one zone, which would fork one
+  // snapshot history on a harmless casing or alias change.
+  const timezone = new Intl.DateTimeFormat("en-US", { timeZone: rawTimezone })
+    .resolvedOptions().timeZone;
   const weekStartsOn = requireNonBlank(input.weekStartsOn, "weekStartsOn");
   if (!(WEEK_START_DAYS as readonly string[]).includes(weekStartsOn)) {
     throw new RangeError(

--- a/packages/remnic-core/src/activity/timeline/week-config-hash.ts
+++ b/packages/remnic-core/src/activity/timeline/week-config-hash.ts
@@ -6,8 +6,12 @@
  * caller derives the same value for the same inputs. Stable across category
  * order and key insertion order; any semantic change produces a new digest,
  * which keys a new snapshot file instead of mutating an unrelated period.
+ *
+ * Values are validated, not merely non-blank: a typo like `"Not/AZone"` or
+ * `"monady"` would otherwise get a durable snapshot identity, and correcting
+ * the typo later would fork the stored history instead of continuing it.
  */
-import { hashActivityBody } from "../digest.js";
+import { assertValidTimezone, hashActivityBody } from "../digest.js";
 
 export interface WeeklyConfigInput {
   timezone: string;
@@ -15,6 +19,17 @@ export interface WeeklyConfigInput {
   /** Category definitions that shape the snapshot. */
   categories: readonly { id: string; name: string }[];
 }
+
+/** Week-start vocabulary. Lowercase day names, matching the config surface. */
+export const WEEK_START_DAYS = Object.freeze([
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+] as const);
 
 function requireNonBlank(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim() === "") {
@@ -28,7 +43,15 @@ export function computeWeeklyConfigHash(input: WeeklyConfigInput): string {
     throw new RangeError("input must be a WeeklyConfigInput object");
   }
   const timezone = requireNonBlank(input.timezone, "timezone");
+  // Same IANA check the activity config and weekly builder apply, so an
+  // unusable timezone cannot acquire a snapshot identity here.
+  assertValidTimezone(timezone);
   const weekStartsOn = requireNonBlank(input.weekStartsOn, "weekStartsOn");
+  if (!(WEEK_START_DAYS as readonly string[]).includes(weekStartsOn)) {
+    throw new RangeError(
+      `weekStartsOn must be one of ${WEEK_START_DAYS.join(", ")}; got ${JSON.stringify(weekStartsOn)}`,
+    );
+  }
   if (!Array.isArray(input.categories)) {
     throw new RangeError("categories must be an array of category definitions");
   }


### PR DESCRIPTION
## Summary

Computes the `configHash` that #2052's snapshot key already requires. `weekly-persist.ts` has consumed a `configHash` since it landed, but nothing produced one — so every caller would have invented its own, and two callers would have disagreed, silently splitting or colliding stored snapshots.

`computeWeeklyConfigHash` is stable across category array order and object key insertion order, because a harmless reorder must not orphan every stored snapshot. It changes for every semantic change the issue names: renamed category, added category, removed category, different timezone, different week start — each tested individually.

Duplicate category ids throw rather than hashing, since two definitions for one id make the snapshot key ambiguous. The digest length is asserted in a test so a future algorithm swap is a visible, deliberate change rather than a silent one that invalidates stored snapshots.

Part of #2052 (hash helper; the persist call site passes its own value today, so wiring is a later slice and the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/timeline/week-config-hash.test.ts` — 12/12
- Covers order-independence on both axes, all five semantic changes, duplicate ids, blank field rejection, digest shape, and that the caller's array is not sorted in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an exported helper for generating stable hashes from weekly configuration settings, including timezone, week start, and categories.
  * Hashes remain consistent regardless of category ordering and use a standardized lowercase format.
  * Added validation for invalid settings, duplicate category IDs, and blank fields.
* **Bug Fixes**
  * Preserves the original category list while processing configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->