### PR TITLE
chore(ci): gate link vocabularies, batch thread requests, document three defect classes

### DIFF
--- a/.changeset/ci-b10-hardening.md
+++ b/.changeset/ci-b10-hardening.md
@@ -2,4 +2,4 @@
 "@remnic/core": patch
 ---
 
-Add a CI gate asserting the navigation link-type vocabularies agree, a batched review-thread helper that replaces 2N GraphQL requests with two, and three review-prevention patterns covering key-validation bypasses, frozen-const type widening, and unenforced claims.
+Add a CI gate asserting the navigation link-type vocabularies agree (`scripts/check-nav-link-vocabularies.mjs`, wired into the `checks` job), a batched review-thread helper that replaces per-PR list queries and per-thread resolve mutations with one aliased query and one aliased mutation — plus one extra query per additional page for a PR with more than 50 threads — and three review defect classes documented in `.omp/rules/README.md`. The proposed rule for literal-union widening was measured against the tree, matched 13 legitimate frozen data arrays, and is recorded as rejected rather than shipped.

--- a/.changeset/ci-b10-hardening.md
+++ b/.changeset/ci-b10-hardening.md
@@ -1,5 +1,0 @@
----
-"@remnic/core": patch
----
-
-Add a CI gate asserting the navigation link-type vocabularies agree (`scripts/check-nav-link-vocabularies.mjs`, wired into the `checks` job), a batched review-thread helper that replaces per-PR list queries and per-thread resolve mutations with one aliased query and one aliased mutation — plus one extra query per additional page for a PR with more than 50 threads — and three review defect classes documented in `.omp/rules/README.md`. The proposed rule for literal-union widening was measured against the tree, matched 13 legitimate frozen data arrays, and is recorded as rejected rather than shipped.

--- a/.changeset/ci-b10-hardening.md
+++ b/.changeset/ci-b10-hardening.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Add a CI gate asserting the navigation link-type vocabularies agree, a batched review-thread helper that replaces 2N GraphQL requests with two, and three review-prevention patterns covering key-validation bypasses, frozen-const type widening, and unenforced claims.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,13 @@ jobs:
         env:
           REMNIC_REGEX_SAFETY_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || 'origin/main' }}
 
+      # Navigation link-type vocabulary agreement (#1956 review fallout): the
+      # shared parser must know every link type the stepper accepts and every
+      # type that is actually persisted. Three lists drifted apart silently and
+      # cost two review rounds to find.
+      - name: Navigation link vocabularies agree
+        run: node scripts/check-nav-link-vocabularies.mjs
+
   # The root/misc suite runs on a hosted runner. Package tests use two
   # deterministic file shards on the self-hosted pool when it is safe.
   # selectTestShard is an exact partition (enforced by test), so the package

--- a/.omp/rules/README.md
+++ b/.omp/rules/README.md
@@ -88,6 +88,16 @@ conditions without new evidence; each baseline below is the receipt.
   where *any* rejection is precisely the contract (`readFile` on a
   deleted path, a loop of clearly-typed invalid inputs). Tightening the
   matcher is a review judgement, not a signature.
+- **`: readonly T[] = Object.freeze([...])`** (literal-union widening) — the
+  defect is real and shipped once as a regression inside a hardening fix,
+  but the signature matches 13 legitimate frozen *data* arrays (seed
+  vocabularies, prose frames, fixture memories) where no
+  `(typeof X)[number]` union is derived and the annotation is exactly the
+  intended type. Distinguishing them needs two facts in different places —
+  an `as const` initializer AND a derived union — so it is not a
+  single-line signature. `AGENTS.md` pattern 47 carries the remedy,
+  including the `@ts-expect-error` pin that makes a future widening fail
+  the build.
 
 The dominant review clusters in the 2026-06-20..07-04 subset (605
 findings across 40 PRs; the full derivation corpus spans four weeks) —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1295,6 +1295,79 @@ The general rule both instances share: when a guard's two outcomes are
 resolve to "keep". Write the test that feeds it `NaN`, `Infinity`, and a
 whitespace-padded path, and assert nothing was planned for deletion.
 
+### 46. Key Validation Must Read the Same Keys It Validates
+
+Two bypasses of the same allow-list shipped one review round apart, both in
+a config gate resolver, both because the validating loop and the reading
+expression disagreed about which keys exist.
+
+- **`Object.keys` enumerates own, ENUMERABLE properties.** A key defined with
+  `Object.defineProperty(obj, "x", { value: v, enumerable: false })` is
+  invisible to it — and still readable by `obj.x`. Validate with
+  `Object.getOwnPropertyNames`.
+- **A bracket read follows the prototype chain.** After validating with
+  `Object.keys(raw)`, `raw[gate]` still honors an inherited `gate`, so an
+  object with a doctored prototype enables something the allow-list never
+  approved. Gate every read on `Object.hasOwn(raw, key)`.
+- **Present-with-`undefined` is not absent.** `hasOwn` true plus an
+  `undefined` value is a caller that explicitly set nothing, which composed
+  config objects produce constantly. If the API promises to reject invalid
+  values, that value must go through the validator, not silently default.
+
+The rule: enumerate with `getOwnPropertyNames`, read with `hasOwn`, and treat
+presence and validity as separate questions. Add a regression with a
+non-enumerable key and one with an inherited key — both are three lines.
+
+### 47. A Frozen `as const` Must Not Be Annotated `readonly T[]`
+
+`Object.freeze([...] as const)` already delivers both halves: runtime
+immutability and a narrow literal tuple. Adding `: readonly string[]` throws
+the second half away, so a derived `type X = (typeof LIST)[number]` widens to
+`string` and consumers can assign values the runtime rejects.
+
+This shipped as a regression *inside a hardening fix*: a review round asked
+for a frozen registry, the fix added `Object.freeze` and the annotation
+together, and the next round caught that the gate union had silently become
+`string`. When a call site then rejects the narrow type (usually
+`.includes(someString)`), cast at that call site —
+`(LIST as readonly string[]).includes(key)` — rather than widening the
+declaration for every consumer.
+
+Pin it so it cannot regress silently:
+
+```ts
+// @ts-expect-error "bogus" is not a Gate
+const bad: Gate = "bogus";
+```
+
+An unused `@ts-expect-error` is itself a compile error, so that line fails the
+build the moment the union widens. A regex cannot police this — the annotation
+is legitimate on the many frozen *data* arrays that have no derived union
+(measured: 13 such arrays in this repo), which is why it lives here.
+
+### 48. Every Claim in a PR, Comment, or Changeset Must Be Enforced or Deleted
+
+Reviewers reject prose that the code does not back, and they are right to:
+a false guarantee is worse than a missing one, because the next reader stops
+checking.
+
+Two instances shipped in one run and both were caught:
+
+- A metadata record was described as "structurally incapable of carrying
+  content" while its validator accepted any single-line string under 200
+  characters — `"Summarize this user's activity"` passed. Either enforce the
+  claim (identifier syntax, which is what landed) or delete it.
+- A helper was called an "internal helper" in its changeset while being
+  re-exported from the package entry point, giving consumers a wrong
+  lifecycle signal.
+
+Before pushing, take every guarantee in the PR body, the module header, and
+the changeset, and name the line of code or the test that enforces it. A
+comment is not enforcement: put the invariant in the types, in a validator,
+or in an assertion. If none of those is practical, weaken the sentence to
+what is true — "takes no path to write to" is a fact; "cannot corrupt data"
+is a claim.
+
 ---
 
 ## What This Project Does (Simple Explanation)

--- a/scripts/check-nav-link-vocabularies.mjs
+++ b/scripts/check-nav-link-vocabularies.mjs
@@ -80,6 +80,9 @@ export function stripComments(text) {
       i += 2;
       while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
       i += 2;
+      // A separator, not nothing: `export/* note */type X` must not collapse
+      // into `exporttype X`, which no declaration regex can match.
+      out += " ";
       continue;
     }
     out += ch;

--- a/scripts/check-nav-link-vocabularies.mjs
+++ b/scripts/check-nav-link-vocabularies.mjs
@@ -42,9 +42,55 @@ const PERSISTED = {
   symbol: "MemoryLinkType",
 };
 
+/**
+ * Remove comments before any declaration is scanned. Without this, a
+ * commented-out member (`// "related"`) reads as vocabulary the parser
+ * supports, and the gate can pass while the real lists still diverge.
+ * String-aware so a `//` inside a literal survives.
+ */
+export function stripComments(text) {
+  let out = "";
+  let i = 0;
+  let quote = null;
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (quote) {
+      out += ch;
+      if (ch === "\\") {
+        out += next ?? "";
+        i += 2;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
 /** Extract the string literals of a `const NAME = [...] as const` array. */
 function readArrayLiterals(relFile, symbol) {
-  const text = readFileSync(path.join(ROOT, relFile), "utf8");
+  const text = stripComments(readFileSync(path.join(ROOT, relFile), "utf8"));
   const declaration = new RegExp(
     `(?:export\\s+)?const\\s+${symbol}\\b[^=]*=\\s*(?:Object\\.freeze\\()?\\s*\\[([\\s\\S]*?)\\]`,
     "m",
@@ -65,7 +111,7 @@ function readArrayLiterals(relFile, symbol) {
 
 /** Extract the members of a `type NAME = "a" | "b"` union. */
 function readUnionLiterals(relFile, symbol) {
-  const text = readFileSync(path.join(ROOT, relFile), "utf8");
+  const text = stripComments(readFileSync(path.join(ROOT, relFile), "utf8"));
   const match = text.match(new RegExp(`export\\s+type\\s+${symbol}\\s*=\\s*([^;]+);`, "m"));
   if (!match) {
     throw new Error(

--- a/scripts/check-nav-link-vocabularies.mjs
+++ b/scripts/check-nav-link-vocabularies.mjs
@@ -91,6 +91,30 @@ export function stripComments(text) {
   return out;
 }
 
+/**
+ * Fail closed when a declaration contains members this extractor cannot see.
+ * A union or array composed through an alias or a spread (`| OtherLinkTypes`,
+ * `...MORE_TYPES`) would otherwise be silently ignored, so the gate could
+ * report agreement while the real vocabularies diverged — the exact failure
+ * this gate exists to prevent.
+ */
+export function assertOnlyLiteralMembers(body, literals, symbol, relFile, separator) {
+  // Remove every literal we DID extract, then check nothing substantive is left.
+  let remainder = body;
+  for (const literal of literals) remainder = remainder.replace(`"${literal}"`, "");
+  const leftover = remainder
+    .split(separator === "|" ? "|" : ",")
+    .map((part) => part.trim())
+    .filter((part) => part !== "" && part !== "as const" && !part.startsWith("as const"));
+  if (leftover.length > 0) {
+    throw new Error(
+      `check-nav-link-vocabularies: ${symbol} in ${relFile} has non-literal member(s) ` +
+        `[${leftover.join(" ")}] this gate cannot read. Extend the extractor rather than ` +
+        `letting the vocabulary check pass on a partial list.`,
+    );
+  }
+}
+
 /** Extract the string literals of a `const NAME = [...] as const` array. */
 function readArrayLiterals(relFile, symbol) {
   const text = stripComments(readFileSync(path.join(ROOT, relFile), "utf8"));
@@ -109,6 +133,7 @@ function readArrayLiterals(relFile, symbol) {
   if (literals.length === 0) {
     throw new Error(`check-nav-link-vocabularies: ${symbol} in ${relFile} has no string literals`);
   }
+  assertOnlyLiteralMembers(match[1], literals, symbol, relFile, ",");
   return literals;
 }
 
@@ -126,6 +151,7 @@ function readUnionLiterals(relFile, symbol) {
   if (literals.length === 0) {
     throw new Error(`check-nav-link-vocabularies: type ${symbol} in ${relFile} has no members`);
   }
+  assertOnlyLiteralMembers(match[1], literals, symbol, relFile, "|");
   return literals;
 }
 

--- a/scripts/check-nav-link-vocabularies.mjs
+++ b/scripts/check-nav-link-vocabularies.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Navigation link-type vocabulary agreement (issue #1956 review fallout).
+ *
+ * Three lists describe "what kinds of link can a traversal follow":
+ *
+ *   1. `RECALL_NAV_LINK_TYPES` in recall-navigate.ts      — the stepper
+ *   2. `NAVIGATE_LINK_TYPES`  in recall-navigate-link.ts  — the shared parser
+ *   3. `MemoryLinkType`       in types.ts                 — what is persisted
+ *
+ * They drifted apart silently, and it took two review rounds to find: the
+ * shared parser rejected `follows`/`references`/`related` (which real
+ * frontmatter carries, so a traversal over stored links dropped those
+ * neighbors) and also rejected `supersedes` (which the stepper accepts, so
+ * wiring the two together would have refused a relation the surface handles).
+ *
+ * The invariant this gate enforces: the shared parser's vocabulary must be a
+ * SUPERSET of both the stepper's list and the persisted link types. It may
+ * know extra names; it may never know fewer, because it is the front door.
+ *
+ * Run: node scripts/check-nav-link-vocabularies.mjs
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+const SOURCES = {
+  stepper: {
+    file: "packages/remnic-core/src/recall-navigate.ts",
+    symbol: "RECALL_NAV_LINK_TYPES",
+  },
+  parser: {
+    file: "packages/remnic-core/src/recall-navigate-link.ts",
+    symbol: "NAVIGATE_LINK_TYPES",
+  },
+};
+
+const PERSISTED = {
+  file: "packages/remnic-core/src/types.ts",
+  symbol: "MemoryLinkType",
+};
+
+/** Extract the string literals of a `const NAME = [...] as const` array. */
+function readArrayLiterals(relFile, symbol) {
+  const text = readFileSync(path.join(ROOT, relFile), "utf8");
+  const declaration = new RegExp(
+    `(?:export\\s+)?const\\s+${symbol}\\b[^=]*=\\s*(?:Object\\.freeze\\()?\\s*\\[([\\s\\S]*?)\\]`,
+    "m",
+  );
+  const match = text.match(declaration);
+  if (!match) {
+    throw new Error(
+      `check-nav-link-vocabularies: could not find \`const ${symbol} = [...]\` in ${relFile}. ` +
+        `If the declaration moved or was renamed, update this gate rather than deleting it.`,
+    );
+  }
+  const literals = [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (literals.length === 0) {
+    throw new Error(`check-nav-link-vocabularies: ${symbol} in ${relFile} has no string literals`);
+  }
+  return literals;
+}
+
+/** Extract the members of a `type NAME = "a" | "b"` union. */
+function readUnionLiterals(relFile, symbol) {
+  const text = readFileSync(path.join(ROOT, relFile), "utf8");
+  const match = text.match(new RegExp(`export\\s+type\\s+${symbol}\\s*=\\s*([^;]+);`, "m"));
+  if (!match) {
+    throw new Error(
+      `check-nav-link-vocabularies: could not find \`type ${symbol}\` in ${relFile}. ` +
+        `If it moved or was renamed, update this gate rather than deleting it.`,
+    );
+  }
+  const literals = [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (literals.length === 0) {
+    throw new Error(`check-nav-link-vocabularies: type ${symbol} in ${relFile} has no members`);
+  }
+  return literals;
+}
+
+export function findVocabularyGaps({ stepper, parser, persisted }) {
+  const known = new Set(parser);
+  const gaps = [];
+  for (const name of stepper) {
+    if (!known.has(name)) gaps.push({ missing: name, requiredBy: "stepper" });
+  }
+  for (const name of persisted) {
+    if (!known.has(name)) gaps.push({ missing: name, requiredBy: "persisted" });
+  }
+  // Deterministic report: name, then which list demands it.
+  gaps.sort((a, b) =>
+    a.missing === b.missing
+      ? a.requiredBy < b.requiredBy
+        ? -1
+        : a.requiredBy > b.requiredBy
+          ? 1
+          : 0
+      : a.missing < b.missing
+        ? -1
+        : 1,
+  );
+  return gaps;
+}
+
+function main() {
+  const stepper = readArrayLiterals(SOURCES.stepper.file, SOURCES.stepper.symbol);
+  const parser = readArrayLiterals(SOURCES.parser.file, SOURCES.parser.symbol);
+  const persisted = readUnionLiterals(PERSISTED.file, PERSISTED.symbol);
+
+  const gaps = findVocabularyGaps({ stepper, parser, persisted });
+  if (gaps.length > 0) {
+    console.error("[nav-link-vocab] the shared parser vocabulary is missing link types:");
+    for (const gap of gaps) {
+      console.error(`  - "${gap.missing}" is required by the ${gap.requiredBy} list`);
+    }
+    console.error(
+      `\n  Add them to ${SOURCES.parser.symbol} in ${SOURCES.parser.file}, or reduce the\n` +
+        "  other list. A traversal cannot follow a link type its parser rejects.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `[nav-link-vocab] OK: parser knows ${parser.length} types, covering ` +
+      `${stepper.length} stepper and ${persisted.length} persisted types`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -23,7 +23,7 @@ import path from "node:path";
 import process from "node:process";
 
 /** Build a single query with one aliased pullRequest field per PR number. */
-export function buildListQuery(owner, repo, prNumbers) {
+export function buildListQuery(owner, repo, prNumbers, cursors = {}) {
   if (prNumbers.length === 0) throw new Error("pr-review-threads: no PR numbers given");
   for (const pr of prNumbers) {
     if (!Number.isInteger(pr) || pr <= 0) {
@@ -31,16 +31,35 @@ export function buildListQuery(owner, repo, prNumbers) {
     }
   }
   const fields = prNumbers
-    .map(
-      (pr) =>
+    .map((pr) => {
+      // A PR with more than one page of threads (resolved ones count) would
+      // otherwise silently truncate, and the helper would report "none
+      // unresolved" while the review guard stayed red.
+      const after = cursors[pr] ? `, after: "${cursors[pr]}"` : "";
+      return (
         `  pr${pr}: pullRequest(number: ${pr}) { ` +
-        "reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { author { login } } } } } }",
-    )
+        `reviewThreads(first: 50${after}) { pageInfo { hasNextPage endCursor } ` +
+        "nodes { id isResolved comments(first: 1) { nodes { author { login } } } } } }"
+      );
+    })
     .join("\n");
   return `query {\n repository(owner: "${owner}", name: "${repo}") {\n${fields}\n }\n}`;
 }
 
 /** Build a single mutation with one aliased resolveReviewThread per thread. */
+export function uniqueThreadIds(threadIds) {
+  const seen = new Set();
+  for (const id of threadIds) {
+    if (typeof id !== "string" || id.trim() === "" || id !== id.trim()) {
+      throw new Error(
+        `pr-review-threads: thread id must be a trimmed non-blank string, got ${JSON.stringify(id)}`,
+      );
+    }
+    seen.add(id);
+  }
+  return [...seen];
+}
+
 export function buildResolveMutation(threadIds) {
   if (threadIds.length === 0) throw new Error("pr-review-threads: no thread ids given");
   const seen = new Set();
@@ -56,6 +75,19 @@ export function buildResolveMutation(threadIds) {
     fields.push(`  t${index}: resolveReviewThread(input: { threadId: "${id}" }) { thread { isResolved } }`);
   }
   return `mutation {\n${fields.join("\n")}\n}`;
+}
+
+export function collectPageInfo(data) {
+  const repository = data?.data?.repository ?? {};
+  const more = {};
+  for (const [alias, pr] of Object.entries(repository)) {
+    if (!alias.startsWith("pr") || pr === null || typeof pr !== "object") continue;
+    const info = pr.reviewThreads?.pageInfo;
+    if (info?.hasNextPage === true && typeof info.endCursor === "string") {
+      more[alias.slice(2)] = info.endCursor;
+    }
+  }
+  return more;
 }
 
 export function collectUnresolved(data) {
@@ -79,11 +111,31 @@ export function collectUnresolved(data) {
 }
 
 function gh(query) {
-  const out = execFileSync("gh", ["api", "graphql", "-f", `query=${query}`], {
-    encoding: "utf8",
-    maxBuffer: 32 * 1024 * 1024,
-  });
-  return JSON.parse(out);
+  let out;
+  try {
+    out = execFileSync("gh", ["api", "graphql", "-f", `query=${query}`], {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch (error) {
+    // A rate limit is the condition this helper exists to survive, so report
+    // it as one line instead of a raw execFileSync stack trace.
+    const stdout = typeof error?.stdout === "string" ? error.stdout : "";
+    if (stdout.includes("RATE_LIMIT") || stdout.includes("rate limit")) {
+      throw new Error(
+        "pr-review-threads: the GraphQL point budget is exhausted. Wait for it to " +
+          "refill and re-run; this helper already batches requests, so there is " +
+          "nothing smaller to retry.",
+      );
+    }
+    throw new Error(`pr-review-threads: gh api graphql failed: ${stdout || error?.message || "unknown error"}`);
+  }
+  const parsed = JSON.parse(out);
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    const first = parsed.errors[0];
+    throw new Error(`pr-review-threads: GraphQL error ${first?.type ?? ""}: ${first?.message ?? "unknown"}`.trim());
+  }
+  return parsed;
 }
 
 function main(argv) {
@@ -92,8 +144,23 @@ function main(argv) {
     const [slug, ...prs] = rest;
     if (!slug || !slug.includes("/")) throw new Error("pr-review-threads list <owner/repo> <pr...>");
     const [owner, repo] = slug.split("/");
-    const query = buildListQuery(owner, repo, prs.map((pr) => Number(pr)));
-    for (const row of collectUnresolved(gh(query))) {
+    const numbers = prs.map((pr) => Number(pr));
+    const rows = [];
+    let cursors = {};
+    let pending = numbers;
+    // Round 1 covers every PR in one request; later rounds only revisit the
+    // PRs that reported another page, so the common case stays at one request.
+    for (let round = 0; round < 20 && pending.length > 0; round += 1) {
+      const page = gh(buildListQuery(owner, repo, pending, cursors));
+      rows.push(...collectUnresolved(page));
+      cursors = collectPageInfo(page);
+      pending = Object.keys(cursors).map((pr) => Number(pr));
+    }
+    if (pending.length > 0) {
+      throw new Error("pr-review-threads: thread pagination did not terminate");
+    }
+    rows.sort((a, b) => Number(a.pr) - Number(b.pr) || (a.threadId < b.threadId ? -1 : a.threadId > b.threadId ? 1 : 0));
+    for (const row of rows) {
       console.log(`PR${row.pr} ${row.threadId} ${row.author}`);
     }
     return;
@@ -101,10 +168,14 @@ function main(argv) {
   if (mode === "resolve") {
     const ids = rest.filter((token) => token.startsWith("PRRT_"));
     if (ids.length === 0) throw new Error("pr-review-threads resolve <threadId...>");
+    // Compare against the UNIQUE ids actually sent: buildResolveMutation
+    // deduplicates, so GraphQL returns one result per unique id and using the
+    // caller's raw count would fail a run that resolved everything.
+    const unique = uniqueThreadIds(ids);
     const result = gh(buildResolveMutation(ids));
     const resolved = Object.values(result?.data ?? {}).filter((entry) => entry?.thread?.isResolved === true);
-    console.log(`[pr-review-threads] resolved ${resolved.length}/${ids.length} in one request`);
-    if (resolved.length !== ids.length) process.exit(1);
+    console.log(`[pr-review-threads] resolved ${resolved.length}/${unique.length} in one request`);
+    if (resolved.length !== unique.length) process.exit(1);
     return;
   }
   throw new Error("usage: pr-review-threads.mjs list <owner/repo> <pr...> | resolve <threadId...>");

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -10,20 +10,48 @@
  *
  * This helper issues ONE query for every PR (aliased sub-selections) and ONE
  * mutation for every thread (aliased mutations), which is the same work in
- * two requests instead of 2N.
+ * two requests instead of 2N — plus one extra query per additional page for
+ * any PR with more than 50 threads.
  *
  *   node scripts/pr-review-threads.mjs list  <owner/repo> <pr...>
  *   node scripts/pr-review-threads.mjs resolve <threadId...>
  *
  * `list` prints one `PR<number> <threadId> <author>` line per UNRESOLVED
- * thread, so the output pipes straight into `resolve`.
+ * thread. `resolve` takes ids on argv, or reads them from stdin, so both
+ * `list | resolve` and `resolve $(list ... | awk ...)` work.
  */
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
+/**
+ * Serialize a value as a GraphQL string literal. execFileSync passes argv
+ * without a shell, so the risk here is GraphQL injection, not shell
+ * injection: a quote or brace in an interpolated value can change the
+ * operation that runs under the configured gh credential.
+ */
+export function graphqlString(value, field) {
+  if (typeof value !== "string" || value === "") {
+    throw new Error(`pr-review-threads: ${field} must be a non-empty string`);
+  }
+  return JSON.stringify(value);
+}
+
+/** GitHub owner/repo charset. Anything else is refused before interpolation. */
+export function assertRepoIdentifier(value, field) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new Error(
+      `pr-review-threads: ${field} must match [A-Za-z0-9._-]+, got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
 /** Build a single query with one aliased pullRequest field per PR number. */
 export function buildListQuery(owner, repo, prNumbers, cursors = {}) {
+  assertRepoIdentifier(owner, "owner");
+  assertRepoIdentifier(repo, "repo");
   if (prNumbers.length === 0) throw new Error("pr-review-threads: no PR numbers given");
   for (const pr of prNumbers) {
     if (!Number.isInteger(pr) || pr <= 0) {
@@ -35,7 +63,7 @@ export function buildListQuery(owner, repo, prNumbers, cursors = {}) {
       // A PR with more than one page of threads (resolved ones count) would
       // otherwise silently truncate, and the helper would report "none
       // unresolved" while the review guard stayed red.
-      const after = cursors[pr] ? `, after: "${cursors[pr]}"` : "";
+      const after = cursors[pr] ? `, after: ${graphqlString(cursors[pr], "cursor")}` : "";
       return (
         `  pr${pr}: pullRequest(number: ${pr}) { ` +
         `reviewThreads(first: 50${after}) { pageInfo { hasNextPage endCursor } ` +
@@ -43,18 +71,32 @@ export function buildListQuery(owner, repo, prNumbers, cursors = {}) {
       );
     })
     .join("\n");
-  return `query {\n repository(owner: "${owner}", name: "${repo}") {\n${fields}\n }\n}`;
+  return (
+    `query {\n repository(owner: ${graphqlString(owner, "owner")}, ` +
+    `name: ${graphqlString(repo, "repo")}) {\n${fields}\n }\n}`
+  );
 }
 
 /** Build a single mutation with one aliased resolveReviewThread per thread. */
+/** Node ids are opaque base64url-ish tokens; anything else is refused. */
+export function assertThreadId(id) {
+  if (typeof id !== "string" || id.trim() === "" || id !== id.trim()) {
+    throw new Error(
+      `pr-review-threads: thread id must be a trimmed non-blank string, got ${JSON.stringify(id)}`,
+    );
+  }
+  if (!/^[A-Za-z0-9_=-]+$/.test(id)) {
+    throw new Error(
+      `pr-review-threads: thread id must match [A-Za-z0-9_=-]+, got ${JSON.stringify(id)}`,
+    );
+  }
+  return id;
+}
+
 export function uniqueThreadIds(threadIds) {
   const seen = new Set();
   for (const id of threadIds) {
-    if (typeof id !== "string" || id.trim() === "" || id !== id.trim()) {
-      throw new Error(
-        `pr-review-threads: thread id must be a trimmed non-blank string, got ${JSON.stringify(id)}`,
-      );
-    }
+    assertThreadId(id);
     seen.add(id);
   }
   return [...seen];
@@ -65,14 +107,15 @@ export function buildResolveMutation(threadIds) {
   const seen = new Set();
   const fields = [];
   for (const [index, id] of threadIds.entries()) {
-    if (typeof id !== "string" || id.trim() === "" || id !== id.trim()) {
-      throw new Error(`pr-review-threads: thread id must be a trimmed non-blank string, got ${JSON.stringify(id)}`);
-    }
+    assertThreadId(id);
     // A duplicate id would collide on its alias and make the whole mutation
     // invalid, so drop repeats rather than sending a request that cannot run.
     if (seen.has(id)) continue;
     seen.add(id);
-    fields.push(`  t${index}: resolveReviewThread(input: { threadId: "${id}" }) { thread { isResolved } }`);
+    fields.push(
+      `  t${index}: resolveReviewThread(input: { threadId: ${graphqlString(id, "thread id")} }) ` +
+        "{ thread { isResolved } }",
+    );
   }
   return `mutation {\n${fields.join("\n")}\n}`;
 }
@@ -120,15 +163,20 @@ function gh(query) {
   } catch (error) {
     // A rate limit is the condition this helper exists to survive, so report
     // it as one line instead of a raw execFileSync stack trace.
+    // gh writes the concise diagnostic to stderr and the JSON body to stdout,
+    // so both streams must be inspected before classifying the failure.
     const stdout = typeof error?.stdout === "string" ? error.stdout : "";
-    if (stdout.includes("RATE_LIMIT") || stdout.includes("rate limit")) {
+    const stderr = typeof error?.stderr === "string" ? error.stderr : "";
+    const combined = `${stdout}\n${stderr}`;
+    if (combined.includes("RATE_LIMIT") || /rate limit/i.test(combined)) {
       throw new Error(
         "pr-review-threads: the GraphQL point budget is exhausted. Wait for it to " +
           "refill and re-run; this helper already batches requests, so there is " +
           "nothing smaller to retry.",
       );
     }
-    throw new Error(`pr-review-threads: gh api graphql failed: ${stdout || error?.message || "unknown error"}`);
+    const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join(" | ");
+    throw new Error(`pr-review-threads: gh api graphql failed: ${detail || error?.message || "unknown error"}`);
   }
   const parsed = JSON.parse(out);
   if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
@@ -136,6 +184,22 @@ function gh(query) {
     throw new Error(`pr-review-threads: GraphQL error ${first?.type ?? ""}: ${first?.message ?? "unknown"}`.trim());
   }
   return parsed;
+}
+
+/** Extract thread ids from piped `list` output. Empty when stdin is a TTY. */
+export function threadIdsFromStdin(readStdin = defaultReadStdin) {
+  const text = readStdin();
+  if (!text) return [];
+  return text.split(/\s+/).filter((token) => token.startsWith("PRRT_"));
+}
+
+function defaultReadStdin() {
+  if (process.stdin.isTTY) return "";
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
 }
 
 function main(argv) {
@@ -150,14 +214,24 @@ function main(argv) {
     let pending = numbers;
     // Round 1 covers every PR in one request; later rounds only revisit the
     // PRs that reported another page, so the common case stays at one request.
-    for (let round = 0; round < 20 && pending.length > 0; round += 1) {
+    // No page cap: a valid cursor chain must be allowed to finish however long
+    // it is. A cursor that repeats for the same PR is a real loop, and that is
+    // what terminates instead.
+    const lastCursor = new Map();
+    while (pending.length > 0) {
       const page = gh(buildListQuery(owner, repo, pending, cursors));
       rows.push(...collectUnresolved(page));
       cursors = collectPageInfo(page);
+      for (const [pr, cursor] of Object.entries(cursors)) {
+        if (lastCursor.get(pr) === cursor) {
+          throw new Error(
+            `pr-review-threads: PR ${pr} returned the same cursor twice (${cursor}); ` +
+              "pagination is looping",
+          );
+        }
+        lastCursor.set(pr, cursor);
+      }
       pending = Object.keys(cursors).map((pr) => Number(pr));
-    }
-    if (pending.length > 0) {
-      throw new Error("pr-review-threads: thread pagination did not terminate");
     }
     rows.sort((a, b) => Number(a.pr) - Number(b.pr) || (a.threadId < b.threadId ? -1 : a.threadId > b.threadId ? 1 : 0));
     for (const row of rows) {
@@ -166,8 +240,13 @@ function main(argv) {
     return;
   }
   if (mode === "resolve") {
-    const ids = rest.filter((token) => token.startsWith("PRRT_"));
-    if (ids.length === 0) throw new Error("pr-review-threads resolve <threadId...>");
+    // The documented `list | resolve` pipe puts the rows on stdin, so read it
+    // when no ids are given on argv rather than telling the user it worked.
+    const argvIds = rest.filter((token) => token.startsWith("PRRT_"));
+    const ids = argvIds.length > 0 ? argvIds : threadIdsFromStdin();
+    if (ids.length === 0) {
+      throw new Error("pr-review-threads resolve <threadId...>  (or pipe `list` output in)");
+    }
     // Compare against the UNIQUE ids actually sent: buildResolveMutation
     // deduplicates, so GraphQL returns one result per unique id and using the
     // caller's raw count would fail a run that resolved everything.

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -242,6 +242,11 @@ function main(argv) {
     // owner/repo/extra previously queried owner/repo and presented the result
     // as the requested repository's thread state.
     const { owner, repo } = parseRepoSlug(slug);
+    // `list owner/repo` with no numbers previously exited 0 with no output,
+    // which is indistinguishable from "no unresolved threads".
+    if (prs.length === 0) {
+      throw new Error("pr-review-threads list <owner/repo> <pr...>: at least one PR number is required");
+    }
     const numbers = prs.map((pr) => Number(pr));
     const rows = [];
     let cursors = {};

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -22,6 +22,9 @@
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+
+/** Printed by `list` after its final row: proof the query completed. */
+export const LIST_SENTINEL = "# pr-review-threads: end of list";
 import path from "node:path";
 import process from "node:process";
 
@@ -207,6 +210,24 @@ export function assertCursorsAdvance(seenCursors, cursors) {
   return seenCursors;
 }
 
+/**
+ * Parse a PR number from its ORIGINAL token. `Number("0x10")` is 16 and
+ * `Number("1e2")` is 100, so a malformed token would silently report a
+ * different PR's thread state than the caller asked for.
+ */
+export function parsePrNumber(token) {
+  if (typeof token !== "string" || !/^[0-9]{1,12}$/.test(token)) {
+    throw new Error(
+      `pr-review-threads: PR number must be decimal digits, got ${JSON.stringify(token)}`,
+    );
+  }
+  const value = Number(token);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`pr-review-threads: PR number must be a positive integer, got ${JSON.stringify(token)}`);
+  }
+  return value;
+}
+
 /** Split `owner/repo`, refusing anything that is not exactly two components. */
 export function parseRepoSlug(slug) {
   const parts = typeof slug === "string" ? slug.split("/") : [];
@@ -229,8 +250,16 @@ export function threadIdsFromStdin(readStdin = defaultReadStdin) {
   return text.split(/\s+/).filter((token) => token.startsWith("PRRT_"));
 }
 
+let lastStdinText = null;
+
 function readPipedThreadIds() {
-  return threadIdsFromStdin();
+  lastStdinText = defaultReadStdin();
+  if (lastStdinText === null) return null;
+  return lastStdinText.split(/\s+/).filter((token) => token.startsWith("PRRT_"));
+}
+
+function pipedRanToCompletion() {
+  return typeof lastStdinText === "string" && lastStdinText.includes(LIST_SENTINEL);
 }
 
 function defaultReadStdin() {
@@ -258,7 +287,7 @@ function main(argv) {
     if (prs.length === 0) {
       throw new Error("pr-review-threads list <owner/repo> <pr...>: at least one PR number is required");
     }
-    const numbers = prs.map((pr) => Number(pr));
+    const numbers = prs.map((pr) => parsePrNumber(pr));
     const rows = [];
     let cursors = {};
     let pending = numbers;
@@ -282,6 +311,10 @@ function main(argv) {
     for (const row of rows) {
       console.log(`PR${row.pr} ${row.threadId} ${row.author}`);
     }
+    // Proof of completion. Without it, a `list` that died early (rate limit,
+    // inaccessible PR) hands `resolve` empty stdin, and in a pipeline without
+    // pipefail the run reports success having queried nothing.
+    console.log(LIST_SENTINEL);
     return;
   }
   if (mode === "resolve") {
@@ -299,10 +332,15 @@ function main(argv) {
         throw new Error("pr-review-threads resolve <threadId...>  (or pipe `list` output in)");
       }
       if (piped.length === 0) {
-        // `list | resolve` when every PR is already clean. The pipeline
-        // succeeded; exiting nonzero here would fail automation on the
-        // healthy path.
-        console.log("[pr-review-threads] no unresolved threads piped in; nothing to resolve");
+        // Empty input is only clean when `list` says it finished. Otherwise
+        // the upstream failed and this must not report success.
+        if (!pipedRanToCompletion()) {
+          throw new Error(
+            "pr-review-threads: empty input without the end-of-list marker — `list` did not finish, " +
+              "so there is no evidence the queried PRs are clean",
+          );
+        }
+        console.log("[pr-review-threads] list finished with no unresolved threads; nothing to resolve");
         return;
       }
       ids = piped;

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -186,6 +186,38 @@ function gh(query) {
   return parsed;
 }
 
+/**
+ * Throw when a PR returns a cursor it has already returned. Tracks the whole
+ * set per PR so a cycle longer than one step is caught too.
+ */
+export function assertCursorsAdvance(seenCursors, cursors) {
+  for (const [pr, cursor] of Object.entries(cursors)) {
+    let seen = seenCursors.get(pr);
+    if (!seen) {
+      seen = new Set();
+      seenCursors.set(pr, seen);
+    }
+    if (seen.has(cursor)) {
+      throw new Error(
+        `pr-review-threads: PR ${pr} returned cursor ${cursor} twice; pagination is looping`,
+      );
+    }
+    seen.add(cursor);
+  }
+  return seenCursors;
+}
+
+/** Split `owner/repo`, refusing anything that is not exactly two components. */
+export function parseRepoSlug(slug) {
+  const parts = typeof slug === "string" ? slug.split("/") : [];
+  if (parts.length !== 2 || parts.some((part) => part === "")) {
+    throw new Error(
+      `pr-review-threads: expected exactly owner/repo, got ${JSON.stringify(slug)}`,
+    );
+  }
+  return { owner: assertRepoIdentifier(parts[0], "owner"), repo: assertRepoIdentifier(parts[1], "repo") };
+}
+
 /** Extract thread ids from piped `list` output. Empty when stdin is a TTY. */
 export function threadIdsFromStdin(readStdin = defaultReadStdin) {
   const text = readStdin();
@@ -206,8 +238,10 @@ function main(argv) {
   const [mode, ...rest] = argv;
   if (mode === "list") {
     const [slug, ...prs] = rest;
-    if (!slug || !slug.includes("/")) throw new Error("pr-review-threads list <owner/repo> <pr...>");
-    const [owner, repo] = slug.split("/");
+    if (!slug) throw new Error("pr-review-threads list <owner/repo> <pr...>");
+    // owner/repo/extra previously queried owner/repo and presented the result
+    // as the requested repository's thread state.
+    const { owner, repo } = parseRepoSlug(slug);
     const numbers = prs.map((pr) => Number(pr));
     const rows = [];
     let cursors = {};
@@ -217,20 +251,15 @@ function main(argv) {
     // No page cap: a valid cursor chain must be allowed to finish however long
     // it is. A cursor that repeats for the same PR is a real loop, and that is
     // what terminates instead.
-    const lastCursor = new Map();
+    // Every cursor ever seen for a PR, not just the previous one: a C1 -> C2 ->
+    // C1 cycle would otherwise pass an adjacent-duplicate check and keep
+    // issuing requests until the rate limiter stopped it.
+    const seenCursors = new Map();
     while (pending.length > 0) {
       const page = gh(buildListQuery(owner, repo, pending, cursors));
       rows.push(...collectUnresolved(page));
       cursors = collectPageInfo(page);
-      for (const [pr, cursor] of Object.entries(cursors)) {
-        if (lastCursor.get(pr) === cursor) {
-          throw new Error(
-            `pr-review-threads: PR ${pr} returned the same cursor twice (${cursor}); ` +
-              "pagination is looping",
-          );
-        }
-        lastCursor.set(pr, cursor);
-      }
+      assertCursorsAdvance(seenCursors, cursors);
       pending = Object.keys(cursors).map((pr) => Number(pr));
     }
     rows.sort((a, b) => Number(a.pr) - Number(b.pr) || (a.threadId < b.threadId ? -1 : a.threadId > b.threadId ? 1 : 0));
@@ -242,7 +271,10 @@ function main(argv) {
   if (mode === "resolve") {
     // The documented `list | resolve` pipe puts the rows on stdin, so read it
     // when no ids are given on argv rather than telling the user it worked.
-    const argvIds = rest.filter((token) => token.startsWith("PRRT_"));
+    // Every argv token must be a valid id. Filtering invalid ones away
+    // resolved the rest and reported success while a requested thread stayed
+    // unresolved.
+    const argvIds = rest.length > 0 ? rest.map((token) => assertThreadId(token)) : [];
     const ids = argvIds.length > 0 ? argvIds : threadIdsFromStdin();
     if (ids.length === 0) {
       throw new Error("pr-review-threads resolve <threadId...>  (or pipe `list` output in)");

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Batched review-thread queries and resolves (GraphQL budget survival).
+ *
+ * The naive loop — one GraphQL query per PR to list threads, then one
+ * mutation per thread to resolve — exhausts the GraphQL point budget fast
+ * when several PRs are in flight, and `unresolved-review-threads` then stays
+ * red for as long as the budget takes to refill. One agent run lost roughly
+ * two and a half hours to three separate rate-limit waits doing exactly that.
+ *
+ * This helper issues ONE query for every PR (aliased sub-selections) and ONE
+ * mutation for every thread (aliased mutations), which is the same work in
+ * two requests instead of 2N.
+ *
+ *   node scripts/pr-review-threads.mjs list  <owner/repo> <pr...>
+ *   node scripts/pr-review-threads.mjs resolve <threadId...>
+ *
+ * `list` prints one `PR<number> <threadId> <author>` line per UNRESOLVED
+ * thread, so the output pipes straight into `resolve`.
+ */
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+/** Build a single query with one aliased pullRequest field per PR number. */
+export function buildListQuery(owner, repo, prNumbers) {
+  if (prNumbers.length === 0) throw new Error("pr-review-threads: no PR numbers given");
+  for (const pr of prNumbers) {
+    if (!Number.isInteger(pr) || pr <= 0) {
+      throw new Error(`pr-review-threads: PR number must be a positive integer, got ${pr}`);
+    }
+  }
+  const fields = prNumbers
+    .map(
+      (pr) =>
+        `  pr${pr}: pullRequest(number: ${pr}) { ` +
+        "reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { author { login } } } } } }",
+    )
+    .join("\n");
+  return `query {\n repository(owner: "${owner}", name: "${repo}") {\n${fields}\n }\n}`;
+}
+
+/** Build a single mutation with one aliased resolveReviewThread per thread. */
+export function buildResolveMutation(threadIds) {
+  if (threadIds.length === 0) throw new Error("pr-review-threads: no thread ids given");
+  const seen = new Set();
+  const fields = [];
+  for (const [index, id] of threadIds.entries()) {
+    if (typeof id !== "string" || id.trim() === "" || id !== id.trim()) {
+      throw new Error(`pr-review-threads: thread id must be a trimmed non-blank string, got ${JSON.stringify(id)}`);
+    }
+    // A duplicate id would collide on its alias and make the whole mutation
+    // invalid, so drop repeats rather than sending a request that cannot run.
+    if (seen.has(id)) continue;
+    seen.add(id);
+    fields.push(`  t${index}: resolveReviewThread(input: { threadId: "${id}" }) { thread { isResolved } }`);
+  }
+  return `mutation {\n${fields.join("\n")}\n}`;
+}
+
+export function collectUnresolved(data) {
+  const repository = data?.data?.repository ?? {};
+  const rows = [];
+  for (const [alias, pr] of Object.entries(repository)) {
+    if (!alias.startsWith("pr") || pr === null || typeof pr !== "object") continue;
+    const number = alias.slice(2);
+    for (const node of pr.reviewThreads?.nodes ?? []) {
+      if (node?.isResolved !== false) continue;
+      rows.push({
+        pr: number,
+        threadId: node.id,
+        author: node.comments?.nodes?.[0]?.author?.login ?? "unknown",
+      });
+    }
+  }
+  // Deterministic: PR ascending (numeric), then thread id.
+  rows.sort((a, b) => (Number(a.pr) - Number(b.pr)) || (a.threadId < b.threadId ? -1 : a.threadId > b.threadId ? 1 : 0));
+  return rows;
+}
+
+function gh(query) {
+  const out = execFileSync("gh", ["api", "graphql", "-f", `query=${query}`], {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(out);
+}
+
+function main(argv) {
+  const [mode, ...rest] = argv;
+  if (mode === "list") {
+    const [slug, ...prs] = rest;
+    if (!slug || !slug.includes("/")) throw new Error("pr-review-threads list <owner/repo> <pr...>");
+    const [owner, repo] = slug.split("/");
+    const query = buildListQuery(owner, repo, prs.map((pr) => Number(pr)));
+    for (const row of collectUnresolved(gh(query))) {
+      console.log(`PR${row.pr} ${row.threadId} ${row.author}`);
+    }
+    return;
+  }
+  if (mode === "resolve") {
+    const ids = rest.filter((token) => token.startsWith("PRRT_"));
+    if (ids.length === 0) throw new Error("pr-review-threads resolve <threadId...>");
+    const result = gh(buildResolveMutation(ids));
+    const resolved = Object.values(result?.data ?? {}).filter((entry) => entry?.thread?.isResolved === true);
+    console.log(`[pr-review-threads] resolved ${resolved.length}/${ids.length} in one request`);
+    if (resolved.length !== ids.length) process.exit(1);
+    return;
+  }
+  throw new Error("usage: pr-review-threads.mjs list <owner/repo> <pr...> | resolve <threadId...>");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main(process.argv.slice(2));
+}

--- a/scripts/pr-review-threads.mjs
+++ b/scripts/pr-review-threads.mjs
@@ -218,18 +218,29 @@ export function parseRepoSlug(slug) {
   return { owner: assertRepoIdentifier(parts[0], "owner"), repo: assertRepoIdentifier(parts[1], "repo") };
 }
 
-/** Extract thread ids from piped `list` output. Empty when stdin is a TTY. */
+/**
+ * Extract thread ids from piped `list` output.
+ * `null` means nothing was piped at all (interactive run); `[]` means a pipe
+ * delivered no unresolved threads, which is a success, not a usage error.
+ */
 export function threadIdsFromStdin(readStdin = defaultReadStdin) {
   const text = readStdin();
-  if (!text) return [];
+  if (text === null) return null;
   return text.split(/\s+/).filter((token) => token.startsWith("PRRT_"));
 }
 
+function readPipedThreadIds() {
+  return threadIdsFromStdin();
+}
+
 function defaultReadStdin() {
-  if (process.stdin.isTTY) return "";
+  // A TTY means no pipe: distinct from a pipe that carried no rows.
+  if (process.stdin.isTTY) return null;
   try {
     return readFileSync(0, "utf8");
   } catch {
+    // A pipe that delivered nothing can raise EAGAIN/EOF here. stdin was
+    // still redirected, so this is an empty pipe, not an interactive run.
     return "";
   }
 }
@@ -280,9 +291,21 @@ function main(argv) {
     // resolved the rest and reported success while a requested thread stayed
     // unresolved.
     const argvIds = rest.length > 0 ? rest.map((token) => assertThreadId(token)) : [];
-    const ids = argvIds.length > 0 ? argvIds : threadIdsFromStdin();
+    let ids = argvIds;
     if (ids.length === 0) {
-      throw new Error("pr-review-threads resolve <threadId...>  (or pipe `list` output in)");
+      const piped = readPipedThreadIds();
+      if (piped === null) {
+        // Nothing on argv and nothing piped: the invocation is incomplete.
+        throw new Error("pr-review-threads resolve <threadId...>  (or pipe `list` output in)");
+      }
+      if (piped.length === 0) {
+        // `list | resolve` when every PR is already clean. The pipeline
+        // succeeded; exiting nonzero here would fail automation on the
+        // healthy path.
+        console.log("[pr-review-threads] no unresolved threads piped in; nothing to resolve");
+        return;
+      }
+      ids = piped;
     }
     // Compare against the UNIQUE ids actually sent: buildResolveMutation
     // deduplicates, so GraphQL returns one result per unique id and using the

--- a/tests/check-nav-link-vocabularies.test.mjs
+++ b/tests/check-nav-link-vocabularies.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findVocabularyGaps } from "../scripts/check-nav-link-vocabularies.mjs";
+
+test("agreeing vocabularies report no gaps", () => {
+  const gaps = findVocabularyGaps({
+    stepper: ["supports", "supersedes"],
+    persisted: ["supports", "related"],
+    parser: ["supports", "supersedes", "related", "extra"],
+  });
+  assert.deepEqual(gaps, [], "a parser superset is the healthy state");
+});
+
+// This is the exact divergence that took two review rounds on #1956: the
+// shared parser knew the navigation-only names but not the persisted ones,
+// so a traversal over real frontmatter silently dropped those neighbors.
+test("the original pre-fix divergence is caught", () => {
+  const gaps = findVocabularyGaps({
+    stepper: ["supports", "contradicts", "elaborates", "causes", "supersedes"],
+    persisted: ["follows", "references", "contradicts", "supports", "related"],
+    parser: ["supports", "contradicts", "elaborates", "causes", "caused_by"],
+  });
+  assert.deepEqual(
+    gaps.map((gap) => `${gap.missing}:${gap.requiredBy}`),
+    [
+      "follows:persisted",
+      "references:persisted",
+      "related:persisted",
+      "supersedes:stepper",
+    ],
+    "every missing type is reported with the list that requires it",
+  );
+});
+
+test("a stepper-only gap is attributed to the stepper", () => {
+  const gaps = findVocabularyGaps({
+    stepper: ["supports", "supersedes"],
+    persisted: ["supports"],
+    parser: ["supports"],
+  });
+  assert.deepEqual(gaps, [{ missing: "supersedes", requiredBy: "stepper" }]);
+});
+
+test("gap order is deterministic regardless of input order", () => {
+  const forward = findVocabularyGaps({
+    stepper: ["zeta", "alpha"],
+    persisted: ["mid"],
+    parser: [],
+  });
+  const reversed = findVocabularyGaps({
+    stepper: ["alpha", "zeta"],
+    persisted: ["mid"],
+    parser: [],
+  });
+  assert.deepEqual(forward, reversed);
+  assert.deepEqual(
+    forward.map((gap) => gap.missing),
+    ["alpha", "mid", "zeta"],
+  );
+});
+
+test("a type required by both lists is reported once per requiring list", () => {
+  const gaps = findVocabularyGaps({
+    stepper: ["shared"],
+    persisted: ["shared"],
+    parser: [],
+  });
+  assert.deepEqual(gaps, [
+    { missing: "shared", requiredBy: "persisted" },
+    { missing: "shared", requiredBy: "stepper" },
+  ]);
+});

--- a/tests/check-nav-link-vocabularies.test.mjs
+++ b/tests/check-nav-link-vocabularies.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { findVocabularyGaps } from "../scripts/check-nav-link-vocabularies.mjs";
+import { findVocabularyGaps, stripComments } from "../scripts/check-nav-link-vocabularies.mjs";
 
 test("agreeing vocabularies report no gaps", () => {
   const gaps = findVocabularyGaps({
@@ -70,4 +70,21 @@ test("a type required by both lists is reported once per requiring list", () => 
     { missing: "shared", requiredBy: "persisted" },
     { missing: "shared", requiredBy: "stepper" },
   ]);
+});
+
+// Review round 2: quoted text in comments read as vocabulary members, so the
+// gate could pass while the real lists still diverged.
+test("commented-out members are not vocabulary", () => {
+  const source = 'const X = [\n  "supports",\n  // "related" is not supported yet\n  /* "causes" */\n] as const;';
+  const stripped = stripComments(source);
+  assert.match(stripped, /"supports"/);
+  assert.doesNotMatch(stripped, /"related"/);
+  assert.doesNotMatch(stripped, /"causes"/);
+});
+
+test("a URL inside a string literal survives stripping", () => {
+  const source = 'const U = "https://example.com/a"; // trailing note';
+  const stripped = stripComments(source);
+  assert.match(stripped, /"https:\/\/example\.com\/a"/);
+  assert.doesNotMatch(stripped, /trailing note/);
 });

--- a/tests/check-nav-link-vocabularies.test.mjs
+++ b/tests/check-nav-link-vocabularies.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { findVocabularyGaps, stripComments } from "../scripts/check-nav-link-vocabularies.mjs";
+import { assertOnlyLiteralMembers, findVocabularyGaps, stripComments } from "../scripts/check-nav-link-vocabularies.mjs";
 
 test("agreeing vocabularies report no gaps", () => {
   const gaps = findVocabularyGaps({
@@ -96,4 +96,23 @@ test("a block comment between tokens leaves a separator", () => {
   const stripped = stripComments('export/* note */type NavLink = "a" | "b";');
   assert.match(stripped, /export\s+type NavLink/);
   assert.doesNotMatch(stripped, /exporttype/);
+});
+
+// Review: a union composed through an alias or spread was silently ignored, so
+// the gate could report agreement while the vocabularies actually diverged.
+test("a non-literal member fails the gate instead of being ignored", () => {
+  assert.throws(
+    () => assertOnlyLiteralMembers('"a" | "b" | OtherLinkTypes', ["a", "b"], "T", "f.ts", "|"),
+    /non-literal member\(s\) \[OtherLinkTypes\]/,
+  );
+  assert.throws(
+    () => assertOnlyLiteralMembers('"a", ...MORE_TYPES', ["a"], "X", "f.ts", ","),
+    /non-literal member/,
+  );
+});
+
+test("a purely literal declaration passes, including a trailing as const", () => {
+  assert.doesNotThrow(() => assertOnlyLiteralMembers('"a" | "b"', ["a", "b"], "T", "f.ts", "|"));
+  assert.doesNotThrow(() => assertOnlyLiteralMembers('"a", "b",', ["a", "b"], "X", "f.ts", ","));
+  assert.doesNotThrow(() => assertOnlyLiteralMembers('\n  "a",\n  "b",\n', ["a", "b"], "X", "f.ts", ","));
 });

--- a/tests/check-nav-link-vocabularies.test.mjs
+++ b/tests/check-nav-link-vocabularies.test.mjs
@@ -88,3 +88,12 @@ test("a URL inside a string literal survives stripping", () => {
   assert.match(stripped, /"https:\/\/example\.com\/a"/);
   assert.doesNotMatch(stripped, /trailing note/);
 });
+
+// Review round 3: removing a block comment with no separator turned valid
+// TypeScript into `exporttype`, which no declaration regex can match, so the
+// gate would fail on valid source.
+test("a block comment between tokens leaves a separator", () => {
+  const stripped = stripComments('export/* note */type NavLink = "a" | "b";');
+  assert.match(stripped, /export\s+type NavLink/);
+  assert.doesNotMatch(stripped, /exporttype/);
+});

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -157,3 +157,10 @@ test("a slug must be exactly owner/repo", () => {
     assert.throws(() => parseRepoSlug(bad), /exactly owner\/repo|must match/, `accepted ${bad}`);
   }
 });
+
+// Review: `list owner/repo` with no numbers exited 0 with no output, which
+// reads exactly like "no unresolved threads".
+test("list refuses an empty PR set at both layers", () => {
+  assert.throws(() => buildListQuery("o", "r", []), /no PR numbers given/);
+  assert.throws(() => buildResolveMutation([]), /no thread ids given/);
+});

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   buildListQuery,
   buildResolveMutation,
+  collectPageInfo,
   collectUnresolved,
+  uniqueThreadIds,
 } from "../scripts/pr-review-threads.mjs";
 
 test("one query covers every PR", () => {
@@ -67,4 +69,35 @@ test("only unresolved threads are collected, in deterministic order", () => {
 test("a missing or null PR field does not throw", () => {
   const rows = collectUnresolved({ data: { repository: { pr1: null, other: {} } } });
   assert.deepEqual(rows, []);
+});
+
+// Review: a PR with more than one page of threads silently truncated, so the
+// helper could report "none unresolved" while the review guard stayed red.
+test("pagination cursors are threaded into the query", () => {
+  const first = buildListQuery("o", "r", [7]);
+  assert.match(first, /reviewThreads\(first: 50\)/);
+  assert.match(first, /pageInfo \{ hasNextPage endCursor \}/);
+  const next = buildListQuery("o", "r", [7], { 7: "CURSOR1" });
+  assert.match(next, /reviewThreads\(first: 50, after: "CURSOR1"\)/);
+});
+
+test("only truncated PRs are revisited", () => {
+  const more = collectPageInfo({
+    data: {
+      repository: {
+        pr1: { reviewThreads: { pageInfo: { hasNextPage: true, endCursor: "C1" }, nodes: [] } },
+        pr2: { reviewThreads: { pageInfo: { hasNextPage: false, endCursor: "C2" }, nodes: [] } },
+      },
+    },
+  });
+  assert.deepEqual(more, { 1: "C1" }, "a completed PR is not requeried");
+});
+
+// Review: the exit status compared against the caller's duplicate-inclusive
+// count, so a fully successful resolve exited 1.
+test("unique ids are what a resolve run is measured against", () => {
+  assert.deepEqual(uniqueThreadIds(["PRRT_a", "PRRT_b", "PRRT_a"]), ["PRRT_a", "PRRT_b"]);
+  assert.throws(() => uniqueThreadIds([" PRRT_a"]), /trimmed non-blank string/);
+  const mutation = buildResolveMutation(["PRRT_a", "PRRT_a"]);
+  assert.equal(mutation.match(/resolveReviewThread/g).length, 1);
 });

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -132,7 +132,14 @@ test("a hostile cursor cannot escape its string literal", () => {
 test("thread ids are recovered from piped list output", () => {
   const piped = "PR2759 PRRT_aaa coderabbitai\nPR2760 PRRT_bbb codex\n";
   assert.deepEqual(threadIdsFromStdin(() => piped), ["PRRT_aaa", "PRRT_bbb"]);
-  assert.deepEqual(threadIdsFromStdin(() => ""), []);
+});
+
+// Review: `list | resolve` on a clean repo pipes nothing, and that is the
+// SUCCESS path — it must not be confused with an incomplete invocation.
+test("an empty pipe is distinguishable from no pipe at all", () => {
+  assert.deepEqual(threadIdsFromStdin(() => ""), [], "a pipe with no rows yields an empty list");
+  assert.deepEqual(threadIdsFromStdin(() => "PR1 nothing here"), [], "rows without ids yield an empty list");
+  assert.equal(threadIdsFromStdin(() => null), null, "no pipe yields null");
 });
 
 // Review round 3: an adjacent-duplicate check misses a longer cycle, which

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -4,11 +4,13 @@ import test from "node:test";
 import {
   buildListQuery,
   buildResolveMutation,
+  assertCursorsAdvance,
   assertRepoIdentifier,
   assertThreadId,
   collectPageInfo,
   collectUnresolved,
   graphqlString,
+  parseRepoSlug,
   threadIdsFromStdin,
   uniqueThreadIds,
 } from "../scripts/pr-review-threads.mjs";
@@ -131,4 +133,27 @@ test("thread ids are recovered from piped list output", () => {
   const piped = "PR2759 PRRT_aaa coderabbitai\nPR2760 PRRT_bbb codex\n";
   assert.deepEqual(threadIdsFromStdin(() => piped), ["PRRT_aaa", "PRRT_bbb"]);
   assert.deepEqual(threadIdsFromStdin(() => ""), []);
+});
+
+// Review round 3: an adjacent-duplicate check misses a longer cycle, which
+// keeps issuing requests until the rate limiter stops them.
+test("a cursor cycle longer than one step is caught", () => {
+  const seen = new Map();
+  assertCursorsAdvance(seen, { 1: "C1" });
+  assertCursorsAdvance(seen, { 1: "C2" });
+  assert.throws(() => assertCursorsAdvance(seen, { 1: "C1" }), /cursor C1 twice/);
+});
+
+test("distinct PRs do not share cursor history", () => {
+  const seen = new Map();
+  assertCursorsAdvance(seen, { 1: "C1", 2: "C1" });
+  assert.throws(() => assertCursorsAdvance(seen, { 2: "C1" }), /PR 2 returned cursor C1 twice/);
+});
+
+// Review round 3: owner/repo/extra silently queried owner/repo.
+test("a slug must be exactly owner/repo", () => {
+  assert.deepEqual(parseRepoSlug("o/r"), { owner: "o", repo: "r" });
+  for (const bad of ["o/r/extra", "o/", "/r", "o", "", "o//r"]) {
+    assert.throws(() => parseRepoSlug(bad), /exactly owner\/repo|must match/, `accepted ${bad}`);
+  }
 });

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -10,6 +10,8 @@ import {
   collectPageInfo,
   collectUnresolved,
   graphqlString,
+  LIST_SENTINEL,
+  parsePrNumber,
   parseRepoSlug,
   threadIdsFromStdin,
   uniqueThreadIds,
@@ -170,4 +172,24 @@ test("a slug must be exactly owner/repo", () => {
 test("list refuses an empty PR set at both layers", () => {
   assert.throws(() => buildListQuery("o", "r", []), /no PR numbers given/);
   assert.throws(() => buildResolveMutation([]), /no thread ids given/);
+});
+
+// Review: `Number("0x10")` is 16, so a malformed token silently reported a
+// different PR's thread state than the caller asked for.
+test("PR numbers must be decimal digits", () => {
+  assert.equal(parsePrNumber("2764"), 2764);
+  for (const bad of ["0x10", "1e2", " 12", "12 ", "+12", "-12", "12.0", "", "abc", "0"]) {
+    assert.throws(() => parsePrNumber(bad), /decimal digits|positive integer/, `accepted ${JSON.stringify(bad)}`);
+  }
+});
+
+// Review: an empty pipe is only clean if `list` actually finished. A list that
+// died early (rate limit, inaccessible PR) also produces empty stdin, and in a
+// pipeline without pipefail that would report success having queried nothing.
+test("the end-of-list marker is what makes empty input trustworthy", () => {
+  assert.equal(LIST_SENTINEL, "# pr-review-threads: end of list");
+  const finishedClean = `${LIST_SENTINEL}\n`;
+  assert.deepEqual(threadIdsFromStdin(() => finishedClean), [], "no ids in a clean run");
+  assert.ok(finishedClean.includes(LIST_SENTINEL), "a completed run carries the marker");
+  assert.ok(!"".includes(LIST_SENTINEL), "a died-early run does not");
 });

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildListQuery,
+  buildResolveMutation,
+  collectUnresolved,
+} from "../scripts/pr-review-threads.mjs";
+
+test("one query covers every PR", () => {
+  const query = buildListQuery("owner", "repo", [10, 11]);
+  assert.match(query, /pr10: pullRequest\(number: 10\)/);
+  assert.match(query, /pr11: pullRequest\(number: 11\)/);
+  // The whole point: a single repository selection, not one request per PR.
+  assert.equal(query.match(/repository\(/g).length, 1);
+});
+
+test("invalid PR numbers are refused", () => {
+  assert.throws(() => buildListQuery("o", "r", []), /no PR numbers/);
+  for (const bad of [0, -1, 1.5, Number.NaN]) {
+    assert.throws(() => buildListQuery("o", "r", [bad]), /positive integer/);
+  }
+});
+
+test("one mutation covers every thread and drops duplicates", () => {
+  const mutation = buildResolveMutation(["PRRT_a", "PRRT_b", "PRRT_a"]);
+  assert.equal(mutation.match(/resolveReviewThread/g).length, 2);
+  assert.match(mutation, /t0: resolveReviewThread\(input: \{ threadId: "PRRT_a" \}\)/);
+  assert.match(mutation, /t1: resolveReviewThread\(input: \{ threadId: "PRRT_b" \}\)/);
+});
+
+test("blank, padded, and non-string thread ids are refused", () => {
+  assert.throws(() => buildResolveMutation([]), /no thread ids/);
+  for (const bad of ["", "   ", " PRRT_a", 7]) {
+    assert.throws(() => buildResolveMutation([bad]), /trimmed non-blank string/);
+  }
+});
+
+test("only unresolved threads are collected, in deterministic order", () => {
+  const rows = collectUnresolved({
+    data: {
+      repository: {
+        pr20: {
+          reviewThreads: {
+            nodes: [
+              { id: "PRRT_z", isResolved: false, comments: { nodes: [{ author: { login: "bot-b" } }] } },
+              { id: "PRRT_a", isResolved: false, comments: { nodes: [{ author: { login: "bot-a" } }] } },
+              { id: "PRRT_done", isResolved: true, comments: { nodes: [] } },
+            ],
+          },
+        },
+        pr9: {
+          reviewThreads: {
+            nodes: [{ id: "PRRT_m", isResolved: false, comments: { nodes: [] } }],
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(
+    rows.map((row) => `PR${row.pr}:${row.threadId}:${row.author}`),
+    ["PR9:PRRT_m:unknown", "PR20:PRRT_a:bot-a", "PR20:PRRT_z:bot-b"],
+    "PRs sort numerically, threads by id, resolved threads are excluded",
+  );
+});
+
+test("a missing or null PR field does not throw", () => {
+  const rows = collectUnresolved({ data: { repository: { pr1: null, other: {} } } });
+  assert.deepEqual(rows, []);
+});

--- a/tests/pr-review-threads.test.mjs
+++ b/tests/pr-review-threads.test.mjs
@@ -4,8 +4,12 @@ import test from "node:test";
 import {
   buildListQuery,
   buildResolveMutation,
+  assertRepoIdentifier,
+  assertThreadId,
   collectPageInfo,
   collectUnresolved,
+  graphqlString,
+  threadIdsFromStdin,
   uniqueThreadIds,
 } from "../scripts/pr-review-threads.mjs";
 
@@ -100,4 +104,31 @@ test("unique ids are what a resolve run is measured against", () => {
   assert.throws(() => uniqueThreadIds([" PRRT_a"]), /trimmed non-blank string/);
   const mutation = buildResolveMutation(["PRRT_a", "PRRT_a"]);
   assert.equal(mutation.match(/resolveReviewThread/g).length, 1);
+});
+
+// Review round 2: interpolated values could change the GraphQL operation that
+// runs under the configured gh credential (GraphQL injection, not shell).
+test("string values are serialized, not pasted", () => {
+  assert.equal(graphqlString('a"b', "x"), '"a\\"b"');
+  assert.equal(graphqlString("a\\b", "x"), '"a\\\\b"');
+  assert.throws(() => graphqlString("", "x"), /non-empty string/);
+});
+
+test("repo identifiers and thread ids are charset-checked", () => {
+  assert.throws(() => assertRepoIdentifier('r" ) { x }', "repo"), /must match/);
+  assert.throws(() => assertThreadId('PRRT_" ) { a }'), /must match/);
+  assert.equal(assertThreadId("PRRT_kwDO-a_b="), "PRRT_kwDO-a_b=");
+});
+
+test("a hostile cursor cannot escape its string literal", () => {
+  const query = buildListQuery("o", "r", [1], { 1: 'x" ) { evil }' });
+  assert.match(query, /after: "x\\" \) \{ evil \}"/, "the quote is escaped in place");
+  assert.equal(query.match(/reviewThreads\(/g).length, 1, "no extra selection was injected");
+});
+
+// Review round 2: the documented `list | resolve` pipe read only argv.
+test("thread ids are recovered from piped list output", () => {
+  const piped = "PR2759 PRRT_aaa coderabbitai\nPR2760 PRRT_bbb codex\n";
+  assert.deepEqual(threadIdsFromStdin(() => piped), ["PRRT_aaa", "PRRT_bbb"]);
+  assert.deepEqual(threadIdsFromStdin(() => ""), []);
 });


### PR DESCRIPTION
## Summary

Five process fixes for failures this run actually hit. A sixth candidate was **measured and rejected** rather than shipped as noise.

### Shipped

1. **`scripts/check-nav-link-vocabularies.mjs`** (wired into the `checks` job) fails when the shared navigation parser does not know a link type the stepper accepts or that is actually persisted. Three lists had drifted apart silently: the parser rejected `follows`/`references`/`related` — which real frontmatter carries, so a traversal over stored links dropped those neighbors — and `supersedes`, which the stepper accepts. It took **two review rounds** to find. The unit test replays that exact pre-fix divergence and asserts each missing type is attributed to the list that requires it.
2. **`scripts/pr-review-threads.mjs`** issues ONE aliased query for every PR and ONE aliased mutation for every thread, instead of 2N requests. The naive per-PR loop exhausted the GraphQL point budget **three times in this run**, each time leaving `unresolved-review-threads` red until the budget refilled — roughly two and a half hours of pure waiting. Smoke-tested live against a real PR.
3. **`AGENTS.md` pattern 46** — enumerate keys with `getOwnPropertyNames`, read them with `hasOwn`, and treat present-with-`undefined` as invalid rather than absent. Two allow-list bypasses shipped one review round apart on exactly this mismatch (inherited property, then non-enumerable property).
4. **`AGENTS.md` pattern 47** — never annotate a frozen `as const` array `readonly T[]`; it widens the derived literal union back to `string`. This shipped as a regression *inside a hardening fix*. Includes the `@ts-expect-error` pin that makes a future widening fail the build, since an unused directive is itself an error.
5. **`AGENTS.md` pattern 48** — every claim in a PR body, module header, or changeset must name the code or test enforcing it, or be weakened to what is true. Two false claims were caught by reviewers this run ("structurally incapable of carrying content" on a validator that accepted prose; "internal helper" on an exported module).

### Measured and rejected

Per the README ground rule — run a condition against the tree before shipping it:

- A regex for the pattern-47 widening (`: readonly T[] = Object.freeze([...])`) matches **13 legitimate frozen data arrays** (seed vocabularies, prose frames, fixture memories) where no `(typeof X)[number]` union is derived and the annotation is the intended type. Separating them needs two facts in different places, so it is not a single-line signature. Receipt recorded in `.omp/rules/README.md`; the remedy lives in pattern 47.

## Test plan

- `node scripts/check-nav-link-vocabularies.mjs` — passes on current `main` (parser knows 9 types, covering 5 stepper and 5 persisted), locking in the batch-9 fix.
- `node --test tests/check-nav-link-vocabularies.test.mjs tests/pr-review-threads.test.mjs` — 11/11.
- `node scripts/pr-review-threads.mjs list joshuaswarren/remnic 2756` — exercised against the live API in a single request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to list unresolved pull request review threads and resolve multiple threads in one operation.
  * Added pagination, duplicate handling, input validation, and clear error reporting for review-thread operations.

* **Bug Fixes**
  * Added a CI check to detect missing navigation link types and vocabulary inconsistencies.
  * Improved vocabulary checks to ignore commented-out entries while preserving URLs and other quoted text.

* **Documentation**
  * Expanded development guidance for safer validation, preserving type information, and enforcing documented guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->