### PR TITLE
feat(activity): stamp journal memories with their source and day

### DIFF
--- a/.changeset/1987-journal-provenance.md
+++ b/.changeset/1987-journal-provenance.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add the exported `buildJournalMemoryProvenance` helper for journal-derived memories: given a journal source validated through the journal-source parser (`"file"` or `"vault"`) and a `YYYY-MM-DD` calendar day, it returns the exact tags `["journal", "journal-day:<date>"]`, `structuredAttributes.journalSource` set to the source (string values only, so vault-sourced journal candidates are distinguishable from file-sourced ones), and `validAt` pinned to the day start in UTC (`<date>T00:00:00.000Z`). Pure: no I/O, no clock. Caller wiring into journal memory generation is a later slice. Part of #1987

--- a/packages/remnic-core/src/activity/index.ts
+++ b/packages/remnic-core/src/activity/index.ts
@@ -18,6 +18,7 @@ export * from "./timeline/index.js";
 export * from "./journal.js";
 export * from "./journal-vault-read.js";
 export * from "./journal-vault-prereq.js";
+export * from "./journal-vault-provenance.js";
 export { stripRemnicOwnedRegions } from "./journal-strip.js";
 export * from "./memory-gen.js";
 export * from "./privacy.js";

--- a/packages/remnic-core/src/activity/journal-vault-provenance.test.ts
+++ b/packages/remnic-core/src/activity/journal-vault-provenance.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildJournalMemoryProvenance } from "./journal-vault-provenance.js";
+
+test("vault source produces the documented tags, attributes, and validAt", () => {
+  assert.deepEqual(
+    buildJournalMemoryProvenance({ source: "vault", date: "2026-08-01" }),
+    {
+      tags: ["journal", "journal-day:2026-08-01"],
+      structuredAttributes: { journalSource: "vault" },
+      validAt: "2026-08-01T00:00:00.000Z",
+    },
+  );
+});
+
+test("file source differs only in the attribute value", () => {
+  const vault = buildJournalMemoryProvenance({ source: "vault", date: "2026-08-01" });
+  const file = buildJournalMemoryProvenance({ source: "file", date: "2026-08-01" });
+  assert.deepEqual(file.structuredAttributes, { journalSource: "file" });
+  assert.deepEqual(file.tags, vault.tags);
+  assert.equal(file.validAt, vault.validAt);
+});
+
+test("every structured attribute value is a string", () => {
+  for (const source of ["file", "vault"] as const) {
+    const { structuredAttributes } = buildJournalMemoryProvenance({
+      source,
+      date: "2026-08-01",
+    });
+    for (const [key, value] of Object.entries(structuredAttributes)) {
+      assert.equal(typeof value, "string", `${key} must be a string`);
+    }
+  }
+});
+
+test("unknown source throws RangeError naming source", () => {
+  for (const source of ["memoryDir", "vault ", "Vault", ""]) {
+    assert.throws(
+      () => buildJournalMemoryProvenance({ source, date: "2026-08-01" }),
+      RangeError,
+    );
+    assert.throws(
+      () => buildJournalMemoryProvenance({ source, date: "2026-08-01" }),
+      /source/,
+    );
+  }
+});
+
+test("non-string source is rejected, not defaulted", () => {
+  assert.throws(
+    () =>
+      buildJournalMemoryProvenance({
+        source: undefined as unknown as string,
+        date: "2026-08-01",
+      }),
+    RangeError,
+  );
+});
+
+test("malformed date throws RangeError naming date", () => {
+  for (const date of [
+    "2026-8-1",
+    "2026-02-30",
+    "2026-13-01",
+    "2026-02-29",
+    "",
+    " 2026-08-01",
+    "2026-08-01 ",
+    "0026-01-01",
+  ]) {
+    assert.throws(
+      () => buildJournalMemoryProvenance({ source: "vault", date }),
+      RangeError,
+    );
+    assert.throws(
+      () => buildJournalMemoryProvenance({ source: "vault", date }),
+      /date/,
+    );
+  }
+});
+
+test("non-string date is rejected, not defaulted", () => {
+  assert.throws(
+    () =>
+      buildJournalMemoryProvenance({
+        source: "vault",
+        date: 20260801 as unknown as string,
+      }),
+    RangeError,
+  );
+});
+
+test("real leap day is accepted", () => {
+  assert.equal(
+    buildJournalMemoryProvenance({ source: "vault", date: "2024-02-29" }).validAt,
+    "2024-02-29T00:00:00.000Z",
+  );
+});
+
+test("tags are exactly two entries in order", () => {
+  const { tags } = buildJournalMemoryProvenance({ source: "vault", date: "2026-08-01" });
+  assert.equal(tags.length, 2);
+  assert.deepEqual(tags, ["journal", "journal-day:2026-08-01"]);
+});
+
+test("two calls are deep-equal and share no mutable state", () => {
+  const first = buildJournalMemoryProvenance({ source: "vault", date: "2026-08-01" });
+  first.tags.push("mutated");
+  first.structuredAttributes.journalSource = "mutated";
+  first.validAt = "mutated";
+  assert.deepEqual(
+    buildJournalMemoryProvenance({ source: "vault", date: "2026-08-01" }),
+    {
+      tags: ["journal", "journal-day:2026-08-01"],
+      structuredAttributes: { journalSource: "vault" },
+      validAt: "2026-08-01T00:00:00.000Z",
+    },
+  );
+});

--- a/packages/remnic-core/src/activity/journal-vault-provenance.ts
+++ b/packages/remnic-core/src/activity/journal-vault-provenance.ts
@@ -1,0 +1,67 @@
+/**
+ * Build provenance for journal-derived memories (issue #1987).
+ *
+ * Pure: no I/O, no clock — the day comes from the caller. The source is
+ * validated through the journal-source parser, so `structuredAttributes.
+ * journalSource` is always a canonical journal source value ("file" |
+ * "vault"), never a re-declared copy of the allow-list. Exported helper;
+ * caller wiring into journal memory generation is a later slice.
+ */
+import { resolveJournalSource } from "./journal-source.js";
+
+export interface JournalMemoryProvenance {
+  tags: string[];
+  structuredAttributes: Record<string, string>;
+  validAt: string;
+}
+
+const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function buildJournalMemoryProvenance(input: {
+  /** Journal source; must be one of the journal-source allow-list values. */
+  source: string;
+  /** Journal day, YYYY-MM-DD. */
+  date: string;
+}): JournalMemoryProvenance {
+  if (typeof input.source !== "string") {
+    throw new RangeError("journal provenance source must be a string");
+  }
+  const resolved = resolveJournalSource({
+    source: input.source,
+    // Provenance never consumes the heading; vault mode just requires a
+    // non-empty one to resolve.
+    heading: "journal",
+  });
+  if (!resolved.ok) {
+    throw new RangeError(
+      `journal provenance source must be one of "file", "vault": ${JSON.stringify(input.source)}`,
+    );
+  }
+
+  if (typeof input.date !== "string" || !DAY_PATTERN.test(input.date)) {
+    throw new RangeError(
+      `journal provenance date must be exactly YYYY-MM-DD: ${JSON.stringify(input.date)}`,
+    );
+  }
+  const [year, month, day] = input.date
+    .split("-")
+    .map(Number) as [number, number, number];
+  // Round-trip through UTC rejects non-calendar days (2026-02-30) and the
+  // two-digit-year Date.UTC remap (0026 -> 1926) without reading a clock.
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  if (
+    utc.getUTCFullYear() !== year ||
+    utc.getUTCMonth() !== month - 1 ||
+    utc.getUTCDate() !== day
+  ) {
+    throw new RangeError(
+      `journal provenance date must be a real calendar day: ${input.date}`,
+    );
+  }
+
+  return {
+    tags: ["journal", `journal-day:${input.date}`],
+    structuredAttributes: { journalSource: resolved.mode },
+    validAt: `${input.date}T00:00:00.000Z`,
+  };
+}


### PR DESCRIPTION
## Summary

Implements #1987's provenance requirement: journal-derived memories "additionally carry `structuredAttributes.journalSource: "vault"` so review UI and future audits can distinguish vault-sourced journal candidates from memoryDir ones. **String values only**", plus the `journal` / `journal-day:<date>` tags and the `valid_at` pin the issue specifies.

`buildJournalMemoryProvenance` enforces the string-only rule in the return type, and a test asserts every attribute value is a string so a future field cannot smuggle a number or object into a shape the review UI reads.

The source is validated through the existing journal-source parser rather than a second allow-list, and an unknown value throws instead of defaulting to `memoryDir` — defaulting would defeat the one thing the attribute exists to do. The date must be a real calendar day (`2026-02-30` is refused, not rolled over), and the helper never reads the clock: the day comes from the caller so a re-run pins the same `valid_at`.

Part of #1987 (provenance builder; the review-gated extraction pass that consumes it is a later slice, so the issue stays open).

## Test plan

- `NODE_OPTIONS=--conditions=remnic-source npx tsx --test packages/remnic-core/src/activity/journal-vault-provenance.test.ts` — 10/10
- Covers both sources differing only in the attribute value, the exact two-tag array and its order, string-only attribute values, unknown source rejection, malformed and impossible dates, and deep-equality across calls.
